### PR TITLE
feat(screening): UI sketches from PR #7 as references for Phase 1+

### DIFF
--- a/frontend/components/articles/CSVImportDialog.tsx
+++ b/frontend/components/articles/CSVImportDialog.tsx
@@ -1,0 +1,365 @@
+/**
+ * Dialog for importing articles from a Scopus CSV export file.
+ *
+ * Flow:
+ * 1. User selects a CSV file
+ * 2. CSV is parsed client-side for preview
+ * 3. CSV is uploaded to backend for processing
+ * 4. Articles are bulk-inserted with deduplication by DOI
+ */
+
+import {useCallback, useState} from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {Button} from '@/components/ui/button';
+import {ScrollArea} from '@/components/ui/scroll-area';
+import {Badge} from '@/components/ui/badge';
+import {AlertCircle, CheckCircle2, FileSpreadsheet, Loader2, Upload} from 'lucide-react';
+import {supabase} from '@/integrations/supabase/client';
+import {toast} from 'sonner';
+import {t} from '@/lib/copy';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
+
+interface CSVPreviewRow {
+    title: string;
+    authors: string;
+    year: string;
+    journal: string;
+    doi: string;
+}
+
+interface ImportResult {
+    successCount: number;
+    failCount: number;
+    duplicateCount: number;
+    errors: string[];
+}
+
+interface CSVImportDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    projectId: string;
+    onImportComplete?: () => void;
+}
+
+export function CSVImportDialog({
+    open,
+    onOpenChange,
+    projectId,
+    onImportComplete,
+}: CSVImportDialogProps) {
+    const [file, setFile] = useState<File | null>(null);
+    const [preview, setPreview] = useState<CSVPreviewRow[]>([]);
+    const [totalRows, setTotalRows] = useState(0);
+    const [importing, setImporting] = useState(false);
+    const [result, setResult] = useState<ImportResult | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const reset = useCallback(() => {
+        setFile(null);
+        setPreview([]);
+        setTotalRows(0);
+        setImporting(false);
+        setResult(null);
+        setError(null);
+    }, []);
+
+    const parseCSVPreview = (text: string): {rows: CSVPreviewRow[], total: number} => {
+        const lines = text.split('\n');
+        if (lines.length < 2) return {rows: [], total: 0};
+
+        // Simple CSV header parsing
+        const headers = lines[0].split(',').map(h => h.trim().replace(/^"|"$/g, ''));
+        const titleIdx = headers.indexOf('Title');
+        const authorsIdx = headers.indexOf('Authors');
+        const yearIdx = headers.indexOf('Year');
+        const journalIdx = headers.indexOf('Source title');
+        const doiIdx = headers.indexOf('DOI');
+
+        if (titleIdx === -1) {
+            throw new Error('CSV must have a "Title" column. Expected Scopus export format.');
+        }
+
+        // Parse rows (simple — handles basic quoting)
+        const rows: CSVPreviewRow[] = [];
+        let total = 0;
+
+        for (let i = 1; i < lines.length; i++) {
+            const line = lines[i].trim();
+            if (!line) continue;
+
+            // Simple field extraction (handles quoted fields with commas)
+            const fields: string[] = [];
+            let current = '';
+            let inQuotes = false;
+            for (const char of line) {
+                if (char === '"') {
+                    inQuotes = !inQuotes;
+                } else if (char === ',' && !inQuotes) {
+                    fields.push(current.trim());
+                    current = '';
+                } else {
+                    current += char;
+                }
+            }
+            fields.push(current.trim());
+
+            const title = (fields[titleIdx] || '').replace(/^"|"$/g, '');
+            if (!title) continue;
+
+            total++;
+
+            if (rows.length < 10) {
+                rows.push({
+                    title: title.length > 70 ? title.slice(0, 70) + '...' : title,
+                    authors: (fields[authorsIdx] || '').replace(/^"|"$/g, '').slice(0, 50),
+                    year: (fields[yearIdx] || '').replace(/^"|"$/g, ''),
+                    journal: (fields[journalIdx] || '').replace(/^"|"$/g, '').slice(0, 40),
+                    doi: (fields[doiIdx] || '').replace(/^"|"$/g, '').slice(0, 30),
+                });
+            }
+        }
+
+        return {rows, total};
+    };
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const selectedFile = e.target.files?.[0];
+        e.target.value = '';
+        reset();
+        if (!selectedFile) return;
+
+        if (!selectedFile.name.endsWith('.csv')) {
+            setError('Please select a .csv file');
+            return;
+        }
+
+        setFile(selectedFile);
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const text = reader.result as string;
+                const {rows, total} = parseCSVPreview(text);
+                if (total === 0) {
+                    setError('No articles found in CSV file');
+                    return;
+                }
+                setPreview(rows);
+                setTotalRows(total);
+                setError(null);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : 'Error reading CSV');
+            }
+        };
+        reader.onerror = () => setError('Failed to read file');
+        reader.readAsText(selectedFile, 'UTF-8');
+    };
+
+    const handleImport = async () => {
+        if (!file) return;
+        setImporting(true);
+        setError(null);
+
+        try {
+            const {data: {session}} = await supabase.auth.getSession();
+            if (!session?.access_token) {
+                throw new Error('Authentication required');
+            }
+
+            const formData = new FormData();
+            formData.append('project_id', projectId);
+            formData.append('file', file);
+
+            const response = await fetch(`${API_BASE_URL}/api/v1/article-import/csv-import`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${session.access_token}`,
+                },
+                body: formData,
+            });
+
+            const data = await response.json();
+
+            if (!data.ok) {
+                throw new Error(data.error?.message || 'Import failed');
+            }
+
+            const importResult: ImportResult = data.data;
+            setResult(importResult);
+
+            if (importResult.successCount > 0) {
+                toast.success(`${importResult.successCount} article(s) imported successfully!`);
+                onImportComplete?.();
+            }
+            if (importResult.duplicateCount > 0) {
+                toast.info(`${importResult.duplicateCount} duplicate(s) skipped (same DOI).`);
+            }
+            if (importResult.failCount > 0) {
+                toast.warning(`${importResult.failCount} article(s) failed to import.`);
+            }
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Unknown error';
+            setError(message);
+            toast.error(message);
+        } finally {
+            setImporting(false);
+        }
+    };
+
+    const handleOpenChange = (next: boolean) => {
+        if (!next && importing) {
+            return; // Prevent closing during import
+        }
+        if (!next) reset();
+        onOpenChange(next);
+    };
+
+    const handleClose = () => {
+        reset();
+        onOpenChange(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <FileSpreadsheet className="h-5 w-5"/>
+                        Import from CSV (Scopus)
+                    </DialogTitle>
+                    <DialogDescription>
+                        Select a .csv file exported from Scopus. Articles will be imported with deduplication by DOI.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                    {/* File selector */}
+                    {!result && (
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="file"
+                                accept=".csv"
+                                onChange={handleFileChange}
+                                className="hidden"
+                                id="csv-import-input"
+                            />
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                className="shrink-0"
+                                onClick={() => document.getElementById('csv-import-input')?.click()}
+                                disabled={importing}
+                            >
+                                <Upload className="h-4 w-4 mr-2"/>
+                                Select CSV file
+                            </Button>
+                            {file && (
+                                <span className="text-[13px] text-muted-foreground truncate" title={file.name}>
+                                    {file.name}
+                                </span>
+                            )}
+                        </div>
+                    )}
+
+                    {error && (
+                        <div className="flex items-start gap-2 text-sm text-destructive bg-destructive/5 rounded-md p-3">
+                            <AlertCircle className="h-4 w-4 mt-0.5 shrink-0"/>
+                            {error}
+                        </div>
+                    )}
+
+                    {/* Preview */}
+                    {preview.length > 0 && !result && (
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-2">
+                                <Badge variant="secondary" className="text-xs">
+                                    {totalRows} article(s)
+                                </Badge>
+                                <span className="text-[13px] text-muted-foreground">Preview (first 10):</span>
+                            </div>
+                            <ScrollArea className="h-[200px] rounded-md border border-border/40 p-3">
+                                <ul className="text-[13px] text-foreground space-y-2 list-none">
+                                    {preview.map((row, i) => (
+                                        <li key={i} className="space-y-0.5">
+                                            <p className="font-medium">{i + 1}. {row.title}</p>
+                                            <p className="text-muted-foreground text-xs">
+                                                {[row.authors, row.journal, row.year, row.doi].filter(Boolean).join(' | ')}
+                                            </p>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </ScrollArea>
+                        </div>
+                    )}
+
+                    {/* Import result */}
+                    {result && (
+                        <div className="space-y-3 py-2">
+                            <div className="flex items-center gap-2">
+                                <CheckCircle2 className="h-5 w-5 text-green-500"/>
+                                <span className="font-medium text-sm">Import complete</span>
+                            </div>
+                            <div className="grid grid-cols-3 gap-3">
+                                <div className="rounded-md border border-border/40 p-3 text-center">
+                                    <p className="text-2xl font-semibold text-green-600">{result.successCount}</p>
+                                    <p className="text-xs text-muted-foreground">Imported</p>
+                                </div>
+                                <div className="rounded-md border border-border/40 p-3 text-center">
+                                    <p className="text-2xl font-semibold text-yellow-600">{result.duplicateCount}</p>
+                                    <p className="text-xs text-muted-foreground">Duplicates</p>
+                                </div>
+                                <div className="rounded-md border border-border/40 p-3 text-center">
+                                    <p className="text-2xl font-semibold text-red-600">{result.failCount}</p>
+                                    <p className="text-xs text-muted-foreground">Failed</p>
+                                </div>
+                            </div>
+                            {result.errors.length > 0 && (
+                                <ScrollArea className="h-[100px] rounded-md border border-border/40 p-3">
+                                    <ul className="text-xs text-muted-foreground space-y-1 list-none">
+                                        {result.errors.map((err, i) => (
+                                            <li key={i}>{err}</li>
+                                        ))}
+                                    </ul>
+                                </ScrollArea>
+                            )}
+                        </div>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    {result ? (
+                        <Button onClick={handleClose}>
+                            Close
+                        </Button>
+                    ) : (
+                        <>
+                            <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={importing}>
+                                {t('common', 'cancel')}
+                            </Button>
+                            <Button
+                                onClick={handleImport}
+                                disabled={totalRows === 0 || importing}
+                            >
+                                {importing ? (
+                                    <>
+                                        <Loader2 className="h-4 w-4 mr-2 animate-spin"/>
+                                        Importing...
+                                    </>
+                                ) : (
+                                    `Import ${totalRows} article(s)`
+                                )}
+                            </Button>
+                        </>
+                    )}
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/articles/PDFImportDialog.tsx
+++ b/frontend/components/articles/PDFImportDialog.tsx
@@ -1,0 +1,555 @@
+/**
+ * Dialog for importing an article from a PDF file.
+ *
+ * Flow:
+ * 1. User selects a PDF file
+ * 2. PDF is uploaded to Supabase Storage
+ * 3. Backend extracts metadata via AI (OpenAI Responses API)
+ * 4. User reviews extracted metadata in a form
+ * 5. Article is created with metadata + linked PDF
+ */
+
+import {useCallback, useState} from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {Button} from '@/components/ui/button';
+import {Input} from '@/components/ui/input';
+import {Label} from '@/components/ui/label';
+import {Textarea} from '@/components/ui/textarea';
+import {ScrollArea} from '@/components/ui/scroll-area';
+import {Badge} from '@/components/ui/badge';
+import {Brain, CheckCircle2, FileUp, Loader2, Upload} from 'lucide-react';
+import {supabase} from '@/integrations/supabase/client';
+import {toast} from 'sonner';
+import {t} from '@/lib/copy';
+import {validateFile} from '@/lib/file-validation';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
+
+interface ExtractedMetadata {
+    title: string | null;
+    abstract: string | null;
+    authors: string[] | null;
+    publicationYear: number | null;
+    publicationMonth: number | null;
+    journalTitle: string | null;
+    journalIssn: string | null;
+    volume: string | null;
+    issue: string | null;
+    pages: string | null;
+    doi: string | null;
+    pmid: string | null;
+    pmcid: string | null;
+    keywords: string[] | null;
+    articleType: string | null;
+    language: string | null;
+    urlLanding: string | null;
+    studyDesign: string | null;
+}
+
+interface PDFImportDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    projectId: string;
+    onImportComplete?: () => void;
+}
+
+type Step = 'upload' | 'extracting' | 'review' | 'saving';
+
+export function PDFImportDialog({
+    open,
+    onOpenChange,
+    projectId,
+    onImportComplete,
+}: PDFImportDialogProps) {
+    const [step, setStep] = useState<Step>('upload');
+    const [pdfFile, setPdfFile] = useState<File | null>(null);
+    const [storageKey, setStorageKey] = useState<string | null>(null);
+    const [metadata, setMetadata] = useState<ExtractedMetadata | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    // Editable form state (populated from AI extraction)
+    const [formData, setFormData] = useState({
+        title: '',
+        abstract: '',
+        authors: '',
+        publication_year: '',
+        publication_month: '',
+        journal_title: '',
+        journal_issn: '',
+        volume: '',
+        issue: '',
+        pages: '',
+        doi: '',
+        pmid: '',
+        pmcid: '',
+        keywords: '',
+        article_type: '',
+        language: '',
+        url_landing: '',
+        study_design: '',
+    });
+
+    const reset = useCallback(() => {
+        setStep('upload');
+        setPdfFile(null);
+        setStorageKey(null);
+        setMetadata(null);
+        setError(null);
+        setFormData({
+            title: '', abstract: '', authors: '', publication_year: '',
+            publication_month: '', journal_title: '', journal_issn: '',
+            volume: '', issue: '', pages: '', doi: '', pmid: '', pmcid: '',
+            keywords: '', article_type: '', language: '', url_landing: '',
+            study_design: '',
+        });
+    }, []);
+
+    const populateForm = (m: ExtractedMetadata) => {
+        setFormData({
+            title: m.title || '',
+            abstract: m.abstract || '',
+            authors: m.authors?.join(', ') || '',
+            publication_year: m.publicationYear?.toString() || '',
+            publication_month: m.publicationMonth?.toString() || '',
+            journal_title: m.journalTitle || '',
+            journal_issn: m.journalIssn || '',
+            volume: m.volume || '',
+            issue: m.issue || '',
+            pages: m.pages || '',
+            doi: m.doi || '',
+            pmid: m.pmid || '',
+            pmcid: m.pmcid || '',
+            keywords: m.keywords?.join(', ') || '',
+            article_type: m.articleType || '',
+            language: m.language || '',
+            url_landing: m.urlLanding || '',
+            study_design: m.studyDesign || '',
+        });
+    };
+
+    const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = '';
+        if (!file) return;
+
+        const validation = validateFile(file);
+        if (!validation.valid) {
+            setError(validation.error || 'Invalid file');
+            return;
+        }
+
+        setPdfFile(file);
+        setError(null);
+        setStep('extracting');
+
+        try {
+            // Step 1: Upload PDF to Supabase Storage with a temp article ID
+            const tempId = crypto.randomUUID();
+            const fileExt = file.name.split('.').pop();
+            const key = `${projectId}/${tempId}/${Date.now()}.${fileExt}`;
+
+            const {error: uploadError} = await supabase.storage
+                .from('articles')
+                .upload(key, file);
+
+            if (uploadError) {
+                throw new Error(`Upload failed: ${uploadError.message}`);
+            }
+            setStorageKey(key);
+
+            // Step 2: Call backend to extract metadata via AI
+            const {data: {session}} = await supabase.auth.getSession();
+            if (!session?.access_token) {
+                throw new Error('Authentication required');
+            }
+
+            const formPayload = new FormData();
+            formPayload.append('project_id', projectId);
+            formPayload.append('storage_key', key);
+            formPayload.append('original_filename', file.name);
+
+            const response = await fetch(`${API_BASE_URL}/api/v1/article-import/pdf-extract-metadata`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${session.access_token}`,
+                },
+                body: formPayload,
+            });
+
+            const result = await response.json();
+
+            if (!result.ok) {
+                throw new Error(result.error?.message || 'Metadata extraction failed');
+            }
+
+            const extracted: ExtractedMetadata = result.data.metadata;
+            setMetadata(extracted);
+            populateForm(extracted);
+            setStep('review');
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Unknown error';
+            setError(message);
+            setStep('upload');
+
+            // Cleanup uploaded file on failure
+            if (storageKey) {
+                await supabase.storage.from('articles').remove([storageKey]);
+                setStorageKey(null);
+            }
+        }
+    };
+
+    const handleSave = async () => {
+        if (!formData.title.trim()) {
+            toast.error(t('articles', 'titleRequiredToast'));
+            return;
+        }
+        if (!storageKey || !pdfFile) {
+            toast.error('No PDF file uploaded');
+            return;
+        }
+
+        setStep('saving');
+
+        try {
+            const parseDateValue = (value: string): number | null => {
+                if (!value.trim()) return null;
+                const num = parseInt(value.trim(), 10);
+                return isNaN(num) ? null : num;
+            };
+
+            const {data: {session}} = await supabase.auth.getSession();
+            if (!session?.access_token) {
+                throw new Error('Authentication required');
+            }
+
+            const payload = {
+                projectId: projectId,
+                storageKey: storageKey,
+                originalFilename: pdfFile.name,
+                fileBytes: pdfFile.size,
+                title: formData.title.trim(),
+                abstract: formData.abstract.trim() || null,
+                authors: formData.authors.trim()
+                    ? formData.authors.split(',').map(a => a.trim())
+                    : null,
+                publicationYear: parseDateValue(formData.publication_year),
+                publicationMonth: parseDateValue(formData.publication_month),
+                journalTitle: formData.journal_title.trim() || null,
+                journalIssn: formData.journal_issn.trim() || null,
+                volume: formData.volume.trim() || null,
+                issue: formData.issue.trim() || null,
+                pages: formData.pages.trim() || null,
+                doi: formData.doi.trim() || null,
+                pmid: formData.pmid.trim() || null,
+                pmcid: formData.pmcid.trim() || null,
+                keywords: formData.keywords.trim()
+                    ? formData.keywords.split(',').map(k => k.trim())
+                    : null,
+                articleType: formData.article_type.trim() || null,
+                language: formData.language.trim() || null,
+                urlLanding: formData.url_landing.trim() || null,
+                studyDesign: formData.study_design.trim() || null,
+            };
+
+            const response = await fetch(`${API_BASE_URL}/api/v1/article-import/pdf-create-article`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${session.access_token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+            });
+
+            const result = await response.json();
+
+            if (!result.ok) {
+                throw new Error(result.error?.message || 'Failed to create article');
+            }
+
+            toast.success(t('articles', 'articleCreatedSuccess'));
+            onImportComplete?.();
+            onOpenChange(false);
+            reset();
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Unknown error';
+            toast.error(message);
+            setStep('review');
+        }
+    };
+
+    const handleOpenChange = (next: boolean) => {
+        if (!next && step !== 'upload') {
+            if (window.confirm('Closing will discard the extracted data. Continue?')) {
+                // Cleanup uploaded file
+                if (storageKey) {
+                    supabase.storage.from('articles').remove([storageKey]);
+                }
+                reset();
+                onOpenChange(false);
+            }
+            return;
+        }
+        if (!next) reset();
+        onOpenChange(next);
+    };
+
+    const updateField = (field: string, value: string) => {
+        setFormData(prev => ({...prev, [field]: value}));
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className="max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <Brain className="h-5 w-5"/>
+                        Import from PDF (AI extraction)
+                    </DialogTitle>
+                    <DialogDescription>
+                        Upload a PDF and AI will extract the bibliographic metadata automatically.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {/* Step: Upload */}
+                {step === 'upload' && (
+                    <div className="space-y-4 py-4">
+                        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed border-border/50 p-8 hover:border-border transition-colors">
+                            <FileUp className="h-10 w-10 text-muted-foreground/50"/>
+                            <div className="text-center">
+                                <p className="text-sm font-medium">Select a PDF file</p>
+                                <p className="text-xs text-muted-foreground mt-1">
+                                    AI will extract title, authors, abstract, DOI and more
+                                </p>
+                            </div>
+                            <input
+                                type="file"
+                                accept="application/pdf"
+                                onChange={handleFileSelect}
+                                className="hidden"
+                                id="pdf-import-input"
+                            />
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => document.getElementById('pdf-import-input')?.click()}
+                            >
+                                <Upload className="h-4 w-4 mr-2"/>
+                                Select PDF
+                            </Button>
+                        </div>
+                        {error && (
+                            <p className="text-sm text-destructive" role="alert">{error}</p>
+                        )}
+                    </div>
+                )}
+
+                {/* Step: Extracting */}
+                {step === 'extracting' && (
+                    <div className="flex flex-col items-center justify-center gap-4 py-12">
+                        <Loader2 className="h-8 w-8 animate-spin text-primary"/>
+                        <div className="text-center">
+                            <p className="text-sm font-medium">Extracting metadata from PDF...</p>
+                            <p className="text-xs text-muted-foreground mt-1">
+                                {pdfFile?.name} ({((pdfFile?.size || 0) / 1024 / 1024).toFixed(1)} MB)
+                            </p>
+                        </div>
+                    </div>
+                )}
+
+                {/* Step: Review */}
+                {step === 'review' && (
+                    <ScrollArea className="flex-1 max-h-[60vh] pr-4">
+                        <div className="space-y-4 py-2">
+                            <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/30 rounded-md px-3 py-2">
+                                <CheckCircle2 className="h-3.5 w-3.5 text-green-500"/>
+                                Metadata extracted from <span className="font-medium">{pdfFile?.name}</span>. Review and edit before saving.
+                            </div>
+
+                            <div>
+                                <Label htmlFor="pdf-title">{t('articles', 'titleRequired')}</Label>
+                                <Input
+                                    id="pdf-title"
+                                    value={formData.title}
+                                    onChange={(e) => updateField('title', e.target.value)}
+                                    placeholder={t('articles', 'titlePlaceholder')}
+                                />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="pdf-abstract">{t('articles', 'abstract')}</Label>
+                                <Textarea
+                                    id="pdf-abstract"
+                                    value={formData.abstract}
+                                    onChange={(e) => updateField('abstract', e.target.value)}
+                                    rows={3}
+                                />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="pdf-authors">{t('articles', 'authors')}</Label>
+                                <Input
+                                    id="pdf-authors"
+                                    value={formData.authors}
+                                    onChange={(e) => updateField('authors', e.target.value)}
+                                    placeholder={t('articles', 'authorsPlaceholder')}
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-4">
+                                <div>
+                                    <Label htmlFor="pdf-year">{t('articles', 'publicationYear')}</Label>
+                                    <Input
+                                        id="pdf-year"
+                                        type="number"
+                                        value={formData.publication_year}
+                                        onChange={(e) => updateField('publication_year', e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="pdf-month">{t('articles', 'publicationMonth')}</Label>
+                                    <Input
+                                        id="pdf-month"
+                                        type="number"
+                                        value={formData.publication_month}
+                                        onChange={(e) => updateField('publication_month', e.target.value)}
+                                    />
+                                </div>
+                            </div>
+
+                            <div>
+                                <Label htmlFor="pdf-journal">{t('articles', 'journalTitle')}</Label>
+                                <Input
+                                    id="pdf-journal"
+                                    value={formData.journal_title}
+                                    onChange={(e) => updateField('journal_title', e.target.value)}
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-3 gap-4">
+                                <div>
+                                    <Label htmlFor="pdf-volume">Volume</Label>
+                                    <Input
+                                        id="pdf-volume"
+                                        value={formData.volume}
+                                        onChange={(e) => updateField('volume', e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="pdf-issue">{t('articles', 'issue')}</Label>
+                                    <Input
+                                        id="pdf-issue"
+                                        value={formData.issue}
+                                        onChange={(e) => updateField('issue', e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="pdf-pages">{t('articles', 'pages')}</Label>
+                                    <Input
+                                        id="pdf-pages"
+                                        value={formData.pages}
+                                        onChange={(e) => updateField('pages', e.target.value)}
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="grid grid-cols-3 gap-4">
+                                <div>
+                                    <Label htmlFor="pdf-doi">DOI</Label>
+                                    <Input
+                                        id="pdf-doi"
+                                        value={formData.doi}
+                                        onChange={(e) => updateField('doi', e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="pdf-pmid">PMID</Label>
+                                    <Input
+                                        id="pdf-pmid"
+                                        value={formData.pmid}
+                                        onChange={(e) => updateField('pmid', e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="pdf-pmcid">PMCID</Label>
+                                    <Input
+                                        id="pdf-pmcid"
+                                        value={formData.pmcid}
+                                        onChange={(e) => updateField('pmcid', e.target.value)}
+                                    />
+                                </div>
+                            </div>
+
+                            <div>
+                                <Label htmlFor="pdf-keywords">{t('articles', 'keywords')}</Label>
+                                <Input
+                                    id="pdf-keywords"
+                                    value={formData.keywords}
+                                    onChange={(e) => updateField('keywords', e.target.value)}
+                                    placeholder={t('articles', 'keywordsPlaceholder')}
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-3 gap-4">
+                                <div>
+                                    <Label htmlFor="pdf-type">Type</Label>
+                                    <Input
+                                        id="pdf-type"
+                                        value={formData.article_type}
+                                        onChange={(e) => updateField('article_type', e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="pdf-lang">{t('articles', 'languageLabel')}</Label>
+                                    <Input
+                                        id="pdf-lang"
+                                        value={formData.language}
+                                        onChange={(e) => updateField('language', e.target.value)}
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="pdf-design">{t('articles', 'studyDesignLabel')}</Label>
+                                    <Input
+                                        id="pdf-design"
+                                        value={formData.study_design}
+                                        onChange={(e) => updateField('study_design', e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </ScrollArea>
+                )}
+
+                {/* Step: Saving */}
+                {step === 'saving' && (
+                    <div className="flex flex-col items-center justify-center gap-4 py-12">
+                        <Loader2 className="h-8 w-8 animate-spin text-primary"/>
+                        <p className="text-sm font-medium">{t('articles', 'saving')}</p>
+                    </div>
+                )}
+
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => handleOpenChange(false)}
+                        disabled={step === 'extracting' || step === 'saving'}
+                    >
+                        {t('common', 'cancel')}
+                    </Button>
+                    {step === 'review' && (
+                        <Button onClick={handleSave}>
+                            {t('articles', 'createArticle')}
+                        </Button>
+                    )}
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/components/screening/ScreeningCardView.tsx
+++ b/frontend/components/screening/ScreeningCardView.tsx
@@ -1,0 +1,289 @@
+/**
+ * Card-based screening interface.
+ *
+ * Shows one article at a time with title, abstract, criteria checklist,
+ * and include/exclude/maybe buttons with keyboard shortcuts.
+ */
+
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import {Button} from '@/components/ui/button';
+import {Badge} from '@/components/ui/badge';
+import {Checkbox} from '@/components/ui/checkbox';
+import {Textarea} from '@/components/ui/textarea';
+import {ScrollArea} from '@/components/ui/scroll-area';
+import {
+    CheckCircle2,
+    ChevronLeft,
+    ChevronRight,
+    Loader2,
+    Minus,
+    XCircle,
+    HelpCircle,
+    Brain,
+} from 'lucide-react';
+import {supabase} from '@/integrations/supabase/client';
+import {toast} from 'sonner';
+import {useScreeningConfig} from '@/hooks/screening/useScreeningConfig';
+import {useScreeningDecisions} from '@/hooks/screening/useScreeningDecisions';
+import {useScreeningProgress} from '@/hooks/screening/useScreeningProgress';
+import type {Article} from '@/types/article';
+import type {ScreeningCriterion} from '@/types/screening';
+
+interface ScreeningCardViewProps {
+    projectId: string;
+    phase: 'title_abstract' | 'full_text';
+}
+
+export function ScreeningCardView({projectId, phase}: ScreeningCardViewProps) {
+    const [articles, setArticles] = useState<Article[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [reason, setReason] = useState('');
+    const [criteriaResponses, setCriteriaResponses] = useState<Record<string, boolean>>({});
+
+    const {config} = useScreeningConfig(projectId, phase);
+    const {decisions, decide, isDeciding} = useScreeningDecisions(projectId, phase);
+    const {progress} = useScreeningProgress(projectId, phase);
+
+    // Load articles
+    useEffect(() => {
+        const load = async () => {
+            setLoading(true);
+            const {data, error} = await supabase
+                .from('articles')
+                .select('id, title, abstract, authors, publication_year, journal_title, doi, keywords')
+                .eq('project_id', projectId)
+                .order('created_at', {ascending: true});
+
+            if (data) setArticles(data as Article[]);
+            setLoading(false);
+        };
+        load();
+    }, [projectId]);
+
+    // Get articles that haven't been screened yet by current user
+    const decidedArticleIds = useMemo(() => {
+        return new Set(decisions.map(d => d.articleId));
+    }, [decisions]);
+
+    const pendingArticles = useMemo(() => {
+        return articles.filter(a => !decidedArticleIds.has(a.id));
+    }, [articles, decidedArticleIds]);
+
+    const currentArticle = pendingArticles[currentIndex];
+
+    const criteria: ScreeningCriterion[] = config?.criteria ?? [];
+
+    // Keyboard shortcuts
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLInputElement) return;
+            if (!currentArticle || isDeciding) return;
+
+            if (e.key === '1') handleDecision('include');
+            else if (e.key === '2') handleDecision('exclude');
+            else if (e.key === '3') handleDecision('maybe');
+            else if (e.key === 'ArrowRight') goNext();
+            else if (e.key === 'ArrowLeft') goPrev();
+        };
+
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    });
+
+    const handleDecision = useCallback(async (decision: string) => {
+        if (!currentArticle) return;
+        try {
+            await decide({
+                articleId: currentArticle.id,
+                decision,
+                reason: reason.trim() || undefined,
+                criteriaResponses,
+            });
+            setReason('');
+            setCriteriaResponses({});
+            toast.success(`Article ${decision === 'include' ? 'included' : decision === 'exclude' ? 'excluded' : 'marked as maybe'}`);
+        } catch {
+            toast.error('Error submitting decision');
+        }
+    }, [currentArticle, decide, reason, criteriaResponses]);
+
+    const goNext = () => setCurrentIndex(i => Math.min(i + 1, pendingArticles.length - 1));
+    const goPrev = () => setCurrentIndex(i => Math.max(i - 1, 0));
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-20">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground"/>
+            </div>
+        );
+    }
+
+    if (pendingArticles.length === 0) {
+        return (
+            <div className="text-center py-20">
+                <CheckCircle2 className="h-10 w-10 text-green-500 mx-auto mb-3"/>
+                <p className="text-sm font-medium">All articles have been screened!</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                    {articles.length} article(s) screened in {phase === 'title_abstract' ? 'title/abstract' : 'full-text'} phase.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            {/* Progress bar */}
+            {progress && (
+                <div className="flex items-center gap-3">
+                    <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+                        <div
+                            className="h-full bg-primary rounded-full transition-all"
+                            style={{width: `${progress.totalArticles > 0 ? (progress.screened / progress.totalArticles) * 100 : 0}%`}}
+                        />
+                    </div>
+                    <span className="text-xs text-muted-foreground shrink-0">
+                        {progress.screened}/{progress.totalArticles}
+                    </span>
+                </div>
+            )}
+
+            {/* Article card */}
+            <div className="rounded-lg border border-border/50 bg-card">
+                {/* Header */}
+                <div className="flex items-center justify-between px-5 py-3 border-b border-border/30">
+                    <div className="flex items-center gap-2">
+                        <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={goPrev} disabled={currentIndex === 0}>
+                            <ChevronLeft className="h-4 w-4"/>
+                        </Button>
+                        <span className="text-xs text-muted-foreground">
+                            {currentIndex + 1} of {pendingArticles.length} pending
+                        </span>
+                        <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={goNext} disabled={currentIndex >= pendingArticles.length - 1}>
+                            <ChevronRight className="h-4 w-4"/>
+                        </Button>
+                    </div>
+                    <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                        <kbd className="px-1.5 py-0.5 bg-muted rounded text-[10px]">1</kbd> Include
+                        <kbd className="px-1.5 py-0.5 bg-muted rounded text-[10px]">2</kbd> Exclude
+                        <kbd className="px-1.5 py-0.5 bg-muted rounded text-[10px]">3</kbd> Maybe
+                    </div>
+                </div>
+
+                {/* Content */}
+                <ScrollArea className="max-h-[50vh]">
+                    <div className="p-5 space-y-4">
+                        {/* Title */}
+                        <h3 className="text-base font-semibold leading-snug">
+                            {currentArticle?.title || 'Untitled'}
+                        </h3>
+
+                        {/* Metadata badges */}
+                        <div className="flex flex-wrap gap-1.5">
+                            {currentArticle?.authors?.slice(0, 3).map((a, i) => (
+                                <Badge key={i} variant="secondary" className="text-[10px]">{a}</Badge>
+                            ))}
+                            {(currentArticle?.authors?.length ?? 0) > 3 && (
+                                <Badge variant="secondary" className="text-[10px]">
+                                    +{(currentArticle?.authors?.length ?? 0) - 3} more
+                                </Badge>
+                            )}
+                            {currentArticle?.publication_year && (
+                                <Badge variant="outline" className="text-[10px]">{currentArticle.publication_year}</Badge>
+                            )}
+                            {currentArticle?.journal_title && (
+                                <Badge variant="outline" className="text-[10px]">{currentArticle.journal_title}</Badge>
+                            )}
+                        </div>
+
+                        {/* Abstract */}
+                        {currentArticle?.abstract && (
+                            <div className="space-y-1">
+                                <p className="text-xs font-medium text-muted-foreground">Abstract</p>
+                                <p className="text-sm leading-relaxed text-foreground/90">
+                                    {currentArticle.abstract}
+                                </p>
+                            </div>
+                        )}
+
+                        {/* Keywords */}
+                        {currentArticle?.keywords && currentArticle.keywords.length > 0 && (
+                            <div className="flex flex-wrap gap-1">
+                                {currentArticle.keywords.map((kw, i) => (
+                                    <Badge key={i} variant="secondary" className="text-[10px] font-normal">{kw}</Badge>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </ScrollArea>
+
+                {/* Criteria checklist */}
+                {criteria.length > 0 && (
+                    <div className="px-5 py-3 border-t border-border/30 space-y-2">
+                        <p className="text-xs font-medium text-muted-foreground">Criteria</p>
+                        <div className="space-y-1.5">
+                            {criteria.map(c => (
+                                <label key={c.id} className="flex items-start gap-2 text-sm cursor-pointer">
+                                    <Checkbox
+                                        checked={criteriaResponses[c.id] ?? false}
+                                        onCheckedChange={(checked) =>
+                                            setCriteriaResponses(prev => ({...prev, [c.id]: !!checked}))
+                                        }
+                                        className="mt-0.5"
+                                    />
+                                    <span className={`flex-1 ${c.type === 'exclusion' ? 'text-red-600 dark:text-red-400' : ''}`}>
+                                        <span className="text-[10px] font-semibold uppercase mr-1">
+                                            [{c.type === 'inclusion' ? 'IN' : 'EX'}]
+                                        </span>
+                                        {c.label}
+                                    </span>
+                                </label>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Reason input */}
+                <div className="px-5 py-3 border-t border-border/30">
+                    <Textarea
+                        value={reason}
+                        onChange={(e) => setReason(e.target.value)}
+                        placeholder="Reason for decision (optional)"
+                        rows={1}
+                        className="text-sm resize-none"
+                    />
+                </div>
+
+                {/* Decision buttons */}
+                <div className="flex items-center gap-2 px-5 py-3 border-t border-border/30 bg-muted/20">
+                    <Button
+                        onClick={() => handleDecision('include')}
+                        disabled={isDeciding}
+                        className="flex-1 bg-green-600 hover:bg-green-700 text-white"
+                    >
+                        {isDeciding ? <Loader2 className="h-4 w-4 animate-spin mr-1"/> : <CheckCircle2 className="h-4 w-4 mr-1"/>}
+                        Include
+                    </Button>
+                    <Button
+                        onClick={() => handleDecision('exclude')}
+                        disabled={isDeciding}
+                        variant="destructive"
+                        className="flex-1"
+                    >
+                        <XCircle className="h-4 w-4 mr-1"/>
+                        Exclude
+                    </Button>
+                    <Button
+                        onClick={() => handleDecision('maybe')}
+                        disabled={isDeciding}
+                        variant="outline"
+                        className="flex-1"
+                    >
+                        <HelpCircle className="h-4 w-4 mr-1"/>
+                        Maybe
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/screening/ScreeningInterface.tsx
+++ b/frontend/components/screening/ScreeningInterface.tsx
@@ -1,0 +1,91 @@
+/**
+ * Main screening interface with tabs: Screening / Dashboard / Configuration.
+ * Follows AssessmentInterface.tsx pattern.
+ */
+
+import {useState} from 'react';
+import {Button} from '@/components/ui/button';
+import {ScreeningCardView} from './ScreeningCardView';
+import {ScreeningDashboard} from './dashboard/ScreeningDashboard';
+import {ScreeningConfigEditor} from './config/ScreeningConfigEditor';
+
+interface ScreeningInterfaceProps {
+    projectId: string;
+}
+
+type ScreeningTab = 'screening' | 'dashboard' | 'configuration';
+
+export function ScreeningInterface({projectId}: ScreeningInterfaceProps) {
+    const [activeTab, setActiveTab] = useState<ScreeningTab>('screening');
+    const [phase, setPhase] = useState<'title_abstract' | 'full_text'>('title_abstract');
+
+    return (
+        <div className="space-y-4">
+            {/* Phase selector */}
+            <div className="flex items-center gap-2">
+                <div className="flex items-center gap-0.5 bg-muted/30 rounded-lg p-0.5">
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className={`h-7 px-3 text-xs font-medium rounded-md transition-colors ${
+                            phase === 'title_abstract'
+                                ? 'bg-background text-foreground shadow-sm'
+                                : 'text-muted-foreground hover:text-foreground'
+                        }`}
+                        onClick={() => setPhase('title_abstract')}
+                    >
+                        Title / Abstract
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className={`h-7 px-3 text-xs font-medium rounded-md transition-colors ${
+                            phase === 'full_text'
+                                ? 'bg-background text-foreground shadow-sm'
+                                : 'text-muted-foreground hover:text-foreground'
+                        }`}
+                        onClick={() => setPhase('full_text')}
+                    >
+                        Full Text
+                    </Button>
+                </div>
+
+                <div className="flex-1"/>
+
+                {/* Tab navigation */}
+                <div className="flex items-center gap-0.5">
+                    {([
+                        {value: 'screening' as const, label: 'Screening'},
+                        {value: 'dashboard' as const, label: 'Dashboard'},
+                        {value: 'configuration' as const, label: 'Configuration'},
+                    ]).map(({value, label}) => (
+                        <Button
+                            key={value}
+                            variant="ghost"
+                            size="sm"
+                            className={`h-7 px-3 text-xs font-medium rounded-md transition-colors ${
+                                activeTab === value
+                                    ? 'bg-muted/50 text-foreground'
+                                    : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+                            }`}
+                            onClick={() => setActiveTab(value)}
+                        >
+                            {label}
+                        </Button>
+                    ))}
+                </div>
+            </div>
+
+            {/* Tab content */}
+            {activeTab === 'screening' && (
+                <ScreeningCardView projectId={projectId} phase={phase}/>
+            )}
+            {activeTab === 'dashboard' && (
+                <ScreeningDashboard projectId={projectId} phase={phase}/>
+            )}
+            {activeTab === 'configuration' && (
+                <ScreeningConfigEditor projectId={projectId} phase={phase}/>
+            )}
+        </div>
+    );
+}

--- a/frontend/components/screening/config/ScreeningConfigEditor.tsx
+++ b/frontend/components/screening/config/ScreeningConfigEditor.tsx
@@ -1,0 +1,214 @@
+/**
+ * Screening configuration editor.
+ *
+ * Manage inclusion/exclusion criteria, dual review, blind mode, and AI settings.
+ */
+
+import {useCallback, useEffect, useState} from 'react';
+import {Button} from '@/components/ui/button';
+import {Input} from '@/components/ui/input';
+import {Label} from '@/components/ui/label';
+import {Switch} from '@/components/ui/switch';
+import {Textarea} from '@/components/ui/textarea';
+import {Badge} from '@/components/ui/badge';
+import {Loader2, Plus, Trash2} from 'lucide-react';
+import {toast} from 'sonner';
+import {useScreeningConfig} from '@/hooks/screening/useScreeningConfig';
+import type {ScreeningCriterion} from '@/types/screening';
+
+interface ScreeningConfigEditorProps {
+    projectId: string;
+    phase: 'title_abstract' | 'full_text';
+}
+
+export function ScreeningConfigEditor({projectId, phase}: ScreeningConfigEditorProps) {
+    const {config, isLoading, updateConfig, isUpdating} = useScreeningConfig(projectId, phase);
+
+    const [criteria, setCriteria] = useState<ScreeningCriterion[]>([]);
+    const [dualReview, setDualReview] = useState(false);
+    const [blindMode, setBlindMode] = useState(false);
+    const [aiModel, setAiModel] = useState('gpt-4o-mini');
+    const [aiInstruction, setAiInstruction] = useState('');
+
+    // Populate from config
+    useEffect(() => {
+        if (config) {
+            setCriteria(config.criteria || []);
+            setDualReview(config.requireDualReview);
+            setBlindMode(config.blindMode);
+            setAiModel(config.aiModelName || 'gpt-4o-mini');
+            setAiInstruction(config.aiSystemInstruction || '');
+        }
+    }, [config]);
+
+    const addCriterion = (type: 'inclusion' | 'exclusion') => {
+        setCriteria(prev => [
+            ...prev,
+            {id: crypto.randomUUID(), type, label: '', description: ''},
+        ]);
+    };
+
+    const updateCriterion = (id: string, field: string, value: string) => {
+        setCriteria(prev =>
+            prev.map(c => c.id === id ? {...c, [field]: value} : c)
+        );
+    };
+
+    const removeCriterion = (id: string) => {
+        setCriteria(prev => prev.filter(c => c.id !== id));
+    };
+
+    const handleSave = useCallback(async () => {
+        try {
+            await updateConfig({
+                requireDualReview: dualReview,
+                blindMode: blindMode,
+                criteria: criteria.filter(c => c.label.trim()),
+                aiModelName: aiModel,
+                aiSystemInstruction: aiInstruction.trim() || undefined,
+            });
+            toast.success('Configuration saved');
+        } catch {
+            toast.error('Error saving configuration');
+        }
+    }, [updateConfig, dualReview, blindMode, criteria, aiModel, aiInstruction]);
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center py-20">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground"/>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6 max-w-2xl">
+            {/* Review settings */}
+            <div className="space-y-4">
+                <h3 className="text-sm font-medium">Review settings</h3>
+
+                <div className="flex items-center justify-between rounded-lg border border-border/40 p-3">
+                    <div>
+                        <p className="text-sm font-medium">Dual review</p>
+                        <p className="text-xs text-muted-foreground">Require two independent reviewers per article</p>
+                    </div>
+                    <Switch checked={dualReview} onCheckedChange={setDualReview}/>
+                </div>
+
+                <div className="flex items-center justify-between rounded-lg border border-border/40 p-3">
+                    <div>
+                        <p className="text-sm font-medium">Blind mode</p>
+                        <p className="text-xs text-muted-foreground">Hide other reviewers&apos; decisions until both have screened</p>
+                    </div>
+                    <Switch checked={blindMode} onCheckedChange={setBlindMode}/>
+                </div>
+            </div>
+
+            {/* Criteria */}
+            <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-medium">Screening criteria</h3>
+                    <div className="flex items-center gap-1">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs"
+                            onClick={() => addCriterion('inclusion')}
+                        >
+                            <Plus className="h-3 w-3 mr-1"/>
+                            Inclusion
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs"
+                            onClick={() => addCriterion('exclusion')}
+                        >
+                            <Plus className="h-3 w-3 mr-1"/>
+                            Exclusion
+                        </Button>
+                    </div>
+                </div>
+
+                {criteria.length === 0 && (
+                    <p className="text-xs text-muted-foreground text-center py-6 border border-dashed border-border/50 rounded-lg">
+                        No criteria defined. Add inclusion or exclusion criteria to guide screening.
+                    </p>
+                )}
+
+                <div className="space-y-2">
+                    {criteria.map(c => (
+                        <div key={c.id} className="flex items-start gap-2 rounded-lg border border-border/40 p-3">
+                            <Badge
+                                variant={c.type === 'inclusion' ? 'default' : 'destructive'}
+                                className="mt-0.5 text-[10px] shrink-0"
+                            >
+                                {c.type === 'inclusion' ? 'IN' : 'EX'}
+                            </Badge>
+                            <div className="flex-1 space-y-1.5">
+                                <Input
+                                    value={c.label}
+                                    onChange={(e) => updateCriterion(c.id, 'label', e.target.value)}
+                                    placeholder="Criterion label"
+                                    className="h-7 text-sm"
+                                />
+                                <Input
+                                    value={c.description || ''}
+                                    onChange={(e) => updateCriterion(c.id, 'description', e.target.value)}
+                                    placeholder="Description (optional)"
+                                    className="h-7 text-xs"
+                                />
+                            </div>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                                onClick={() => removeCriterion(c.id)}
+                            >
+                                <Trash2 className="h-3.5 w-3.5"/>
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* AI settings */}
+            <div className="space-y-4">
+                <h3 className="text-sm font-medium">AI screening settings</h3>
+
+                <div>
+                    <Label className="text-xs">Model</Label>
+                    <Input
+                        value={aiModel}
+                        onChange={(e) => setAiModel(e.target.value)}
+                        placeholder="gpt-4o-mini"
+                        className="h-8 text-sm mt-1"
+                    />
+                </div>
+
+                <div>
+                    <Label className="text-xs">Custom system instruction (optional)</Label>
+                    <Textarea
+                        value={aiInstruction}
+                        onChange={(e) => setAiInstruction(e.target.value)}
+                        placeholder="Additional instructions for the AI screening model..."
+                        rows={3}
+                        className="text-sm mt-1"
+                    />
+                </div>
+            </div>
+
+            {/* Save button */}
+            <div className="flex justify-end pt-2">
+                <Button onClick={handleSave} disabled={isUpdating}>
+                    {isUpdating ? (
+                        <>
+                            <Loader2 className="h-4 w-4 animate-spin mr-1"/>
+                            Saving...
+                        </>
+                    ) : 'Save configuration'}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/screening/dashboard/ScreeningDashboard.tsx
+++ b/frontend/components/screening/dashboard/ScreeningDashboard.tsx
@@ -1,0 +1,150 @@
+/**
+ * Screening dashboard with progress stats, PRISMA counts, and inter-rater metrics.
+ */
+
+import {Badge} from '@/components/ui/badge';
+import {Loader2} from 'lucide-react';
+import {useScreeningDashboard} from '@/hooks/screening/useScreeningProgress';
+
+interface ScreeningDashboardProps {
+    projectId: string;
+    phase: 'title_abstract' | 'full_text';
+}
+
+export function ScreeningDashboard({projectId, phase}: ScreeningDashboardProps) {
+    const {dashboard, isLoading} = useScreeningDashboard(projectId, phase);
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center py-20">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground"/>
+            </div>
+        );
+    }
+
+    if (!dashboard) {
+        return (
+            <div className="text-center py-20 text-sm text-muted-foreground">
+                No screening data yet. Configure criteria and start screening.
+            </div>
+        );
+    }
+
+    const progress = phase === 'title_abstract'
+        ? dashboard.titleAbstractProgress
+        : dashboard.fullTextProgress;
+
+    const prisma = dashboard.prisma;
+    const kappa = dashboard.cohensKappa;
+
+    return (
+        <div className="space-y-6">
+            {/* Progress stats */}
+            {progress && (
+                <div>
+                    <h3 className="text-sm font-medium mb-3">
+                        {phase === 'title_abstract' ? 'Title/Abstract' : 'Full-Text'} Screening Progress
+                    </h3>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3">
+                        {([
+                            {label: 'Total', value: progress.totalArticles, color: 'text-foreground'},
+                            {label: 'Screened', value: progress.screened, color: 'text-blue-600'},
+                            {label: 'Pending', value: progress.pending, color: 'text-yellow-600'},
+                            {label: 'Included', value: progress.included, color: 'text-green-600'},
+                            {label: 'Excluded', value: progress.excluded, color: 'text-red-600'},
+                            {label: 'Maybe', value: progress.maybe, color: 'text-orange-600'},
+                            {label: 'Conflicts', value: progress.conflicts, color: 'text-purple-600'},
+                        ]).map(({label, value, color}) => (
+                            <div key={label} className="rounded-lg border border-border/40 p-3 text-center">
+                                <p className={`text-2xl font-semibold ${color}`}>{value}</p>
+                                <p className="text-[10px] text-muted-foreground mt-0.5">{label}</p>
+                            </div>
+                        ))}
+                    </div>
+
+                    {/* Progress bar */}
+                    <div className="mt-3 h-2 bg-muted rounded-full overflow-hidden flex">
+                        {progress.totalArticles > 0 && (
+                            <>
+                                <div
+                                    className="h-full bg-green-500 transition-all"
+                                    style={{width: `${(progress.included / progress.totalArticles) * 100}%`}}
+                                    title={`Included: ${progress.included}`}
+                                />
+                                <div
+                                    className="h-full bg-red-500 transition-all"
+                                    style={{width: `${(progress.excluded / progress.totalArticles) * 100}%`}}
+                                    title={`Excluded: ${progress.excluded}`}
+                                />
+                                <div
+                                    className="h-full bg-orange-400 transition-all"
+                                    style={{width: `${(progress.maybe / progress.totalArticles) * 100}%`}}
+                                    title={`Maybe: ${progress.maybe}`}
+                                />
+                            </>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {/* Inter-rater reliability */}
+            {kappa !== null && kappa !== undefined && (
+                <div>
+                    <h3 className="text-sm font-medium mb-3">Inter-Rater Reliability</h3>
+                    <div className="rounded-lg border border-border/40 p-4 max-w-xs">
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm text-muted-foreground">Cohen&apos;s Kappa</span>
+                            <Badge variant={
+                                kappa >= 0.8 ? 'default' :
+                                kappa >= 0.6 ? 'secondary' :
+                                'destructive'
+                            }>
+                                {kappa.toFixed(3)}
+                            </Badge>
+                        </div>
+                        <p className="text-[10px] text-muted-foreground mt-1">
+                            {kappa >= 0.8 ? 'Almost perfect agreement' :
+                             kappa >= 0.6 ? 'Substantial agreement' :
+                             kappa >= 0.4 ? 'Moderate agreement' :
+                             kappa >= 0.2 ? 'Fair agreement' :
+                             'Slight agreement'}
+                        </p>
+                    </div>
+                </div>
+            )}
+
+            {/* PRISMA Flow */}
+            <div>
+                <h3 className="text-sm font-medium mb-3">PRISMA 2020 Flow</h3>
+                <div className="space-y-2">
+                    {/* Identification */}
+                    <div className="rounded-lg border border-border/40 p-3">
+                        <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">Identification</p>
+                        <p className="text-sm">Records identified: <span className="font-semibold">{prisma.totalImported}</span></p>
+                        <p className="text-sm">Duplicates removed: <span className="font-semibold">{prisma.duplicatesRemoved}</span></p>
+                    </div>
+
+                    {/* Screening */}
+                    <div className="rounded-lg border border-border/40 p-3">
+                        <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">Screening</p>
+                        <p className="text-sm">Records screened: <span className="font-semibold">{prisma.titleAbstractScreened}</span></p>
+                        <p className="text-sm">Records excluded: <span className="font-semibold text-red-600">{prisma.titleAbstractExcluded}</span></p>
+                    </div>
+
+                    {/* Eligibility */}
+                    <div className="rounded-lg border border-border/40 p-3">
+                        <p className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">Eligibility</p>
+                        <p className="text-sm">Full-text assessed: <span className="font-semibold">{prisma.fullTextAssessed}</span></p>
+                        <p className="text-sm">Full-text excluded: <span className="font-semibold text-red-600">{prisma.fullTextExcluded}</span></p>
+                    </div>
+
+                    {/* Included */}
+                    <div className="rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950/30 p-3">
+                        <p className="text-[10px] font-semibold text-green-700 dark:text-green-400 uppercase tracking-wider mb-2">Included</p>
+                        <p className="text-sm">Studies included: <span className="font-semibold text-green-700 dark:text-green-400">{prisma.included}</span></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/hooks/screening/index.ts
+++ b/frontend/hooks/screening/index.ts
@@ -1,0 +1,3 @@
+export {useScreeningConfig} from './useScreeningConfig';
+export {useScreeningDecisions} from './useScreeningDecisions';
+export {useScreeningProgress, useScreeningDashboard} from './useScreeningProgress';

--- a/frontend/hooks/screening/useScreeningConfig.ts
+++ b/frontend/hooks/screening/useScreeningConfig.ts
@@ -1,0 +1,36 @@
+/**
+ * Hook for managing screening configuration.
+ */
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {getScreeningConfig, upsertScreeningConfig} from '@/services/screeningService';
+import type {ScreeningCriterion} from '@/types/screening';
+
+export function useScreeningConfig(projectId: string, phase: string) {
+    const queryClient = useQueryClient();
+
+    const query = useQuery({
+        queryKey: ['screening-config', projectId, phase],
+        queryFn: () => getScreeningConfig(projectId, phase),
+        enabled: !!projectId && !!phase,
+    });
+
+    const mutation = useMutation({
+        mutationFn: (data: {
+            requireDualReview?: boolean;
+            blindMode?: boolean;
+            criteria?: ScreeningCriterion[];
+            aiModelName?: string;
+            aiSystemInstruction?: string;
+        }) => upsertScreeningConfig({projectId, phase, ...data}),
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['screening-config', projectId, phase]});
+        },
+    });
+
+    return {
+        config: query.data,
+        isLoading: query.isLoading,
+        updateConfig: mutation.mutateAsync,
+        isUpdating: mutation.isPending,
+    };
+}

--- a/frontend/hooks/screening/useScreeningDecisions.ts
+++ b/frontend/hooks/screening/useScreeningDecisions.ts
@@ -1,0 +1,35 @@
+/**
+ * Hook for managing screening decisions.
+ */
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {getDecisions, submitDecision} from '@/services/screeningService';
+
+export function useScreeningDecisions(projectId: string, phase: string) {
+    const queryClient = useQueryClient();
+
+    const query = useQuery({
+        queryKey: ['screening-decisions', projectId, phase],
+        queryFn: () => getDecisions(projectId, phase),
+        enabled: !!projectId && !!phase,
+    });
+
+    const decideMutation = useMutation({
+        mutationFn: (data: {
+            articleId: string;
+            decision: string;
+            reason?: string;
+            criteriaResponses?: Record<string, boolean>;
+        }) => submitDecision({projectId, phase, ...data}),
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['screening-decisions', projectId, phase]});
+            queryClient.invalidateQueries({queryKey: ['screening-progress', projectId, phase]});
+        },
+    });
+
+    return {
+        decisions: query.data ?? [],
+        isLoading: query.isLoading,
+        decide: decideMutation.mutateAsync,
+        isDeciding: decideMutation.isPending,
+    };
+}

--- a/frontend/hooks/screening/useScreeningProgress.ts
+++ b/frontend/hooks/screening/useScreeningProgress.ts
@@ -1,0 +1,35 @@
+/**
+ * Hook for fetching screening progress stats.
+ */
+import {useQuery} from '@tanstack/react-query';
+import {getProgress, getDashboard} from '@/services/screeningService';
+
+export function useScreeningProgress(projectId: string, phase: string) {
+    const query = useQuery({
+        queryKey: ['screening-progress', projectId, phase],
+        queryFn: () => getProgress(projectId, phase),
+        enabled: !!projectId && !!phase,
+        refetchInterval: 10000,
+    });
+
+    return {
+        progress: query.data,
+        isLoading: query.isLoading,
+        refetch: query.refetch,
+    };
+}
+
+export function useScreeningDashboard(projectId: string, phase: string) {
+    const query = useQuery({
+        queryKey: ['screening-dashboard', projectId, phase],
+        queryFn: () => getDashboard(projectId, phase),
+        enabled: !!projectId && !!phase,
+        refetchInterval: 15000,
+    });
+
+    return {
+        dashboard: query.data,
+        isLoading: query.isLoading,
+        refetch: query.refetch,
+    };
+}

--- a/frontend/lib/copy/screening.ts
+++ b/frontend/lib/copy/screening.ts
@@ -1,0 +1,95 @@
+/**
+ * UI copy for screening area. English only.
+ */
+export const screening = {
+    // Tabs
+    tabScreening: 'Screening',
+    tabDashboard: 'Dashboard',
+    tabConfiguration: 'Configuration',
+
+    // Phase selector
+    phaseTitleAbstract: 'Title / Abstract',
+    phaseFullText: 'Full Text',
+
+    // Card view
+    allScreened: 'All articles have been screened!',
+    allScreenedDesc: '{{n}} article(s) screened in {{phase}} phase.',
+    pending: 'pending',
+    include: 'Include',
+    exclude: 'Exclude',
+    maybe: 'Maybe',
+    reasonPlaceholder: 'Reason for decision (optional)',
+
+    // Keyboard shortcuts
+    shortcutInclude: '1',
+    shortcutExclude: '2',
+    shortcutMaybe: '3',
+
+    // Criteria
+    criteriaTitle: 'Screening criteria',
+    addInclusion: 'Inclusion',
+    addExclusion: 'Exclusion',
+    criterionLabelPlaceholder: 'Criterion label',
+    criterionDescPlaceholder: 'Description (optional)',
+    noCriteria: 'No criteria defined. Add inclusion or exclusion criteria to guide screening.',
+
+    // Config
+    reviewSettings: 'Review settings',
+    dualReview: 'Dual review',
+    dualReviewDesc: 'Require two independent reviewers per article',
+    blindMode: 'Blind mode',
+    blindModeDesc: "Hide other reviewers' decisions until both have screened",
+    aiSettings: 'AI screening settings',
+    aiModel: 'Model',
+    aiInstruction: 'Custom system instruction (optional)',
+    aiInstructionPlaceholder: 'Additional instructions for the AI screening model...',
+    saveConfig: 'Save configuration',
+    savingConfig: 'Saving...',
+    configSaved: 'Configuration saved',
+    configError: 'Error saving configuration',
+
+    // Dashboard
+    progressTitle: '{{phase}} Screening Progress',
+    total: 'Total',
+    screened: 'Screened',
+    included: 'Included',
+    excluded: 'Excluded',
+    conflicts: 'Conflicts',
+
+    // Inter-rater
+    interRaterTitle: 'Inter-Rater Reliability',
+    cohensKappa: "Cohen's Kappa",
+    almostPerfect: 'Almost perfect agreement',
+    substantial: 'Substantial agreement',
+    moderate: 'Moderate agreement',
+    fair: 'Fair agreement',
+    slight: 'Slight agreement',
+
+    // PRISMA
+    prismaTitle: 'PRISMA 2020 Flow',
+    identification: 'Identification',
+    recordsIdentified: 'Records identified',
+    duplicatesRemoved: 'Duplicates removed',
+    recordsScreened: 'Records screened',
+    recordsExcluded: 'Records excluded',
+    eligibility: 'Eligibility',
+    fullTextAssessed: 'Full-text assessed',
+    fullTextExcluded: 'Full-text excluded',
+    studiesIncluded: 'Studies included',
+
+    // AI
+    aiScreening: 'AI Screening',
+    aiScreenBatch: 'AI screen all pending',
+    aiScreening1: 'AI screening article...',
+    aiScreeningBatch: 'AI screening {{n}} articles...',
+    aiScreeningComplete: 'AI screening complete',
+    aiScreeningError: 'AI screening error',
+
+    // Decision feedback
+    articleIncluded: 'Article included',
+    articleExcluded: 'Article excluded',
+    articleMaybe: 'Article marked as maybe',
+    decisionError: 'Error submitting decision',
+} as const;
+
+export type ScreeningCopy = typeof screening;

--- a/frontend/services/screeningService.ts
+++ b/frontend/services/screeningService.ts
@@ -1,0 +1,142 @@
+/**
+ * API client for the screening workflow endpoints.
+ */
+
+import {apiClient} from '@/integrations/api/client';
+import type {
+    ScreeningConfig,
+    ScreeningConflict,
+    ScreeningDashboardData,
+    ScreeningDecision,
+    ScreeningProgressStats,
+    PRISMAFlowData,
+    ScreeningCriterion,
+} from '@/types/screening';
+
+// =================== CONFIG ===================
+
+export async function getScreeningConfig(projectId: string, phase: string): Promise<ScreeningConfig | null> {
+    return apiClient<ScreeningConfig | null>(`/api/v1/screening/config/${projectId}/${phase}`);
+}
+
+export async function upsertScreeningConfig(data: {
+    projectId: string;
+    phase: string;
+    requireDualReview?: boolean;
+    blindMode?: boolean;
+    criteria?: ScreeningCriterion[];
+    aiModelName?: string;
+    aiSystemInstruction?: string;
+}): Promise<ScreeningConfig> {
+    return apiClient<ScreeningConfig>('/api/v1/screening/config', {
+        method: 'POST',
+        body: data,
+    });
+}
+
+// =================== DECISIONS ===================
+
+export async function submitDecision(data: {
+    projectId: string;
+    articleId: string;
+    phase: string;
+    decision: string;
+    reason?: string;
+    criteriaResponses?: Record<string, boolean>;
+}): Promise<ScreeningDecision> {
+    return apiClient<ScreeningDecision>('/api/v1/screening/decide', {
+        method: 'POST',
+        body: data,
+    });
+}
+
+export async function getDecisions(projectId: string, phase: string): Promise<ScreeningDecision[]> {
+    return apiClient<ScreeningDecision[]>(`/api/v1/screening/decisions/${projectId}/${phase}`);
+}
+
+// =================== PROGRESS ===================
+
+export async function getProgress(projectId: string, phase: string): Promise<ScreeningProgressStats> {
+    return apiClient<ScreeningProgressStats>(`/api/v1/screening/progress/${projectId}/${phase}`);
+}
+
+// =================== CONFLICTS ===================
+
+export async function getConflicts(projectId: string, phase: string): Promise<ScreeningConflict[]> {
+    return apiClient<ScreeningConflict[]>(`/api/v1/screening/conflicts/${projectId}/${phase}`);
+}
+
+export async function resolveConflict(conflictId: string, data: {
+    decision: string;
+    reason?: string;
+}): Promise<ScreeningConflict> {
+    return apiClient<ScreeningConflict>(`/api/v1/screening/conflicts/${conflictId}/resolve`, {
+        method: 'POST',
+        body: data,
+    });
+}
+
+// =================== AI SCREENING ===================
+
+export async function aiScreenArticle(data: {
+    projectId: string;
+    articleId: string;
+    phase: string;
+    model?: string;
+}): Promise<{suggestionId: string; decision: string; relevanceScore: number; reasoning: string}> {
+    return apiClient('/api/v1/screening/ai', {
+        method: 'POST',
+        body: data,
+        timeout: 120000,
+    });
+}
+
+export async function aiScreenBatch(data: {
+    projectId: string;
+    articleIds: string[];
+    phase: string;
+    model?: string;
+}): Promise<{success_count: number; fail_count: number; suggestion_ids: string[]}> {
+    return apiClient('/api/v1/screening/ai/batch', {
+        method: 'POST',
+        body: data,
+        timeout: 300000,
+    });
+}
+
+// =================== PRISMA ===================
+
+export async function getPRISMACounts(projectId: string): Promise<PRISMAFlowData> {
+    return apiClient<PRISMAFlowData>(`/api/v1/screening/prisma/${projectId}`);
+}
+
+// =================== DASHBOARD ===================
+
+export async function getDashboard(projectId: string, phase: string): Promise<ScreeningDashboardData> {
+    return apiClient<ScreeningDashboardData>(`/api/v1/screening/dashboard/${projectId}/${phase}`);
+}
+
+// =================== BULK ===================
+
+export async function bulkDecide(data: {
+    projectId: string;
+    articleIds: string[];
+    phase: string;
+    decision: string;
+    reason?: string;
+}): Promise<{count: number}> {
+    return apiClient('/api/v1/screening/bulk-decide', {
+        method: 'POST',
+        body: data,
+    });
+}
+
+export async function advanceToFullText(data: {
+    projectId: string;
+    articleIds?: string[];
+}): Promise<{count: number}> {
+    return apiClient('/api/v1/screening/advance-to-fulltext', {
+        method: 'POST',
+        body: data,
+    });
+}

--- a/frontend/types/screening.ts
+++ b/frontend/types/screening.ts
@@ -1,0 +1,94 @@
+/**
+ * TypeScript types for the screening workflow.
+ */
+
+export interface ScreeningCriterion {
+    id: string;
+    type: 'inclusion' | 'exclusion';
+    label: string;
+    description?: string;
+}
+
+export interface ScreeningConfig {
+    id: string;
+    projectId: string;
+    phase: 'title_abstract' | 'full_text';
+    isActive: boolean;
+    requireDualReview: boolean;
+    blindMode: boolean;
+    criteria: ScreeningCriterion[];
+    aiModelName: string | null;
+    aiSystemInstruction: string | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export type ScreeningDecisionValue = 'include' | 'exclude' | 'maybe';
+
+export interface ScreeningDecision {
+    id: string;
+    projectId: string;
+    articleId: string;
+    reviewerId: string;
+    phase: string;
+    decision: ScreeningDecisionValue;
+    reason: string | null;
+    criteriaResponses: Record<string, boolean>;
+    isAiAssisted: boolean;
+    createdAt: string;
+}
+
+export interface ScreeningConflict {
+    id: string;
+    projectId: string;
+    articleId: string;
+    phase: string;
+    status: 'none' | 'conflict' | 'resolved';
+    resolvedBy: string | null;
+    resolvedDecision: ScreeningDecisionValue | null;
+    resolvedReason: string | null;
+    resolvedAt: string | null;
+    createdAt: string;
+}
+
+export interface ScreeningProgressStats {
+    totalArticles: number;
+    screened: number;
+    pending: number;
+    included: number;
+    excluded: number;
+    maybe: number;
+    conflicts: number;
+}
+
+export interface PRISMAFlowData {
+    totalImported: number;
+    duplicatesRemoved: number;
+    titleAbstractScreened: number;
+    titleAbstractExcluded: number;
+    fullTextAssessed: number;
+    fullTextExcluded: number;
+    included: number;
+}
+
+export interface ScreeningDashboardData {
+    titleAbstractProgress: ScreeningProgressStats | null;
+    fullTextProgress: ScreeningProgressStats | null;
+    prisma: PRISMAFlowData;
+    cohensKappa: number | null;
+}
+
+export interface AIScreeningSuggestion {
+    id: string;
+    articleId: string;
+    decision: ScreeningDecisionValue;
+    relevanceScore: number | null;
+    reasoning: string | null;
+    criteriaEvaluations: Array<{
+        criterion_id: string;
+        met: boolean | null;
+        reasoning: string;
+    }>;
+    status: 'pending' | 'accepted' | 'rejected';
+    createdAt: string;
+}


### PR DESCRIPTION
## Summary

This PR contributes only the **frontend UI sketches** from the original PR #7 attempt (which is fully superseded by the design in #34). It deliberately ships **no backend, no wiring, no models, no migrations**, all of which will be redone greenfield in Phase 0/1+ following the spec in #34.

Goal: have visual/UX references in the tree so Phase 1+ implementation can iterate on top of them instead of starting from blank files.

## What's included (13 files, +2104 LOC, frontend only)

- `screening/`: ScreeningInterface, ScreeningCardView, config/ScreeningConfigEditor, dashboard/ScreeningDashboard
- `articles/`: CSVImportDialog, PDFImportDialog
- `hooks/screening/`: useScreeningConfig, useScreeningDecisions, useScreeningProgress (+ index)
- `services/screeningService.ts`, `types/screening.ts`, `lib/copy/screening.ts`

## What's NOT included (intentionally)

Per the spec in #34 (which explicitly says it "preserves only frontend UI sketches"), the following from PR #7 are dropped:

- All backend (8 files): `screening.py` endpoint, `screening_service.py`, `ai_screening_service.py`, `screening_repository.py`, `models/screening.py`, `pdf_metadata_extraction_service.py`, `article_import_service.py`, `article_import.py` endpoint
- Alembic migration `20260329_007_add_screening_tables.py` and `supabase/migrations/0003_screening_enums.sql` (will be replaced by `0011_add_screening.py` + `0004_screening_enums.sql` per spec)
- Frontend modifications to `ArticlesList.tsx`, `sidebarConfig.ts`, `ProjectContext.tsx`, `ProjectView.tsx`, `lib/copy/articles.ts`, `lib/copy/index.ts`, `lib/copy/layout.ts` (upstream advanced 194 commits, these need manual reapplication when Phase 1 lands)

## Known refactors required before wiring (per spec in #34)

These sketches will not compile/run cleanly against the Phase 1 backend without:

- **CSV parser**: replace hand-rolled `split(',')` with `papaparse` (spec section 7.1, §12.3 regression case)
- **Direct supabase calls**: CSV/PDF dialogs and ScreeningCardView call `supabase.auth/storage` directly; per spec all data flow must go through `apiClient` (spec §5)
- **PDFImportDialog**: drop AI metadata extraction path (PDF AI is deferred to Phase β, spec §8.4)
- **Endpoints/types**: align with new `/screening/*` API surface (spec §6) and new `screening_status` / `screening_decision` enums (spec §4.1)
- **Decision panel**: spec §9.1 requires 4 buttons (Include / Exclude / Exclude w/ reason / Maybe with `1`/`2`/`e`/`3`); current sketch has 3 buttons (`1`/`2`/`3`)
- **Component layout**: align with spec §7.1 component tree (queue/conflicts/dashboard/settings/overlays/shared)

## Test plan

- [ ] Visual review of each sketch against spec sections 7.1, 7.5, 9.1
- [ ] Confirm no sketch is wired to any active route (they should be dead code at merge time)
- [ ] Confirm Phase 0 plan in #34 references these as starting points for Phase 1 components

## Context

Discussed via WhatsApp with @raphaelfh on 2026-05-02/03. Original PR #7 had architectural conflicts with the post-DB-refactor `dev` (migrations 0007-0010, HITL unification, pdf-viewer rewrite) and the design pivots in #34. Rather than rebase 5228 lines through 194 commits of churn, we extract the salvageable UI sketches and let Phase 0+ rebuild the rest greenfield.

🤖 Generated with [Claude Code](https://claude.com/claude-code)