### PR TITLE
Merge dev → main: F2 (extraction_export_service unit tests 24% → 92%) + railway.toml fix

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -24,10 +24,17 @@
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"   # relative to source.rootDirectory (/backend)
 
-[deploy]
-healthcheckPath = "/health"
-restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 3
+# Deliberately NO global [deploy] section.
+#
+# Railway applies railway.toml's [deploy] to EVERY service that reads
+# this config file. The web service needs healthcheckPath="/health";
+# the worker is a Celery process with no HTTP endpoint and fails the
+# deploy if probed at /health (it can't answer, so Railway marks the
+# deployment FAILED after the probe timeout — observed 2026-05-24).
+#
+# Per-service [deploy] config lives in the Railway dashboard, applied
+# via `railway environment edit --service-config <svc> deploy.<key>`.
+# Effective values per service are documented in the inventory below.
 
 # -------------------------------------------------------------------------
 # Project: prumo  (id: 7d7a5e37-c5eb-48f2-9f06-fc8be79dbd2b)
@@ -44,7 +51,8 @@ restartPolicyMaxRetries = 3
 #                            auto-deploy because backend test coverage is
 #                            58.77% < 60% threshold in ci.yml; tracked as
 #                            a separate task)
-#     Healthcheck:           /health (from [deploy] above)
+#     Healthcheck:           /health (set per-service via Railway dashboard)
+#     Restart policy:        ON_FAILURE, max 3 retries (set per-service)
 #     Start command:         Dockerfile CMD
 #                            (alembic upgrade head && gunicorn -k UvicornWorker
 #                             -w 1 -t 120 -b 0.0.0.0:${PORT:-8000} app.main:app)
@@ -56,7 +64,10 @@ restartPolicyMaxRetries = 3
 #     Source:                raphaelfh/prumo, branch main, rootDirectory /backend
 #     Builder:               Dockerfile (Dockerfile within rootDirectory)
 #     Wait for CI:           true  (same as web)
-#     Healthcheck:           none
+#     Healthcheck:           none (Celery has no HTTP endpoint — deliberately
+#                            no per-service deploy.healthcheckPath; the
+#                            railway.toml above no longer sets a global one,
+#                            so the worker is not probed)
 #     Start command:         celery -A app.worker.celery_app worker --loglevel=info
 #                            --queues=extractions,imports,exports,celery
 #                            (override on the service — Dockerfile CMD is for web)


### PR DESCRIPTION
## Summary
Promotes two PRs from dev → main:

- **#120 (F2):** 110 unit tests for \`ExtractionExportService\` (24% → **92%** coverage on that file). Mocks the repo layer; no DB hit. Includes a regression guard for the ALL_USERS 4-tuple key bug (aa9b288).
- **#121:** removes the global \`[deploy]\` block from \`railway.toml\` that was causing every worker auto-deploy to FAIL (worker is Celery — no /health endpoint to probe). Per-service deploy config now lives in the Railway dashboard / service-level config patches.

After this lands and Railway re-attempts the auto-deploy, both web and worker should promote to SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy semantics; web still needs `/health` configured in the dashboard or its deploy health behavior could regress while the worker fix depends on that per-service setup.
> 
> **Overview**
> **Removes the shared `[deploy]` block** from `railway.toml` (`healthcheckPath=/health`, restart policy) because Railway applies that section to every service that loads the file. The Celery **worker** has no HTTP server, so `/health` probes were timing out and marking worker deploys **FAILED** (noted 2026-05-24).
> 
> Deploy settings for **web** vs **worker** are now documented as **per-service** in the Railway dashboard (`deploy.healthcheckPath` only on web; none on worker). The service inventory comments were updated to match—web keeps `/health` and ON_FAILURE retries via dashboard config; worker explicitly has no healthcheck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ad6622b711ba46e457254b9c40c667d03fb959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->