### PR TITLE
sync(dev): backport 3 main-only commits to restore dev → main flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ review-hub.code-workspace
 *.sw?
 .cursor/
 
+# Local Superpowers plugin runtime state (brainstorm sessions, etc.)
+.superpowers/
+
 # Python virtual environments
 .venv
 venv/

--- a/backend/app/api/v1/endpoints/model_extraction.py
+++ b/backend/app/api/v1/endpoints/model_extraction.py
@@ -6,21 +6,94 @@ Identifica and cria instances de modelos with its hierarquias completas.
 """
 
 from time import perf_counter
-
-from fastapi import APIRouter, HTTPException, Request, status
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 
+from app.api.deps.security import get_current_user_sub
 from app.core.deps import CurrentUser, DbSession, SupabaseClient
 from app.core.factories import create_storage_adapter
 from app.core.logging import get_logger
 from app.schemas.common import ApiResponse
-from app.schemas.extraction import ModelExtractionRequest, ModelExtractionResult
+from app.schemas.extraction import (
+    CreateModelHierarchyRequest,
+    CreateModelHierarchyResponse,
+    ModelExtractionRequest,
+    ModelExtractionResult,
+    ModelHierarchyChildResponse,
+)
 from app.services.api_key_service import APIKeyService
+from app.services.model_hierarchy_service import ModelHierarchyService
 from app.services.model_extraction_service import ModelExtractionService
 from app.utils.rate_limiter import limiter
 
 router = APIRouter()
 logger = get_logger(__name__)
+
+
+@router.post(
+    "/manual",
+    response_model=ApiResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create one prediction model hierarchy",
+    description="Creates the parent prediction model and required singleton children in one transaction.",
+)
+@limiter.limit("60/minute")
+async def create_manual_model_hierarchy(
+    request: Request,  # noqa: ARG001
+    payload: CreateModelHierarchyRequest,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse:
+    trace_id = getattr(request.state, "trace_id", None) or "missing-trace-id"
+    service = ModelHierarchyService(db)
+
+    try:
+        result = await service.create_model_hierarchy(
+            project_id=payload.project_id,
+            article_id=payload.article_id,
+            template_id=payload.template_id,
+            user_id=current_user_sub,
+            model_name=payload.model_name,
+            modelling_method=payload.modelling_method,
+        )
+        await db.commit()
+        return ApiResponse.success(
+            CreateModelHierarchyResponse(
+                model_id=result.model_id,
+                model_label=result.model_label,
+                child_instances=[
+                    ModelHierarchyChildResponse(
+                        id=child.id,
+                        entity_type_id=child.entity_type_id,
+                        parent_instance_id=child.parent_instance_id,
+                        label=child.label,
+                    )
+                    for child in result.child_instances
+                ],
+                proposal_run_id=result.proposal_run_id,
+            ),
+            trace_id=trace_id,
+        )
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception as exc:
+        await db.rollback()
+        logger.error(
+            "manual_model_hierarchy_error",
+            trace_id=trace_id,
+            user_id=str(current_user_sub),
+            project_id=str(payload.project_id),
+            article_id=str(payload.article_id),
+            template_id=str(payload.template_id),
+            error=str(exc),
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create model hierarchy",
+        ) from exc
 
 
 @router.post(

--- a/backend/app/schemas/extraction.py
+++ b/backend/app/schemas/extraction.py
@@ -147,6 +147,40 @@ class BatchSectionResult(BaseModel):
 # =================== MODEL EXTRACTION SCHEMAS ===================
 
 
+class CreateModelHierarchyRequest(BaseModel):
+    """Request to create one prediction-model hierarchy for an article."""
+
+    project_id: UUID = Field(..., alias="projectId")
+    article_id: UUID = Field(..., alias="articleId")
+    template_id: UUID = Field(..., alias="templateId")
+    model_name: str = Field(..., alias="modelName")
+    modelling_method: str | None = Field(default=None, alias="modellingMethod")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ModelHierarchyChildResponse(BaseModel):
+    """Child instance created under the parent model instance."""
+
+    id: UUID
+    entity_type_id: UUID = Field(..., alias="entityTypeId")
+    parent_instance_id: UUID = Field(..., alias="parentInstanceId")
+    label: str
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class CreateModelHierarchyResponse(BaseModel):
+    """Response for one-shot hierarchy creation."""
+
+    model_id: UUID = Field(..., alias="modelId")
+    model_label: str = Field(..., alias="modelLabel")
+    child_instances: list[ModelHierarchyChildResponse] = Field(alias="childInstances")
+    proposal_run_id: UUID | None = Field(default=None, alias="proposalRunId")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class ModelExtractionRequest(BaseModel):
     """Request for extraction de modelos de predicao."""
 

--- a/backend/app/services/hitl_session_service.py
+++ b/backend/app/services/hitl_session_service.py
@@ -178,6 +178,7 @@ class HITLSessionService:
         existing_rows = list((await self.db.execute(existing_stmt)).scalars().all())
         by_entity: dict[UUID, UUID] = {row.entity_type_id: row.id for row in existing_rows}
 
+        pending_instances: list[tuple[UUID, ExtractionInstance]] = []
         for et in entity_types:
             # Many-cardinality entity types add instances dynamically through the
             # extraction UI; the session only seeds the singletons (top-level,
@@ -198,9 +199,13 @@ class HITLSessionService:
                 created_by=user_id,
                 status=ExtractionInstanceStatus.PENDING.value,
             )
-            self.db.add(inst)
+            pending_instances.append((et.id, inst))
+
+        if pending_instances:
+            self.db.add_all([inst for _, inst in pending_instances])
             await self.db.flush()
-            by_entity[et.id] = inst.id
+            for entity_type_id, instance in pending_instances:
+                by_entity[entity_type_id] = instance.id
 
         return by_entity
 

--- a/backend/app/services/model_hierarchy_service.py
+++ b/backend/app/services/model_hierarchy_service.py
@@ -1,0 +1,251 @@
+"""Service to create extraction model hierarchy in one transaction."""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.extraction import (
+    ExtractionCardinality,
+    ExtractionEntityType,
+    ExtractionField,
+    ExtractionInstance,
+    ExtractionRun,
+    ExtractionRunStage,
+    ProjectExtractionTemplate,
+)
+from app.models.extraction_workflow import ExtractionProposalSource
+from app.models.extraction_versioning import TemplateKind
+from app.services.extraction_proposal_service import ExtractionProposalService
+
+
+@dataclass
+class ModelHierarchyChild:
+    """Payload for a child instance created with the parent model."""
+
+    id: UUID
+    entity_type_id: UUID
+    parent_instance_id: UUID
+    label: str
+
+
+@dataclass
+class ModelHierarchyResult:
+    """Result envelope returned to the API layer."""
+
+    model_id: UUID
+    model_label: str
+    child_instances: list[ModelHierarchyChild]
+    proposal_run_id: UUID | None
+
+
+class ModelHierarchyService:
+    """Creates `prediction_models` + one-cardinality child sections."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def create_model_hierarchy(
+        self,
+        *,
+        project_id: UUID,
+        article_id: UUID,
+        template_id: UUID,
+        user_id: UUID,
+        model_name: str,
+        modelling_method: str | None = None,
+    ) -> ModelHierarchyResult:
+        model_label = model_name.strip()
+        if not model_label:
+            raise ValueError("modelName is required")
+
+        template = await self.db.get(ProjectExtractionTemplate, template_id)
+        if template is None or template.project_id != project_id:
+            raise ValueError("Template not found in project")
+        if template.kind != TemplateKind.EXTRACTION.value:
+            raise ValueError("Template kind must be extraction")
+
+        model_entity_type = await self._prediction_models_entity_type(template_id)
+        if model_entity_type is None:
+            raise ValueError("prediction_models entity type not found in template")
+
+        child_entity_types = await self._model_singleton_children(model_entity_type.id)
+
+        unique_label = await self._ensure_unique_model_label(
+            article_id=article_id,
+            entity_type_id=model_entity_type.id,
+            base_label=model_label,
+        )
+        sort_order = await self._next_sort_order(
+            article_id=article_id,
+            entity_type_id=model_entity_type.id,
+            parent_instance_id=None,
+        )
+
+        parent = ExtractionInstance(
+            project_id=project_id,
+            article_id=article_id,
+            template_id=template_id,
+            entity_type_id=model_entity_type.id,
+            parent_instance_id=None,
+            label=unique_label,
+            sort_order=sort_order,
+            metadata_={},
+            created_by=user_id,
+        )
+        self.db.add(parent)
+        await self.db.flush()
+
+        children: list[ExtractionInstance] = []
+        for entity_type in child_entity_types:
+            children.append(
+                ExtractionInstance(
+                    project_id=project_id,
+                    article_id=article_id,
+                    template_id=template_id,
+                    entity_type_id=entity_type.id,
+                    parent_instance_id=parent.id,
+                    label=f"{parent.label} - {entity_type.label} 1",
+                    sort_order=0,
+                    metadata_={},
+                    created_by=user_id,
+                )
+            )
+        if children:
+            self.db.add_all(children)
+            await self.db.flush()
+
+        proposal_run_id = await self._record_modelling_method_if_possible(
+            article_id=article_id,
+            template_id=template_id,
+            model_entity_type_id=model_entity_type.id,
+            model_instance_id=parent.id,
+            user_id=user_id,
+            modelling_method=modelling_method,
+        )
+
+        return ModelHierarchyResult(
+            model_id=parent.id,
+            model_label=parent.label,
+            child_instances=[
+                ModelHierarchyChild(
+                    id=child.id,
+                    entity_type_id=child.entity_type_id,
+                    parent_instance_id=parent.id,
+                    label=child.label,
+                )
+                for child in children
+            ],
+            proposal_run_id=proposal_run_id,
+        )
+
+    async def _prediction_models_entity_type(self, template_id: UUID) -> ExtractionEntityType | None:
+        stmt = select(ExtractionEntityType).where(
+            ExtractionEntityType.project_template_id == template_id,
+            ExtractionEntityType.name == "prediction_models",
+        )
+        return (await self.db.execute(stmt)).scalars().first()
+
+    async def _model_singleton_children(self, parent_entity_type_id: UUID) -> list[ExtractionEntityType]:
+        stmt = (
+            select(ExtractionEntityType)
+            .where(
+                ExtractionEntityType.parent_entity_type_id == parent_entity_type_id,
+                ExtractionEntityType.cardinality == ExtractionCardinality.ONE.value,
+            )
+            .order_by(ExtractionEntityType.sort_order.asc())
+        )
+        return list((await self.db.execute(stmt)).scalars().all())
+
+    async def _next_sort_order(
+        self,
+        *,
+        article_id: UUID,
+        entity_type_id: UUID,
+        parent_instance_id: UUID | None,
+    ) -> int:
+        stmt = select(func.count(ExtractionInstance.id)).where(
+            ExtractionInstance.article_id == article_id,
+            ExtractionInstance.entity_type_id == entity_type_id,
+            ExtractionInstance.parent_instance_id.is_(parent_instance_id),
+        )
+        return int((await self.db.execute(stmt)).scalar_one() or 0)
+
+    async def _ensure_unique_model_label(
+        self,
+        *,
+        article_id: UUID,
+        entity_type_id: UUID,
+        base_label: str,
+    ) -> str:
+        candidate = base_label
+        attempt = 1
+        while attempt <= 10:
+            stmt = (
+                select(ExtractionInstance.id)
+                .where(
+                    ExtractionInstance.article_id == article_id,
+                    ExtractionInstance.entity_type_id == entity_type_id,
+                    ExtractionInstance.label == candidate,
+                )
+                .limit(1)
+            )
+            exists = (await self.db.execute(stmt)).scalar_one_or_none()
+            if exists is None:
+                return candidate
+            attempt += 1
+            candidate = f"{base_label} ({attempt})"
+        raise ValueError("Could not derive a unique model label after multiple attempts")
+
+    async def _record_modelling_method_if_possible(
+        self,
+        *,
+        article_id: UUID,
+        template_id: UUID,
+        model_entity_type_id: UUID,
+        model_instance_id: UUID,
+        user_id: UUID,
+        modelling_method: str | None,
+    ) -> UUID | None:
+        if not modelling_method:
+            return None
+
+        field_stmt = select(ExtractionField).where(
+            ExtractionField.entity_type_id == model_entity_type_id,
+            ExtractionField.name == "modelling_method",
+        )
+        field = (await self.db.execute(field_stmt)).scalars().first()
+        if field is None:
+            return None
+
+        run_stmt = (
+            select(ExtractionRun)
+            .where(
+                ExtractionRun.article_id == article_id,
+                ExtractionRun.template_id == template_id,
+                ExtractionRun.kind == TemplateKind.EXTRACTION.value,
+                ExtractionRun.stage.in_(
+                    [
+                        ExtractionRunStage.PROPOSAL.value,
+                        ExtractionRunStage.REVIEW.value,
+                    ]
+                ),
+            )
+            .order_by(ExtractionRun.created_at.desc())
+            .limit(1)
+        )
+        run = (await self.db.execute(run_stmt)).scalars().first()
+        if run is None:
+            return None
+
+        proposal_service = ExtractionProposalService(self.db)
+        await proposal_service.record_proposal(
+            run_id=run.id,
+            instance_id=model_instance_id,
+            field_id=field.id,
+            source=ExtractionProposalSource.HUMAN,
+            source_user_id=user_id,
+            proposed_value={"value": modelling_method},
+        )
+        return run.id

--- a/backend/tests/integration/test_extraction_endpoints.py
+++ b/backend/tests/integration/test_extraction_endpoints.py
@@ -198,3 +198,64 @@ class TestModelExtractionEndpoints:
             assert data.get("trace_id") == trace_id
             assert response.headers.get("X-Trace-Id") == trace_id
             assert mock_service_class.call_args.kwargs["trace_id"] == trace_id
+
+
+class TestManualModelHierarchyEndpoints:
+    """Integration tests for one-shot manual model hierarchy creation."""
+
+    @pytest.mark.asyncio
+    async def test_manual_model_hierarchy_validation(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        response = await client.post(
+            "/api/v1/extraction/models/manual",
+            json={},
+        )
+        assert response.status_code in (400, 422)
+
+    @pytest.mark.asyncio
+    async def test_manual_model_hierarchy_success(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        from app.services.model_hierarchy_service import (
+            ModelHierarchyChild,
+            ModelHierarchyResult,
+        )
+
+        with patch("app.api.v1.endpoints.model_extraction.ModelHierarchyService") as svc_cls:
+            svc = svc_cls.return_value
+            svc.create_model_hierarchy = AsyncMock(
+                return_value=ModelHierarchyResult(
+                    model_id=uuid4(),
+                    model_label="Cox Model",
+                    child_instances=[
+                        ModelHierarchyChild(
+                            id=uuid4(),
+                            entity_type_id=uuid4(),
+                            parent_instance_id=uuid4(),
+                            label="Cox Model - Population 1",
+                        )
+                    ],
+                    proposal_run_id=None,
+                )
+            )
+
+            response = await client.post(
+                "/api/v1/extraction/models/manual",
+                json={
+                    "projectId": str(uuid4()),
+                    "articleId": str(uuid4()),
+                    "templateId": str(uuid4()),
+                    "modelName": "Cox Model",
+                    "modellingMethod": "logistic regression",
+                },
+            )
+
+            assert response.status_code == 201
+            payload = response.json()
+            assert payload["ok"] is True
+            assert payload["data"]["modelLabel"] == "Cox Model"
+            assert len(payload["data"]["childInstances"]) == 1
+            svc.create_model_hierarchy.assert_awaited_once()

--- a/frontend/hooks/extraction/useModelManagement.ts
+++ b/frontend/hooks/extraction/useModelManagement.ts
@@ -16,11 +16,11 @@
 
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {supabase} from '@/integrations/supabase/client';
+import {createManualModelHierarchy} from '@/integrations/api';
 import {useAuth} from '@/contexts/AuthContext';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
 import {extractionInstanceService} from '@/services/extractionInstanceService';
-import {ExtractionValueService} from '@/services/extractionValueService';
 import type {Model} from '@/components/extraction/hierarchy/ModelSelector';
 
 // =================== INTERFACES ===================
@@ -35,7 +35,12 @@ interface UseModelManagementProps {
 
 interface CreateModelResult {
   model: Model;
-  childInstances: any[];
+  childInstances: Array<{
+    id: string;
+    entityTypeId: string;
+    parentInstanceId: string;
+    label: string;
+  }>;
 }
 
 interface UseModelManagementReturn {
@@ -80,11 +85,11 @@ export function useModelManagement({
     // Declared BEFORE loadModels because loadModels depends on it
   const getModelProgress = useCallback(async (instanceId: string): Promise<Model['progress']> => {
     try {
-        // Use optimized SQL function (1 query)
+      // Use optimized SQL function and filter target model.
       const { data, error } = await supabase
         .rpc('calculate_model_progress', {
+          p_project_id: projectId,
           p_article_id: articleId,
-          p_model_id: instanceId
         });
 
       if (error) {
@@ -96,18 +101,21 @@ export function useModelManagement({
         return { completed: 0, total: 0, percentage: 0 };
       }
 
-      const result = data[0];
+      const result = data.find((row) => row.extraction_instance_id === instanceId);
+      if (!result) {
+        return { completed: 0, total: 0, percentage: 0 };
+      }
       return {
-        completed: result.completed_fields || 0,
+        completed: result.filled_fields || 0,
         total: result.total_fields || 0,
-        percentage: result.percentage || 0
+        percentage: Number(result.completion_percentage || 0)
       };
 
     } catch (err) {
         console.error('Error calculating model progress:', err);
       return { completed: 0, total: 0, percentage: 0 };
     }
-  }, [articleId]);
+  }, [articleId, projectId]);
 
     // Load existing models
   const loadModels = useCallback(async () => {
@@ -183,40 +191,6 @@ export function useModelManagement({
     // Ensures ref is available when useEffect tries to use it
   loadModelsRef.current = loadModels;
 
-    // Function to generate unique name
-    const _generateUniqueModelName = useCallback(async (
-    baseName: string,
-    maxAttempts: number = 10
-  ): Promise<string> => {
-    let uniqueName = baseName;
-    let attempt = 1;
-
-    while (attempt <= maxAttempts) {
-        // Check if name already exists in DB
-      const { data: existingInstance, error: checkError } = await supabase
-        .from('extraction_instances')
-        .select('id')
-        .eq('article_id', articleId)
-        .eq('entity_type_id', modelParentEntityTypeId!)
-        .eq('label', uniqueName)
-        .limit(1);
-
-      if (checkError) throw checkError;
-
-        // If not exists, return the name
-      if (!existingInstance || existingInstance.length === 0) {
-        return uniqueName;
-      }
-
-        // If exists, try with numeric suffix
-      attempt++;
-      uniqueName = `${baseName} (${attempt})`;
-    }
-
-    // Se esgotou as tentativas, usar timestamp
-    return `${baseName} (${Date.now()})`;
-  }, [articleId, modelParentEntityTypeId]);
-
     // Create new model (using service - simplified)
   const createModel = useCallback(async (
     modelName: string,
@@ -229,93 +203,38 @@ export function useModelManagement({
 
     try {
         console.warn('🆕 Creating new model:', modelName);
-
-        // 1. Fetch parent entity type
-      const { data: parentEntityType, error: etError } = await supabase
-        .from('extraction_entity_types')
-        .select('*')
-        .eq('id', modelParentEntityTypeId)
-        .single();
-
-      if (etError || !parentEntityType) {
-          throw new Error(t('extraction', 'modelEntityTypeNotFound'));
-      }
-
-        // 2. Fetch child entity types
-      const { data: childEntityTypes, error: childTypesError } = await supabase
-        .from('extraction_entity_types')
-        .select('*')
-        .eq('parent_entity_type_id', modelParentEntityTypeId)
-        .order('sort_order');
-
-      if (childTypesError) throw childTypesError;
-
-        // 3. Delegate hierarchy creation to service
-      const result = await extractionInstanceService.createHierarchy({
-        projectId,
-        articleId,
-        templateId,
-        parentEntityType,
-        childEntityTypes: childEntityTypes || [],
-        label: modelName.trim(),
-        metadata: {},
-        userId: user.id
+      const result = await createManualModelHierarchy({
+        project_id: projectId,
+        article_id: articleId,
+        template_id: templateId,
+        model_name: modelName.trim(),
+        modelling_method: modellingMethod || null,
       });
 
-      // 4. If modellingMethod was provided, persist it as a ReviewerDecision
-      // on the active run. If no run exists yet (extraction hasn't run),
-      // skip silently — the user can fill it via the form afterwards.
-      if (modellingMethod) {
-        const { data: modellingMethodField } = await supabase
-          .from('extraction_fields')
-          .select('id')
-          .eq('entity_type_id', modelParentEntityTypeId)
-          .eq('name', 'modelling_method')
-          .single();
-
-        if (modellingMethodField) {
-          const run = await ExtractionValueService.findActiveRun(articleId, templateId);
-          if (run) {
-            try {
-              await ExtractionValueService.saveValue(
-                run.id,
-                result.parent.id,
-                modellingMethodField.id,
-                modellingMethod,
-              );
-            } catch (writeErr) {
-              console.warn(
-                'Could not persist modelling_method as ReviewerDecision; user can set it via the form.',
-                writeErr,
-              );
-            }
-          } else {
-            console.warn(
-              'No active extraction run; modellingMethod will be set via the form once extraction runs.',
-            );
-          }
-        }
-      }
-
-        // 5. Create Model object
+      // 4. Create Model object
       const newModel: Model = {
-        instanceId: result.parent.id,
-        modelName: result.parent.label,
+        instanceId: result.model_id,
+        modelName: result.model_label,
         progress: { completed: 0, total: 0, percentage: 0 }
       };
 
-        // 6. Update state
+      // 5. Update state
       setModels(prev => [...prev, newModel]);
       setActiveModelId(newModel.instanceId);
 
-        toast.success(t('extraction', 'modelCreatedSuccess').replace('{{label}}', result.parent.label));
+      toast.success(t('extraction', 'modelCreatedSuccess').replace('{{label}}', result.model_label));
 
-        console.warn(`✅ Hierarquia criada: 1 parent + ${result.children.length} children`);
+      console.warn(`✅ Hierarchy created: 1 parent + ${result.child_instances.length} children`);
 
-        // Return model AND created child instances
+      // Return model and created child instances.
       return {
         model: newModel,
-        childInstances: result.children
+        childInstances: result.child_instances.map((child) => ({
+          id: child.id,
+          entityTypeId: child.entity_type_id,
+          parentInstanceId: child.parent_instance_id,
+          label: child.label,
+        })),
       };
 
     } catch (err: any) {

--- a/frontend/hooks/qa/useProjectQATemplate.ts
+++ b/frontend/hooks/qa/useProjectQATemplate.ts
@@ -16,6 +16,10 @@ import type {
 
 import type { QADomain, QATemplate } from "./useQATemplate";
 
+type EntityTypeWithFields = ExtractionEntityType & {
+  extraction_fields?: ExtractionField[];
+};
+
 interface UseProjectQATemplateProps {
   projectTemplateId: string | undefined;
   enabled?: boolean;
@@ -60,31 +64,18 @@ export function useProjectQATemplate({
 
         const etRes = await supabase
           .from("extraction_entity_types")
-          .select("*")
+          .select("*, extraction_fields(*)")
           .eq("project_template_id", projectTemplateId)
           .order("sort_order", { ascending: true });
         if (etRes.error) throw etRes.error;
 
-        const entityIds = (etRes.data ?? []).map((e) => e.id);
-        const fieldsRes = entityIds.length
-          ? await supabase
-              .from("extraction_fields")
-              .select("*")
-              .in("entity_type_id", entityIds)
-              .order("sort_order", { ascending: true })
-          : { data: [], error: null };
-        if (fieldsRes.error) throw fieldsRes.error;
-
-        const fieldsByEntity = new Map<string, ExtractionField[]>();
-        for (const f of fieldsRes.data ?? []) {
-          const list = fieldsByEntity.get(f.entity_type_id) ?? [];
-          list.push(f as ExtractionField);
-          fieldsByEntity.set(f.entity_type_id, list);
-        }
-
-        const grouped: QADomain[] = (etRes.data ?? []).map((et) => ({
+        const entities = (etRes.data as EntityTypeWithFields[] | null) ?? [];
+        const grouped: QADomain[] = entities.map((et) => ({
+          // Keep deterministic field order for stable rendering.
+          // Related fields are loaded in the same query.
           entityType: et as ExtractionEntityType,
-          fields: fieldsByEntity.get(et.id) ?? [],
+          fields: ([...(et.extraction_fields ?? [])]
+            .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))) as ExtractionField[],
         }));
 
         if (!cancelled) {

--- a/frontend/integrations/api/client.ts
+++ b/frontend/integrations/api/client.ts
@@ -264,4 +264,35 @@ export async function modelExtractionClient<T>(
   });
 }
 
+export interface ManualModelHierarchyRequest {
+  project_id: string;
+  article_id: string;
+  template_id: string;
+  model_name: string;
+  modelling_method?: string | null;
+}
+
+export interface ManualModelHierarchyChild {
+  id: string;
+  entity_type_id: string;
+  parent_instance_id: string;
+  label: string;
+}
+
+export interface ManualModelHierarchyResponse {
+  model_id: string;
+  model_label: string;
+  child_instances: ManualModelHierarchyChild[];
+  proposal_run_id?: string | null;
+}
+
+export async function createManualModelHierarchy(
+  body: ManualModelHierarchyRequest
+): Promise<ManualModelHierarchyResponse> {
+  return apiClient<ManualModelHierarchyResponse>("/api/v1/extraction/models/manual", {
+    method: "POST",
+    body,
+  });
+}
+
 

--- a/frontend/integrations/api/index.ts
+++ b/frontend/integrations/api/index.ts
@@ -7,8 +7,11 @@ export {
   zoteroClient,
   sectionExtractionClient,
   modelExtractionClient,
+  createManualModelHierarchy,
   ApiError,
   type ApiResponse,
   type ApiRequestOptions,
+  type ManualModelHierarchyRequest,
+  type ManualModelHierarchyResponse,
   type ZoteroAction,
 } from "./client";

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -88,26 +88,31 @@ export default function QualityAssessmentFullScreen() {
     }
     setResolvedTemplate(null);
     void (async () => {
-      const { data: projectRow } = await supabase
-        .from("project_extraction_templates")
-        .select("id")
-        .eq("id", templateId)
-        .eq("kind", "quality_assessment")
-        .maybeSingle();
+      const [projectRes, globalRes] = await Promise.all([
+        supabase
+          .from("project_extraction_templates")
+          .select("id")
+          .eq("id", templateId)
+          .eq("kind", "quality_assessment")
+          .maybeSingle(),
+        supabase
+          .from("extraction_templates_global")
+          .select("id")
+          .eq("id", templateId)
+          .eq("kind", "quality_assessment")
+          .maybeSingle(),
+      ]);
       if (cancelled) return;
-      if (projectRow?.id) {
-        setResolvedTemplate({ kind: "project", id: projectRow.id });
+      if (projectRes.error && globalRes.error) {
+        setResolvedTemplate({ kind: "missing" });
         return;
       }
-      const { data: globalRow } = await supabase
-        .from("extraction_templates_global")
-        .select("id")
-        .eq("id", templateId)
-        .eq("kind", "quality_assessment")
-        .maybeSingle();
-      if (cancelled) return;
-      if (globalRow?.id) {
-        setResolvedTemplate({ kind: "global", id: globalRow.id });
+      if (projectRes.data?.id) {
+        setResolvedTemplate({ kind: "project", id: projectRes.data.id });
+        return;
+      }
+      if (globalRes.data?.id) {
+        setResolvedTemplate({ kind: "global", id: globalRes.data.id });
       } else {
         setResolvedTemplate({ kind: "missing" });
       }

--- a/frontend/test/hooks/useModelManagement.test.tsx
+++ b/frontend/test/hooks/useModelManagement.test.tsx
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/copy", () => ({
+  t: () => "ok",
+}));
+
+vi.mock("@/integrations/api", () => ({
+  createManualModelHierarchy: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+    from: vi.fn(),
+  },
+}));
+
+import { createManualModelHierarchy } from "@/integrations/api";
+import { useModelManagement } from "@/hooks/extraction/useModelManagement";
+
+const createManualModelHierarchyMock =
+  createManualModelHierarchy as unknown as ReturnType<typeof vi.fn>;
+
+describe("useModelManagement", () => {
+  beforeEach(() => {
+    createManualModelHierarchyMock.mockReset();
+  });
+
+  it("creates a model via one backend call", async () => {
+    createManualModelHierarchyMock.mockResolvedValueOnce({
+      model_id: "model-1",
+      model_label: "Cox",
+      child_instances: [
+        {
+          id: "child-1",
+          entity_type_id: "et-1",
+          parent_instance_id: "model-1",
+          label: "Cox - Population 1",
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useModelManagement({
+        projectId: "project-1",
+        articleId: "article-1",
+        templateId: "template-1",
+        modelParentEntityTypeId: "et-parent",
+        enabled: false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.createModel("Cox", "logistic regression");
+    });
+
+    expect(createManualModelHierarchyMock).toHaveBeenCalledWith({
+      project_id: "project-1",
+      article_id: "article-1",
+      template_id: "template-1",
+      model_name: "Cox",
+      modelling_method: "logistic regression",
+    });
+    expect(result.current.activeModelId).toBe("model-1");
+    expect(result.current.models).toHaveLength(1);
+    expect(result.current.models[0].modelName).toBe("Cox");
+  });
+});

--- a/render.yaml
+++ b/render.yaml
@@ -1,13 +1,23 @@
+# Render Blueprint (Infrastructure as Code).
+# After pushing: Dashboard → Blueprints → connect this repo; use Render's flow to
+# attach or migrate your existing web service so settings sync from this file.
+# https://docs.render.com/docs/infrastructure-as-code
+
 services:
   - type: web
-    name: review-hub-backend
+    # Must match the Render service name when adopting Blueprint on an existing instance.
+    name: prumo
     runtime: python
     rootDir: backend
+    branch: main
+    region: virginia
+    plan: free
     buildCommand: pip install -e .
     # Gunicorn default worker timeout is 30s; template clone + DB round-trips to
     # Supabase often exceed that in production. Keep this >= frontend clone timeout.
     startCommand: alembic upgrade head && gunicorn -k uvicorn.workers.UvicornWorker -w 1 -t 120 -b 0.0.0.0:$PORT app.main:app
-    envVars: &backend_env
+    healthCheckPath: /health
+    envVars:
       - key: DATABASE_URL
         sync: false
       - key: DIRECT_DATABASE_URL
@@ -20,8 +30,9 @@ services:
         sync: false
       - key: OPENAI_API_KEY
         sync: false
+      # Set in the dashboard (do not rotate via generateValue when migrating an existing service).
       - key: ENCRYPTION_KEY
-        generateValue: true
+        sync: false
       - key: DEBUG
         value: false
       - key: PYTHON_VERSION


### PR DESCRIPTION
## Summary

Three commits landed on \`origin/main\` directly, bypassing \`dev\`. This PR backports them to \`dev\` so the canonical flow (changes go to \`dev\` first, then propagate to \`main\`) is restored.

After this merges, \`origin/dev\` and \`origin/main\` will be aligned (modulo PRs currently in flight: #34, #35, #36).

## Cherry-picked commits (chronological)

| SHA on this branch | Original SHA on main | Title | Files |
|---|---|---|---|
| \`6ee6be9\` | \`6aeb1af\` | chore(render): align Blueprint with prod (name, region, health check) | render.yaml |
| \`2b7ca83\` | \`20c5ec6\` | chore: ignore local .superpowers plugin state | .gitignore |
| \`88952b1\` | \`5d776cc\` | perf(hitl): cut extraction model creation round trips | 11 files (+611/-158), incl. new \`model_hierarchy_service.py\` and matching tests |

All three were authored by you and already shipped to main — this PR is a pure history-alignment operation, not a re-review of the changes themselves. Cherry-picks were clean (no conflicts).

## Why this happened

The HITL perf + render config + .superpowers gitignore commits landed directly on main during prior sessions (likely Cursor commits with auto-push to main configured). Going forward, all changes route via \`dev\` per \`CLAUDE.md\`.

## Test plan

- [ ] Verify the cherry-picked HITL perf commit doesn't conflict with anything currently on \`dev\` — clean cherry-pick suggests no.
- [ ] Confirm \`make test-backend\` is still green (the perf commit shipped tests; they should still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)