### PR TITLE
cleanup(pdf_processor): drop dead section-detection and token-estimation methods

### DIFF
--- a/backend/app/services/pdf_processor.py
+++ b/backend/app/services/pdf_processor.py
@@ -4,7 +4,6 @@ PDF Processor Service.
 Processamento avancado de files PDF:
 - Extracao de texto por pagina
 - Chunking inteligente
-- Deteccao de sections
 - Cache de texto extraido
 """
 
@@ -12,7 +11,6 @@ import hashlib
 import io
 import re
 from dataclasses import dataclass
-from typing import Any
 
 from pypdf import PdfReader
 
@@ -59,27 +57,6 @@ class PDFProcessor(LoggerMixin):
 
     Extrai texto, metadata and faz chunking inteligente.
     """
-
-    # Padroes for deteccao de sections
-    SECTION_PATTERNS = [
-        r"^(?:abstract|summary)\s*$",
-        r"^(?:\d+\.?\s*)?introduction",
-        r"^(?:\d+\.?\s*)?background",
-        r"^(?:\d+\.?\s*)?methods?",
-        r"^(?:\d+\.?\s*)?materials?\s+(?:and|&)\s+methods?",
-        r"^(?:\d+\.?\s*)?results?",
-        r"^(?:\d+\.?\s*)?discussion",
-        r"^(?:\d+\.?\s*)?conclusion",
-        r"^(?:\d+\.?\s*)?references?",
-        r"^(?:\d+\.?\s*)?bibliography",
-        r"^(?:\d+\.?\s*)?appendix",
-        r"^(?:\d+\.?\s*)?supplementary",
-    ]
-
-    def __init__(self):
-        self._compiled_patterns = [
-            re.compile(p, re.IGNORECASE | re.MULTILINE) for p in self.SECTION_PATTERNS
-        ]
 
     async def extract_text(self, pdf_data: bytes) -> str:
         """
@@ -249,83 +226,6 @@ class PDFProcessor(LoggerMixin):
             )
             return PDFMetadata(pages=0, md5_hash="")
 
-    async def detect_sections(self, text: str) -> list[dict[str, Any]]:
-        """
-        Detecta sections in the texto do PDF.
-
-        Args:
-            text: Texto do PDF.
-
-        Returns:
-            List de sections detectadas with posicao.
-        """
-        sections = []
-        lines = text.split("\n")
-
-        for i, line in enumerate(lines):
-            line_clean = line.strip()
-            if not line_clean or len(line_clean) > 100:
-                continue
-
-            for pattern in self._compiled_patterns:
-                if pattern.match(line_clean):
-                    sections.append(
-                        {
-                            "name": line_clean,
-                            "line_number": i + 1,
-                            "char_position": text.find(line),
-                        }
-                    )
-                    break
-
-        self.logger.info(
-            "sections_detected",
-            count=len(sections),
-        )
-
-        return sections
-
-    async def extract_section_text(
-        self,
-        text: str,
-        section_name: str,
-        next_section_name: str | None = None,
-    ) -> str:
-        """
-        Extrai texto de uma section especifica.
-
-        Args:
-            text: Texto completo do PDF.
-            section_name: Nome da section a extrair.
-            next_section_name: Nome da proxima section (para delimitar).
-
-        Returns:
-            Texto da section.
-        """
-        # Encontrar inicio da section
-        pattern = re.compile(
-            rf"^.*{re.escape(section_name)}.*$",
-            re.IGNORECASE | re.MULTILINE,
-        )
-        match = pattern.search(text)
-
-        if not match:
-            return ""
-
-        start_pos = match.end()
-
-        # Encontrar fim da section
-        if next_section_name:
-            end_pattern = re.compile(
-                rf"^.*{re.escape(next_section_name)}.*$",
-                re.IGNORECASE | re.MULTILINE,
-            )
-            end_match = end_pattern.search(text[start_pos:])
-            if end_match:
-                return text[start_pos : start_pos + end_match.start()].strip()
-
-        return text[start_pos:].strip()
-
     def _clean_text(self, text: str) -> str:
         """
         Limpa texto extraido do PDF.
@@ -344,17 +244,3 @@ class PDFProcessor(LoggerMixin):
         text = re.sub(r"\n{3,}", "\n\n", text)
 
         return text.strip()
-
-    def estimate_tokens(self, text: str) -> int:
-        """
-        Estima numero de tokens for um texto.
-
-        Usa aproximacao de ~4 caracteres por token for ingles.
-
-        Args:
-            text: Texto for estimar.
-
-        Returns:
-            Numero estimado de tokens.
-        """
-        return len(text) // 4

--- a/backend/tests/unit/test_pdf_processor.py
+++ b/backend/tests/unit/test_pdf_processor.py
@@ -109,15 +109,6 @@ class TestPDFProcessor:
         with pytest.raises(ValueError, match="Failed to extract"):
             await pdf_processor.extract_text(invalid_pdf)
 
-    def test_estimate_tokens(self, pdf_processor: PDFProcessor) -> None:
-        """Test estimativa de tokens."""
-        text = "Hello world! " * 100  # ~1300 caracteres
-
-        tokens = pdf_processor.estimate_tokens(text)
-
-        # Aproximadamente 4 caracteres por token
-        assert 200 < tokens < 500
-
     def test_clean_text(self, pdf_processor: PDFProcessor) -> None:
         """Test limpeza de texto."""
         dirty_text = "Hello\x00World\n\n\n\nTest"
@@ -126,65 +117,3 @@ class TestPDFProcessor:
 
         assert "\x00" not in clean
         assert "\n\n\n\n" not in clean
-
-
-class TestSectionDetection:
-    """Testes para detecção de seções."""
-
-    @pytest.mark.asyncio
-    async def test_detect_sections_finds_common_sections(
-        self,
-        pdf_processor: PDFProcessor,
-    ) -> None:
-        """Test que detecta seções comuns de artigos científicos."""
-        text = """
-        Abstract
-        This is the abstract.
-        
-        Introduction
-        This is the introduction.
-        
-        Methods
-        This describes the methods.
-        
-        Results
-        These are the results.
-        
-        Discussion
-        This is the discussion.
-        
-        Conclusion
-        This is the conclusion.
-        
-        References
-        1. Reference one.
-        """
-
-        sections = await pdf_processor.detect_sections(text)
-
-        assert len(sections) >= 5
-        section_names = [s["name"].lower() for s in sections]
-
-        assert any("abstract" in n for n in section_names)
-        assert any("introduction" in n for n in section_names)
-        assert any("method" in n for n in section_names)
-
-    @pytest.mark.asyncio
-    async def test_extract_section_text(
-        self,
-        pdf_processor: PDFProcessor,
-    ) -> None:
-        """Test extração de texto de uma seção."""
-        text = """
-        Introduction
-        This is the introduction content.
-        It has multiple lines.
-        
-        Methods
-        This is the methods section.
-        """
-
-        intro_text = await pdf_processor.extract_section_text(text, "Introduction", "Methods")
-
-        assert "introduction content" in intro_text.lower()
-        assert "methods section" not in intro_text.lower()


### PR DESCRIPTION
## Changes

`backend/app/services/pdf_processor.py` — last touched 2026-03-30, untouched for >14 days.

### Dead code removed (185 net LOC across 2 files)

- **`detect_sections`** (36 lines) — `grep -rn detect_sections` returns 0 hits outside the definition and its now-deleted test.
- **`extract_section_text`** (41 lines) — `grep -rn extract_section_text` returns 0 hits outside the definition and its now-deleted test.
- **`estimate_tokens`** (15 lines) — `grep -rn estimate_tokens` returns 0 hits outside the definition and its now-deleted test.
- **`SECTION_PATTERNS` class attribute + `__init__`** (20 lines) — existed solely to compile the patterns for `detect_sections`; nothing else reads `_compiled_patterns`.
- **`from typing import Any`** import (1 line) — only appeared in the `detect_sections` return-type annotation.

### Grep evidence

```
$ grep -rn "detect_sections" --include="*.py" --include="*.ts" --include="*.tsx" .
(no output — 0 hits outside deleted test)

$ grep -rn "extract_section_text" --include="*.py" --include="*.ts" --include="*.tsx" .
(no output — 0 hits outside deleted test)

$ grep -rn "estimate_tokens" --include="*.py" --include="*.ts" --include="*.tsx" .
(no output — 0 hits)
```

### Tests dropped (per rules: remove tests of code you removed)

- `TestSectionDetection` class (60 lines) — covered `detect_sections` and `extract_section_text`
- `test_estimate_tokens` (8 lines) — covered `estimate_tokens`

### Surviving tests — all green

```
tests/unit/test_pdf_processor.py::TestPDFProcessor::test_extract_text_returns_string PASSED
tests/unit/test_pdf_processor.py::TestPDFProcessor::test_extract_pages_returns_list PASSED
tests/unit/test_pdf_processor.py::TestPDFProcessor::test_get_metadata_returns_pdfmetadata PASSED
tests/unit/test_pdf_processor.py::TestPDFProcessor::test_extract_text_chunked PASSED
tests/unit/test_pdf_processor.py::TestPDFProcessor::test_extract_text_invalid_pdf_raises_error PASSED
tests/unit/test_pdf_processor.py::TestPDFProcessor::test_clean_text PASSED

6 passed in 0.03s
```

Full unit suite (154 tests): all passed.

### Lint

```
make lint-backend → All checks passed!
ruff check + ruff format --check → All checks passed! 2 files already formatted
```

### Scope compliance

| Constraint | Status |
|---|---|
| ≤200 net LOC | ✅ 185 lines removed |
| ≤15 files | ✅ 2 files |
| One module only | ✅ `pdf_processor` |
| No API/model/migration changes | ✅ |
| No new abstractions | ✅ |
| No public symbol renames | ✅ |

### Note

`extract_text_chunked` and `get_metadata` are also unreachable from outside the class today, but removing them plus their tests would have pushed the total past 200 net LOC. Left for a follow-up cleanup PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGbK3ppjKJ2zav7z6HJLWd)_