### PR TITLE
Merge dev → main: railway.toml + deployment.md (GitHub auto-deploy state)

### DIFF
--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Last updated: 2026-05-24.
+Last updated: 2026-05-24 (post GitHub auto-deploy wiring).
 
 ## Topology
 
@@ -90,7 +90,36 @@ To roll back the frontend, change `VITE_API_URL` in Vercel back to the previous 
 
 ## Deploys are triggered by
 
-- Push to `main` → Railway auto-deploys `web` and `worker` (both services watch the same branch — once GitHub repo is connected to Railway services; until then deploys are manual via `railway up backend --path-as-root --service <name>`).
-- Push to `dev` → no deploy. Use `dev` for staging-style integration; promote to `main` to ship.
+Both `web` and `worker` are wired to `raphaelfh/prumo` branch `main`,
+root directory `/backend`, builder `DOCKERFILE`, with **Wait for CI**
+enabled (Railway holds the deploy until the GitHub Actions workflow
+on the head commit passes).
+
+- Push to `main` → Railway queues a deploy for both services. If CI
+  passes, deploys promote. If CI fails or is skipped, the Railway
+  deployment is marked `SKIPPED` and stays pending until a newer
+  commit's CI goes green.
+- Push to `dev` → no deploy. Use `dev` for staging-style integration;
+  promote to `main` to ship.
+
+### Current constraint (2026-05-24)
+
+The backend `--cov-fail-under=60` gate in `.github/workflows/ci.yml`
+is failing on `main` (current coverage 58.77%, threshold 60%). Until
+that is resolved — either by adding tests for the excel-export feature
+or by ratcheting the threshold down — every `main` push will SKIP the
+Railway auto-deploy. The fallback is a manual deploy:
+
+```bash
+railway up backend --path-as-root --service web --detach -m "<msg>"
+railway up backend --path-as-root --service worker --detach -m "<msg>"
+```
+
+After the coverage debt is paid down and CI is green, no extra config
+is needed — Railway will resume auto-deploying.
+
+## Rollback fast paths
+
+(See "Rollback" section above for details.)
 
 (This mirrors the previous Render behavior — see the memory entry `reference_railway_deploys_from_main`.)

--- a/railway.toml
+++ b/railway.toml
@@ -1,17 +1,28 @@
 # Railway Infrastructure as Code — prumo backend.
 #
 # Source of truth for build settings. Service-level overrides (worker
-# start command, CORS_ORIGINS, REDIS_URL reference variables) live in
-# the Railway dashboard per service; the table at the bottom of this
-# file documents which keys live where.
+# start command, CORS_ORIGINS, REDIS_URL reference variables, source
+# repo + branch + rootDirectory) live in the Railway dashboard per
+# service; the inventory at the bottom of this file documents which
+# keys live where.
 #
-# To apply this file: install the Railway CLI (`brew install railway`),
-# run `railway login`, then `railway up backend --path-as-root --service <name>`
-# from the repo root for each service.
+# Both services now auto-deploy from `raphaelfh/prumo` branch `main`
+# via the Railway GitHub App. Manual deploys (fallback) use:
+#   railway up backend --path-as-root --service web --detach
+#   railway up backend --path-as-root --service worker --detach
+#
+# NOTE: this file lives at the repo root for documentation. Because
+# both services have `source.rootDirectory = "/backend"`, the effective
+# build context is `backend/`, so `build.dockerfilePath` is set on the
+# services to `Dockerfile` (NOT `backend/Dockerfile`). The values
+# below describe the *logical* topology — the Railway dashboard config
+# is the runtime source of truth (Railway does not read this file as
+# config-as-code by default; per Railway docs, the config file path
+# must be set explicitly with an absolute path if you want it loaded).
 
 [build]
 builder = "DOCKERFILE"
-dockerfilePath = "backend/Dockerfile"
+dockerfilePath = "Dockerfile"   # relative to source.rootDirectory (/backend)
 
 [deploy]
 healthcheckPath = "/health"
@@ -26,8 +37,13 @@ restartPolicyMaxRetries = 3
 # Services (configured in Railway dashboard, documented here):
 #
 #   web   (id: 2faf7ece-db11-4f16-8ec3-e63a839b08a8)
-#     Region:                US East
-#     Builder:               Dockerfile (this file)
+#     Source:                raphaelfh/prumo, branch main, rootDirectory /backend
+#     Builder:               Dockerfile (Dockerfile within rootDirectory)
+#     Wait for CI:           true  (Railway waits for GitHub Actions to pass
+#                            before promoting a build — currently blocks
+#                            auto-deploy because backend test coverage is
+#                            58.77% < 60% threshold in ci.yml; tracked as
+#                            a separate task)
 #     Healthcheck:           /health (from [deploy] above)
 #     Start command:         Dockerfile CMD
 #                            (alembic upgrade head && gunicorn -k UvicornWorker
@@ -37,11 +53,13 @@ restartPolicyMaxRetries = 3
 #                            REDIS_URL=${{Redis.REDIS_URL}}
 #
 #   worker  (id: 7acd0799-9685-4445-971a-707bc1b9c41f)
-#     Region:                US East
-#     Builder:               Dockerfile (this file)
+#     Source:                raphaelfh/prumo, branch main, rootDirectory /backend
+#     Builder:               Dockerfile (Dockerfile within rootDirectory)
+#     Wait for CI:           true  (same as web)
 #     Healthcheck:           none
 #     Start command:         celery -A app.worker.celery_app worker --loglevel=info
 #                            --queues=extractions,imports,exports,celery
+#                            (override on the service — Dockerfile CMD is for web)
 #     Public domain:         no
 #     Variables override:    REDIS_URL=${{Redis.REDIS_URL}}
 #


### PR DESCRIPTION
## Summary
Promotes PR #116 from dev → main: documents that Railway services are now wired to GitHub auto-deploy (web + worker on \`main\`, root \`/backend\`, Wait for CI on), with a callout about the current backend coverage gate blocking auto-deploys until tests are added.

Pure documentation — no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to deployment and Railway topology; no application or infrastructure code paths are modified.
> 
> **Overview**
> **Deployment docs now reflect live Railway wiring:** both `web` and `worker` auto-deploy from `raphaelfh/prumo` on `main` with root directory `/backend`, Dockerfile builder, and **Wait for CI** so Railway only promotes after GitHub Actions passes. Pushes to `dev` still do not deploy.
> 
> **Operational callout added:** while backend coverage stays below the `--cov-fail-under=60` gate in CI (~58.77% today), `main` pushes will mark Railway deployments **SKIPPED**; the doc lists manual `railway up` commands as the fallback until tests or threshold work lands.
> 
> **`railway.toml` is updated in parallel:** `dockerfilePath` is documented as `Dockerfile` relative to `/backend` root, GitHub App auto-deploy and manual fallback commands are spelled out, and the service inventory now includes source repo/branch, Wait for CI, and the coverage blocker. The file is clarified as documentation—the dashboard remains runtime source of truth unless config-as-code is explicitly wired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 991e80ab88564930bc112902ab4b82a28356d2a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->