### PR TITLE
Merge dev → main: F5 — pytest marker hygiene

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -125,10 +125,14 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-addopts = "-v --tb=short"
+# --strict-markers: typo'd marker (@pytest.mark.intergration vs integration)
+# now fails the test instead of silently being ignored. Catches the class
+# of "marker doesn't filter what you think it filters" bug.
+addopts = "-v --tb=short --strict-markers"
 markers = [
     "e2e: end-to-end tests against live stack",
     "performance: performance-sensitive or long-running tests",
+    "integration: integration test requiring db_session + seeded fixtures from tests/integration/conftest.py",
 ]
 
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -40,11 +40,30 @@ from collections.abc import AsyncGenerator
 from typing import NamedTuple
 from uuid import UUID
 
+import pytest
 import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import settings
+
+# =================== AUTO MARKER ===================
+# Every test collected under tests/integration/ gets the ``integration``
+# marker automatically. Saves us from putting
+# ``pytestmark = pytest.mark.integration`` at the top of all 40+ files.
+# Pairs with ``--strict-markers`` in pyproject so typo'd markers fail
+# instead of being silently ignored.
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,  # noqa: ARG001
+    items: list[pytest.Item],
+) -> None:
+    """Auto-apply ``@pytest.mark.integration`` to every test in this dir."""
+    for item in items:
+        if "tests/integration/" in str(item.fspath):
+            item.add_marker(pytest.mark.integration)
+
 
 # =================== SENTINEL UUIDS ===================
 


### PR DESCRIPTION
Promotes F5 (PR #126) — `--strict-markers` + auto-applied `integration` marker. No behavioral changes; enables future CI job splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only pytest configuration and collection hooks; no application runtime or test assertion behavior changes.
> 
> **Overview**
> Tightens pytest marker handling so misspelled markers fail collection instead of being ignored, and so integration tests can be selected reliably (e.g. for future CI splits).
> 
> **Pytest config** adds `--strict-markers` to default `addopts` and registers a documented `integration` marker in `pyproject.toml`.
> 
> **Integration suite** applies `@pytest.mark.integration` automatically during collection for anything under `tests/integration/` via `pytest_collection_modifyitems` in `tests/integration/conftest.py`, `, avoiding per-file `pytestmark` boilerplate across many files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c0132c889e5f3f304728e21a329250e79a84fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->