### PR TITLE
Merge dev → main: F3 ratchet + F4 unit tests (coverage 64.06% → 72.15%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,17 +191,27 @@ jobs:
       - name: Seed default data (PROBAST + QUADAS-2 templates)
         run: uv run python -m app.seed
 
-      # Coverage threshold lowered from 70 to 60 to match current reality
-      # (actual is ~60.07%). The 70 target was aspirational and never
-      # actually achieved. Ratchet upward as coverage grows; do NOT lower
-      # again once raised.
+      # Coverage gate timeline:
+      #   - was 70 (aspirational, never met)
+      #   - lowered to 60 to match the pre-2026-05-24 reality (~60.07%)
+      #   - 2026-05-24: F1 (seeded integration conftest) unblocked 196
+      #     silently-skipped integration tests; F2 covered
+      #     extraction_export_service.py (24% → 92%). Combined floor on
+      #     main: 64.06%.
+      #   - Gate raised to 62 (floor − 2 pt margin). Next ratchet target:
+      #     70% once F4 (repos/services unit tests) lands. After F4,
+      #     adopt `--cov-branch` (branch coverage is stricter; measure
+      #     first before changing the gate again).
+      #
+      # Hard rule: never lower this once raised. If a PR drops coverage,
+      # the PR adds tests, not the gate that gets relaxed.
       - name: Run tests with coverage
         run: |
           uv run pytest tests/ \
             --cov=app \
             --cov-report=xml \
             --cov-report=term-missing \
-            --cov-fail-under=60
+            --cov-fail-under=62
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/backend/tests/unit/test_api_key_service.py
+++ b/backend/tests/unit/test_api_key_service.py
@@ -1,0 +1,630 @@
+"""Unit tests for app.services.api_key_service.
+
+Pure-mock — no database or network hits.
+The Fernet encryption/decryption is exercised via real crypto (settings
+supplies ENCRYPTION_KEY) — only DB and HTTP calls are mocked.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.user_api_key import UserAPIKey
+from app.services.api_key_service import APIKeyService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+USER_UUID = uuid.uuid4()
+KEY_UUID = uuid.uuid4()
+# Real user_id (UUID string) so derive_encryption_key works
+USER_ID_STR = str(USER_UUID)
+
+
+def make_key(
+    *,
+    id: uuid.UUID | None = None,
+    user_id: uuid.UUID | None = None,
+    provider: str = "openai",
+    is_active: bool = True,
+    is_default: bool = False,
+    encrypted_api_key: str | None = None,
+    validation_status: str = "pending",
+) -> MagicMock:
+    key = MagicMock(spec=UserAPIKey)
+    key.id = id or uuid.uuid4()
+    key.user_id = user_id or USER_UUID
+    key.provider = provider
+    key.is_active = is_active
+    key.is_default = is_default
+    key.encrypted_api_key = encrypted_api_key or "enc-placeholder"
+    key.validation_status = validation_status
+    key.key_name = None
+    return key
+
+
+def make_service(
+    user_id: str | uuid.UUID | None = None,
+    repo: MagicMock | None = None,
+) -> APIKeyService:
+    db = AsyncMock()
+    svc = APIKeyService(db=db, user_id=user_id or USER_ID_STR)
+    if repo is not None:
+        svc._repo = repo
+    return svc
+
+
+def make_repo() -> MagicMock:
+    repo = MagicMock()
+    repo.list_by_user = AsyncMock(return_value=[])
+    repo.get_default = AsyncMock(return_value=None)
+    repo.create_key = AsyncMock()
+    repo.set_validation_status = AsyncMock()
+    repo.update_last_used = AsyncMock()
+    repo.get_by_id_and_user = AsyncMock(return_value=None)
+    repo.set_default = AsyncMock(return_value=True)
+    repo.update_key_name = AsyncMock(return_value=True)
+    repo.deactivate = AsyncMock(return_value=True)
+    repo.hard_delete = AsyncMock(return_value=True)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Construction / property guards
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    def test_valid_uuid_string_sets_user_id(self) -> None:
+        svc = make_service()
+        assert svc._user_id == USER_UUID
+
+    def test_uuid_object_sets_user_id(self) -> None:
+        svc = make_service(user_id=USER_UUID)
+        assert svc._user_id == USER_UUID
+
+    def test_invalid_uuid_string_leaves_user_id_none(self) -> None:
+        svc = make_service(user_id="not-a-uuid")
+        assert svc._user_id is None
+
+    def test_user_id_property_raises_for_invalid_string(self) -> None:
+        svc = make_service(user_id="not-a-uuid")
+        with pytest.raises(ValueError):
+            _ = svc.user_id
+
+
+# ---------------------------------------------------------------------------
+# Encryption helpers (_encrypt / _decrypt)
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptDecrypt:
+    def test_round_trip(self) -> None:
+        svc = make_service()
+        plaintext = "sk-test-12345"
+        encrypted = svc._encrypt(plaintext)
+        assert encrypted != plaintext
+        decrypted = svc._decrypt(encrypted)
+        assert decrypted == plaintext
+
+    def test_different_users_produce_different_ciphertext(self) -> None:
+        svc1 = make_service(user_id=str(uuid.uuid4()))
+        svc2 = make_service(user_id=str(uuid.uuid4()))
+        enc1 = svc1._encrypt("key")
+        enc2 = svc2._encrypt("key")
+        assert enc1 != enc2
+
+
+# ---------------------------------------------------------------------------
+# list_keys
+# ---------------------------------------------------------------------------
+
+
+class TestListKeys:
+    @pytest.mark.asyncio
+    async def test_delegates_to_repo(self) -> None:
+        repo = make_repo()
+        keys = [make_key()]
+        repo.list_by_user = AsyncMock(return_value=keys)
+        svc = make_service(repo=repo)
+
+        result = await svc.list_keys()
+
+        repo.list_by_user.assert_awaited_once_with(USER_UUID, active_only=True)
+        assert result == keys
+
+    @pytest.mark.asyncio
+    async def test_active_only_false_passed_through(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        await svc.list_keys(active_only=False)
+
+        repo.list_by_user.assert_awaited_once_with(USER_UUID, active_only=False)
+
+
+# ---------------------------------------------------------------------------
+# save_key
+# ---------------------------------------------------------------------------
+
+
+class TestSaveKey:
+    @pytest.mark.asyncio
+    async def test_raises_for_unsupported_provider(self) -> None:
+        svc = make_service()
+        with pytest.raises(ValueError, match="not supported"):
+            await svc.save_key("unknown_provider", "key-abc")
+
+    @pytest.mark.asyncio
+    async def test_saves_key_without_validation(self) -> None:
+        repo = make_repo()
+        created = make_key(id=KEY_UUID)
+        repo.create_key = AsyncMock(return_value=created)
+        svc = make_service(repo=repo)
+
+        result = await svc.save_key("openai", "sk-abc", validate=False)
+
+        assert result["id"] == str(KEY_UUID)
+        assert result["provider"] == "openai"
+        assert result["validation_status"] == "pending"
+        repo.create_key.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_validation_invalid_does_not_raise(self) -> None:
+        repo = make_repo()
+        created = make_key(id=KEY_UUID)
+        repo.create_key = AsyncMock(return_value=created)
+        svc = make_service(repo=repo)
+
+        validation_result = {"status": "invalid", "message": "Bad key"}
+        with patch.object(svc, "_validate_key", AsyncMock(return_value=validation_result)):
+            result = await svc.save_key("openai", "bad-key", validate=True)
+
+        assert result["validation_status"] == "invalid"
+        repo.set_validation_status.assert_awaited_once_with(created.id, "invalid")
+
+    @pytest.mark.asyncio
+    async def test_valid_key_updates_validation_status(self) -> None:
+        repo = make_repo()
+        created = make_key(id=KEY_UUID)
+        repo.create_key = AsyncMock(return_value=created)
+        svc = make_service(repo=repo)
+
+        with patch.object(
+            svc,
+            "_validate_key",
+            AsyncMock(return_value={"status": "valid", "message": "OK"}),
+        ):
+            result = await svc.save_key("openai", "sk-good", validate=True)
+
+        assert result["validation_status"] == "valid"
+
+    @pytest.mark.asyncio
+    async def test_pending_status_does_not_call_set_validation(self) -> None:
+        repo = make_repo()
+        created = make_key(id=KEY_UUID)
+        repo.create_key = AsyncMock(return_value=created)
+        svc = make_service(repo=repo)
+
+        with patch.object(
+            svc,
+            "_validate_key",
+            AsyncMock(return_value={"status": "pending"}),
+        ):
+            await svc.save_key("openai", "sk-x", validate=True)
+
+        repo.set_validation_status.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# get_key_for_provider
+# ---------------------------------------------------------------------------
+
+
+class TestGetKeyForProvider:
+    @pytest.mark.asyncio
+    async def test_returns_decrypted_user_key(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        plaintext = "sk-test-provider-key"
+        encrypted = svc._encrypt(plaintext)
+        key = make_key(encrypted_api_key=encrypted)
+        repo.get_default = AsyncMock(return_value=key)
+
+        result = await svc.get_key_for_provider("openai")
+
+        assert result == plaintext
+        repo.update_last_used.assert_awaited_once_with(key.id)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_global_key(self) -> None:
+        repo = make_repo()
+        repo.get_default = AsyncMock(return_value=None)
+        svc = make_service(repo=repo)
+
+        with patch.object(svc, "_get_global_key", return_value="global-key"):
+            result = await svc.get_key_for_provider("openai")
+
+        assert result == "global-key"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_fallback(self) -> None:
+        repo = make_repo()
+        repo.get_default = AsyncMock(return_value=None)
+        svc = make_service(repo=repo)
+
+        with patch.object(svc, "_get_global_key", return_value=None):
+            result = await svc.get_key_for_provider("anthropic", use_fallback=False)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_user_id_goes_straight_to_fallback(self) -> None:
+        svc = APIKeyService(db=AsyncMock(), user_id="not-uuid")
+
+        with patch.object(svc, "_get_global_key", return_value="fallback-key"):
+            result = await svc.get_key_for_provider("openai")
+
+        assert result == "fallback-key"
+
+
+# ---------------------------------------------------------------------------
+# get_decrypted_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetDecryptedKey:
+    @pytest.mark.asyncio
+    async def test_returns_decrypted_key_when_found(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        plaintext = "sk-decrypted-value"
+        encrypted = svc._encrypt(plaintext)
+        key = make_key(encrypted_api_key=encrypted)
+        repo.get_by_id_and_user = AsyncMock(return_value=key)
+
+        result = await svc.get_decrypted_key(KEY_UUID)
+
+        assert result == plaintext
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+        repo.get_by_id_and_user = AsyncMock(return_value=None)
+
+        result = await svc.get_decrypted_key(KEY_UUID)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _get_global_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetGlobalKey:
+    def test_openai_returns_settings_key(self) -> None:
+        svc = make_service()
+        # settings.OPENAI_API_KEY is "x" in test env
+        result = svc._get_global_key("openai")
+        # Acceptable: either "x" or None (depending on env), but no exception
+        assert result is not None or result is None
+
+    def test_unknown_provider_returns_none(self) -> None:
+        svc = make_service()
+        result = svc._get_global_key("unknown_provider")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# set_default
+# ---------------------------------------------------------------------------
+
+
+class TestSetDefault:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_successful(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        result = await svc.set_default(KEY_UUID)
+
+        assert result is True
+        repo.set_default.assert_awaited_once_with(KEY_UUID, USER_UUID)
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_repo_returns_false(self) -> None:
+        repo = make_repo()
+        repo.set_default = AsyncMock(return_value=False)
+        svc = make_service(repo=repo)
+
+        result = await svc.set_default(KEY_UUID)
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# update_key_name
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateKeyName:
+    @pytest.mark.asyncio
+    async def test_returns_true_on_success(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        result = await svc.update_key_name(KEY_UUID, "New Name")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_found(self) -> None:
+        repo = make_repo()
+        repo.update_key_name = AsyncMock(return_value=False)
+        svc = make_service(repo=repo)
+
+        result = await svc.update_key_name(KEY_UUID, "Name")
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# deactivate_key
+# ---------------------------------------------------------------------------
+
+
+class TestDeactivateKey:
+    @pytest.mark.asyncio
+    async def test_deactivates_successfully(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        result = await svc.deactivate_key(KEY_UUID)
+
+        assert result is True
+        repo.deactivate.assert_awaited_once_with(KEY_UUID, USER_UUID)
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_not_found(self) -> None:
+        repo = make_repo()
+        repo.deactivate = AsyncMock(return_value=False)
+        svc = make_service(repo=repo)
+
+        result = await svc.deactivate_key(KEY_UUID)
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# delete_key
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteKey:
+    @pytest.mark.asyncio
+    async def test_deletes_successfully(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        result = await svc.delete_key(KEY_UUID)
+
+        assert result is True
+        repo.hard_delete.assert_awaited_once_with(KEY_UUID, USER_UUID)
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_found(self) -> None:
+        repo = make_repo()
+        repo.hard_delete = AsyncMock(return_value=False)
+        svc = make_service(repo=repo)
+
+        result = await svc.delete_key(KEY_UUID)
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# revalidate_key
+# ---------------------------------------------------------------------------
+
+
+class TestRevalidateKey:
+    @pytest.mark.asyncio
+    async def test_raises_when_key_not_found(self) -> None:
+        repo = make_repo()
+        repo.get_by_id_and_user = AsyncMock(return_value=None)
+        svc = make_service(repo=repo)
+
+        with pytest.raises(ValueError, match="not found"):
+            await svc.revalidate_key(KEY_UUID)
+
+    @pytest.mark.asyncio
+    async def test_returns_validation_result(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        plaintext = "sk-real-key"
+        key = make_key(encrypted_api_key=svc._encrypt(plaintext), provider="openai")
+        repo.get_by_id_and_user = AsyncMock(return_value=key)
+        repo.set_validation_status = AsyncMock()
+
+        validation = {"status": "valid", "message": "OK"}
+        with patch.object(svc, "_validate_key", AsyncMock(return_value=validation)):
+            result = await svc.revalidate_key(KEY_UUID)
+
+        assert result["status"] == "valid"
+        repo.set_validation_status.assert_awaited_once_with(KEY_UUID, "valid")
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_key_id(self) -> None:
+        repo = make_repo()
+        svc = make_service(repo=repo)
+
+        key = make_key(encrypted_api_key=svc._encrypt("sk-x"), provider="openai")
+        repo.get_by_id_and_user = AsyncMock(return_value=key)
+
+        with patch.object(svc, "_validate_key", AsyncMock(return_value={"status": "valid"})):
+            result = await svc.revalidate_key(str(KEY_UUID))
+
+        assert result["status"] == "valid"
+
+
+# ---------------------------------------------------------------------------
+# _validate_key (dispatch + exception handling)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKey:
+    @pytest.mark.asyncio
+    async def test_unknown_provider_returns_pending(self) -> None:
+        svc = make_service()
+        result = await svc._validate_key("unknown", "some-key")
+        assert result["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_pending(self) -> None:
+        svc = make_service()
+        with patch.object(svc, "_validate_openai", AsyncMock(side_effect=RuntimeError("timeout"))):
+            result = await svc._validate_key("openai", "key")
+        assert result["status"] == "pending"
+        assert "Validation error" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Provider validators (httpx mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOpenai:
+    @pytest.mark.asyncio
+    async def test_200_returns_valid(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_openai("sk-good")
+        assert result["status"] == "valid"
+
+    @pytest.mark.asyncio
+    async def test_401_returns_invalid(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_openai("sk-bad")
+        assert result["status"] == "invalid"
+
+    @pytest.mark.asyncio
+    async def test_429_returns_valid_rate_limited(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_openai("sk-rate-limited")
+        assert result["status"] == "valid"
+
+
+class TestValidateAnthropic:
+    @pytest.mark.asyncio
+    async def test_200_returns_valid(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_anthropic("claude-key")
+        assert result["status"] == "valid"
+
+    @pytest.mark.asyncio
+    async def test_401_returns_invalid(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_anthropic("bad-key")
+        assert result["status"] == "invalid"
+
+    @pytest.mark.asyncio
+    async def test_500_returns_valid_when_no_auth_in_body(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = '{"error": "server_error"}'
+        mock_response.json.return_value = {"error": "server_error"}
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_anthropic("key")
+        assert result["status"] == "valid"
+
+
+class TestValidateGemini:
+    @pytest.mark.asyncio
+    async def test_200_returns_valid(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_gemini("gemini-key")
+        assert result["status"] == "valid"
+
+    @pytest.mark.asyncio
+    async def test_400_returns_invalid(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_gemini("bad-key")
+        assert result["status"] == "invalid"
+
+
+class TestValidateGrok:
+    @pytest.mark.asyncio
+    async def test_200_returns_valid(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_grok("grok-key")
+        assert result["status"] == "valid"
+
+    @pytest.mark.asyncio
+    async def test_401_returns_invalid(self) -> None:
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            result = await svc._validate_grok("bad-key")
+        assert result["status"] == "invalid"

--- a/backend/tests/unit/test_article_repository.py
+++ b/backend/tests/unit/test_article_repository.py
@@ -1,0 +1,584 @@
+"""Unit tests for app.repositories.article_repository.
+
+Pure-mock — no database hit. Tests all repository classes in the module:
+ArticleRepository, ArticleSyncRunRepository, ArticleSyncEventRepository,
+ArticleFileRepository.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.article import Article, ArticleFile
+from app.models.article_author import ArticleSyncEvent, ArticleSyncRun
+from app.repositories.article_repository import (
+    ArticleFileRepository,
+    ArticleRepository,
+    ArticleSyncEventRepository,
+    ArticleSyncRunRepository,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PROJECT_ID = uuid.uuid4()
+ARTICLE_ID = uuid.uuid4()
+RUN_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+def make_article(
+    *,
+    id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    title: str = "Test Article",
+) -> MagicMock:
+    art = MagicMock(spec=Article)
+    art.id = id or uuid.uuid4()
+    art.project_id = project_id or PROJECT_ID
+    art.title = title
+    art.doi = "10.1234/test"
+    art.url_landing = None
+    art.zotero_item_key = None
+    art.ingestion_source = "manual"
+    art.sync_state = "active"
+    art.removed_at_source_at = None
+    art.updated_at = datetime.now(UTC)
+    art.files = []
+    return art
+
+
+def make_scalars_result(items: list) -> MagicMock:
+    scalars = MagicMock()
+    scalars.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    return result
+
+
+def make_scalar_one_or_none(item) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = item
+    return result
+
+
+def make_scalar_one(val) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one.return_value = val
+    return result
+
+
+def make_db() -> AsyncMock:
+    db = AsyncMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# ArticleRepository.get_by_project
+# ---------------------------------------------------------------------------
+
+
+class TestGetByProject:
+    @pytest.mark.asyncio
+    async def test_returns_articles(self) -> None:
+        db = make_db()
+        arts = [make_article(), make_article()]
+        db.execute = AsyncMock(return_value=make_scalars_result(arts))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_project(PROJECT_ID)
+
+        assert result == arts
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_project_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_project(str(PROJECT_ID))
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_passes_pagination_params(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ArticleRepository(db)
+
+        await repo.get_by_project(PROJECT_ID, skip=10, limit=5)
+
+        db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# ArticleRepository.get_with_files
+# ---------------------------------------------------------------------------
+
+
+class TestGetWithFiles:
+    @pytest.mark.asyncio
+    async def test_returns_article_when_found(self) -> None:
+        db = make_db()
+        art = make_article()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(art))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_with_files(ARTICLE_ID)
+
+        assert result is art
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_with_files(ARTICLE_ID)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_with_files(str(ARTICLE_ID))
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ArticleRepository.get_by_ids
+# ---------------------------------------------------------------------------
+
+
+class TestGetByIds:
+    @pytest.mark.asyncio
+    async def test_empty_ids_returns_empty(self) -> None:
+        db = make_db()
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_ids([], PROJECT_ID)
+
+        assert result == []
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_articles_in_requested_order(self) -> None:
+        db = make_db()
+        id1 = uuid.uuid4()
+        id2 = uuid.uuid4()
+        art1 = make_article(id=id1)
+        art2 = make_article(id=id2)
+        # DB returns them in reversed order
+        db.execute = AsyncMock(return_value=make_scalars_result([art2, art1]))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_ids([id1, id2], PROJECT_ID)
+
+        assert result[0].id == id1
+        assert result[1].id == id2
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_ids(self) -> None:
+        db = make_db()
+        id1 = uuid.uuid4()
+        art = make_article(id=id1)
+        db.execute = AsyncMock(return_value=make_scalars_result([art]))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_ids([str(id1)], str(PROJECT_ID))
+
+        assert result[0].id == id1
+
+    @pytest.mark.asyncio
+    async def test_skips_ids_not_in_db_result(self) -> None:
+        db = make_db()
+        id1 = uuid.uuid4()
+        id2 = uuid.uuid4()
+        art1 = make_article(id=id1)
+        db.execute = AsyncMock(return_value=make_scalars_result([art1]))
+        repo = ArticleRepository(db)
+
+        # id2 not returned by DB
+        result = await repo.get_by_ids([id1, id2], PROJECT_ID)
+
+        assert len(result) == 1
+        assert result[0].id == id1
+
+
+# ---------------------------------------------------------------------------
+# ArticleRepository.get_by_zotero_item_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetByZoteroItemKey:
+    @pytest.mark.asyncio
+    async def test_returns_article(self) -> None:
+        db = make_db()
+        art = make_article()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(art))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_zotero_item_key(PROJECT_ID, "ABCDE123")
+
+        assert result is art
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_missing_key(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_zotero_item_key(PROJECT_ID, "NOPE")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ArticleRepository.count_by_project
+# ---------------------------------------------------------------------------
+
+
+class TestCountByProject:
+    @pytest.mark.asyncio
+    async def test_returns_count(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one(7))
+        repo = ArticleRepository(db)
+
+        result = await repo.count_by_project(PROJECT_ID)
+
+        assert result == 7
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_project_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one(0))
+        repo = ArticleRepository(db)
+
+        result = await repo.count_by_project(str(PROJECT_ID))
+
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# ArticleRepository.get_by_canonical_identity
+# ---------------------------------------------------------------------------
+
+
+class TestGetByCanonicalIdentity:
+    @pytest.mark.asyncio
+    async def test_uses_zotero_key_when_provided(self) -> None:
+        db = make_db()
+        art = make_article()
+        repo = ArticleRepository(db)
+
+        with patch.object(
+            repo, "get_by_zotero_item_key", AsyncMock(return_value=art)
+        ) as mock_zotero:
+            result = await repo.get_by_canonical_identity(PROJECT_ID, zotero_item_key="KEY123")
+
+        assert result is art
+        mock_zotero.assert_awaited_once_with(PROJECT_ID, "KEY123")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_clauses(self) -> None:
+        db = make_db()
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_canonical_identity(PROJECT_ID)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_queries_by_doi(self) -> None:
+        db = make_db()
+        art = make_article()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(art))
+        repo = ArticleRepository(db)
+
+        result = await repo.get_by_canonical_identity(PROJECT_ID, doi="10.1234/x")
+
+        assert result is art
+
+
+# ---------------------------------------------------------------------------
+# ArticleRepository.upsert_by_canonical_identity
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertByCanonicalIdentity:
+    @pytest.mark.asyncio
+    async def test_updates_existing_article(self) -> None:
+        db = make_db()
+        existing = make_article()
+        repo = ArticleRepository(db)
+
+        with patch.object(repo, "get_by_canonical_identity", AsyncMock(return_value=existing)):
+            art, created = await repo.upsert_by_canonical_identity(
+                project_id=PROJECT_ID,
+                payload={"title": "New Title"},
+                canonical_identity={"zotero_item_key": "K"},
+            )
+
+        assert created is False
+        assert art is existing
+
+    @pytest.mark.asyncio
+    async def test_creates_new_article(self) -> None:
+        db = make_db()
+        new_art = make_article()
+        repo = ArticleRepository(db)
+
+        with (
+            patch.object(repo, "get_by_canonical_identity", AsyncMock(return_value=None)),
+            patch.object(repo, "create", AsyncMock(return_value=new_art)),
+        ):
+            art, created = await repo.upsert_by_canonical_identity(
+                project_id=PROJECT_ID,
+                payload={"title": "Brand New"},
+                canonical_identity={"doi": "10.1/new"},
+            )
+
+        assert created is True
+        assert art is new_art
+
+
+# ---------------------------------------------------------------------------
+# ArticleRepository.mark_removed_at_source / mark_reactivated
+# ---------------------------------------------------------------------------
+
+
+class TestMarkArticleState:
+    @pytest.mark.asyncio
+    async def test_mark_removed_sets_state(self) -> None:
+        db = make_db()
+        art = make_article()
+        repo = ArticleRepository(db)
+
+        result = await repo.mark_removed_at_source(art)
+
+        assert art.sync_state == "removed_at_source"
+        assert result is art
+
+    @pytest.mark.asyncio
+    async def test_mark_reactivated_clears_removed_at(self) -> None:
+        db = make_db()
+        art = make_article()
+        art.removed_at_source_at = datetime.now(UTC)
+        repo = ArticleRepository(db)
+
+        result = await repo.mark_reactivated(art)
+
+        assert art.sync_state == "reactivated"
+        assert art.removed_at_source_at is None
+        assert result is art
+
+
+# ---------------------------------------------------------------------------
+# ArticleSyncRunRepository
+# ---------------------------------------------------------------------------
+
+
+class TestArticleSyncRunRepository:
+    @pytest.mark.asyncio
+    async def test_create_run_sets_status_pending(self) -> None:
+        db = make_db()
+        repo = ArticleSyncRunRepository(db)
+        created_run = MagicMock(spec=ArticleSyncRun)
+
+        with patch.object(repo, "create", AsyncMock(return_value=created_run)):
+            result = await repo.create_run(
+                project_id=PROJECT_ID,
+                requested_by_user_id=USER_ID,
+                source="zotero",
+                source_collection_key=None,
+            )
+
+        assert result is created_run
+
+    @pytest.mark.asyncio
+    async def test_get_owned_run_returns_run(self) -> None:
+        db = make_db()
+        sync_run = MagicMock(spec=ArticleSyncRun)
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(sync_run))
+        repo = ArticleSyncRunRepository(db)
+
+        result = await repo.get_owned_run(RUN_ID, USER_ID)
+
+        assert result is sync_run
+
+    @pytest.mark.asyncio
+    async def test_update_counts_sets_completed_at_for_terminal_status(self) -> None:
+        db = make_db()
+        run = MagicMock(spec=ArticleSyncRun)
+        run.total_received = 0
+        run.persisted = 0
+        run.updated = 0
+        run.skipped = 0
+        run.failed = 0
+        run.removed_at_source = 0
+        run.reactivated = 0
+        repo = ArticleSyncRunRepository(db)
+
+        await repo.update_counts(run, {"persisted": 5, "total_received": 5}, "completed")
+
+        assert run.status == "completed"
+        assert run.completed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_update_counts_no_completed_at_for_running(self) -> None:
+        db = make_db()
+        run = MagicMock(spec=ArticleSyncRun)
+        run.total_received = 0
+        run.persisted = 0
+        run.updated = 0
+        run.skipped = 0
+        run.failed = 0
+        run.removed_at_source = 0
+        run.reactivated = 0
+        run.completed_at = None
+        repo = ArticleSyncRunRepository(db)
+
+        await repo.update_counts(run, {}, "running")
+
+        assert run.completed_at is None
+
+
+# ---------------------------------------------------------------------------
+# ArticleSyncEventRepository
+# ---------------------------------------------------------------------------
+
+
+class TestArticleSyncEventRepository:
+    @pytest.mark.asyncio
+    async def test_create_event_sets_processed_at(self) -> None:
+        db = make_db()
+        repo = ArticleSyncEventRepository(db)
+        created = MagicMock(spec=ArticleSyncEvent)
+
+        with patch.object(repo, "create", AsyncMock(return_value=created)):
+            result = await repo.create_event(
+                project_id=PROJECT_ID,
+                sync_run_id=RUN_ID,
+                status="success",
+                zotero_item_key="K1",
+                article_id=ARTICLE_ID,
+            )
+
+        assert result is created
+
+    @pytest.mark.asyncio
+    async def test_list_run_events_returns_events_and_count(self) -> None:
+        db = make_db()
+        events = [MagicMock(spec=ArticleSyncEvent)]
+        scalars_result = make_scalars_result(events)
+        count_result = make_scalar_one(1)
+        db.execute = AsyncMock(side_effect=[scalars_result, count_result])
+        repo = ArticleSyncEventRepository(db)
+
+        result_events, total = await repo.list_run_events(sync_run_id=RUN_ID)
+
+        assert result_events == events
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_list_run_events_with_status_filter(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(side_effect=[make_scalars_result([]), make_scalar_one(0)])
+        repo = ArticleSyncEventRepository(db)
+
+        events, total = await repo.list_run_events(sync_run_id=RUN_ID, status_filter="failed")
+
+        assert events == []
+        assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_list_failed_by_run_returns_only_failed(self) -> None:
+        db = make_db()
+        failed_event = MagicMock(spec=ArticleSyncEvent)
+        failed_event.status = "failed"
+        db.execute = AsyncMock(return_value=make_scalars_result([failed_event]))
+        repo = ArticleSyncEventRepository(db)
+
+        result = await repo.list_failed_by_run(RUN_ID)
+
+        assert result == [failed_event]
+
+
+# ---------------------------------------------------------------------------
+# ArticleFileRepository
+# ---------------------------------------------------------------------------
+
+
+class TestArticleFileRepository:
+    @pytest.mark.asyncio
+    async def test_get_by_article_returns_files(self) -> None:
+        db = make_db()
+        files = [MagicMock(spec=ArticleFile)]
+        db.execute = AsyncMock(return_value=make_scalars_result(files))
+        repo = ArticleFileRepository(db)
+
+        result = await repo.get_by_article(ARTICLE_ID)
+
+        assert result == files
+
+    @pytest.mark.asyncio
+    async def test_get_by_article_with_type_filter(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ArticleFileRepository(db)
+
+        result = await repo.get_by_article(ARTICLE_ID, file_type="pdf")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_latest_pdf_returns_file(self) -> None:
+        db = make_db()
+        pdf = MagicMock(spec=ArticleFile)
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(pdf))
+        repo = ArticleFileRepository(db)
+
+        result = await repo.get_latest_pdf(ARTICLE_ID)
+
+        assert result is pdf
+
+    @pytest.mark.asyncio
+    async def test_get_latest_pdf_returns_none_when_absent(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ArticleFileRepository(db)
+
+        result = await repo.get_latest_pdf(ARTICLE_ID)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_by_storage_key_returns_file(self) -> None:
+        db = make_db()
+        f = MagicMock(spec=ArticleFile)
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(f))
+        repo = ArticleFileRepository(db)
+
+        result = await repo.get_by_storage_key("articles/file.pdf")
+
+        assert result is f
+
+    @pytest.mark.asyncio
+    async def test_get_by_article_accepts_string_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ArticleFileRepository(db)
+
+        result = await repo.get_by_article(str(ARTICLE_ID))
+
+        assert result == []

--- a/backend/tests/unit/test_articles_export_service.py
+++ b/backend/tests/unit/test_articles_export_service.py
@@ -1,0 +1,490 @@
+"""Unit tests for app.services.articles_export_service.
+
+Pure-mock — no database or network calls. Covers the public API of
+ArticlesExportService plus the module-level pure helpers.
+"""
+
+import io
+import uuid
+import zipfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.articles_export_service import (
+    ArticlesExportService,
+    _authors_ris,
+    _build_csv,
+    _build_rdf,
+    _build_ris,
+    _sanitize_folder_name,
+    _xml_esc,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_article(
+    *,
+    title: str = "Test Article",
+    authors: list[str] | None = None,
+    publication_year: int | None = 2024,
+    journal_title: str | None = "Nature",
+    doi: str | None = "10.1234/test",
+    pmid: str | None = "12345678",
+    keywords: list[str] | None = None,
+    abstract: str | None = "Test abstract",
+    files: list | None = None,
+) -> MagicMock:
+    art = MagicMock()
+    art.id = uuid.uuid4()
+    art.title = title
+    art.authors = authors or ["Smith, J", "Doe, A"]
+    art.publication_year = publication_year
+    art.journal_title = journal_title
+    art.doi = doi
+    art.pmid = pmid
+    art.keywords = keywords or ["ml", "nlp"]
+    art.abstract = abstract
+    art.files = files or []
+    return art
+
+
+def make_service(
+    storage: MagicMock | None = None,
+) -> ArticlesExportService:
+    db = AsyncMock()
+    if storage is None:
+        storage = AsyncMock()
+    return ArticlesExportService(db=db, user_id="user-abc", storage=storage, trace_id="t-1")
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_folder_name
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeFolderName:
+    def test_returns_id_prefix_and_sanitized_title(self) -> None:
+        aid = uuid.UUID("12345678-0000-0000-0000-000000000000")
+        result = _sanitize_folder_name("Hello World", aid)
+        assert result == f"{aid}_Hello_World"
+
+    def test_strips_invalid_chars(self) -> None:
+        aid = uuid.UUID("12345678-0000-0000-0000-000000000000")
+        result = _sanitize_folder_name('My<>:"/\\|?*Title', aid)
+        assert "<" not in result and ">" not in result and ":" not in result
+
+    def test_empty_title_falls_back_to_article(self) -> None:
+        aid = uuid.UUID("12345678-0000-0000-0000-000000000000")
+        result = _sanitize_folder_name("", aid)
+        assert result == f"{aid}_article"
+
+    def test_none_title_falls_back_to_article(self) -> None:
+        aid = uuid.UUID("12345678-0000-0000-0000-000000000000")
+        result = _sanitize_folder_name(None, aid)  # type: ignore[arg-type]
+        assert result == f"{aid}_article"
+
+    def test_collapses_whitespace_to_underscore(self) -> None:
+        aid = uuid.UUID("12345678-0000-0000-0000-000000000000")
+        result = _sanitize_folder_name("A  B   C", aid)
+        assert "A_B_C" in result
+
+
+# ---------------------------------------------------------------------------
+# _authors_ris
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "authors, expected",
+    [
+        (None, []),
+        ([], []),
+        (["Smith, J", "  ", "Doe, A"], ["Smith, J", "Doe, A"]),
+        ([""], []),
+    ],
+)
+def test_authors_ris(authors, expected) -> None:
+    assert _authors_ris(authors) == expected
+
+
+# ---------------------------------------------------------------------------
+# _xml_esc
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "s, expected_sub",
+    [
+        ("a & b", "a &amp; b"),
+        ("<tag>", "&lt;tag&gt;"),
+        ('"quoted"', "&quot;quoted&quot;"),
+    ],
+)
+def test_xml_esc(s, expected_sub) -> None:
+    assert _xml_esc(s) == expected_sub
+
+
+# ---------------------------------------------------------------------------
+# _build_csv
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCsv:
+    def test_header_row_present(self) -> None:
+        content = _build_csv([])
+        assert b"title" in content and b"authors" in content
+
+    def test_article_row_included(self) -> None:
+        art = make_article(title="My Title", authors=["Alice", "Bob"])
+        content = _build_csv([art])
+        assert b"My Title" in content
+        assert b"Alice; Bob" in content
+
+    def test_missing_optional_fields_are_empty(self) -> None:
+        art = make_article(
+            doi=None,
+            pmid=None,
+            journal_title=None,
+            keywords=None,
+            abstract=None,
+        )
+        content = _build_csv([art])
+        # Should not raise and header still present
+        assert b"title" in content
+
+    def test_newlines_in_abstract_replaced(self) -> None:
+        art = make_article(abstract="line1\nline2")
+        content = _build_csv([art])
+        assert b"line1 line2" in content
+
+    def test_multiple_articles(self) -> None:
+        arts = [make_article(title=f"Article {i}") for i in range(5)]
+        content = _build_csv(arts)
+        assert content.count(b"Article") == 5
+
+
+# ---------------------------------------------------------------------------
+# _build_ris
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRis:
+    def test_ty_and_er_markers(self) -> None:
+        art = make_article()
+        content = _build_ris([art])
+        assert b"TY  - JOUR" in content
+        assert b"ER  - " in content
+
+    def test_title_and_doi(self) -> None:
+        art = make_article(title="Foo", doi="10.999/foo")
+        content = _build_ris([art])
+        assert b"TI  - Foo" in content
+        assert b"DO  - 10.999/foo" in content
+
+    def test_missing_year_not_included(self) -> None:
+        art = make_article(publication_year=None)
+        content = _build_ris([art])
+        assert b"PY  -" not in content
+
+    def test_missing_doi_not_included(self) -> None:
+        art = make_article(doi=None)
+        content = _build_ris([art])
+        assert b"DO  -" not in content
+
+    def test_abstract_truncated_to_255(self) -> None:
+        art = make_article(abstract="X" * 300)
+        content = _build_ris([art])
+        lines = content.decode().split("\r\n")
+        ab_line = next((line for line in lines if line.startswith("AB")), None)
+        assert ab_line is not None
+        assert len(ab_line) <= 262  # "AB  - " (6 chars) prefix + 255 chars + \r separator
+
+    def test_multiple_authors(self) -> None:
+        art = make_article(authors=["Alpha, A", "Beta, B"])
+        content = _build_ris([art])
+        assert b"AU  - Alpha, A" in content
+        assert b"AU  - Beta, B" in content
+
+
+# ---------------------------------------------------------------------------
+# _build_rdf
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRdf:
+    def test_valid_xml_structure(self) -> None:
+        art = make_article()
+        content = _build_rdf([art])
+        assert b"<?xml version" in content
+        assert b"rdf:RDF" in content
+        assert b"</rdf:RDF>" in content
+
+    def test_article_id_in_rdf(self) -> None:
+        art = make_article()
+        content = _build_rdf([art])
+        assert art.id.hex.encode() in content
+
+    def test_escapes_special_chars_in_title(self) -> None:
+        art = make_article(title="A & B < C")
+        content = _build_rdf([art])
+        assert b"&amp;" in content
+        assert b"&lt;" in content
+
+    def test_no_creator_for_empty_author(self) -> None:
+        art = make_article(authors=["  "])
+        content = _build_rdf([art])
+        assert b"dc:creator" not in content
+
+
+# ---------------------------------------------------------------------------
+# ArticlesExportService.get_articles_for_export
+# ---------------------------------------------------------------------------
+
+
+class TestGetArticlesForExport:
+    @pytest.mark.asyncio
+    async def test_delegates_to_article_repo(self) -> None:
+        svc = make_service()
+        project_id = uuid.uuid4()
+        article_ids = [uuid.uuid4()]
+        expected = [make_article()]
+
+        with patch("app.services.articles_export_service.ArticleRepository") as MockRepo:
+            MockRepo.return_value.get_by_ids = AsyncMock(return_value=expected)
+            result = await svc.get_articles_for_export(project_id, article_ids, include_files=False)
+
+        assert result == expected
+        MockRepo.return_value.get_by_ids.assert_awaited_once_with(
+            article_ids, project_id, include_files=False
+        )
+
+
+# ---------------------------------------------------------------------------
+# ArticlesExportService.run_export — file_scope="none"
+# ---------------------------------------------------------------------------
+
+
+class TestRunExportFileScope:
+    @pytest.mark.asyncio
+    async def test_empty_articles_returns_empty_bytes(self) -> None:
+        svc = make_service()
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=[])):
+            content, ct, fname, skipped = await svc.run_export(uuid.uuid4(), [], ["csv"], "none")
+        assert content == b""
+        assert ct == "application/octet-stream"
+
+    @pytest.mark.asyncio
+    async def test_single_csv_format_returns_csv(self) -> None:
+        svc = make_service()
+        arts = [make_article(title="T1")]
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=arts)):
+            content, ct, fname, skipped = await svc.run_export(
+                uuid.uuid4(), [arts[0].id], ["csv"], "none"
+            )
+        assert ct == "text/csv"
+        assert fname == "articles_export.csv"
+        assert b"T1" in content
+
+    @pytest.mark.asyncio
+    async def test_single_ris_format_returns_ris(self) -> None:
+        svc = make_service()
+        arts = [make_article()]
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=arts)):
+            content, ct, fname, _ = await svc.run_export(
+                uuid.uuid4(), [arts[0].id], ["ris"], "none"
+            )
+        assert ct == "application/x-research-info-systems"
+        assert fname == "articles_export.ris"
+        assert b"TY  - JOUR" in content
+
+    @pytest.mark.asyncio
+    async def test_single_rdf_format_returns_rdf(self) -> None:
+        svc = make_service()
+        arts = [make_article()]
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=arts)):
+            content, ct, fname, _ = await svc.run_export(
+                uuid.uuid4(), [arts[0].id], ["rdf"], "none"
+            )
+        assert ct == "application/rdf+xml"
+        assert fname == "articles_export.rdf"
+
+    @pytest.mark.asyncio
+    async def test_multiple_formats_returns_zip(self) -> None:
+        svc = make_service()
+        arts = [make_article()]
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=arts)):
+            content, ct, fname, _ = await svc.run_export(
+                uuid.uuid4(), [arts[0].id], ["csv", "ris"], "none"
+            )
+        assert ct == "application/zip"
+        zf = zipfile.ZipFile(io.BytesIO(content))
+        names = zf.namelist()
+        assert "articles_export.csv" in names
+        assert "articles_export.ris" in names
+
+
+# ---------------------------------------------------------------------------
+# ArticlesExportService.run_export — file_scope="main_only"
+# ---------------------------------------------------------------------------
+
+
+class TestRunExportMainOnly:
+    @pytest.mark.asyncio
+    async def test_zip_contains_metadata_and_main_pdf(self) -> None:
+        storage = AsyncMock()
+        storage.download = AsyncMock(return_value=b"%PDF-fake")
+        svc = make_service(storage)
+
+        main_file = MagicMock()
+        main_file.file_role = "MAIN"
+        main_file.storage_key = "files/main.pdf"
+        main_file.original_filename = "paper.pdf"
+
+        arts = [make_article(files=[main_file])]
+
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=arts)):
+            content, ct, fname, skipped = await svc.run_export(
+                uuid.uuid4(), [arts[0].id], ["csv"], "main_only"
+            )
+
+        assert ct == "application/zip"
+        zf = zipfile.ZipFile(io.BytesIO(content))
+        names = zf.namelist()
+        assert "articles_export.csv" in names
+        assert "paper.pdf" in names
+        assert skipped == []
+
+    @pytest.mark.asyncio
+    async def test_storage_failure_adds_to_skipped_and_readme(self) -> None:
+        storage = AsyncMock()
+        storage.download = AsyncMock(side_effect=RuntimeError("storage unavailable"))
+        svc = make_service(storage)
+
+        main_file = MagicMock()
+        main_file.file_role = "MAIN"
+        main_file.storage_key = "files/main.pdf"
+        main_file.original_filename = "bad.pdf"
+
+        art = make_article(files=[main_file])
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=[art])):
+            content, ct, fname, skipped = await svc.run_export(
+                uuid.uuid4(), [art.id], ["csv"], "main_only"
+            )
+
+        assert len(skipped) == 1
+        assert skipped[0]["storage_key"] == "files/main.pdf"
+        zf = zipfile.ZipFile(io.BytesIO(content))
+        assert "README_export.txt" in zf.namelist()
+
+    @pytest.mark.asyncio
+    async def test_article_without_main_file_skipped_silently(self) -> None:
+        storage = AsyncMock()
+        svc = make_service(storage)
+        # file_role != MAIN
+        supp = MagicMock()
+        supp.file_role = "SUPPLEMENT"
+        art = make_article(files=[supp])
+
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=[art])):
+            _, _, _, skipped = await svc.run_export(uuid.uuid4(), [art.id], ["csv"], "main_only")
+        assert skipped == []
+
+
+# ---------------------------------------------------------------------------
+# ArticlesExportService.run_export — file_scope="all"
+# ---------------------------------------------------------------------------
+
+
+class TestRunExportAll:
+    @pytest.mark.asyncio
+    async def test_each_article_gets_own_folder(self) -> None:
+        storage = AsyncMock()
+        storage.download = AsyncMock(return_value=b"%PDF")
+        svc = make_service(storage)
+
+        f = MagicMock()
+        f.storage_key = "files/doc.pdf"
+        f.original_filename = "doc.pdf"
+
+        art = make_article(title="Art One", files=[f])
+
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=[art])):
+            content, ct, _, skipped = await svc.run_export(uuid.uuid4(), [art.id], ["csv"], "all")
+
+        zf = zipfile.ZipFile(io.BytesIO(content))
+        names = zf.namelist()
+        # Should have folder/article.csv and folder/doc.pdf
+        assert any("article.csv" in n for n in names)
+        assert any("doc.pdf" in n for n in names)
+        assert skipped == []
+
+    @pytest.mark.asyncio
+    async def test_storage_failure_in_all_scope_adds_skipped(self) -> None:
+        storage = AsyncMock()
+        storage.download = AsyncMock(side_effect=OSError("fail"))
+        svc = make_service(storage)
+
+        f = MagicMock()
+        f.storage_key = "files/bad.pdf"
+        f.original_filename = "bad.pdf"
+
+        art = make_article(files=[f])
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=[art])):
+            content, _, _, skipped = await svc.run_export(uuid.uuid4(), [art.id], ["csv"], "all")
+
+        assert len(skipped) == 1
+
+
+# ---------------------------------------------------------------------------
+# ArticlesExportService.run_export_async
+# ---------------------------------------------------------------------------
+
+
+class TestRunExportAsync:
+    @pytest.mark.asyncio
+    async def test_uploads_and_returns_download_url(self) -> None:
+        storage = AsyncMock()
+        storage.upload = AsyncMock()
+        storage.get_signed_url = AsyncMock(return_value="https://example.com/export.zip")
+        svc = make_service(storage)
+
+        arts = [make_article()]
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=arts)):
+            result = await svc.run_export_async(
+                project_id=uuid.uuid4(),
+                article_ids=[arts[0].id],
+                formats=["csv"],
+                file_scope="none",
+                job_id="job-123",
+            )
+
+        assert result["download_url"] == "https://example.com/export.zip"
+        assert "expires_at" in result
+        assert "skipped_files" in result
+        storage.upload.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_path_uses_user_id_and_job_id(self) -> None:
+        storage = AsyncMock()
+        storage.upload = AsyncMock()
+        storage.get_signed_url = AsyncMock(return_value="https://x.com/file.zip")
+        svc = make_service(storage)
+
+        arts = [make_article()]
+        with patch.object(svc, "get_articles_for_export", AsyncMock(return_value=arts)):
+            await svc.run_export_async(
+                project_id=uuid.uuid4(),
+                article_ids=[arts[0].id],
+                formats=["csv"],
+                file_scope="none",
+                job_id="my-job",
+            )
+
+        call_args = storage.upload.call_args
+        path_arg = call_args[0][1]
+        assert "user-abc" in path_arg
+        assert "my-job" in path_arg

--- a/backend/tests/unit/test_extraction_repository.py
+++ b/backend/tests/unit/test_extraction_repository.py
@@ -1,0 +1,432 @@
+"""Unit tests for app.repositories.extraction_repository.
+
+Pure-mock — no database hit. Tests all repository classes:
+ExtractionTemplateRepository, GlobalTemplateRepository,
+ExtractionEntityTypeRepository, ExtractionInstanceRepository.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.extraction import (
+    ExtractionEntityType,
+    ExtractionInstance,
+    ExtractionTemplateGlobal,
+    ProjectExtractionTemplate,
+)
+from app.repositories.extraction_repository import (
+    ExtractionEntityTypeRepository,
+    ExtractionInstanceRepository,
+    ExtractionTemplateRepository,
+    GlobalTemplateRepository,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PROJECT_ID = uuid.uuid4()
+TEMPLATE_ID = uuid.uuid4()
+ENTITY_TYPE_ID = uuid.uuid4()
+INSTANCE_ID = uuid.uuid4()
+ARTICLE_ID = uuid.uuid4()
+
+
+def make_scalars_result(items: list) -> MagicMock:
+    scalars = MagicMock()
+    scalars.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    return result
+
+
+def make_scalar_one_or_none(item) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = item
+    return result
+
+
+def make_db() -> AsyncMock:
+    db = AsyncMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+def make_entity_type(
+    *,
+    id: uuid.UUID | None = None,
+    role: str = "study_section",
+    parent: uuid.UUID | None = None,
+    sort_order: int = 0,
+) -> MagicMock:
+    et = MagicMock(spec=ExtractionEntityType)
+    et.id = id or uuid.uuid4()
+    et.role = role
+    et.parent_entity_type_id = parent
+    et.sort_order = sort_order
+    et.fields = []
+    return et
+
+
+def make_instance(
+    *,
+    id: uuid.UUID | None = None,
+    article_id: uuid.UUID | None = None,
+    entity_type_id: uuid.UUID | None = None,
+    parent_instance_id: uuid.UUID | None = None,
+) -> MagicMock:
+    inst = MagicMock(spec=ExtractionInstance)
+    inst.id = id or uuid.uuid4()
+    inst.article_id = article_id or ARTICLE_ID
+    inst.entity_type_id = entity_type_id or ENTITY_TYPE_ID
+    inst.parent_instance_id = parent_instance_id
+    inst.sort_order = 0
+    inst.values = []
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# ExtractionTemplateRepository
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionTemplateRepository:
+    @pytest.mark.asyncio
+    async def test_get_by_project_returns_templates(self) -> None:
+        db = make_db()
+        templates = [MagicMock(spec=ProjectExtractionTemplate)]
+        db.execute = AsyncMock(return_value=make_scalars_result(templates))
+        repo = ExtractionTemplateRepository(db)
+
+        result = await repo.get_by_project(PROJECT_ID)
+
+        assert result == templates
+
+    @pytest.mark.asyncio
+    async def test_get_by_project_accepts_string_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ExtractionTemplateRepository(db)
+
+        result = await repo.get_by_project(str(PROJECT_ID))
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_with_entity_types_returns_template(self) -> None:
+        db = make_db()
+        tmpl = MagicMock(spec=ProjectExtractionTemplate)
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(tmpl))
+        repo = ExtractionTemplateRepository(db)
+
+        result = await repo.get_with_entity_types(TEMPLATE_ID)
+
+        assert result is tmpl
+
+    @pytest.mark.asyncio
+    async def test_get_with_entity_types_returns_none(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ExtractionTemplateRepository(db)
+
+        result = await repo.get_with_entity_types(TEMPLATE_ID)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_with_entity_types_accepts_string_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ExtractionTemplateRepository(db)
+
+        result = await repo.get_with_entity_types(str(TEMPLATE_ID))
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# GlobalTemplateRepository
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalTemplateRepository:
+    # NOTE: ExtractionTemplateGlobal.is_active does not exist on the ORM model.
+    # GlobalTemplateRepository.get_active() references this missing column, which
+    # makes the WHERE clause raise AttributeError at query-build time.
+    # Bug documented in DONE_WITH_CONCERNS. Tests are xfail to capture intent.
+
+    @pytest.mark.xfail(
+        reason=(
+            "BUG: ExtractionTemplateGlobal has no is_active column; "
+            "get_active() raises AttributeError — see DONE_WITH_CONCERNS"
+        ),
+        strict=True,
+    )
+    @pytest.mark.asyncio
+    async def test_get_active_returns_active_templates(self) -> None:
+        db = make_db()
+        tmpl = MagicMock(spec=ExtractionTemplateGlobal)
+        db.execute = AsyncMock(return_value=make_scalars_result([tmpl]))
+        repo = GlobalTemplateRepository(db)
+        result = await repo.get_active()
+        assert result == [tmpl]
+
+    @pytest.mark.xfail(
+        reason=(
+            "BUG: ExtractionTemplateGlobal has no is_active column; "
+            "get_active() raises AttributeError — see DONE_WITH_CONCERNS"
+        ),
+        strict=True,
+    )
+    @pytest.mark.asyncio
+    async def test_get_active_returns_empty_when_none(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = GlobalTemplateRepository(db)
+        result = await repo.get_active()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# ExtractionEntityTypeRepository
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionEntityTypeRepository:
+    @pytest.mark.asyncio
+    async def test_get_by_template_project(self) -> None:
+        db = make_db()
+        types = [make_entity_type()]
+        db.execute = AsyncMock(return_value=make_scalars_result(types))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_by_template(TEMPLATE_ID, is_project_template=True)
+
+        assert result == types
+
+    @pytest.mark.asyncio
+    async def test_get_by_template_global(self) -> None:
+        db = make_db()
+        types = [make_entity_type()]
+        db.execute = AsyncMock(return_value=make_scalars_result(types))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_by_template(TEMPLATE_ID, is_project_template=False)
+
+        assert result == types
+
+    @pytest.mark.asyncio
+    async def test_get_by_template_accepts_string_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_by_template(str(TEMPLATE_ID))
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_with_fields_returns_entity_type(self) -> None:
+        db = make_db()
+        et = make_entity_type()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(et))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_with_fields(ENTITY_TYPE_ID)
+
+        assert result is et
+
+    @pytest.mark.asyncio
+    async def test_get_with_fields_returns_none(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_with_fields(ENTITY_TYPE_ID)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_by_role_project_template(self) -> None:
+        db = make_db()
+        et = make_entity_type(role="model_container")
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(et))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_by_role("model_container", TEMPLATE_ID)
+
+        assert result is et
+
+    @pytest.mark.asyncio
+    async def test_get_by_role_global_template(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_by_role("study_section", TEMPLATE_ID, is_project_template=False)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_by_role_accepts_string_template_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_by_role("model_container", str(TEMPLATE_ID))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_children_without_cardinality(self) -> None:
+        db = make_db()
+        children = [make_entity_type(), make_entity_type()]
+        db.execute = AsyncMock(return_value=make_scalars_result(children))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_children(ENTITY_TYPE_ID)
+
+        assert result == children
+
+    @pytest.mark.asyncio
+    async def test_get_children_with_cardinality_filter(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_children(ENTITY_TYPE_ID, cardinality="many")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_children_accepts_string_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ExtractionEntityTypeRepository(db)
+
+        result = await repo.get_children(str(ENTITY_TYPE_ID))
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# ExtractionInstanceRepository
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionInstanceRepository:
+    @pytest.mark.asyncio
+    async def test_get_by_article_returns_all(self) -> None:
+        db = make_db()
+        instances = [make_instance()]
+        db.execute = AsyncMock(return_value=make_scalars_result(instances))
+        repo = ExtractionInstanceRepository(db)
+
+        result = await repo.get_by_article(ARTICLE_ID)
+
+        assert result == instances
+
+    @pytest.mark.asyncio
+    async def test_get_by_article_with_entity_type_filter(self) -> None:
+        db = make_db()
+        inst = make_instance(entity_type_id=ENTITY_TYPE_ID)
+        db.execute = AsyncMock(return_value=make_scalars_result([inst]))
+        repo = ExtractionInstanceRepository(db)
+
+        result = await repo.get_by_article(ARTICLE_ID, entity_type_id=ENTITY_TYPE_ID)
+
+        assert result == [inst]
+
+    @pytest.mark.asyncio
+    async def test_get_by_article_accepts_string_ids(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ExtractionInstanceRepository(db)
+
+        result = await repo.get_by_article(str(ARTICLE_ID))
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_by_article_with_string_entity_type_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ExtractionInstanceRepository(db)
+
+        result = await repo.get_by_article(ARTICLE_ID, entity_type_id=str(ENTITY_TYPE_ID))
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_children_returns_list(self) -> None:
+        db = make_db()
+        children = [make_instance(), make_instance()]
+        db.execute = AsyncMock(return_value=make_scalars_result(children))
+        repo = ExtractionInstanceRepository(db)
+
+        result = await repo.get_children(INSTANCE_ID)
+
+        assert result == children
+
+    @pytest.mark.asyncio
+    async def test_get_children_accepts_string_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = ExtractionInstanceRepository(db)
+
+        result = await repo.get_children(str(INSTANCE_ID))
+
+        assert result == []
+
+    # NOTE: ExtractionInstance.values relationship does not exist on the ORM model.
+    # ExtractionInstanceRepository.get_with_values() calls selectinload(ExtractionInstance.values)
+    # which raises AttributeError at query-build time. Bug documented in DONE_WITH_CONCERNS.
+
+    @pytest.mark.xfail(
+        reason=(
+            "BUG: ExtractionInstance has no 'values' relationship; "
+            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
+        ),
+        strict=True,
+    )
+    @pytest.mark.asyncio
+    async def test_get_with_values_returns_instance(self) -> None:
+        db = make_db()
+        inst = make_instance()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(inst))
+        repo = ExtractionInstanceRepository(db)
+        result = await repo.get_with_values(INSTANCE_ID)
+        assert result is inst
+
+    @pytest.mark.xfail(
+        reason=(
+            "BUG: ExtractionInstance has no 'values' relationship; "
+            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
+        ),
+        strict=True,
+    )
+    @pytest.mark.asyncio
+    async def test_get_with_values_returns_none(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ExtractionInstanceRepository(db)
+        result = await repo.get_with_values(INSTANCE_ID)
+        assert result is None
+
+    @pytest.mark.xfail(
+        reason=(
+            "BUG: ExtractionInstance has no 'values' relationship; "
+            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
+        ),
+        strict=True,
+    )
+    @pytest.mark.asyncio
+    async def test_get_with_values_accepts_string_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = ExtractionInstanceRepository(db)
+        result = await repo.get_with_values(str(INSTANCE_ID))
+        assert result is None

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -873,3 +873,777 @@ class TestExtractOneEntityTypeForRun:
         )
 
         service._fields_with_recent_human_proposal.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _generate_extraction_summary (lines 897-927)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateExtractionSummary:
+    """Covers _generate_extraction_summary including all branches."""
+
+    def _make_entity_type(self, name: str = "MySection", label: str | None = None):
+        et = MagicMock()
+        et.name = name
+        et.label = label
+        return et
+
+    def test_empty_data_returns_no_data_message(self, service):
+        et = self._make_entity_type("Section A")
+        result = service._generate_extraction_summary(et, {})
+        assert result == "Section A: No data extracted"
+
+    def test_none_values_are_skipped(self, service):
+        et = self._make_entity_type("Section B")
+        data = {"field1": None, "field2": None}
+        result = service._generate_extraction_summary(et, data)
+        assert "No data extracted" in result or "Section B" in result
+
+    def test_dict_value_uses_value_key(self, service):
+        et = self._make_entity_type("Section C")
+        data = {"field1": {"value": "extracted_val", "confidence": 0.9}}
+        result = service._generate_extraction_summary(et, data)
+        assert "extracted_val" in result
+
+    def test_plain_value_included(self, service):
+        et = self._make_entity_type("Section D")
+        data = {"field1": "plain_value"}
+        result = service._generate_extraction_summary(et, data)
+        assert "plain_value" in result
+
+    def test_label_preferred_over_name(self, service):
+        et = self._make_entity_type("MyName", label="MyLabel")
+        data = {"f": "v"}
+        result = service._generate_extraction_summary(et, data)
+        assert "MyLabel" in result
+        assert "MyName" not in result
+
+    def test_truncates_at_200_chars(self, service):
+        et = self._make_entity_type("Section")
+        data = {"field": "X" * 300}
+        result = service._generate_extraction_summary(et, data)
+        assert len(result) <= 200
+
+    def test_more_indicator_when_more_than_three_fields(self, service):
+        et = self._make_entity_type("Section")
+        data = {f"field{i}": f"val{i}" for i in range(5)}
+        result = service._generate_extraction_summary(et, data)
+        assert "..." in result
+
+    def test_no_more_indicator_for_three_or_fewer_fields(self, service):
+        et = self._make_entity_type("Section")
+        data = {"a": "1", "b": "2"}
+        result = service._generate_extraction_summary(et, data)
+        # Only trailing ... from truncation if long, not the more_indicator
+        # With 2 short fields this should not have "..." unless it's truncated
+        assert len(result) <= 200
+
+
+# ---------------------------------------------------------------------------
+# _get_child_entity_types edge cases (lines 964-998)
+# ---------------------------------------------------------------------------
+
+
+class TestGetChildEntityTypesEdgeCases:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_parent_instance_not_found(self, service):
+        service._instances.get_by_id = AsyncMock(return_value=None)
+        result = await service._get_child_entity_types(
+            template_id=uuid4(),
+            parent_instance_id=uuid4(),
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_child_entity_types(self, service):
+        parent = MagicMock()
+        parent.entity_type_id = uuid4()
+        service._instances.get_by_id = AsyncMock(return_value=parent)
+        service._entity_types.get_children = AsyncMock(return_value=[])
+        result = await service._get_child_entity_types(
+            template_id=uuid4(),
+            parent_instance_id=uuid4(),
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_filters_by_section_ids(self, service):
+        parent = MagicMock()
+        parent.entity_type_id = uuid4()
+        service._instances.get_by_id = AsyncMock(return_value=parent)
+
+        id1 = uuid4()
+        id2 = uuid4()
+        et1 = MagicMock()
+        et1.id = id1
+        et2 = MagicMock()
+        et2.id = id2
+        service._entity_types.get_children = AsyncMock(return_value=[et1, et2])
+
+        result = await service._get_child_entity_types(
+            template_id=uuid4(),
+            parent_instance_id=uuid4(),
+            section_ids=[id1],
+        )
+        assert len(result) == 1
+        assert result[0].id == id1
+
+
+# ---------------------------------------------------------------------------
+# _build_extraction_schema — allowed_values branches (lines 1034-1068)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildExtractionSchemaAllowedValues:
+    def test_allowed_values_as_list_of_strings(self, service):
+        field = MagicMock()
+        field.name = "status"
+        field.field_type = "string"
+        field.description = "Status"
+        field.llm_description = None
+        field.is_required = False
+        field.allowed_values = ["active", "inactive", "pending"]
+
+        et = MagicMock()
+        et.fields = [field]
+        schema = service._build_extraction_schema(et)
+
+        assert "enum" in schema["properties"]["status"]
+        assert schema["properties"]["status"]["enum"] == ["active", "inactive", "pending"]
+
+    def test_allowed_values_as_dict_with_options(self, service):
+        field = MagicMock()
+        field.name = "risk"
+        field.field_type = "string"
+        field.description = "Risk level"
+        field.llm_description = None
+        field.is_required = False
+        field.allowed_values = {"options": [{"value": "low"}, {"value": "high"}]}
+
+        et = MagicMock()
+        et.fields = [field]
+        schema = service._build_extraction_schema(et)
+
+        assert schema["properties"]["risk"]["enum"] == ["low", "high"]
+
+    def test_allowed_values_options_appended_to_description(self, service):
+        field = MagicMock()
+        field.name = "choice"
+        field.field_type = "string"
+        field.description = "Pick one"
+        field.llm_description = None
+        field.is_required = False
+        field.allowed_values = ["yes", "no"]
+
+        et = MagicMock()
+        et.fields = [field]
+        schema = service._build_extraction_schema(et)
+
+        assert "Must be one of" in schema["properties"]["choice"]["description"]
+
+    def test_allowed_values_empty_list_no_enum(self, service):
+        field = MagicMock()
+        field.name = "nopts"
+        field.field_type = "string"
+        field.description = "desc"
+        field.llm_description = None
+        field.is_required = False
+        field.allowed_values = []
+
+        et = MagicMock()
+        et.fields = [field]
+        schema = service._build_extraction_schema(et)
+
+        assert "enum" not in schema["properties"]["nopts"]
+
+    def test_llm_description_preferred_over_description(self, service):
+        field = MagicMock()
+        field.name = "f"
+        field.field_type = "string"
+        field.description = "plain desc"
+        field.llm_description = "llm desc"
+        field.is_required = False
+        field.allowed_values = None
+
+        et = MagicMock()
+        et.fields = [field]
+        schema = service._build_extraction_schema(et)
+
+        assert schema["properties"]["f"]["description"] == "llm desc"
+
+    def test_multiselect_maps_to_array_type(self, service):
+        field = MagicMock()
+        field.name = "tags"
+        field.field_type = "multiselect"
+        field.description = "tags"
+        field.llm_description = None
+        field.is_required = False
+        field.allowed_values = None
+
+        et = MagicMock()
+        et.fields = [field]
+        schema = service._build_extraction_schema(et)
+
+        assert schema["properties"]["tags"]["type"] == "array"
+
+
+# ---------------------------------------------------------------------------
+# _extract_with_llm — memory context branch (lines 1120-1124)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractWithLLMMemoryContext:
+    @pytest.mark.asyncio
+    async def test_memory_context_included_in_prompt(self, service):
+        from app.services.openai_service import OpenAIResponse, OpenAIUsage
+
+        captured: list[dict] = []
+
+        async def capture_call(messages, **kwargs):  # noqa: ARG001
+            captured.extend(messages)
+            return OpenAIResponse(
+                content="{}",
+                usage=OpenAIUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+                model="gpt-4o-mini",
+            )
+
+        service.openai_service.chat_completion_full = AsyncMock(side_effect=capture_call)
+
+        et = MagicMock()
+        et.name = "Methods"
+        et.description = "methods section"
+
+        memory = [
+            {"entity_type_name": "Participants", "summary": "N=100 patients"},
+        ]
+
+        await service._extract_with_llm(
+            pdf_text="article text",
+            entity_type=et,
+            schema={"type": "object", "properties": {}},
+            model="gpt-4o-mini",
+            memory_context=memory,
+        )
+
+        user_prompt = captured[1]["content"]
+        assert "CONTEXT FROM PREVIOUSLY EXTRACTED SECTIONS" in user_prompt
+        assert "Participants" in user_prompt
+        assert "N=100 patients" in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# _create_suggestions — branches (lines 1248+)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSuggestions:
+    def _make_run(self):
+        run = MagicMock()
+        run.id = uuid4()
+        run.project_id = uuid4()
+        run.article_id = uuid4()
+        run.template_id = uuid4()
+        return run
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_extracted_data(self, service):
+        run = self._make_run()
+        result = await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={},
+            run=run,
+        )
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_entity_type_not_found(self, service):
+        service._entity_types.get_with_fields = AsyncMock(return_value=None)
+        run = self._make_run()
+        result = await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"field": "value"},
+            run=run,
+        )
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_none_values(self, service):
+        field_id = uuid4()
+        field = MagicMock()
+        field.id = field_id
+        field.name = "f1"
+        et = MagicMock()
+        et.fields = [field]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        instance = MagicMock()
+        instance.id = uuid4()
+        instance.parent_instance_id = None
+        service._instances.get_by_article = AsyncMock(return_value=[instance])
+        service._proposals.record_proposal = AsyncMock(return_value=MagicMock(id=uuid4()))
+        service.db.flush = AsyncMock()
+
+        run = self._make_run()
+        result = await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"f1": None},
+            run=run,
+        )
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_unknown_field_names(self, service):
+        field = MagicMock()
+        field.id = uuid4()
+        field.name = "known_field"
+        et = MagicMock()
+        et.fields = [field]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        instance = MagicMock()
+        instance.id = uuid4()
+        instance.parent_instance_id = None
+        service._instances.get_by_article = AsyncMock(return_value=[instance])
+        service._proposals.record_proposal = AsyncMock(return_value=MagicMock(id=uuid4()))
+        service.db.flush = AsyncMock()
+
+        run = self._make_run()
+        result = await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"unknown_field": "value"},
+            run=run,
+        )
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_records_proposal_for_plain_value(self, service):
+        field_id = uuid4()
+        field = MagicMock()
+        field.id = field_id
+        field.name = "title"
+        et = MagicMock()
+        et.fields = [field]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        instance = MagicMock()
+        instance.id = uuid4()
+        instance.parent_instance_id = None
+        service._instances.get_by_article = AsyncMock(return_value=[instance])
+        proposal = MagicMock()
+        proposal.id = uuid4()
+        service._proposals.record_proposal = AsyncMock(return_value=proposal)
+        service.db.flush = AsyncMock()
+
+        run = self._make_run()
+        result = await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"title": "A Study"},
+            run=run,
+        )
+        assert result == 1
+        service._proposals.record_proposal.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_records_proposal_for_enriched_dict_value(self, service):
+        field_id = uuid4()
+        field = MagicMock()
+        field.id = field_id
+        field.name = "sample_size"
+        et = MagicMock()
+        et.fields = [field]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        instance = MagicMock()
+        instance.id = uuid4()
+        instance.parent_instance_id = None
+        service._instances.get_by_article = AsyncMock(return_value=[instance])
+        proposal = MagicMock()
+        proposal.id = uuid4()
+        service._proposals.record_proposal = AsyncMock(return_value=proposal)
+        service.db.add = MagicMock()
+        service.db.flush = AsyncMock()
+
+        run = self._make_run()
+        result = await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={
+                "sample_size": {
+                    "value": 150,
+                    "confidence": 0.9,
+                    "reasoning": "stated in methods",
+                    "evidence": {"text": "150 patients enrolled", "page_number": 2},
+                }
+            },
+            run=run,
+        )
+        assert result == 1
+        # Evidence row should have been added
+        service.db.add.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_creates_instance_when_missing(self, service):
+        """When no instance exists, _create_suggestions auto-creates one."""
+        field_id = uuid4()
+        field = MagicMock()
+        field.id = field_id
+        field.name = "f"
+        et = MagicMock()
+        et.label = "My Label"
+        et.sort_order = 1
+        et.fields = [field]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        # No existing instances
+        service._instances.get_by_article = AsyncMock(return_value=[])
+        new_instance = MagicMock()
+        new_instance.id = uuid4()
+        service._instances.create = AsyncMock(return_value=new_instance)
+        proposal = MagicMock()
+        proposal.id = uuid4()
+        service._proposals.record_proposal = AsyncMock(return_value=proposal)
+        service.db.flush = AsyncMock()
+
+        run = self._make_run()
+        result = await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"f": "val"},
+            run=run,
+        )
+        assert result == 1
+        service._instances.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_parent_instance_used_to_resolve_template_id(self, service):
+        """When parent_instance_id is provided and no instance exists,
+        the parent's template_id is inherited."""
+        field_id = uuid4()
+        field = MagicMock()
+        field.id = field_id
+        field.name = "f"
+        et = MagicMock()
+        et.label = None
+        et.name = "S"
+        et.sort_order = 0
+        et.fields = [field]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        service._instances.get_by_article = AsyncMock(return_value=[])
+
+        parent = MagicMock()
+        parent_template_id = uuid4()
+        parent.template_id = parent_template_id
+        service._instances.get_by_id = AsyncMock(return_value=parent)
+
+        new_instance = MagicMock()
+        new_instance.id = uuid4()
+        service._instances.create = AsyncMock(return_value=new_instance)
+        proposal = MagicMock()
+        proposal.id = uuid4()
+        service._proposals.record_proposal = AsyncMock(return_value=proposal)
+        service.db.flush = AsyncMock()
+
+        run = self._make_run()
+        parent_instance_id = uuid4()
+
+        with patch(
+            "app.services.section_extraction_service.ExtractionInstance"
+        ) as mock_instance_class:
+            mock_created = MagicMock()
+            mock_created.id = uuid4()
+            mock_instance_class.return_value = mock_created
+            service._instances.create = AsyncMock(return_value=mock_created)
+            await service._create_suggestions(
+                project_id=run.project_id,
+                article_id=run.article_id,
+                entity_type_id=uuid4(),
+                parent_instance_id=parent_instance_id,
+                extracted_data={"f": "v"},
+                run=run,
+            )
+
+        # Verify the parent was looked up
+        service._instances.get_by_id.assert_awaited_once_with(parent_instance_id)
+
+    @pytest.mark.asyncio
+    async def test_evidence_without_text_not_added(self, service):
+        """Evidence dicts without 'text' key should not produce a db.add call."""
+        field_id = uuid4()
+        field = MagicMock()
+        field.id = field_id
+        field.name = "f"
+        et = MagicMock()
+        et.fields = [field]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        instance = MagicMock()
+        instance.id = uuid4()
+        instance.parent_instance_id = None
+        service._instances.get_by_article = AsyncMock(return_value=[instance])
+        proposal = MagicMock()
+        proposal.id = uuid4()
+        service._proposals.record_proposal = AsyncMock(return_value=proposal)
+        service.db.add = MagicMock()
+        service.db.flush = AsyncMock()
+
+        run = self._make_run()
+        await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"f": {"value": "x", "evidence": {"page_number": 1}}},
+            run=run,
+        )
+        service.db.add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# extract_section — exception path (lines 270-281)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSectionException:
+    @pytest.mark.asyncio
+    async def test_marks_run_as_failed_on_exception(self, service):
+        run = MagicMock()
+        run.id = uuid4()
+        service._lifecycle.create_run = AsyncMock(return_value=run)
+        service._lifecycle.advance_stage = AsyncMock(return_value=run)
+        service._runs.start_run = AsyncMock()
+        service._runs.fail_run = AsyncMock()
+
+        service._article_files.get_latest_pdf = AsyncMock(
+            side_effect=RuntimeError("pdf fetch failed")
+        )
+
+        with pytest.raises(RuntimeError, match="pdf fetch failed"):
+            await service.extract_section(
+                project_id=uuid4(),
+                article_id=uuid4(),
+                template_id=uuid4(),
+                entity_type_id=uuid4(),
+            )
+
+        service._runs.fail_run.assert_awaited_once_with(run.id, "pdf fetch failed")
+
+
+# ---------------------------------------------------------------------------
+# extract_all_sections (lines 593-760)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAllSections:
+    def _make_run(self):
+        run = MagicMock()
+        run.id = uuid4()
+        return run
+
+    def _minimal_lifecycle_wire(self, service, run):
+        service._lifecycle.create_run = AsyncMock(return_value=run)
+        service._lifecycle.advance_stage = AsyncMock(return_value=run)
+        service._runs.start_run = AsyncMock()
+        service._runs.complete_run = AsyncMock()
+        service._runs.fail_run = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_batch_with_no_child_sections(self, service):
+        run = self._make_run()
+        self._minimal_lifecycle_wire(service, run)
+
+        service._instances.get_by_id = AsyncMock(return_value=None)
+        service._entity_types.get_children = AsyncMock(return_value=[])
+
+        result = await service.extract_all_sections(
+            project_id=uuid4(),
+            article_id=uuid4(),
+            template_id=uuid4(),
+            parent_instance_id=uuid4(),
+            pdf_text="pre-processed text",
+        )
+
+        assert result.total_sections == 0
+        assert result.successful_sections == 0
+        assert result.failed_sections == 0
+        assert result.total_suggestions_created == 0
+        service._runs.complete_run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_batch_fetches_pdf_when_not_provided(self, service):
+        run = self._make_run()
+        self._minimal_lifecycle_wire(service, run)
+
+        service._instances.get_by_id = AsyncMock(return_value=None)
+        service._entity_types.get_children = AsyncMock(return_value=[])
+        mock_file = MagicMock()
+        mock_file.storage_key = "test.pdf"
+        service._article_files.get_latest_pdf = AsyncMock(return_value=mock_file)
+        service.storage.download = AsyncMock(return_value=b"%PDF")
+        service.pdf_processor.extract_text = AsyncMock(return_value="pdf text")
+
+        await service.extract_all_sections(
+            project_id=uuid4(),
+            article_id=uuid4(),
+            template_id=uuid4(),
+            parent_instance_id=uuid4(),
+            # No pdf_text provided → should fetch from storage
+        )
+
+        service._article_files.get_latest_pdf.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_batch_collects_failed_sections(self, service):
+        run = self._make_run()
+        self._minimal_lifecycle_wire(service, run)
+
+        parent = MagicMock()
+        parent.entity_type_id = uuid4()
+        service._instances.get_by_id = AsyncMock(return_value=parent)
+
+        child1 = MagicMock()
+        child1.id = uuid4()
+        child1.name = "Section A"
+        service._entity_types.get_children = AsyncMock(return_value=[child1])
+
+        # _extract_section_with_memory raises for child1
+        service._extract_section_with_memory = AsyncMock(side_effect=RuntimeError("llm error"))
+
+        result = await service.extract_all_sections(
+            project_id=uuid4(),
+            article_id=uuid4(),
+            template_id=uuid4(),
+            parent_instance_id=uuid4(),
+            pdf_text="text",
+        )
+
+        assert result.failed_sections == 1
+        assert result.successful_sections == 0
+        section_entry = result.sections[0]
+        assert section_entry["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_batch_accumulates_memory_history(self, service):
+        run = self._make_run()
+        self._minimal_lifecycle_wire(service, run)
+
+        parent = MagicMock()
+        parent.entity_type_id = uuid4()
+        service._instances.get_by_id = AsyncMock(return_value=parent)
+
+        child1 = MagicMock()
+        child1.id = uuid4()
+        child1.name = "Sec1"
+        child1.label = "Section 1"
+
+        service._entity_types.get_children = AsyncMock(return_value=[child1])
+        service._extract_section_with_memory = AsyncMock(
+            return_value={
+                "suggestions_created": 2,
+                "tokens_total": 100,
+                "summary": "Sec1: N=50",
+            }
+        )
+
+        result = await service.extract_all_sections(
+            project_id=uuid4(),
+            article_id=uuid4(),
+            template_id=uuid4(),
+            parent_instance_id=uuid4(),
+            pdf_text="text",
+        )
+
+        assert result.successful_sections == 1
+        assert result.total_suggestions_created == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_fails_run_on_unexpected_error(self, service):
+        run = self._make_run()
+        service._lifecycle.create_run = AsyncMock(return_value=run)
+        service._lifecycle.advance_stage = AsyncMock(return_value=run)
+        service._runs.start_run = AsyncMock()
+        service._runs.fail_run = AsyncMock()
+
+        # Make the PDF fetch explode unexpectedly (before any section loops)
+        service._instances.get_by_id = AsyncMock(side_effect=RuntimeError("db exploded"))
+
+        with pytest.raises(RuntimeError, match="db exploded"):
+            await service.extract_all_sections(
+                project_id=uuid4(),
+                article_id=uuid4(),
+                template_id=uuid4(),
+                parent_instance_id=uuid4(),
+                pdf_text="text",
+            )
+
+        service._runs.fail_run.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# extract_for_run — entity error path (lines 370-386)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractForRunErrorPath:
+    @pytest.mark.asyncio
+    async def test_entity_failure_recorded_in_section_results(self, service):
+        from app.models.extraction import ExtractionRunStage
+
+        run = MagicMock()
+        run.id = uuid4()
+        run.project_id = uuid4()
+        run.article_id = uuid4()
+        run.template_id = uuid4()
+        run.stage = ExtractionRunStage.PROPOSAL.value
+        run.kind = "extraction"
+
+        template = MagicMock()
+        template.framework = None
+
+        service.db.get = AsyncMock(
+            side_effect=lambda cls, _id: run if "Run" in cls.__name__ else template
+        )
+
+        service._article_files.get_latest_pdf = AsyncMock(
+            return_value=MagicMock(storage_key="f.pdf")
+        )
+        service.storage.download = AsyncMock(return_value=b"%PDF")
+        service.pdf_processor.extract_text = AsyncMock(return_value="text")
+
+        failing_et = MagicMock()
+        failing_et.id = uuid4()
+        failing_et.name = "BadSection"
+
+        scalars = MagicMock()
+        scalars.all.return_value = [failing_et]
+        execute_result = MagicMock()
+        execute_result.scalars.return_value = scalars
+        service.db.execute = AsyncMock(return_value=execute_result)
+
+        service._entity_types.get_with_fields = AsyncMock(
+            side_effect=RuntimeError("type fetch error")
+        )
+
+        service._runs.start_run = AsyncMock()
+        service._runs.complete_run = AsyncMock()
+        service._runs.fail_run = AsyncMock()
+        service._lifecycle.advance_stage = AsyncMock()
+
+        result = await service.extract_for_run(run_id=run.id)
+
+        assert result.failed_sections == 1
+        assert result.sections[0]["success"] is False
+        assert "type fetch error" in result.sections[0]["error"]

--- a/backend/tests/unit/test_user_api_key_repository.py
+++ b/backend/tests/unit/test_user_api_key_repository.py
@@ -1,0 +1,510 @@
+"""Unit tests for app.repositories.user_api_key_repository.
+
+Pure-mock — no database hit. AsyncSession is mocked via AsyncMock.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.user_api_key import UserAPIKey
+from app.repositories.user_api_key_repository import UserAPIKeyRepository
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+USER_ID = uuid.uuid4()
+KEY_ID = uuid.uuid4()
+
+
+def make_key(
+    *,
+    id: uuid.UUID | None = None,
+    user_id: uuid.UUID | None = None,
+    provider: str = "openai",
+    is_active: bool = True,
+    is_default: bool = False,
+) -> UserAPIKey:
+    key = MagicMock(spec=UserAPIKey)
+    key.id = id or uuid.uuid4()
+    key.user_id = user_id or USER_ID
+    key.provider = provider
+    key.is_active = is_active
+    key.is_default = is_default
+    key.encrypted_api_key = "enc-key"
+    key.key_name = "My key"
+    key.validation_status = "pending"
+    key.key_metadata = {}
+    return key
+
+
+def make_scalars_result(items: list) -> MagicMock:
+    """Return a mock whose .scalars().all() yields items."""
+    scalars = MagicMock()
+    scalars.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    return result
+
+
+def make_scalar_one_or_none(item) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = item
+    return result
+
+
+def make_rowcount(n: int) -> MagicMock:
+    result = MagicMock()
+    result.rowcount = n
+    return result
+
+
+def make_db() -> AsyncMock:
+    db = AsyncMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# list_by_user
+# ---------------------------------------------------------------------------
+
+
+class TestListByUser:
+    @pytest.mark.asyncio
+    async def test_returns_active_keys_by_default(self) -> None:
+        db = make_db()
+        keys = [make_key(), make_key()]
+        db.execute = AsyncMock(return_value=make_scalars_result(keys))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.list_by_user(USER_ID)
+
+        assert result == keys
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_user_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalars_result([]))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.list_by_user(str(USER_ID))
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_active_only_false_includes_inactive(self) -> None:
+        db = make_db()
+        keys = [make_key(is_active=False)]
+        db.execute = AsyncMock(return_value=make_scalars_result(keys))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.list_by_user(USER_ID, active_only=False)
+
+        assert result == keys
+
+
+# ---------------------------------------------------------------------------
+# get_default
+# ---------------------------------------------------------------------------
+
+
+class TestGetDefault:
+    @pytest.mark.asyncio
+    async def test_returns_default_key(self) -> None:
+        db = make_db()
+        key = make_key(is_default=True)
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(key))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.get_default(USER_ID, "openai")
+
+        assert result is key
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.get_default(USER_ID, "anthropic")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_user_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.get_default(str(USER_ID), "openai")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_by_user_and_provider
+# ---------------------------------------------------------------------------
+
+
+class TestGetByUserAndProvider:
+    @pytest.mark.asyncio
+    async def test_returns_matching_keys(self) -> None:
+        db = make_db()
+        keys = [make_key(provider="anthropic")]
+        db.execute = AsyncMock(return_value=make_scalars_result(keys))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.get_by_user_and_provider(USER_ID, "anthropic")
+
+        assert result == keys
+
+    @pytest.mark.asyncio
+    async def test_active_only_false_returns_all(self) -> None:
+        db = make_db()
+        keys = [make_key(is_active=False, provider="gemini")]
+        db.execute = AsyncMock(return_value=make_scalars_result(keys))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.get_by_user_and_provider(USER_ID, "gemini", active_only=False)
+
+        assert result == keys
+
+
+# ---------------------------------------------------------------------------
+# get_by_id_and_user
+# ---------------------------------------------------------------------------
+
+
+class TestGetByIdAndUser:
+    @pytest.mark.asyncio
+    async def test_returns_key_when_owned(self) -> None:
+        db = make_db()
+        key = make_key()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(key))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.get_by_id_and_user(KEY_ID, USER_ID)
+
+        assert result is key
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_owned(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.get_by_id_and_user(KEY_ID, USER_ID)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_converts_string_ids(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.get_by_id_and_user(str(KEY_ID), str(USER_ID))
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# create_key
+# ---------------------------------------------------------------------------
+
+
+class TestCreateKey:
+    @pytest.mark.asyncio
+    async def test_creates_key_with_correct_attributes(self) -> None:
+        db = make_db()
+        repo = UserAPIKeyRepository(db)
+        created = make_key()
+
+        with patch.object(repo, "create", AsyncMock(return_value=created)) as mock_create:
+            result = await repo.create_key(
+                user_id=USER_ID,
+                provider="openai",
+                encrypted_api_key="enc-123",
+                key_name="My key",
+                is_default=True,
+                metadata={"model": "gpt-4"},
+            )
+
+        assert result is created
+        call_kwargs = mock_create.call_args[0][0]
+        assert call_kwargs.provider == "openai"
+        assert call_kwargs.encrypted_api_key == "enc-123"
+        assert call_kwargs.is_default is True
+        assert call_kwargs.is_active is True
+        assert call_kwargs.key_name == "My key"
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_user_id(self) -> None:
+        db = make_db()
+        repo = UserAPIKeyRepository(db)
+        created = make_key()
+
+        with patch.object(repo, "create", AsyncMock(return_value=created)):
+            result = await repo.create_key(
+                user_id=str(USER_ID),
+                provider="anthropic",
+                encrypted_api_key="enc-abc",
+            )
+
+        assert result is created
+
+    @pytest.mark.asyncio
+    async def test_defaults_metadata_to_empty_dict(self) -> None:
+        db = make_db()
+        repo = UserAPIKeyRepository(db)
+        created = make_key()
+
+        with patch.object(repo, "create", AsyncMock(return_value=created)) as mock_create:
+            await repo.create_key(
+                user_id=USER_ID,
+                provider="openai",
+                encrypted_api_key="enc",
+            )
+
+        call_kwargs = mock_create.call_args[0][0]
+        assert call_kwargs.key_metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# unset_default
+# ---------------------------------------------------------------------------
+
+
+class TestUnsetDefault:
+    @pytest.mark.asyncio
+    async def test_returns_rowcount(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(2))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.unset_default(USER_ID, "openai")
+
+        assert result == 2
+
+    @pytest.mark.asyncio
+    async def test_with_exclude_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(1))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.unset_default(USER_ID, "openai", exclude_id=KEY_ID)
+
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_with_string_exclude_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(1))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.unset_default(USER_ID, "openai", exclude_id=str(KEY_ID))
+
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# set_default
+# ---------------------------------------------------------------------------
+
+
+class TestSetDefault:
+    @pytest.mark.asyncio
+    async def test_returns_false_when_key_not_found(self) -> None:
+        db = make_db()
+        repo = UserAPIKeyRepository(db)
+
+        with patch.object(repo, "get_by_id", AsyncMock(return_value=None)):
+            result = await repo.set_default(KEY_ID, USER_ID)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_wrong_owner(self) -> None:
+        db = make_db()
+        key = make_key(user_id=uuid.uuid4())  # different user
+        repo = UserAPIKeyRepository(db)
+
+        with patch.object(repo, "get_by_id", AsyncMock(return_value=key)):
+            result = await repo.set_default(KEY_ID, USER_ID)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_and_sets_flag_when_valid(self) -> None:
+        db = make_db()
+        key = make_key(user_id=USER_ID)
+        db.refresh = AsyncMock()
+        repo = UserAPIKeyRepository(db)
+
+        with (
+            patch.object(repo, "get_by_id", AsyncMock(return_value=key)),
+            patch.object(repo, "unset_default", AsyncMock(return_value=0)),
+        ):
+            result = await repo.set_default(KEY_ID, USER_ID)
+
+        assert result is True
+        assert key.is_default is True
+
+
+# ---------------------------------------------------------------------------
+# update_key_name
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateKeyName:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_updated(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(1))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.update_key_name(KEY_ID, USER_ID, "New Name")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_row_matched(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(0))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.update_key_name(KEY_ID, USER_ID, "Name")
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# update_last_used
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateLastUsed:
+    @pytest.mark.asyncio
+    async def test_executes_update_without_error(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=MagicMock())
+        repo = UserAPIKeyRepository(db)
+
+        await repo.update_last_used(KEY_ID)
+
+        db.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_key_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=MagicMock())
+        repo = UserAPIKeyRepository(db)
+
+        await repo.update_last_used(str(KEY_ID))
+
+        db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# set_validation_status
+# ---------------------------------------------------------------------------
+
+
+class TestSetValidationStatus:
+    @pytest.mark.asyncio
+    async def test_executes_update(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=MagicMock())
+        repo = UserAPIKeyRepository(db)
+
+        await repo.set_validation_status(KEY_ID, "valid")
+
+        db.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_accepts_string_key_id(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=MagicMock())
+        repo = UserAPIKeyRepository(db)
+
+        await repo.set_validation_status(str(KEY_ID), "invalid")
+
+        db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# deactivate
+# ---------------------------------------------------------------------------
+
+
+class TestDeactivate:
+    @pytest.mark.asyncio
+    async def test_returns_true_on_match(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(1))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.deactivate(KEY_ID, USER_ID)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_found(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(0))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.deactivate(KEY_ID, USER_ID)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_converts_string_ids(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(1))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.deactivate(str(KEY_ID), str(USER_ID))
+
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# hard_delete
+# ---------------------------------------------------------------------------
+
+
+class TestHardDelete:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_deleted(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(1))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.hard_delete(KEY_ID, USER_ID)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_found(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(0))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.hard_delete(KEY_ID, USER_ID)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_converts_string_ids(self) -> None:
+        db = make_db()
+        db.execute = AsyncMock(return_value=make_rowcount(1))
+        repo = UserAPIKeyRepository(db)
+
+        result = await repo.hard_delete(str(KEY_ID), str(USER_ID))
+
+        assert result is True


### PR DESCRIPTION
## Summary
Promotes two PRs from dev → main:

- **#123 (F3):** Ratchet \`--cov-fail-under\` from 60 → 62 (floor − 2 pt margin). New comment in \`ci.yml\` documents the timeline + hard rule "never lower once raised".
- **#124 (F4):** 229 unit tests for 6 undertested modules:
  - \`articles_export_service.py\` 15% → 96%
  - \`user_api_key_repository.py\` 21% → 94%
  - \`article_repository.py\` 25% → 94%
  - \`extraction_repository.py\` 26% → 97%
  - \`api_key_service.py\` 30% → 93%
  - \`section_extraction_service.py\` 64% → 92%

**Overall backend coverage: 64.06% → 72.15%** on main (CI verified).

F4 also surfaced two real bugs in \`extraction_repository.py\` marked as ``@pytest.mark.xfail(strict=True)``:
1. \`GlobalTemplateRepository.get_active()\` references missing \`ExtractionTemplateGlobal.is_active\` column → AttributeError.
2. \`ExtractionInstanceRepository.get_with_values()\` references missing \`ExtractionInstance.values\` relationship → AttributeError.

Both will auto-flip to XPASS when fixed (separate PR scope).

## Test plan
- CI: 820 passed, 5 skipped, 5 xfailed, coverage 72.15%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and CI threshold changes; no application logic modified in the diff. The xfail tests document pre-existing repository bugs rather than introducing new behavior.
> 
> **Overview**
> This PR **raises the backend CI coverage floor** from `--cov-fail-under=60` to **62** and replaces the short comment with a **coverage gate timeline** (history, F4 context, next ratchet toward 70%, and a rule to never lower the gate).
> 
> It adds **~2k lines of pure-mock unit tests** (no DB/network) for undertested repos/services: **`APIKeyService`** (encrypt/decrypt, CRUD, provider validation via mocked httpx), **`UserAPIKeyRepository`**, **`ArticleRepository`** (+ sync run/event and file repos), **`ArticlesExportService`** (CSV/RIS/RDF helpers and export zip scopes), and **`ExtractionRepository`** classes. **`test_section_extraction_service.py`** gains broad coverage for summaries, schema building, LLM memory context, suggestions, batch extraction, and failure paths.
> 
> **`test_extraction_repository.py`** marks **`GlobalTemplateRepository.get_active()`** and **`ExtractionInstanceRepository.get_with_values()`** as **`@pytest.mark.xfail(strict=True)`**, documenting existing ORM mismatches (`is_active` column and `values` relationship) without changing production code in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f37affcb1ce965762bd306f99c00b9ff9d7986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->