### PR TITLE
db(hardening): drop legacy migration_status + lock down public functions + tighten RLS

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,4 +36,4 @@ ENCRYPTION_KEY="review_hub_default_key_change_me_in_production"
 # =================== LANGSMITH (OPCIONAL) ===================
 LANGCHAIN_TRACING_V2=false
 LANGCHAIN_API_KEY=""
-LANGCHAIN_PROJECT="review-hub"
+LANGCHAIN_PROJECT="prumo"

--- a/backend/alembic/versions/0007_drop_migration_status.py
+++ b/backend/alembic/versions/0007_drop_migration_status.py
@@ -1,0 +1,37 @@
+"""drop legacy migration_status table
+
+Revision ID: 0007_drop_migration_status
+Revises: 0006_article_text_blocks
+Create Date: 2026-04-29
+
+The ``migration_status`` table came in via the squashed ``baseline_v1.sql``
+(it was created by an earlier project's bespoke migration tracker, before
+the project standardised on Alembic). No application code reads or writes
+it, so it's pure dead weight and triggers a ``rls_disabled_in_public``
+advisor lint.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0007_drop_migration_status"
+down_revision = "0006_article_text_blocks"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS public.migration_status CASCADE;")
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS public.migration_status (
+            id SERIAL PRIMARY KEY,
+            migration_name VARCHAR NOT NULL UNIQUE,
+            executed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            notes TEXT
+        );
+        """
+    )

--- a/backend/alembic/versions/0008_function_hardening.py
+++ b/backend/alembic/versions/0008_function_hardening.py
@@ -1,0 +1,93 @@
+"""harden public functions: pin search_path + revoke anon EXECUTE on SECURITY DEFINER
+
+Revision ID: 0008_function_hardening
+Revises: 0007_drop_migration_status
+Create Date: 2026-04-29
+
+Two classes of fixes flagged by the Supabase database linter:
+
+1. ``function_search_path_mutable`` — every function under public must
+   pin ``search_path`` to a known list so callers cannot redirect lookups
+   to a hostile schema. We set ``search_path = public, pg_catalog``.
+
+2. ``anon_security_definer_function_executable`` /
+   ``authenticated_security_definer_function_executable`` — every
+   ``SECURITY DEFINER`` function under public is callable through
+   ``/rest/v1/rpc/<fn>`` by default. Most of these are RLS helpers
+   (``is_project_*``) and trigger-only helpers (``handle_new_user``)
+   that should not be exposed as RPC. We revoke EXECUTE from ``anon``
+   and ``public`` and grant only the roles that actually need it.
+
+The full list of SECURITY DEFINER functions:
+  - ``handle_new_user()`` — trigger only, no RPC role needs EXECUTE
+  - ``is_project_member`` / ``is_project_manager`` / ``is_project_reviewer``
+    — RLS helpers; ``authenticated`` keeps EXECUTE so RLS evaluates,
+    ``anon`` is revoked
+  - ``check_cardinality_one`` — RPC used by the frontend, ``authenticated`` only
+  - ``create_project_with_member`` — RPC used by the frontend, ``authenticated`` only
+  - ``find_user_id_by_email`` — RPC used by the frontend, ``authenticated`` only
+  - ``get_project_members`` — RPC used by the frontend, ``authenticated`` only
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0008_function_hardening"
+down_revision = "0007_drop_migration_status"
+branch_labels = None
+depends_on = None
+
+
+# Functions that only need search_path pinning (no SECURITY DEFINER).
+_SEARCH_PATH_ONLY = [
+    "set_updated_at()",
+    "update_updated_at_column()",
+    "enforce_consensus_override_justification()",
+    "validate_extraction_instance_hierarchy()",
+    "validate_instance_project_consistency()",
+    "assert_project_template_has_active_version()",
+    "ensure_single_default_api_key()",
+    "calculate_model_progress(p_project_id uuid, p_article_id uuid)",
+]
+
+
+# SECURITY DEFINER functions: pin search_path + revoke anon/public EXECUTE.
+# Each entry maps signature → roles that should retain EXECUTE.
+_SECURITY_DEFINER = {
+    "handle_new_user()": [],  # trigger only
+    "is_project_member(p_project_id uuid, p_user_id uuid)": ["authenticated"],
+    "is_project_manager(p_project_id uuid, p_user_id uuid)": ["authenticated"],
+    "is_project_reviewer(p_project_id uuid, p_user_id uuid)": ["authenticated"],
+    "check_cardinality_one(p_article_id uuid, p_entity_type_id uuid, p_parent_instance_id uuid)": [
+        "authenticated"
+    ],
+    "create_project_with_member(p_name text, p_description text, p_review_type review_type, p_created_by uuid)": [
+        "authenticated"
+    ],
+    "find_user_id_by_email(p_email text)": ["authenticated"],
+    "get_project_members(p_project_id uuid)": ["authenticated"],
+}
+
+
+def upgrade() -> None:
+    for sig in _SEARCH_PATH_ONLY:
+        op.execute(f"ALTER FUNCTION public.{sig} SET search_path = public, pg_catalog;")
+
+    for sig, keep_roles in _SECURITY_DEFINER.items():
+        op.execute(f"ALTER FUNCTION public.{sig} SET search_path = public, pg_catalog;")
+        op.execute(f"REVOKE EXECUTE ON FUNCTION public.{sig} FROM anon, PUBLIC;")
+        for role in keep_roles:
+            op.execute(f"GRANT EXECUTE ON FUNCTION public.{sig} TO {role};")
+
+
+def downgrade() -> None:
+    for sig in _SEARCH_PATH_ONLY:
+        op.execute(f"ALTER FUNCTION public.{sig} RESET search_path;")
+
+    for sig, keep_roles in _SECURITY_DEFINER.items():
+        op.execute(f"ALTER FUNCTION public.{sig} RESET search_path;")
+        # Restore the broader default grants Supabase ships with.
+        op.execute(f"GRANT EXECUTE ON FUNCTION public.{sig} TO anon, authenticated, service_role;")
+        for role in keep_roles:
+            # No-op: the GRANT above already covers them.
+            _ = role

--- a/backend/alembic/versions/0009_tighten_rls_policies.py
+++ b/backend/alembic/versions/0009_tighten_rls_policies.py
@@ -1,0 +1,107 @@
+"""tighten always-true RLS policies on article_authors and feedback_reports
+
+Revision ID: 0009_tighten_rls_policies
+Revises: 0008_function_hardening
+Create Date: 2026-04-29
+
+Two RLS policies were flagged by the ``rls_policy_always_true`` linter:
+
+1. ``article_authors.article_authors_manage`` — ``ALL`` for authenticated
+   with both USING and WITH CHECK = true. The companion
+   ``article_authors_select`` already restricts SELECT through the
+   article_author_links → articles → project_members chain. We drop the
+   blanket policy and add per-command policies so writes follow the same
+   project-membership gate (INSERT stays open because new authors must be
+   inserted before any link exists).
+
+2. ``feedback_reports.feedback_reports_insert`` — INSERT with WITH CHECK
+   = true and an empty role list (so even ``anon`` could INSERT). Restrict
+   to ``authenticated`` and force ``user_id = auth.uid()`` so no one can
+   spoof another user's feedback.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0009_tighten_rls_policies"
+down_revision = "0008_function_hardening"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- article_authors -----------------------------------------------
+    # Drop the blanket ALL-true policy. The existing ``article_authors_select``
+    # policy stays in place — it already restricts reads to project members.
+    op.execute('DROP POLICY IF EXISTS "article_authors_manage" ON public.article_authors;')
+
+    op.execute(
+        """
+        CREATE POLICY "article_authors_insert" ON public.article_authors
+        FOR INSERT TO authenticated WITH CHECK (true);
+        """
+    )
+    op.execute(
+        """
+        CREATE POLICY "article_authors_update" ON public.article_authors
+        FOR UPDATE TO authenticated
+        USING (
+          EXISTS (
+            SELECT 1
+            FROM public.article_author_links aal
+            JOIN public.articles a ON a.id = aal.article_id
+            WHERE aal.author_id = article_authors.id
+              AND public.is_project_member(a.project_id, auth.uid())
+          )
+        );
+        """
+    )
+    op.execute(
+        """
+        CREATE POLICY "article_authors_delete" ON public.article_authors
+        FOR DELETE TO authenticated
+        USING (
+          EXISTS (
+            SELECT 1
+            FROM public.article_author_links aal
+            JOIN public.articles a ON a.id = aal.article_id
+            WHERE aal.author_id = article_authors.id
+              AND public.is_project_manager(a.project_id, auth.uid())
+          )
+        );
+        """
+    )
+
+    # --- feedback_reports ----------------------------------------------
+    op.execute('DROP POLICY IF EXISTS "feedback_reports_insert" ON public.feedback_reports;')
+
+    op.execute(
+        """
+        CREATE POLICY "feedback_reports_insert" ON public.feedback_reports
+        FOR INSERT TO authenticated
+        WITH CHECK (user_id = auth.uid());
+        """
+    )
+
+
+def downgrade() -> None:
+    # --- feedback_reports ----------------------------------------------
+    op.execute('DROP POLICY IF EXISTS "feedback_reports_insert" ON public.feedback_reports;')
+    op.execute(
+        """
+        CREATE POLICY "feedback_reports_insert" ON public.feedback_reports
+        FOR INSERT WITH CHECK (true);
+        """
+    )
+
+    # --- article_authors -----------------------------------------------
+    op.execute('DROP POLICY IF EXISTS "article_authors_delete" ON public.article_authors;')
+    op.execute('DROP POLICY IF EXISTS "article_authors_update" ON public.article_authors;')
+    op.execute('DROP POLICY IF EXISTS "article_authors_insert" ON public.article_authors;')
+
+    op.execute(
+        """
+        CREATE POLICY "article_authors_manage" ON public.article_authors
+        FOR ALL TO authenticated USING (true) WITH CHECK (true);
+        """
+    )

--- a/backend/alembic/versions/0010_lock_handle_new_user.py
+++ b/backend/alembic/versions/0010_lock_handle_new_user.py
@@ -1,0 +1,29 @@
+"""revoke EXECUTE on handle_new_user from authenticated
+
+Revision ID: 0010_lock_handle_new_user
+Revises: 0009_tighten_rls_policies
+Create Date: 2026-04-29
+
+``handle_new_user()`` only runs through the ``on_auth_user_created``
+trigger on ``auth.users``. The trigger fires with the function's owner
+privileges (``SECURITY DEFINER``), so signed-in users do not need
+``EXECUTE`` to make profile creation work — and exposing it via
+``/rest/v1/rpc/handle_new_user`` lets a logged-in user call it
+directly with a forged ``NEW`` record. Drop the grant.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0010_lock_handle_new_user"
+down_revision = "0009_tighten_rls_policies"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM authenticated;")
+
+
+def downgrade() -> None:
+    op.execute("GRANT EXECUTE ON FUNCTION public.handle_new_user() TO authenticated;")


### PR DESCRIPTION
## Summary

Cleans up the security advisor gap inherited from the squashed `baseline_v1.sql`. After this PR the Supabase linter goes from **32 → 10** lints; every remaining lint is one of:
- a known operational table (`public.alembic_version` — needs no RLS)
- an intentional SECURITY DEFINER RPC that `authenticated` legitimately needs (`is_project_*`, `create_project_with_member`, etc.)
- a manual setting outside Alembic (`auth_leaked_password_protection` via dashboard, `pg_trgm` placement)

These migrations have already been applied to the remote project (`gdfslcfeobjdxihqtcsk`). Each is idempotent and ships with a downgrade path.

## Migrations

- **0007 — drop `migration_status`** ([0007_drop_migration_status.py](backend/alembic/versions/0007_drop_migration_status.py)). The table came in via the squashed `baseline_v1.sql` and is not read or written by any application code.

- **0008 — function hardening** ([0008_function_hardening.py](backend/alembic/versions/0008_function_hardening.py)).
  - Pins `search_path = public, pg_catalog` on every `public` function (closes `function_search_path_mutable`).
  - Revokes `EXECUTE` from `anon` / `PUBLIC` on every `SECURITY DEFINER` function. `authenticated` retains EXECUTE only where it actually needs it (RPCs and RLS helpers).

- **0009 — tighten RLS** ([0009_tighten_rls_policies.py](backend/alembic/versions/0009_tighten_rls_policies.py)).
  - `article_authors`: drops the blanket ALL-true policy and adds per-command policies. UPDATE/DELETE now require the caller to share a project with the author through `article_author_links → articles → project_members`. INSERT stays open (no project context exists before the link is created).
  - `feedback_reports`: INSERT is now `authenticated`-only and forces `user_id = auth.uid()` so users cannot spoof each other's feedback.

- **0010 — lock down `handle_new_user`** ([0010_lock_handle_new_user.py](backend/alembic/versions/0010_lock_handle_new_user.py)). The trigger fires with the function's owner privileges, so signed-in users do not need EXECUTE — and exposing it via `/rest/v1/rpc/handle_new_user` lets a logged-in user call it with a forged `NEW` record.

## Test plan

- [x] `ruff check` + `ruff format --check` pass on all 4 migration files
- [x] `alembic upgrade head` applied cleanly against remote (now at `0010_lock_handle_new_user`)
- [x] `get_advisors` security: 32 → 10 lints
- [ ] Smoke test login flow on staging (verifies `is_project_member` still callable by `authenticated` for RLS)
- [ ] Smoke test feedback form (verifies INSERT works for own user, fails for spoofed `user_id`)
- [ ] Verify CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)