### PR TITLE
cleanup(openai_service): remove 5 dead methods + unused imports

### DIFF
--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -1,19 +1,15 @@
 """
 OpenAI Service.
 
-Comprehensive wrapper for OpenAI API calls with support for:
+Wrapper for OpenAI API calls with support for:
 - Chat completions with JSON mode
 - Structured outputs (json_schema)
-- Responses API for PDFs
-- Embeddings
 - Retry with exponential backoff
 - Token tracking
 """
 
-import base64
-import json
 import time
-from typing import Any, TypeVar
+from typing import Any
 
 import httpx
 from pydantic import BaseModel
@@ -26,8 +22,6 @@ from tenacity import (
 
 from app.core.config import settings
 from app.core.logging import LoggerMixin
-
-T = TypeVar("T", bound=BaseModel)
 
 
 class OpenAIUsage(BaseModel):
@@ -72,7 +66,6 @@ class OpenAIService(LoggerMixin):
         self.base_url = "https://api.openai.com/v1"
         self._api_key = api_key
         self._client: httpx.AsyncClient | None = None
-        self._using_user_key = api_key is not None
 
     @property
     def api_key(self) -> str:
@@ -80,28 +73,6 @@ class OpenAIService(LoggerMixin):
         if self._api_key:
             return self._api_key
         return settings.OPENAI_API_KEY
-
-    @property
-    def is_using_user_key(self) -> bool:
-        """Indicates whether user key (BYOK) is active."""
-        return self._using_user_key
-
-    def set_api_key(self, api_key: str | None) -> None:
-        """
-        Set dynamic API key.
-
-        Invalidate HTTP client so the new key is used.
-
-        Args:
-            api_key: New API key or None to use global key.
-        """
-        self._api_key = api_key
-        self._using_user_key = api_key is not None
-        # Invalidate client to use new key
-        if self._client and not self._client.is_closed:
-            # Do not close here to avoid async edge cases
-            # Client is recreated on next request
-            self._client = None
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Return reusable HTTP client."""
@@ -231,188 +202,6 @@ class OpenAIService(LoggerMixin):
             finish_reason=choice.get("finish_reason", "stop"),
             duration_ms=duration,
         )
-
-    async def chat_completion_structured(
-        self,
-        messages: list[dict[str, Any]],
-        response_model: type[T],
-        model: str = "gpt-4o-mini",
-        temperature: float = 0.1,
-        max_tokens: int | None = None,
-    ) -> T:
-        """
-        Execute chat completion with Pydantic-structured response.
-
-        Uses json_schema to enforce output format.
-
-        Args:
-            messages: Message list.
-            response_model: Pydantic model for response validation.
-            model: OpenAI model.
-            temperature: Sampling temperature.
-            max_tokens: Token limit.
-
-        Returns:
-            Pydantic model instance.
-        """
-        # Generate JSON schema from Pydantic model
-        schema = response_model.model_json_schema()
-
-        response_format = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": response_model.__name__,
-                "strict": True,
-                "schema": schema,
-            },
-        }
-
-        content = await self.chat_completion(
-            messages=messages,
-            model=model,
-            response_format=response_format,
-            temperature=temperature,
-            max_tokens=max_tokens,
-        )
-
-        # Parse and validate with Pydantic
-        data = json.loads(content)
-        return response_model.model_validate(data)
-
-    async def responses_api_with_pdf(
-        self,
-        pdf_data: bytes | str,
-        system_prompt: str,
-        user_prompt: str,
-        response_format: dict[str, Any] | None = None,
-        model: str = "gpt-4o-mini",
-        filename: str = "document.pdf",
-    ) -> dict[str, Any]:
-        """
-        Use Responses API to analyze PDF directly.
-
-        Args:
-            pdf_data: PDF bytes or base64 string.
-            system_prompt: System prompt.
-            user_prompt: User prompt.
-            response_format: Structured response format.
-            model: Model to use.
-            filename: File name.
-
-        Returns:
-            Dict with output_text, input_tokens, and output_tokens.
-        """
-        start_time = time.time()
-
-        # Convert to base64 if needed
-        if isinstance(pdf_data, bytes):
-            pdf_base64 = base64.b64encode(pdf_data).decode()
-        else:
-            pdf_base64 = pdf_data
-
-        data_url = f"data:application/pdf;base64,{pdf_base64}"
-
-        payload: dict[str, Any] = {
-            "model": model,
-            "input": [
-                {
-                    "role": "system",
-                    "content": [{"type": "input_text", "text": system_prompt}],
-                },
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "input_file",
-                            "file_data": data_url,
-                            "filename": filename,
-                        },
-                        {"type": "input_text", "text": user_prompt},
-                    ],
-                },
-            ],
-        }
-
-        if response_format:
-            payload["text"] = {"format": response_format}
-
-        client = await self._get_client()
-        response = await client.post(
-            f"{self.base_url}/responses",
-            json=payload,
-        )
-
-        duration = (time.time() - start_time) * 1000
-
-        if not response.is_success:
-            error_text = response.text[:500]
-            self.logger.error(
-                "openai_responses_error",
-                trace_id=self.trace_id,
-                status=response.status_code,
-                error=error_text,
-            )
-            raise ValueError(f"OpenAI Responses API error: {response.status_code}")
-
-        result = response.json()
-
-        # Extract output_text
-        output_text = None
-        for item in result.get("output", []):
-            if item.get("type") == "message":
-                for content in item.get("content", []):
-                    if content.get("type") == "output_text":
-                        output_text = content.get("text")
-                        break
-
-        usage = result.get("usage", {})
-
-        self.logger.info(
-            "openai_responses_completion",
-            trace_id=self.trace_id,
-            model=model,
-            duration_ms=duration,
-            input_tokens=usage.get("input_tokens"),
-            output_tokens=usage.get("output_tokens"),
-        )
-
-        return {
-            "output_text": output_text,
-            "input_tokens": usage.get("input_tokens"),
-            "output_tokens": usage.get("output_tokens"),
-            "duration_ms": duration,
-        }
-
-    async def embeddings(
-        self,
-        texts: list[str],
-        model: str = "text-embedding-3-small",
-    ) -> list[list[float]]:
-        """
-        Generate embeddings for texts.
-
-        Args:
-            texts: Text list.
-            model: Embedding model.
-
-        Returns:
-            List of embedding vectors.
-        """
-        client = await self._get_client()
-        response = await client.post(
-            f"{self.base_url}/embeddings",
-            json={
-                "model": model,
-                "input": texts,
-            },
-        )
-
-        if not response.is_success:
-            raise ValueError(f"OpenAI embeddings error: {response.status_code}")
-
-        result = response.json()
-
-        return [item["embedding"] for item in result["data"]]
 
     def build_json_schema_format(
         self,


### PR DESCRIPTION
## Summary

Removes five methods from \`backend/app/services/openai_service.py\` that have **zero call sites** repo-wide outside the file itself, plus the imports that became unused once they were gone.

| Symbol | Kind | Verified callers on \`origin/dev\` |
|---|---|---|
| \`is_using_user_key\` | \`@property\` | 0 |
| \`set_api_key\` | method | 0 |
| \`chat_completion_structured\` | async method | 0 |
| \`responses_api_with_pdf\` | async method | 0 |
| \`embeddings\` | async method | 0 |

Plus dropped imports: \`base64\`, \`json\`, \`TypeVar\`, and the unused \`T = TypeVar(...)\` declaration.

\`\`\`bash
$ for sym in is_using_user_key set_api_key chat_completion_structured responses_api_with_pdf embeddings; do
    echo \"\$sym: \$(git grep -l \\\"\$sym\\\" origin/dev -- '*.py' | grep -v openai_service.py | grep -v test_openai_service.py | wc -l) callers\"
  done
is_using_user_key: 0 callers
set_api_key: 0 callers
chat_completion_structured: 0 callers
responses_api_with_pdf: 0 callers
embeddings: 0 callers
\`\`\`

## Decision: ship full cleanup despite Phase β AI plans

Three of the five methods (\`responses_api_with_pdf\`, \`chat_completion_structured\`, \`embeddings\`) overlap with what AI screening Phase β eventually wants to do (PDF AI metadata extract, structured AI screening verdicts, embeddings for active learning). I considered preserving them but landed on full removal because:

1. **YAGNI** — keeping unused code \"for later\" is just keeping dead code.
2. **The Phase β implementations will likely differ** — current OpenAI structured-outputs API patterns, BYOK key resolution per call, idempotency keys, cost tracking via \`ai_usage_log\`, SSE streaming wrappers — all of which will be designed against actual requirements.
3. **The screening spec already accounts for this** — Phase β explicitly designs the AI service surface from scratch. No future task is blocked by removing these now.

If we change our mind, \`git revert\` brings them back in seconds.

## Spiritual successor to closed PR #14

Same diff, freshly verified against today's \`origin/dev\` and re-tested.

## Test plan

\`\`\`
$ pytest backend/tests/unit/test_openai_service.py -v
============================== 7 passed in 0.01s ===============================
\`\`\`

The 7 existing tests cover \`chat_completion\`, \`chat_completion_full\`, error handling, and the JSON-schema format builder — none reference any of the removed symbols.

## Stats

- 1 file changed: \`backend/app/services/openai_service.py\`
- **+2 / -213** (net -211 LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)