### PR TITLE
Merge dev → main: legacy Render cleanup wave 2

### DIFF
--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,5 +1,5 @@
 ---
-description: Pre-deploy readiness gate — runs verification-before-completion locally then probes Vercel, Supabase and Render. Read-only.
+description: Pre-deploy readiness gate — runs verification-before-completion locally then probes Vercel, Supabase and Railway. Read-only.
 argument-hint: "[--local-only] [--remote-only]"
 allowed-tools:
   - Task
@@ -11,6 +11,8 @@ allowed-tools:
   - mcp__16b9320c-bebb-4437-8372-470b05309b53__list_deployments
   - mcp__16b9320c-bebb-4437-8372-470b05309b53__get_deployment
   - mcp__16b9320c-bebb-4437-8372-470b05309b53__get_runtime_logs
+  - mcp__railway__list_deployments
+  - mcp__railway__get_logs
 model: sonnet
 ---
 
@@ -179,7 +181,7 @@ evidence: |
 ```text
 You are the `remote-deploys` preflight gate for prumo. READ-ONLY.
 
-Three checks across Vercel and Railway:
+Four checks across Vercel and Railway (web + worker + Redis):
 
   A. Vercel — latest deployment.
      Call mcp__16b9320c-bebb-4437-8372-470b05309b53__list_deployments
@@ -194,23 +196,42 @@ Three checks across Vercel and Railway:
      for the last 15 minutes on that deployment. Any HTTP 5xx → WARN.
      Clean → PASS.
 
-  C. Railway — backend health.
+  C. Railway — backend health (web service).
      Run: curl -fsS --max-time 10 -o /dev/null -w "%{http_code}" \
             https://web-production-48b398.up.railway.app/health
      - HTTP 200 → PASS
      - Anything else, or curl exit non-zero → FAIL
 
-Aggregate: worst status across A, B, C wins.
+  D. Railway — worker + Redis health.
+     The worker has no public endpoint, so probe via Railway MCP:
+       1. Call mcp__railway__list_deployments with service_id
+          7acd0799-9685-4445-971a-707bc1b9c41f (worker service in the
+          prumo project, environment production). Take the latest
+          deployment.
+          - status != "SUCCESS" → FAIL ("worker last deploy <status>")
+          - status == "SUCCESS" → continue
+       2. Call mcp__railway__get_logs for the same worker service with
+          limit=40. Look for two markers in the most recent boot block:
+            - "Connected to redis://" → Redis reachable
+            - "celery@... ready." → worker accepting jobs
+          Both present → PASS. Either missing → WARN. Both missing or
+          presence of "[ERROR]" / "ConnectionError" → FAIL.
+     This single check covers both the worker process and Redis — if
+     Redis is down, the worker logs will show "Connection refused" and
+     the gate fails fast.
+
+Aggregate: worst status across A, B, C, D wins.
 
 Return ONLY the following YAML block:
 
 gate: remote-deploys
 status: PASS | WARN | FAIL | UNKNOWN
-summary: <e.g. "Vercel READY 2h ago / no 5xx / Railway /health 200">
+summary: <e.g. "Vercel READY 2h ago / no 5xx / Railway /health 200 / worker+Redis ready">
 evidence: |
   Vercel: <deployment id, readyState, age>
   Vercel logs: <5xx count or "clean">
-  Railway: <status code from /health>
+  Railway web: <status code from /health>
+  Railway worker: <last deploy status, "redis ready" / "redis err">
 ```
 
 ---

--- a/docs/DATABASE_SEEDING.md
+++ b/docs/DATABASE_SEEDING.md
@@ -60,17 +60,20 @@ DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
 3. DATABASE_URL do ambiente de produção
 4. Acesso ao servidor/container onde o backend roda
 
-### Opção 1: Via Render.com (Deploy Automático)
+### Opção 1: Via Railway (Deploy Automático)
 
-O seed é aplicado automaticamente no primeiro deploy via script de inicialização.
+O seed pode ser ligado ao deploy via Dockerfile `CMD` ou via Railway
+`pre_deploy_command`. Hoje o `backend/Dockerfile` roda apenas
+`alembic upgrade head && gunicorn ...` no boot — não chama o seed.
+Para incluir o seed nesse momento:
 
-```yaml
-# render.yaml
-startCommand: |
-  alembic upgrade head && \
-  python -m app.seed && \
-  gunicorn -k uvicorn.workers.UvicornWorker -w 4 app.main:app
+```dockerfile
+# backend/Dockerfile (alteração opcional)
+CMD ["sh", "-c", "alembic upgrade head && python -m app.seed && gunicorn -k uvicorn.workers.UvicornWorker -w 1 -t 120 -b 0.0.0.0:${PORT:-8000} app.main:app"]
 ```
+
+Como `seed.py` é idempotente, rodar a cada boot do `web` é seguro. Para
+o `worker`, evite — ele não precisa rodar seed (e tampouco roda Alembic).
 
 ### Opção 2: Manual (SSH / Script)
 
@@ -189,17 +192,22 @@ make seed
 make backend-start
 ```
 
-### Produção (Render.com)
+### Produção (Railway)
 
 ```bash
 # 1. Push código para GitHub
 git push origin main
 
-# 2. Render detecta push e faz deploy:
-#    a. Build: pip install uv && uv pip install --system -e .
-#    b. Start: alembic upgrade head && python -m app.seed && gunicorn ...
+# 2. Railway detecta push e faz deploy (apenas o serviço `web` roda
+#    Alembic — o worker boota depois):
+#    a. Build: backend/Dockerfile (Python 3.12 + uv pip install -e .)
+#    b. Start: alembic upgrade head && gunicorn ...
+#       (seed só roda se você adicionar `python -m app.seed` ao CMD
+#       — ver Opção 1 acima)
 
-# 3. Verificar logs no Render Dashboard
+# 3. Verificar logs:
+#    railway logs --service web --lines 200
+#    ou via Railway Dashboard
 ```
 
 ### Produção (Manual)
@@ -218,8 +226,8 @@ alembic upgrade head
 # 4. Aplica seed
 DATABASE_URL="$PROD_DATABASE_URL" uv run python -m app.seed
 
-# 5. Restart aplicação
-systemctl restart review-hub-backend
+# 5. Restart aplicação (Railway)
+railway service restart --service web
 ```
 
 ## ⚠️ Troubleshooting

--- a/docs/superpowers/plans/2026-05-21-security-hardening-wave.md
+++ b/docs/superpowers/plans/2026-05-21-security-hardening-wave.md
@@ -1,5 +1,12 @@
 # Security Hardening Wave — 2026-05-21
 
+> **Historical note (2026-05-24):** This plan was written when the backend
+> was still on Render. The architectural references (Render Blueprint,
+> render.yaml, review-hub-backend.onrender.com health URL) are kept as-is
+> for traceability. The current deployment is Railway — see
+> [`docs/architecture/deployment.md`](../../architecture/deployment.md).
+> When re-running similar work today, substitute Railway equivalents.
+
 > **For executor:** Tasks below are self-contained. Run them in order; each
 > ends with a verification step. The migrations in this wave land together
 > in one PR so production RLS state stays consistent.

--- a/docs/superpowers/specs/2026-05-22-preflight-slash-command-design.md
+++ b/docs/superpowers/specs/2026-05-22-preflight-slash-command-design.md
@@ -1,13 +1,13 @@
 # `/preflight` slash command — design
 
-**Status**: design — pending implementation
-**Date**: 2026-05-22
+**Status**: implemented in `.claude/commands/preflight.md`
+**Date**: 2026-05-22 (updated 2026-05-24 for Render → Railway migration)
 
 ## Goal
 
 A single `/preflight` slash command that runs the full pre-deploy
 verification flow for prumo: local code-quality gates plus liveness
-probes against the three remote services (Vercel, Supabase, Render).
+probes against the three remote services (Vercel, Supabase, Railway).
 Output is a green/red gate report aligned with the
 `verification-before-completion` skill's "evidence before claims" rule.
 
@@ -119,5 +119,5 @@ None at design time.
   frontmatter pattern (`description`, `handoffs`).
 - `Makefile` targets `lint-backend`, `test-backend`, `db-lint-migrations`,
   `quality-scan`.
-- `render.yaml`, `vercel.json`, and the Vercel + Supabase MCP servers
-  already configured in this session.
+- `railway.toml`, `vercel.json`, and the Vercel + Supabase + Railway
+  MCP servers configured for this project.


### PR DESCRIPTION
## Summary
Promotes PR #114 (legacy Render cleanup wave 2 + preflight Redis/worker gate) from \`dev\` to \`main\`.

Docs / preflight only — no runtime code or infra config changes. After this merges, the \`/preflight\` slash command's remote-deploys gate will also check the Railway worker and Redis health (not just \`/health\` on web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation and Claude slash-command prompt updates only, with no runtime or infrastructure code changes. Main risk is false positives/negatives in the new Railway worker+Redis log heuristics affecting deploy readiness reporting.
> 
> **Overview**
> Updates the `/preflight` command to treat **Railway as the deployment target** and expands the `remote-deploys` gate to also verify **Railway worker + Redis** by checking the latest worker deployment status and scanning recent logs for boot/Redis-ready markers.
> 
> Refreshes production documentation to reflect the **Render → Railway** migration, including updated seeding/deploy guidance and a historical note clarifying older Render-based security-hardening docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61cbd6fec762c840a8c6469f5f19e321d2643626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->