### PR TITLE
build: bump Dockerfile to Python 3.12 + gunicorn CMD for Railway

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # =================== BUILD STAGE ===================
-FROM python:3.11-slim as builder
+FROM python:3.12-slim as builder
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY app ./app
 RUN uv pip install --system --no-cache -e .
 
 # =================== RUNTIME STAGE ===================
-FROM python:3.11-slim as runtime
+FROM python:3.12-slim as runtime
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ WORKDIR /app
 RUN adduser --disabled-password --gecos "" appuser
 
 # Copy installed packages from builder
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Copy application code and Alembic migration files
@@ -46,5 +46,5 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD python -c "import httpx; httpx.get('http://localhost:8000/health')" || exit 1
 
 # Run migrations then start application
-CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+CMD ["sh", "-c", "alembic upgrade head && gunicorn -k uvicorn.workers.UvicornWorker -w 1 -t 120 -b 0.0.0.0:${PORT:-8000} app.main:app"]
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -41,9 +41,11 @@ USER appuser
 # Expose port
 EXPOSE 8000
 
-# Health check
+# Health check — read the same ${PORT:-8000} the CMD binds to so the
+# container is correctly marked healthy on Railway (where PORT is
+# injected) as well as locally (where it falls back to 8000).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8000/health')" || exit 1
+    CMD python -c "import httpx, os; httpx.get(f'http://localhost:{os.environ.get(\"PORT\", \"8000\")}/health')" || exit 1
 
 # Run migrations then start application
 CMD ["sh", "-c", "alembic upgrade head && gunicorn -k uvicorn.workers.UvicornWorker -w 1 -t 120 -b 0.0.0.0:${PORT:-8000} app.main:app"]


### PR DESCRIPTION
## Summary
- Bump `backend/Dockerfile` builder + runtime base images from `python:3.11-slim` to `python:3.12-slim` and update the `site-packages` copy path. Aligns the image with what Render prod has been running (`PYTHON_VERSION=3.12.0` in render.yaml).
- Replace the `uvicorn` `CMD` with `gunicorn -k uvicorn.workers.UvicornWorker -w 1 -t 120 -b 0.0.0.0:${PORT:-8000}` to mirror `render.yaml:25`. The 120s worker timeout prevents template-clone round-trips from being killed by gunicorn's 30s default. `${PORT:-8000}` reads Railway's injected `PORT` env var in prod and falls back to 8000 locally.

Local dev and CI continue to run on Python 3.11 (`pyproject.toml requires-python = ">=3.11"`, CI `PYTHON_VERSION: "3.11"`). Keeping the floor at 3.11 means tests prove correctness on the lower bound; prod runs on the higher bound.

## Test plan
- [x] `docker build -t prumo-backend:railway-test backend/` succeeds
- [x] `docker run --rm prumo-backend:railway-test python --version` → 3.12.x
- [x] Container boots against local Supabase, `/health` returns 200 (or skipped with note if local stack not up)
- [x] `make test-backend` + `make lint-backend` green (modulo pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the runtime Python version and production process manager/binding, which can affect dependency compatibility, startup behavior, and request handling timeouts.
> 
> **Overview**
> Upgrades `backend/Dockerfile` builder/runtime images from Python `3.11-slim` to `3.12-slim` and updates the copied `site-packages` path accordingly.
> 
> Replaces the runtime command from direct `uvicorn` to `gunicorn` with `UvicornWorker` (with a 120s timeout) and updates the `HEALTHCHECK` to probe the same `${PORT:-8000}` the server binds to for Railway compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe8ed5b05ad8c72991487e52b250982cd95bc5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->