### PR TITLE
chore(env): rename LangSmith project to prumo

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,4 +36,4 @@ ENCRYPTION_KEY="review_hub_default_key_change_me_in_production"
 # =================== LANGSMITH (OPCIONAL) ===================
 LANGCHAIN_TRACING_V2=false
 LANGCHAIN_API_KEY=""
-LANGCHAIN_PROJECT="review-hub"
+LANGCHAIN_PROJECT="prumo"


### PR DESCRIPTION
## Summary

Tiny one-line fix to \`backend/.env.example\`: \`LANGCHAIN_PROJECT="review-hub"\` → \`LANGCHAIN_PROJECT="prumo"\`. Aligns the example env with the project's current name (renamed from \"review-hub\" some time back).

## Why a separate PR

This commit was originally part of the closed PR #15 (\`db(hardening)\`) but it was unrelated to the hardening work and got orphaned when that PR was closed. Salvaging it here as a focused 1-line PR.

## Diff

\`\`\`diff
- LANGCHAIN_PROJECT=\"review-hub\"
+ LANGCHAIN_PROJECT=\"prumo\"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)