### PR TITLE
fix(worker): seal event-loop bug, harden runner, add CI guard

### DIFF
--- a/.github/workflows/worker-smoke.yml
+++ b/.github/workflows/worker-smoke.yml
@@ -45,7 +45,10 @@ jobs:
         run: pip install uv
       - name: Install backend deps
         working-directory: backend
-        run: uv sync --frozen
+        # NOTE: `--frozen` is intentionally omitted because `backend/uv.lock`
+        # is in `.gitignore`. If the project ever starts tracking the
+        # lockfile, add `--frozen` here for reproducible CI installs.
+        run: uv sync
       - name: Boot worker in background
         working-directory: backend
         run: |

--- a/.github/workflows/worker-smoke.yml
+++ b/.github/workflows/worker-smoke.yml
@@ -45,7 +45,7 @@ jobs:
         run: pip install uv
       - name: Install backend deps
         working-directory: backend
-        run: uv sync
+        run: uv sync --frozen
       - name: Boot worker in background
         working-directory: backend
         run: |
@@ -92,6 +92,20 @@ jobs:
               if all(s not in ("PENDING", "STARTED") for s in states):
                   break
               time.sleep(2)
+          final_states = [AsyncResult(i, app=celery_app).state for i in ids]
+          still_pending = [
+              (i, s) for i, s in zip(ids, final_states)
+              if s in ("PENDING", "STARTED")
+          ]
+          if still_pending:
+              import sys
+              print(
+                  f"ERROR: {len(still_pending)} tasks never reached a "
+                  f"terminal state after 45s. States: {final_states}. "
+                  f"This usually means the worker crashed or never picked "
+                  f"up the message. See worker.log."
+              )
+              sys.exit(1)
           PY
       - name: Assert no loop-reuse error in worker log
         working-directory: backend

--- a/.github/workflows/worker-smoke.yml
+++ b/.github/workflows/worker-smoke.yml
@@ -1,0 +1,120 @@
+name: Worker Smoke Test
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/worker/**"
+      - "backend/app/services/exports/**"
+      - "backend/app/services/extraction_export_service.py"
+      - "backend/app/services/articles_export_service.py"
+      - "backend/tests/integration/test_worker_eager_mode.py"
+      - ".github/workflows/worker-smoke.yml"
+
+jobs:
+  worker-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      REDIS_URL: redis://localhost:6379/0
+      # Stub Supabase / OPENAI / encryption — the smoke test mocks the
+      # heavy services and only exercises the task <-> worker contract.
+      SUPABASE_URL: http://localhost:54321
+      SUPABASE_ANON_KEY: stub-anon
+      SUPABASE_SERVICE_ROLE_KEY: stub-service-role
+      ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+      DATABASE_URL: postgresql+asyncpg://stub
+      DIRECT_DATABASE_URL: postgresql://stub
+      OPENAI_API_KEY: sk-stub
+      DEBUG: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        run: pip install uv
+      - name: Install backend deps
+        working-directory: backend
+        run: uv sync
+      - name: Boot worker in background
+        working-directory: backend
+        run: |
+          uv run celery -A app.worker.celery_app worker \
+            --loglevel=info \
+            --queues=extractions,imports,exports,celery \
+            --pool=solo \
+            > worker.log 2>&1 &
+          echo $! > worker.pid
+          for i in {1..30}; do
+            grep -q "celery@.*ready" worker.log && break
+            sleep 1
+          done
+          grep -q "celery@.*ready" worker.log || (echo "Worker never became ready"; cat worker.log; exit 1)
+      - name: Dispatch two sequential extraction_export tasks
+        working-directory: backend
+        run: |
+          uv run python <<'PY'
+          import time
+          from celery.result import AsyncResult
+          from app.worker.celery_app import celery_app
+          ids = []
+          for i in range(2):
+              r = celery_app.send_task(
+                  "app.worker.tasks.extraction_export_tasks.export_extraction_task",
+                  kwargs={
+                      "project_id": "00000000-0000-0000-0000-000000000000",
+                      "template_id": "00000000-0000-0000-0000-000000000000",
+                      "mode": "consensus",
+                      "article_ids": ["00000000-0000-0000-0000-000000000000"],
+                      "article_scope": "current_list",
+                      "user_id": "00000000-0000-0000-0000-000000000000",
+                      "reviewer_id": None,
+                      "include_ai_metadata": False,
+                      "anonymize_reviewer_names": False,
+                  },
+              )
+              ids.append(r.id)
+              print(f"Dispatched #{i}: {r.id}")
+          deadline = time.time() + 45
+          while time.time() < deadline:
+              states = [AsyncResult(i, app=celery_app).state for i in ids]
+              print("States:", states)
+              if all(s not in ("PENDING", "STARTED") for s in states):
+                  break
+              time.sleep(2)
+          PY
+      - name: Assert no loop-reuse error in worker log
+        working-directory: backend
+        run: |
+          if grep -q "attached to a different loop" worker.log; then
+            echo "Loop-reuse bug returned — see worker.log"
+            cat worker.log
+            exit 1
+          fi
+      - name: Assert no NotRegistered in worker log
+        working-directory: backend
+        run: |
+          if grep -q "NotRegistered\|celery.task_unregistered" worker.log; then
+            echo "A task was unregistered — celery_app.include drift"
+            cat worker.log
+            exit 1
+          fi
+      - name: Tail worker log on failure
+        if: failure()
+        working-directory: backend
+        run: tail -200 worker.log
+      - name: Stop worker
+        if: always()
+        working-directory: backend
+        run: |
+          [ -f worker.pid ] && kill "$(cat worker.pid)" || true

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,7 +1,7 @@
 """
 Dependencies Module.
 
-Contem todas as dependencies compartilhadas da aplicacao:
+Contains all shared application dependencies:
 - Database session
 - Supabase client
 - Current user
@@ -23,9 +23,9 @@ logger = get_logger(__name__)
 # =================== DATABASE ===================
 
 # Engine async for PostgreSQL
-# NOTA: O workaround de ::VARCHAR for ENUMs foi REMOVIDO.
-# Agora usamos PostgreSQLEnumType (em app.models.base) que resolve o problema
-# de forma declarativa diretamente nos models SQLAlchemy.
+# NOTE: The ::VARCHAR workaround for ENUMs was REMOVED.
+# We now use PostgreSQLEnumType (in app.models.base), which resolves
+# the problem declaratively at the SQLAlchemy model level.
 engine = create_async_engine(
     settings.async_database_url,
     echo=settings.DEBUG,
@@ -33,9 +33,9 @@ engine = create_async_engine(
     pool_size=10,
     max_overflow=20,
     connect_args={
-        "statement_cache_size": 0,  # ✅ Desabilita prepared statements (compativel with pgbouncer)
+        "statement_cache_size": 0,  # Disable prepared statements (compatible with pgbouncer)
         "server_settings": {
-            "jit": "off",  # Desabilita JIT for melhor performance em queries complexas
+            "jit": "off",  # Disable JIT for better performance on complex queries
         },
     },
 )

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -51,12 +51,12 @@ AsyncSessionLocal = async_sessionmaker(
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     """
-    Dependency que fornece uma sessao de banco de data.
+    Dependency that provides a database session.
 
-    A sessao e automaticamente fechada ao final da request.
+    The session is automatically closed at the end of the request.
 
     Yields:
-        AsyncSession: Sessao do SQLAlchemy.
+        AsyncSession: SQLAlchemy async session.
     """
     async with AsyncSessionLocal() as session:
         try:
@@ -65,7 +65,7 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
             await session.close()
 
 
-# Type alias for uso nas rotas
+# Type alias for use in routes
 DbSession = Annotated[AsyncSession, Depends(get_db)]
 
 
@@ -90,7 +90,7 @@ def get_supabase_client() -> Client:
 
 
 def get_supabase() -> Client:
-    """Dependency for obter Supabase client."""
+    """Dependency to obtain a Supabase client."""
     return get_supabase_client()
 
 
@@ -107,9 +107,9 @@ CurrentUser = Annotated[TokenPayload, Depends(get_current_user)]
 
 class RequestContext:
     """
-    Contexto da requisicao with todas as dependencies comuns.
+    Request context grouping all common dependencies.
 
-    Agrupa db, user and supabase for facilitar passagem for services.
+    Bundles db, user, and supabase to simplify passing them to services.
     """
 
     def __init__(
@@ -124,7 +124,7 @@ class RequestContext:
 
     @property
     def user_id(self) -> str:
-        """user atual."""
+        """Current user id."""
         return self.user.sub
 
 
@@ -134,9 +134,9 @@ async def get_request_context(
     supabase: SupabaseClient,
 ) -> RequestContext:
     """
-    Dependency que fornece contexto completo da requisicao.
+    Dependency that provides the complete request context.
 
-    Util for services que precisam de multiplas dependencies.
+    Useful for services that need multiple dependencies.
     """
     return RequestContext(db=db, user=user, supabase=supabase)
 

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -8,7 +8,6 @@ Contem todas as dependencies compartilhadas da aplicacao:
 """
 
 from collections.abc import AsyncGenerator
-from functools import lru_cache
 from typing import Annotated
 
 from fastapi import Depends
@@ -73,17 +72,16 @@ DbSession = Annotated[AsyncSession, Depends(get_db)]
 # =================== SUPABASE CLIENT ===================
 
 
-@lru_cache
 def get_supabase_client() -> Client:
-    """
-    Return cliente Supabase configurado with service role.
+    """Return a fresh Supabase service-role client.
 
-    Usado for operacoes que precisam de acesso elevado:
-    - Storage operations
-    - Bypass RLS quando necessario
-
-    Returns:
-        Client: Supabase client configurado.
+    NOT cached. The cached version was the root cause of the 2026-05-24
+    event-loop reuse bug — the underlying httpx client binds its
+    connection pool to the loop active at construction time, so reusing
+    one across loops raises ``RuntimeError: <Future ...> attached to a
+    different loop``. Worker tasks construct one per invocation via
+    ``app.worker._runner.run_task``; FastAPI request handlers construct
+    one per request via ``get_supabase`` in this module.
     """
     return create_client(
         settings.SUPABASE_URL,

--- a/backend/app/worker/__init__.py
+++ b/backend/app/worker/__init__.py
@@ -1,9 +1,9 @@
 """
 Celery Worker.
 
-Processamento assincrono de tarefas longas:
-- Extracoes em lote
-- Importacoes do Zotero
+Asynchronous processing of long-running tasks:
+- Batch extractions
+- Zotero imports
 """
 
 from app.worker.celery_app import celery_app

--- a/backend/app/worker/_runner.py
+++ b/backend/app/worker/_runner.py
@@ -1,0 +1,50 @@
+"""Shared async runner for Celery tasks.
+
+Every Celery task in this codebase is a synchronous entry point that
+delegates real work to an async coroutine. This module provides the one
+correct way to bridge the two:
+
+    @celery_app.task
+    def my_task(...):
+        async def run() -> dict:
+            async with AsyncSessionLocal() as db:
+                ...
+        return run_task(run)
+
+Why a fresh ``asyncio.run()`` per invocation:
+
+- A previous iteration of this codebase cached one event loop in a
+  module global and reused it across all task invocations. Combined
+  with ``@lru_cache`` on ``get_supabase_client``, that meant the
+  Supabase httpx client's connection-pool futures were bound to
+  whichever loop ran first — any subsequent task on a different loop
+  raised ``RuntimeError: <Future ...> attached to a different loop``.
+  The bug surfaced on 2026-05-24 against ``export_extraction_task``.
+
+Why the runner takes a *factory*, not a coroutine:
+
+- Coroutines created at import time bind to whichever loop happens to
+  be running when the module is imported (or ``None``). Requiring
+  callers to pass a zero-arg callable defers coroutine construction
+  until ``asyncio.run`` is already running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def run_task(coro_factory: Callable[[], Awaitable[T]]) -> T:
+    """Run an async coroutine in a fresh event loop and return its result."""
+    if not callable(coro_factory):
+        raise TypeError(
+            f"run_task requires a zero-arg callable, got "
+            f"{type(coro_factory).__name__}. Pass the coroutine function "
+            f"itself (e.g. run_task(run)), not the coroutine "
+            f"(e.g. run_task(run()))."
+        )
+    return asyncio.run(coro_factory())

--- a/backend/app/worker/_runner.py
+++ b/backend/app/worker/_runner.py
@@ -7,7 +7,7 @@ correct way to bridge the two:
     @celery_app.task
     def my_task(...):
         async def run() -> dict:
-            async with AsyncSessionLocal() as db:
+            async with worker_session() as db:
                 ...
         return run_task(run)
 

--- a/backend/app/worker/_runner.py
+++ b/backend/app/worker/_runner.py
@@ -32,6 +32,7 @@ Why the runner takes a *factory*, not a coroutine:
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
@@ -39,12 +40,25 @@ T = TypeVar("T")
 
 
 def run_task(coro_factory: Callable[[], Awaitable[T]]) -> T:
-    """Run an async coroutine in a fresh event loop and return its result."""
+    """Run an async coroutine in a fresh event loop and return its result.
+
+    Args:
+        coro_factory: Zero-argument callable that returns the coroutine
+            to run. Must be a callable — passing a coroutine directly
+            defeats the per-call loop guarantee.
+
+    Raises:
+        TypeError: if ``coro_factory`` is a coroutine object or not callable.
+        Exception: re-raises any exception raised by the coroutine.
+    """
+    if inspect.iscoroutine(coro_factory):
+        raise TypeError(
+            "run_task requires a zero-arg callable, got a coroutine object. "
+            "Pass the function itself (e.g. run_task(run)), not the result "
+            "of calling it (e.g. run_task(run()))."
+        )
     if not callable(coro_factory):
         raise TypeError(
-            f"run_task requires a zero-arg callable, got "
-            f"{type(coro_factory).__name__}. Pass the coroutine function "
-            f"itself (e.g. run_task(run)), not the coroutine "
-            f"(e.g. run_task(run()))."
+            f"run_task requires a zero-arg callable, got {type(coro_factory).__name__}."
         )
     return asyncio.run(coro_factory())

--- a/backend/app/worker/_session.py
+++ b/backend/app/worker/_session.py
@@ -1,0 +1,73 @@
+"""Per-task SQLAlchemy session for Celery workers.
+
+The application-wide engine in ``app/core/deps.py`` is a module-level
+global with a pooled connection set bound to the event loop active on
+first checkout. The Celery worker calls ``asyncio.run(...)`` per task
+(via ``app.worker._runner.run_task``), so loops are short-lived; reusing
+the global engine across loops triggers ``RuntimeError: <Future ...>
+attached to a different loop`` on any operation that touches the pool's
+internal waiters.
+
+This module exposes ``worker_session()`` — an async context manager that
+builds a fresh engine with ``NullPool`` (no pooling), yields a session,
+then disposes the engine. Cost: one extra TCP connection per task.
+That's irrelevant for the worker's task rates and eliminates the
+cross-loop hazard at the root.
+
+Usage inside a Celery task:
+
+    @celery_app.task
+    def my_task(...):
+        async def run():
+            async with worker_session() as db:
+                ...
+        return run_task(run)
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
+
+from app.core.config import settings
+
+
+@asynccontextmanager
+async def worker_session() -> AsyncIterator[AsyncSession]:
+    """Yield a SQLAlchemy AsyncSession backed by a per-call engine.
+
+    The engine uses ``NullPool`` — every connection is opened on demand
+    and closed when the session ends. The engine itself is disposed
+    when the context exits, releasing the underlying asyncpg
+    connection. This guarantees no event-loop primitive survives past
+    the task's ``asyncio.run`` boundary.
+    """
+    engine = create_async_engine(
+        settings.async_database_url,
+        echo=settings.DEBUG,
+        poolclass=NullPool,
+        connect_args={
+            "statement_cache_size": 0,  # Compatible with pgbouncer
+            "server_settings": {
+                "jit": "off",  # Better performance for complex queries
+            },
+        },
+    )
+    factory = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+    try:
+        async with factory() as session:
+            yield session
+    finally:
+        await engine.dispose()

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -74,8 +74,26 @@ class LoggedTask(celery_app.Task):
     def on_failure(self, exc, task_id, args, kwargs, _einfo):
         """Log on failure."""
         import structlog
+        from celery.exceptions import NotRegistered
 
         logger = structlog.get_logger()
+        if isinstance(exc, NotRegistered):
+            # P1-class incident: an enqueued task has no handler. Always
+            # caused by a module missing from celery_app.include or a
+            # routing typo. Surface separately so dashboards can alert.
+            logger.error(
+                "celery.task_unregistered",
+                task_id=task_id,
+                task_name=self.name,
+                args=args,
+                kwargs=kwargs,
+                remediation=(
+                    "Check celery_app.include for the missing module and "
+                    "tests/unit/test_celery_app_task_registry.py for the "
+                    "regression guard."
+                ),
+            )
+            return
         logger.error(
             "task_failed",
             task_id=task_id,

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -1,17 +1,17 @@
 """
 Celery Application Configuration.
 
-Configura Celery with Redis como broker and result backend.
+Configures Celery with Redis as broker and result backend.
 """
 
 import os
 
 from celery import Celery
 
-# Configuracao do broker Redis
+# Redis broker configuration
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
-# Criar app Celery
+# Create the Celery app
 celery_app = Celery(
     "review_hub",
     broker=REDIS_URL,
@@ -24,7 +24,7 @@ celery_app = Celery(
     ],
 )
 
-# Configuracoes
+# Configuration
 celery_app.conf.update(
     # Task settings
     task_serializer="json",
@@ -33,19 +33,19 @@ celery_app.conf.update(
     timezone="UTC",
     enable_utc=True,
     # Result settings
-    result_expires=3600,  # 1 hora
+    result_expires=3600,  # 1 hour
     # Task execution
     task_acks_late=True,
     task_reject_on_worker_lost=True,
     # Rate limiting
-    task_default_rate_limit="10/m",  # 10 tasks por minuto por default
+    task_default_rate_limit="10/m",  # 10 tasks per minute by default
     # Retry settings
-    task_default_retry_delay=60,  # 1 minuto entre retries
+    task_default_retry_delay=60,  # 1 minute between retries
     task_max_retries=3,
     # Concurrency
     worker_concurrency=4,
     worker_prefetch_multiplier=2,
-    # Task routes (filas separadas por tipo)
+    # Task routes (queues separated by type)
     task_routes={
         "app.worker.tasks.extraction_tasks.*": {"queue": "extractions"},
         "app.worker.tasks.import_tasks.*": {"queue": "imports"},
@@ -58,10 +58,10 @@ celery_app.conf.update(
 
 # Task base class with logging
 class LoggedTask(celery_app.Task):
-    """Task base with logging estruturado."""
+    """Task base class with structured logging."""
 
     def on_failure(self, exc, task_id, args, kwargs, _einfo):
-        """Log em caso de falha."""
+        """Log on failure."""
         import structlog
 
         logger = structlog.get_logger()
@@ -75,7 +75,7 @@ class LoggedTask(celery_app.Task):
         )
 
     def on_success(self, _retval, task_id, _args, _kwargs):
-        """Log em caso de sucesso."""
+        """Log on success."""
         import structlog
 
         logger = structlog.get_logger()
@@ -86,7 +86,7 @@ class LoggedTask(celery_app.Task):
         )
 
     def on_retry(self, exc, task_id, _args, _kwargs, _einfo):
-        """Log em caso de retry."""
+        """Log on retry."""
         import structlog
 
         logger = structlog.get_logger()
@@ -99,5 +99,5 @@ class LoggedTask(celery_app.Task):
         )
 
 
-# Registrar task base
+# Register the base task class
 celery_app.Task = LoggedTask

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -45,13 +45,24 @@ celery_app.conf.update(
     # Concurrency
     worker_concurrency=4,
     worker_prefetch_multiplier=2,
-    # Task routes (queues separated by type)
+    # Task routes (queues separated by type). Every module in
+    # ``include=`` MUST appear here explicitly — the registry test in
+    # ``tests/unit/test_celery_app_task_registry.py`` enforces this so
+    # new task modules cannot silently fall back to the default
+    # ``celery`` queue (which the Railway worker may or may not be
+    # consuming). The drift guard
+    # ``tests/unit/test_celery_routes_drift.py`` then asserts every
+    # queue named here is in the worker ``--queues=...`` list.
     task_routes={
         "app.worker.tasks.extraction_tasks.*": {"queue": "extractions"},
         "app.worker.tasks.import_tasks.*": {"queue": "imports"},
         # Keep CPU-bound XLSX builds off the LLM-heavy `extractions` queue
         # so a long-running extraction can't starve a user-initiated export.
         "app.worker.tasks.extraction_export_tasks.*": {"queue": "exports"},
+        # Article exports (CSV/RIS/RDF + ZIP) — explicit `celery` queue so
+        # the drift guard has a clean baseline. The Railway worker
+        # consumes `celery` alongside the three named queues.
+        "app.worker.tasks.export_tasks.*": {"queue": "celery"},
     },
 )
 

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -130,3 +130,46 @@ class LoggedTask(celery_app.Task):
 
 # Register the base task class
 celery_app.Task = LoggedTask
+
+
+# Register a signal handler for tasks that the worker receives but
+# cannot find in its registry. Celery routes this through the consumer
+# (signals.task_unknown), not the task instance's on_failure callback —
+# so a NotRegistered branch in on_failure alone would be dead code in
+# production. Keep both paths: the signal is the runtime hook, the
+# on_failure branch is defense in depth in case Celery changes routing.
+from celery.signals import task_unknown  # noqa: E402
+
+
+@task_unknown.connect
+def _on_task_unknown(
+    sender=None,  # noqa: ARG001
+    name: str | None = None,
+    id: str | None = None,  # noqa: A002 — Celery signal kwarg name
+    message=None,  # noqa: ARG001
+    exc: Exception | None = None,  # noqa: ARG001
+    **_kwargs,
+) -> None:
+    """Log unregistered-task events as a P1 incident.
+
+    Triggered by Celery when a worker pops a message whose ``task``
+    header does not match any entry in ``celery_app.tasks``. Always
+    caused by a module missing from ``celery_app.include`` or a routing
+    typo. The regression guard at
+    ``tests/unit/test_celery_app_task_registry.py`` prevents this at CI,
+    and the drift guard at ``tests/unit/test_celery_routes_drift.py``
+    prevents queue/route mismatches; this signal is the runtime safety
+    net.
+    """
+    import structlog
+
+    structlog.get_logger().error(
+        "celery.task_unregistered",
+        task_id=id,
+        task_name=name,
+        remediation=(
+            "Check celery_app.include for the missing module and "
+            "tests/unit/test_celery_app_task_registry.py for the "
+            "regression guard."
+        ),
+    )

--- a/backend/app/worker/tasks/__init__.py
+++ b/backend/app/worker/tasks/__init__.py
@@ -1,5 +1,5 @@
 """
 Celery Tasks.
 
-Tasks assincronas for processamento em background.
+Async tasks for background processing.
 """

--- a/backend/app/worker/tasks/export_tasks.py
+++ b/backend/app/worker/tasks/export_tasks.py
@@ -1,11 +1,13 @@
-"""
-Export Tasks.
+"""Export Celery tasks.
 
-Tasks Celery for exportacao de articles (CSV, RIS, RDF + files).
+Celery tasks that export articles (CSV, RIS, RDF) plus optional PDFs as
+a single ZIP, upload the bundle to storage, and return a signed URL.
 
 The async bridge is via ``app.worker._runner.run_task`` — see that
 module's docstring for the event-loop rationale.
 """
+
+from __future__ import annotations
 
 from uuid import UUID
 
@@ -26,18 +28,17 @@ def export_articles_task(
     file_scope: str,
     user_id: str,
 ) -> dict:
-    """
-    Task for exportacao de articles em background.
+    """Export a set of articles in the background.
 
-    Gera ZIP with metadata (CSV/RIS/RDF) and optionalmente files;
-    faz upload for storage and retorna URL assinada.
+    Builds a ZIP with metadata (CSV/RIS/RDF) and optionally the article
+    files; uploads the bundle to storage and returns a signed URL.
 
     Args:
-        project_id: project.
-        article_ids: List de IDs of the articles (UUID strings).
-        formats: List de formatos: csv, ris, rdf.
-        file_scope: none, main_only, all.
-        user_id: user (para ownership do job).
+        project_id: Project UUID.
+        article_ids: List of article UUIDs to export.
+        formats: List of metadata formats: csv, ris, rdf.
+        file_scope: One of none, main_only, all.
+        user_id: User UUID owning the export job.
 
     Returns:
         Dict with download_url, expires_at, skipped_files, user_id.

--- a/backend/app/worker/tasks/export_tasks.py
+++ b/backend/app/worker/tasks/export_tasks.py
@@ -45,11 +45,12 @@ def export_articles_task(
     """
 
     async def run() -> dict:
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.articles_export_service import ArticlesExportService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             supabase = get_supabase_client()
             storage = create_storage_adapter(supabase)
             service = ArticlesExportService(

--- a/backend/app/worker/tasks/export_tasks.py
+++ b/backend/app/worker/tasks/export_tasks.py
@@ -2,22 +2,15 @@
 Export Tasks.
 
 Tasks Celery for exportacao de articles (CSV, RIS, RDF + files).
+
+The async bridge is via ``app.worker._runner.run_task`` — see that
+module's docstring for the event-loop rationale.
 """
 
-import asyncio
 from uuid import UUID
 
+from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
-
-_WORKER_LOOP: asyncio.AbstractEventLoop | None = None
-
-
-def _run_in_worker_loop(coro):
-    global _WORKER_LOOP
-    if _WORKER_LOOP is None or _WORKER_LOOP.is_closed():
-        _WORKER_LOOP = asyncio.new_event_loop()
-        asyncio.set_event_loop(_WORKER_LOOP)
-    return _WORKER_LOOP.run_until_complete(coro)
 
 
 @celery_app.task(
@@ -49,11 +42,12 @@ def export_articles_task(
     Returns:
         Dict with download_url, expires_at, skipped_files, user_id.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.articles_export_service import ArticlesExportService
 
     async def run() -> dict:
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.articles_export_service import ArticlesExportService
+
         async with AsyncSessionLocal() as session:
             supabase = get_supabase_client()
             storage = create_storage_adapter(supabase)
@@ -73,4 +67,4 @@ def export_articles_task(
             result["user_id"] = user_id
             return result
 
-    return _run_in_worker_loop(run())
+    return run_task(run)

--- a/backend/app/worker/tasks/extraction_export_tasks.py
+++ b/backend/app/worker/tasks/extraction_export_tasks.py
@@ -2,38 +2,30 @@
 
 Background-export worker. Opens its own DB session + storage adapter,
 runs the export service, uploads bytes, returns a signed URL.
+
+The async bridge is via ``app.worker._runner.run_task`` — see that
+module's docstring for the event-loop rationale.
 """
 
 from __future__ import annotations
 
-import asyncio
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from app.core.logging import get_logger
+from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
 
 logger = get_logger(__name__)
 
-_WORKER_LOOP: asyncio.AbstractEventLoop | None = None
-
-#: Signed-URL TTL for the generated `.xlsx`. Matches the articles_export
+#: Signed-URL TTL for the generated ``.xlsx``. Matches the articles_export
 #: convention so users see consistent expiry windows across export types.
 _DOWNLOAD_URL_TTL_SECONDS = 3600
 
-#: Supabase Storage bucket. We reuse the existing `articles` bucket
-#: under a dedicated `exports/extraction/` prefix (research.md §2).
+#: Supabase Storage bucket. We reuse the existing ``articles`` bucket
+#: under a dedicated ``exports/extraction/`` prefix (research.md §2).
 _STORAGE_BUCKET = "articles"
 _STORAGE_PREFIX = "exports/extraction"
-
-
-def _run_in_worker_loop(coro):
-    """Reuse a worker-local event loop across task invocations."""
-    global _WORKER_LOOP
-    if _WORKER_LOOP is None or _WORKER_LOOP.is_closed():
-        _WORKER_LOOP = asyncio.new_event_loop()
-        asyncio.set_event_loop(_WORKER_LOOP)
-    return _WORKER_LOOP.run_until_complete(coro)
 
 
 @celery_app.task(
@@ -47,7 +39,7 @@ def export_extraction_task(
     template_id: str,
     mode: str,
     article_ids: list[str],
-    article_scope: str,  # noqa: ARG001 — currently informational; carried for audit/log
+    article_scope: str,  # noqa: ARG001 — informational; carried for audit/log
     user_id: str,
     reviewer_id: str | None = None,
     include_ai_metadata: bool = False,
@@ -58,15 +50,19 @@ def export_extraction_task(
     Builds the workbook via ``ExtractionExportService``, uploads bytes
     to Supabase Storage, returns ``{download_url, expires_at, user_id}``.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.exports.extraction_xlsx_builder import build_workbook
-    from app.services.extraction_export_service import (
-        ExportMode,
-        ExtractionExportService,
-    )
 
     async def run() -> dict:
+        # Lazy imports + lazy client construction.
+        import asyncio
+
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.exports.extraction_xlsx_builder import build_workbook
+        from app.services.extraction_export_service import (
+            ExportMode,
+            ExtractionExportService,
+        )
+
         async with AsyncSessionLocal() as session:
             supabase = get_supabase_client()
             storage = create_storage_adapter(supabase)
@@ -110,4 +106,4 @@ def export_extraction_task(
                 "user_id": user_id,
             }
 
-    return _run_in_worker_loop(run())
+    return run_task(run)

--- a/backend/app/worker/tasks/extraction_export_tasks.py
+++ b/backend/app/worker/tasks/extraction_export_tasks.py
@@ -9,6 +9,7 @@ module's docstring for the event-loop rationale.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
@@ -53,8 +54,6 @@ def export_extraction_task(
 
     async def run() -> dict:
         # Lazy imports + lazy client construction.
-        import asyncio
-
         from app.core.deps import AsyncSessionLocal, get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.exports.extraction_xlsx_builder import build_workbook

--- a/backend/app/worker/tasks/extraction_export_tasks.py
+++ b/backend/app/worker/tasks/extraction_export_tasks.py
@@ -54,15 +54,16 @@ def export_extraction_task(
 
     async def run() -> dict:
         # Lazy imports + lazy client construction.
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.exports.extraction_xlsx_builder import build_workbook
         from app.services.extraction_export_service import (
             ExportMode,
             ExtractionExportService,
         )
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             supabase = get_supabase_client()
             storage = create_storage_adapter(supabase)
             service = ExtractionExportService(

--- a/backend/app/worker/tasks/extraction_tasks.py
+++ b/backend/app/worker/tasks/extraction_tasks.py
@@ -50,12 +50,13 @@ def extract_section_task(
     """
 
     async def run():
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.api_key_service import APIKeyService
         from app.services.section_extraction_service import SectionExtractionService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 supabase = get_supabase_client()
                 storage = create_storage_adapter(supabase)
@@ -129,12 +130,13 @@ def extract_models_task(
     """
 
     async def run():
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.api_key_service import APIKeyService
         from app.services.model_extraction_service import ModelExtractionService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 supabase = get_supabase_client()
                 storage = create_storage_adapter(supabase)

--- a/backend/app/worker/tasks/extraction_tasks.py
+++ b/backend/app/worker/tasks/extraction_tasks.py
@@ -2,12 +2,15 @@
 Extraction Tasks.
 
 Tasks Celery for processamento de extractions.
+
+The async bridge is via ``app.worker._runner.run_task`` — see that
+module's docstring for the event-loop rationale.
 """
 
-import asyncio
 from typing import Any
 from uuid import UUID
 
+from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
 
 
@@ -42,12 +45,13 @@ def extract_section_task(
     Returns:
         Dict with resultado da extraction.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.api_key_service import APIKeyService
-    from app.services.section_extraction_service import SectionExtractionService
 
     async def run():
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.api_key_service import APIKeyService
+        from app.services.section_extraction_service import SectionExtractionService
+
         async with AsyncSessionLocal() as session:
             try:
                 supabase = get_supabase_client()
@@ -88,7 +92,7 @@ def extract_section_task(
                 raise
 
     try:
-        return asyncio.run(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)
 
@@ -120,12 +124,13 @@ def extract_models_task(
     Returns:
         Dict with modelos extraidos.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.api_key_service import APIKeyService
-    from app.services.model_extraction_service import ModelExtractionService
 
     async def run():
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.api_key_service import APIKeyService
+        from app.services.model_extraction_service import ModelExtractionService
+
         async with AsyncSessionLocal() as session:
             try:
                 supabase = get_supabase_client()
@@ -182,7 +187,7 @@ def extract_models_task(
                 raise
 
     try:
-        return asyncio.run(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)
 

--- a/backend/app/worker/tasks/extraction_tasks.py
+++ b/backend/app/worker/tasks/extraction_tasks.py
@@ -1,11 +1,13 @@
-"""
-Extraction Tasks.
+"""Extraction Celery tasks.
 
-Tasks Celery for processamento de extractions.
+Celery tasks that drive AI-assisted extraction (single-section and
+prediction-model extraction) plus a small batch-fanout helper.
 
 The async bridge is via ``app.worker._runner.run_task`` — see that
 module's docstring for the event-loop rationale.
 """
+
+from __future__ import annotations
 
 from typing import Any
 from uuid import UUID
@@ -30,20 +32,21 @@ def extract_section_task(
     parent_instance_id: str | None = None,
     openai_api_key: str | None = None,
 ) -> dict[str, Any]:
-    """
-    Task for extraction de uma section.
+    """Run AI extraction for a single section of an article.
 
     Args:
-        project_id: project.
-        article_id: article.
-        template_id: template.
-        entity_type_id: entity type.
-        user_id: user.
-        parent_instance_id: instance pai (optional).
-        openai_api_key: API key customizada (BYOK). Se None, busca do user or usa global.
+        project_id: Project UUID.
+        article_id: Article UUID.
+        template_id: Project template UUID.
+        entity_type_id: Entity type UUID to extract.
+        user_id: User UUID owning the run.
+        parent_instance_id: Parent instance UUID, when extracting a child
+            section under a model container (optional).
+        openai_api_key: BYOK override. If ``None``, the user's stored key
+            is resolved; falls back to the global service key.
 
     Returns:
-        Dict with resultado da extraction.
+        Dict with the extraction result summary.
     """
 
     async def run():
@@ -111,18 +114,18 @@ def extract_models_task(
     user_id: str,
     openai_api_key: str | None = None,
 ) -> dict[str, Any]:
-    """
-    Task for extraction de modelos de predicao.
+    """Run AI extraction for prediction models in an article.
 
     Args:
-        project_id: project.
-        article_id: article.
-        template_id: template.
-        user_id: user.
-        openai_api_key: API key customizada (BYOK). Se None, busca do user or usa global.
+        project_id: Project UUID.
+        article_id: Article UUID.
+        template_id: Project template UUID.
+        user_id: User UUID owning the run.
+        openai_api_key: BYOK override. If ``None``, the user's stored key
+            is resolved; falls back to the global service key.
 
     Returns:
-        Dict with modelos extraidos.
+        Dict with the extracted models summary.
     """
 
     async def run():
@@ -205,17 +208,16 @@ def batch_extract_task(
     template_id: str,
     user_id: str,
 ) -> dict[str, Any]:
-    """
-    Task for extraction em batch de multiplos articles.
+    """Fan out model extraction across a batch of articles.
 
     Args:
-        project_id: project.
-        article_ids: List de IDs de articles.
-        template_id: template.
-        user_id: user.
+        project_id: Project UUID.
+        article_ids: List of article UUIDs to extract.
+        template_id: Project template UUID.
+        user_id: User UUID owning the runs.
 
     Returns:
-        Dict with estatisticas do batch.
+        Dict with per-article queue stats for the batch.
     """
     results = {
         "total": len(article_ids),

--- a/backend/app/worker/tasks/import_tasks.py
+++ b/backend/app/worker/tasks/import_tasks.py
@@ -48,11 +48,12 @@ def import_zotero_collection_task(
     """
 
     async def run():
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.zotero_import_service import ZoteroImportService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 supabase = get_supabase_client()
                 storage = create_storage_adapter(supabase)
@@ -121,11 +122,12 @@ def retry_failed_zotero_sync_task(
     limit: int = 100,
 ) -> dict[str, Any]:
     async def run():
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.zotero_import_service import ZoteroImportService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 supabase = get_supabase_client()
                 storage = create_storage_adapter(supabase)
@@ -180,10 +182,10 @@ def sync_zotero_library_task(
     """
 
     async def run():
-        from app.core.deps import AsyncSessionLocal
         from app.services.zotero_service import ZoteroService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 zotero = ZoteroService(
                     db=session,

--- a/backend/app/worker/tasks/import_tasks.py
+++ b/backend/app/worker/tasks/import_tasks.py
@@ -2,23 +2,16 @@
 Import Tasks.
 
 Tasks Celery for importacao de data externos.
+
+The async bridge is via ``app.worker._runner.run_task`` — see that
+module's docstring for the event-loop rationale.
 """
 
-import asyncio
 from typing import Any
 from uuid import UUID
 
+from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
-
-_WORKER_LOOP: asyncio.AbstractEventLoop | None = None
-
-
-def _run_in_worker_loop(coro):
-    global _WORKER_LOOP
-    if _WORKER_LOOP is None or _WORKER_LOOP.is_closed():
-        _WORKER_LOOP = asyncio.new_event_loop()
-        asyncio.set_event_loop(_WORKER_LOOP)
-    return _WORKER_LOOP.run_until_complete(coro)
 
 
 @celery_app.task(
@@ -50,11 +43,12 @@ def import_zotero_collection_task(
     Returns:
         Dict with resultado da importacao.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.zotero_import_service import ZoteroImportService
 
     async def run():
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.zotero_import_service import ZoteroImportService
+
         async with AsyncSessionLocal() as session:
             try:
                 supabase = get_supabase_client()
@@ -104,7 +98,7 @@ def import_zotero_collection_task(
                 raise
 
     try:
-        return _run_in_worker_loop(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)
 
@@ -123,11 +117,11 @@ def retry_failed_zotero_sync_task(
     sync_run_id: str,
     limit: int = 100,
 ) -> dict[str, Any]:
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.zotero_import_service import ZoteroImportService
-
     async def run():
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.zotero_import_service import ZoteroImportService
+
         async with AsyncSessionLocal() as session:
             try:
                 supabase = get_supabase_client()
@@ -159,7 +153,7 @@ def retry_failed_zotero_sync_task(
                 raise
 
     try:
-        return _run_in_worker_loop(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)
 
@@ -182,10 +176,11 @@ def sync_zotero_library_task(
     Returns:
         Dict with resultado da sincronizacao.
     """
-    from app.core.deps import AsyncSessionLocal
-    from app.services.zotero_service import ZoteroService
 
     async def run():
+        from app.core.deps import AsyncSessionLocal
+        from app.services.zotero_service import ZoteroService
+
         async with AsyncSessionLocal() as session:
             try:
                 zotero = ZoteroService(
@@ -222,6 +217,6 @@ def sync_zotero_library_task(
                 raise
 
     try:
-        return _run_in_worker_loop(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)

--- a/backend/app/worker/tasks/import_tasks.py
+++ b/backend/app/worker/tasks/import_tasks.py
@@ -1,11 +1,13 @@
-"""
-Import Tasks.
+"""Import Celery tasks.
 
-Tasks Celery for importacao de data externos.
+Celery tasks that import external data (currently Zotero collections
+and Zotero library sync) into a project.
 
 The async bridge is via ``app.worker._runner.run_task`` — see that
 module's docstring for the event-loop rationale.
 """
+
+from __future__ import annotations
 
 from typing import Any
 from uuid import UUID
@@ -30,18 +32,19 @@ def import_zotero_collection_task(
     update_existing: bool = True,
     sync_run_id: str | None = None,
 ) -> dict[str, Any]:
-    """
-    Task for importacao de collection do Zotero.
+    """Import a Zotero collection into the project.
 
     Args:
-        project_id: project.
-        collection_key: Key da collection in the Zotero.
-        user_id: user.
-        import_pdfs: Se deve importar PDFs.
-        max_items: Maximo de items a importar.
+        project_id: Project UUID.
+        collection_key: Zotero collection key.
+        user_id: User UUID owning the import.
+        import_pdfs: Whether to also import attached PDFs.
+        max_items: Max items to import.
+        update_existing: Whether to update items that already exist.
+        sync_run_id: Existing sync-run UUID to attach to (optional).
 
     Returns:
-        Dict with resultado da importacao.
+        Dict with the import result summary.
     """
 
     async def run():
@@ -167,14 +170,13 @@ def sync_zotero_library_task(
     self,
     user_id: str,
 ) -> dict[str, Any]:
-    """
-    Task for sincronizacao completa da biblioteca Zotero.
+    """Sync the user's full Zotero library metadata.
 
     Args:
-        user_id: user.
+        user_id: User UUID whose Zotero library should be synced.
 
     Returns:
-        Dict with resultado da sincronizacao.
+        Dict with the sync result summary.
     """
 
     async def run():
@@ -188,7 +190,7 @@ def sync_zotero_library_task(
                     user_id=user_id,
                 )
 
-                # Testar conexao
+                # Test the connection
                 connection_result = await zotero.test_connection()
 
                 if not connection_result.get("success"):
@@ -197,7 +199,7 @@ def sync_zotero_library_task(
                         "error": connection_result.get("error"),
                     }
 
-                # Listar collections
+                # List collections
                 collections_result = await zotero.list_collections()
 
                 return {
@@ -209,7 +211,7 @@ def sync_zotero_library_task(
                             "key": c.get("key"),
                             "name": c.get("data", {}).get("name"),
                         }
-                        for c in collections_result.get("collections", [])[:20]  # Limitar
+                        for c in collections_result.get("collections", [])[:20]  # Cap response size
                     ],
                 }
             except Exception:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -137,11 +137,13 @@ markers = [
 
 
 [tool.coverage.run]
-# KISS/DRY: focar coverage no código que está sendo efetivamente exercitado e mantido.
-# Estes diretórios estão atualmente sem testes (0%) e puxam a cobertura para baixo no CI.
+# Focus coverage on code that is actually exercised and maintained.
+# Directories listed here are intentionally excluded — `app/worker/*`
+# was previously here but PR 2 of the worker-hardening plan added real
+# tests (loop-isolation regression + eager-mode integration + drift
+# guard), so it has real coverage numbers now.
 omit = [
     "app/schemas/read_models/*",
-    "app/worker/*",
 ]
 
 [dependency-groups]

--- a/backend/tests/integration/test_worker_eager_mode.py
+++ b/backend/tests/integration/test_worker_eager_mode.py
@@ -10,7 +10,7 @@ on the pytest event loop, so loop reuse is impossible by construction.
 For loop coverage see the CI smoke job added in PR 3.
 
 Each test patches the *imports inside the task closure* (the task
-module imports ``AsyncSessionLocal``, ``get_supabase_client`` and the
+module imports ``worker_session``, ``get_supabase_client`` and the
 service classes lazily inside ``async def run``), then triggers the
 task via ``.apply(kwargs=...)`` which exercises the kwargs serialiser
 and the ``run_task`` async bridge.
@@ -44,7 +44,7 @@ class _FakeAsyncSession:
     """Drop-in for an SQLAlchemy ``AsyncSession`` that records lifecycle.
 
     Tasks call ``await session.commit()`` / ``await session.rollback()``
-    on the result of ``async with AsyncSessionLocal() as session``. We
+    on the result of ``async with worker_session() as session``. We
     don't need real SQL — just need awaitable no-ops so ``async with``
     and the commit/rollback calls succeed without raising.
     """
@@ -58,9 +58,9 @@ class _FakeAsyncSession:
 
 
 def _session_factory_returning(session: _FakeAsyncSession) -> Any:
-    """Return a callable that mimics ``AsyncSessionLocal()``.
+    """Return a callable that mimics ``worker_session()``.
 
-    ``AsyncSessionLocal()`` returns an async context manager whose
+    ``worker_session()`` returns an async context manager whose
     ``__aenter__`` yields the session. We can't use ``MagicMock`` here
     because ``async with`` requires ``__aenter__``/``__aexit__`` to be
     real coroutines.
@@ -106,7 +106,7 @@ def test_export_extraction_task_signature_and_kwargs_alignment() -> None:
             return_value=b"PK\x03\x04minimal-xlsx-bytes",
         ),
         patch(
-            "app.core.deps.AsyncSessionLocal",
+            "app.worker._session.worker_session",
             new=_session_factory_returning(session),
         ),
         patch(
@@ -166,7 +166,7 @@ def test_export_articles_task_signature_and_kwargs_alignment() -> None:
             return_value=MagicMock(),
         ),
         patch(
-            "app.core.deps.AsyncSessionLocal",
+            "app.worker._session.worker_session",
             new=_session_factory_returning(session),
         ),
         patch(
@@ -244,7 +244,7 @@ def test_import_zotero_collection_task_signature_and_kwargs_alignment() -> None:
             return_value=MagicMock(),
         ),
         patch(
-            "app.core.deps.AsyncSessionLocal",
+            "app.worker._session.worker_session",
             new=_session_factory_returning(session),
         ),
         patch(
@@ -316,7 +316,7 @@ def test_extract_section_task_signature_and_kwargs_alignment() -> None:
             return_value=MagicMock(),
         ),
         patch(
-            "app.core.deps.AsyncSessionLocal",
+            "app.worker._session.worker_session",
             new=_session_factory_returning(session),
         ),
         patch(

--- a/backend/tests/integration/test_worker_eager_mode.py
+++ b/backend/tests/integration/test_worker_eager_mode.py
@@ -1,0 +1,340 @@
+"""Eager-mode coverage for every Celery task.
+
+Runs each task synchronously via ``task_always_eager`` +
+``task_eager_propagates``. Validates serialisation (UUIDs come in as
+strings, parse correctly), kwargs alignment, and per-task client
+construction.
+
+Does NOT validate the event-loop bug — eager mode runs the coroutine
+on the pytest event loop, so loop reuse is impossible by construction.
+For loop coverage see the CI smoke job added in PR 3.
+
+Each test patches the *imports inside the task closure* (the task
+module imports ``AsyncSessionLocal``, ``get_supabase_client`` and the
+service classes lazily inside ``async def run``), then triggers the
+task via ``.apply(kwargs=...)`` which exercises the kwargs serialiser
+and the ``run_task`` async bridge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.worker.celery_app import celery_app
+
+# ----------------------------------------------------------------------
+# Shared fixtures / helpers
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def eager_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run every Celery task synchronously in the pytest process."""
+    monkeypatch.setattr(celery_app.conf, "task_always_eager", True)
+    monkeypatch.setattr(celery_app.conf, "task_eager_propagates", True)
+
+
+class _FakeAsyncSession:
+    """Drop-in for an SQLAlchemy ``AsyncSession`` that records lifecycle.
+
+    Tasks call ``await session.commit()`` / ``await session.rollback()``
+    on the result of ``async with AsyncSessionLocal() as session``. We
+    don't need real SQL — just need awaitable no-ops so ``async with``
+    and the commit/rollback calls succeed without raising.
+    """
+
+    def __init__(self) -> None:
+        self.commit = AsyncMock()
+        self.rollback = AsyncMock()
+        self.close = AsyncMock()
+        self.flush = AsyncMock()
+        self.refresh = AsyncMock()
+
+
+def _session_factory_returning(session: _FakeAsyncSession) -> Any:
+    """Return a callable that mimics ``AsyncSessionLocal()``.
+
+    ``AsyncSessionLocal()`` returns an async context manager whose
+    ``__aenter__`` yields the session. We can't use ``MagicMock`` here
+    because ``async with`` requires ``__aenter__``/``__aexit__`` to be
+    real coroutines.
+    """
+
+    @asynccontextmanager
+    async def _cm() -> AsyncIterator[_FakeAsyncSession]:
+        yield session
+
+    def _factory() -> Any:
+        return _cm()
+
+    return _factory
+
+
+# ----------------------------------------------------------------------
+# 1. extraction_export_tasks.export_extraction_task
+# ----------------------------------------------------------------------
+
+
+def test_export_extraction_task_signature_and_kwargs_alignment() -> None:
+    """The 9 task kwargs must align with what the endpoint passes."""
+    from app.worker.tasks.extraction_export_tasks import export_extraction_task
+
+    session = _FakeAsyncSession()
+    fake_service = MagicMock()
+    fake_service.resolve_layout = AsyncMock(return_value=object())
+    fake_storage = MagicMock()
+    fake_storage.upload = AsyncMock(return_value=None)
+    fake_storage.get_signed_url = AsyncMock(return_value="https://signed.example/url")
+
+    with (
+        patch(
+            "app.services.extraction_export_service.ExtractionExportService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.core.factories.create_storage_adapter",
+            return_value=fake_storage,
+        ),
+        patch(
+            "app.services.exports.extraction_xlsx_builder.build_workbook",
+            return_value=b"PK\x03\x04minimal-xlsx-bytes",
+        ),
+        patch(
+            "app.core.deps.AsyncSessionLocal",
+            new=_session_factory_returning(session),
+        ),
+        patch(
+            "app.core.deps.get_supabase_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = export_extraction_task.apply(
+            kwargs={
+                "project_id": str(uuid4()),
+                "template_id": str(uuid4()),
+                "mode": "consensus",
+                "article_ids": [str(uuid4())],
+                "article_scope": "current_list",
+                "user_id": str(uuid4()),
+                "reviewer_id": None,
+                "include_ai_metadata": False,
+                "anonymize_reviewer_names": False,
+            }
+        ).get(timeout=5)
+
+    assert result["download_url"] == "https://signed.example/url"
+    assert "expires_at" in result
+    assert "user_id" in result
+    # Layout resolved, workbook built, bytes uploaded, signed URL returned.
+    fake_service.resolve_layout.assert_awaited_once()
+    fake_storage.upload.assert_awaited_once()
+    fake_storage.get_signed_url.assert_awaited_once()
+
+
+# ----------------------------------------------------------------------
+# 2. export_tasks.export_articles_task
+# ----------------------------------------------------------------------
+
+
+def test_export_articles_task_signature_and_kwargs_alignment() -> None:
+    """Mirror of the extraction export — but for the articles ZIP path."""
+    from app.worker.tasks.export_tasks import export_articles_task
+
+    session = _FakeAsyncSession()
+    fake_service = MagicMock()
+    fake_service.run_export_async = AsyncMock(
+        return_value={
+            "download_url": "https://signed.example/zip",
+            "expires_at": "2026-05-24T12:00:00+00:00",
+            "skipped_files": [],
+        }
+    )
+
+    with (
+        patch(
+            "app.services.articles_export_service.ArticlesExportService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.core.factories.create_storage_adapter",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.core.deps.AsyncSessionLocal",
+            new=_session_factory_returning(session),
+        ),
+        patch(
+            "app.core.deps.get_supabase_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = export_articles_task.apply(
+            kwargs={
+                "project_id": str(uuid4()),
+                "article_ids": [str(uuid4()), str(uuid4())],
+                "formats": ["csv", "ris"],
+                "file_scope": "none",
+                "user_id": str(uuid4()),
+            }
+        ).get(timeout=5)
+
+    assert result["download_url"] == "https://signed.example/zip"
+    assert result["skipped_files"] == []
+    # The task augments the service result with ``user_id`` on the way out.
+    assert "user_id" in result
+    fake_service.run_export_async.assert_awaited_once()
+
+
+# ----------------------------------------------------------------------
+# 3. import_tasks.import_zotero_collection_task
+# ----------------------------------------------------------------------
+
+
+def test_import_zotero_collection_task_signature_and_kwargs_alignment() -> None:
+    """The Zotero collection import — service returns a dataclass with
+    a ``results`` list; the task flattens it into a JSON-safe dict.
+    """
+    from app.services.zotero_import_service import (
+        ZoteroImportItemResult,
+        ZoteroImportResult,
+    )
+    from app.worker.tasks.import_tasks import import_zotero_collection_task
+
+    session = _FakeAsyncSession()
+    fake_service = MagicMock()
+    fake_service.import_collection = AsyncMock(
+        return_value=ZoteroImportResult(
+            total_items=1,
+            imported=1,
+            failed=0,
+            skipped=0,
+            updated=0,
+            removed_at_source=0,
+            reactivated=0,
+            results=[
+                ZoteroImportItemResult(
+                    zotero_key="KEY1",
+                    title="Sample article",
+                    success=True,
+                    article_id=str(uuid4()),
+                    pdf_imported=False,
+                ),
+            ],
+            sync_run_id=str(uuid4()),
+        )
+    )
+
+    with (
+        patch(
+            "app.services.zotero_import_service.ZoteroImportService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.core.factories.create_storage_adapter",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.core.deps.AsyncSessionLocal",
+            new=_session_factory_returning(session),
+        ),
+        patch(
+            "app.core.deps.get_supabase_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = import_zotero_collection_task.apply(
+            kwargs={
+                "project_id": str(uuid4()),
+                "collection_key": "ABCD1234",
+                "user_id": str(uuid4()),
+                "import_pdfs": False,
+                "max_items": 10,
+                "update_existing": True,
+                "sync_run_id": str(uuid4()),
+            }
+        ).get(timeout=5)
+
+    assert result["total_items"] == 1
+    assert result["imported"] == 1
+    assert result["results"][0]["zotero_key"] == "KEY1"
+    fake_service.import_collection.assert_awaited_once()
+    session.commit.assert_awaited()  # task commits on the happy path
+
+
+# ----------------------------------------------------------------------
+# 4. extraction_tasks.extract_section_task
+# ----------------------------------------------------------------------
+
+
+def test_extract_section_task_signature_and_kwargs_alignment() -> None:
+    """The section extractor with BYOK fallback — when ``openai_api_key``
+    is ``None`` the task constructs an APIKeyService and resolves it
+    from the user's stored key.
+    """
+    from app.services.section_extraction_service import SectionExtractionResult
+    from app.worker.tasks.extraction_tasks import extract_section_task
+
+    session = _FakeAsyncSession()
+
+    fake_extraction_service = MagicMock()
+    fake_extraction_service.extract_section = AsyncMock(
+        return_value=SectionExtractionResult(
+            extraction_run_id=str(uuid4()),
+            entity_type_id=str(uuid4()),
+            suggestions_created=3,
+            tokens_prompt=120,
+            tokens_completion=80,
+            tokens_total=200,
+            duration_ms=1234.5,
+        )
+    )
+
+    fake_api_key_service = MagicMock()
+    fake_api_key_service.get_key_for_provider = AsyncMock(return_value="resolved-from-user-keys")
+
+    with (
+        patch(
+            "app.services.section_extraction_service.SectionExtractionService",
+            return_value=fake_extraction_service,
+        ),
+        patch(
+            "app.services.api_key_service.APIKeyService",
+            return_value=fake_api_key_service,
+        ),
+        patch(
+            "app.core.factories.create_storage_adapter",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.core.deps.AsyncSessionLocal",
+            new=_session_factory_returning(session),
+        ),
+        patch(
+            "app.core.deps.get_supabase_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = extract_section_task.apply(
+            kwargs={
+                "project_id": str(uuid4()),
+                "article_id": str(uuid4()),
+                "template_id": str(uuid4()),
+                "entity_type_id": str(uuid4()),
+                "user_id": str(uuid4()),
+                "parent_instance_id": None,
+                # No openai_api_key -> task must resolve via APIKeyService.
+                "openai_api_key": None,
+            }
+        ).get(timeout=5)
+
+    assert result["suggestions_created"] == 3
+    assert result["duration_ms"] == 1234
+    fake_api_key_service.get_key_for_provider.assert_awaited_once_with("openai")
+    fake_extraction_service.extract_section.assert_awaited_once()
+    session.commit.assert_awaited()

--- a/backend/tests/integration/test_worker_eager_mode.py
+++ b/backend/tests/integration/test_worker_eager_mode.py
@@ -189,6 +189,10 @@ def test_export_articles_task_signature_and_kwargs_alignment() -> None:
     # The task augments the service result with ``user_id`` on the way out.
     assert "user_id" in result
     fake_service.run_export_async.assert_awaited_once()
+    # Transaction management belongs to the service — the task body must
+    # not perform a raw commit. Catches a future regression where someone
+    # adds an `await session.commit()` to the task wrapper.
+    session.commit.assert_not_awaited()
 
 
 # ----------------------------------------------------------------------

--- a/backend/tests/unit/test_celery_app_task_registry.py
+++ b/backend/tests/unit/test_celery_app_task_registry.py
@@ -41,3 +41,23 @@ def test_celery_module_is_included(module: str, sample_task: str) -> None:
         f"the worker will reject {sample_task!r} as NotRegistered. "
         f"Add it to the include=[...] list in app/worker/celery_app.py."
     )
+
+
+@pytest.mark.parametrize(("module", "_sample_task"), EXPECTED_TASK_MODULES)
+def test_module_has_explicit_task_route(module: str, _sample_task: str) -> None:
+    """Every task module must have an explicit route — no falling back
+    to the default ``celery`` queue. Prevents future tasks from silently
+    landing on a queue that may or may not be consumed by the worker.
+
+    Pairs with ``tests/unit/test_celery_routes_drift.py`` which then
+    asserts every routed queue is actually consumed by the Railway
+    worker. Together they form a two-step guard: routes must exist
+    (this test) AND must map to a real queue (drift test).
+    """
+    pattern = f"{module}.*"
+    routes = celery_app.conf.task_routes or {}
+    assert pattern in routes, (
+        f"Module {module!r} is in include= but has no entry in "
+        f"task_routes. Add e.g. `{pattern!r}: {{'queue': 'celery'}}` "
+        f"explicitly so the test guarantees no drift."
+    )

--- a/backend/tests/unit/test_celery_routes_drift.py
+++ b/backend/tests/unit/test_celery_routes_drift.py
@@ -31,6 +31,14 @@ SOURCE_FILE = REPO_ROOT / "railway.toml"
 
 #: Pattern matching ``--queues=a,b,c`` in the Railway worker start
 #: command. Allows letters, digits and underscores in queue names.
+#:
+#: NOTE: ``[\w,]+`` is intentionally strict — the captured group stops
+#: at the first character outside ``[A-Za-z0-9_,]``. This means the
+#: queue list in ``railway.toml`` MUST be a contiguous CSV with no
+#: whitespace and no line continuations: ``--queues=a,b,c`` works,
+#: ``--queues=a, b, c`` does NOT (the regex captures only ``a``).
+#: If a future format change introduces spaces or wraps the line,
+#: relax this pattern and add a test that documents the new format.
 QUEUES_PATTERN = re.compile(r"--queues=([\w,]+)")
 
 

--- a/backend/tests/unit/test_celery_routes_drift.py
+++ b/backend/tests/unit/test_celery_routes_drift.py
@@ -1,0 +1,67 @@
+"""Drift guard between task routes and the deployed worker's queue list.
+
+``celery_app.conf.task_routes`` decides which queue each task lands in.
+The Railway worker boots with ``--queues=<csv>`` (set in the Railway
+dashboard; mirrored in ``railway.toml`` for documentation). If the two
+diverge, tasks are enqueued to queues nobody consumes — silent failure.
+
+This test parses the worker start command out of the canonical source
+(``railway.toml`` at the repo root — see the inventory comment block
+in that file) and asserts every queue named in ``task_routes`` is in
+that list.
+
+If the queue list ever moves out of ``railway.toml`` (e.g. into a
+GitHub Actions workflow), update ``SOURCE_FILE`` and ``QUEUES_PATTERN``
+accordingly. The Railway dashboard remains the runtime source of truth;
+this test guards against drift between the dashboard and the in-repo
+documentation, both of which must be updated together.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.worker.celery_app import celery_app
+
+# ``__file__`` -> backend/tests/unit/test_celery_routes_drift.py
+# parents[0] = unit/, [1] = tests/, [2] = backend/, [3] = repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SOURCE_FILE = REPO_ROOT / "railway.toml"
+
+#: Pattern matching ``--queues=a,b,c`` in the Railway worker start
+#: command. Allows letters, digits and underscores in queue names.
+QUEUES_PATTERN = re.compile(r"--queues=([\w,]+)")
+
+
+def _railway_worker_queues() -> set[str]:
+    """Parse the worker ``--queues=<csv>`` flag from the canonical file."""
+    text = SOURCE_FILE.read_text(encoding="utf-8")
+    match = QUEUES_PATTERN.search(text)
+    if not match:
+        raise AssertionError(
+            f"Could not find '--queues=...' in {SOURCE_FILE}. "
+            f"The drift test relies on the worker start command being "
+            f"present there. If you moved the canonical location, "
+            f"update SOURCE_FILE in this test."
+        )
+    return set(match.group(1).split(","))
+
+
+def test_every_routed_queue_is_consumed_by_the_railway_worker() -> None:
+    """Every queue routed in code MUST be consumed by the worker.
+
+    If this fails, either:
+      - add the missing queue to the worker ``--queues`` list in
+        ``railway.toml`` AND in the Railway dashboard, or
+      - drop the route in ``app/worker/celery_app.py``.
+    """
+    routed = {entry["queue"] for entry in celery_app.conf.task_routes.values()}
+    consumed = _railway_worker_queues()
+    missing = routed - consumed
+    assert not missing, (
+        f"Queues routed in celery_app.conf.task_routes but NOT in the "
+        f"Railway worker --queues list: {sorted(missing)}. Either add "
+        f"them to the worker start command in railway.toml (and update "
+        f"the Railway dashboard) or drop the route in celery_app.py."
+    )

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -105,13 +105,50 @@ def test_logged_task_emits_generic_event_for_other_failures(monkeypatch):
     task.name = "real.task"
     task.on_failure(ValueError("boom"), "task-456", (), {}, None)
 
-    assert captured == [(
-        "task_failed",
-        {
-            "task_id": "task-456",
-            "task_name": "real.task",
-            "error": "boom",
-            "args": (),
-            "kwargs": {},
-        },
-    )]
+    assert captured == [
+        (
+            "task_failed",
+            {
+                "task_id": "task-456",
+                "task_name": "real.task",
+                "error": "boom",
+                "args": (),
+                "kwargs": {},
+            },
+        )
+    ]
+
+
+def test_task_unknown_signal_emits_structured_event(monkeypatch):
+    """The runtime hook for NotRegistered is the celery signal — not the
+    task's on_failure callback. Verify the signal handler emits the
+    correct structlog event when fired.
+    """
+    from celery.signals import task_unknown
+
+    captured: list[tuple[str, dict]] = []
+
+    class StubLogger:
+        def error(self, event: str, **kw):
+            captured.append((event, kw))
+
+    monkeypatch.setattr("structlog.get_logger", lambda: StubLogger())
+
+    # Import the celery_app module so the @task_unknown.connect handler
+    # is registered as a side effect.
+    import app.worker.celery_app  # noqa: F401
+
+    task_unknown.send(
+        sender=None,
+        name="ghost.task",
+        id="task-789",
+        message=None,
+        exc=None,
+    )
+
+    matches = [kw for event, kw in captured if event == "celery.task_unregistered"]
+    assert matches, f"Expected celery.task_unregistered event from signal handler, got {captured!r}"
+    kw = matches[-1]
+    assert kw["task_id"] == "task-789"
+    assert kw["task_name"] == "ghost.task"
+    assert "remediation" in kw

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -152,3 +152,32 @@ def test_task_unknown_signal_emits_structured_event(monkeypatch):
     assert kw["task_id"] == "task-789"
     assert kw["task_name"] == "ghost.task"
     assert "remediation" in kw
+
+
+def test_worker_session_uses_fresh_engine_each_call() -> None:
+    """Each worker_session() must construct + dispose its own engine.
+
+    The 2026-05-24 incident root cause was a module-global engine whose
+    asyncpg connection pool bound its waiters to the first event loop
+    that touched it. ``worker_session`` MUST build a per-call engine so
+    no pool state ever crosses ``asyncio.run`` boundaries.
+    """
+    import asyncio
+
+    from app.worker._session import worker_session
+
+    engines_seen: list[int] = []
+
+    async def grab_engine_id() -> None:
+        async with worker_session() as session:
+            engines_seen.append(id(session.bind))
+
+    asyncio.run(grab_engine_id())
+    asyncio.run(grab_engine_id())
+
+    assert len(engines_seen) == 2
+    assert engines_seen[0] != engines_seen[1], (
+        "worker_session must construct a fresh engine per call — "
+        "engine identity reuse is the root cause of the 2026-05-24 "
+        "cross-loop bug."
+    )

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -55,5 +55,10 @@ def test_run_task_rejects_a_bare_coroutine() -> None:
     async def coro() -> int:
         return 1
 
-    with pytest.raises(TypeError, match="callable"):
+    with pytest.raises(TypeError, match="coroutine object"):
         run_task(coro())  # type: ignore[arg-type]
+
+
+def test_run_task_rejects_a_non_callable_non_coroutine() -> None:
+    with pytest.raises(TypeError, match="run_task requires a zero-arg callable"):
+        run_task(42)  # type: ignore[arg-type]

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -62,3 +62,56 @@ def test_run_task_rejects_a_bare_coroutine() -> None:
 def test_run_task_rejects_a_non_callable_non_coroutine() -> None:
     with pytest.raises(TypeError, match="run_task requires a zero-arg callable"):
         run_task(42)  # type: ignore[arg-type]
+
+
+def test_logged_task_emits_specific_event_for_not_registered(monkeypatch):
+    from celery.exceptions import NotRegistered
+
+    from app.worker.celery_app import LoggedTask
+
+    captured: list[tuple[str, dict]] = []
+
+    class StubLogger:
+        def error(self, event: str, **kw):
+            captured.append((event, kw))
+
+    monkeypatch.setattr("structlog.get_logger", lambda: StubLogger())
+
+    task = LoggedTask()
+    task.name = "ghost.task"
+    task.on_failure(NotRegistered("ghost.task"), "task-123", (), {"a": 1}, None)
+
+    assert captured, "on_failure should have logged"
+    event, kw = captured[0]
+    assert event == "celery.task_unregistered"
+    assert kw["task_id"] == "task-123"
+    assert kw["task_name"] == "ghost.task"
+    assert "remediation" in kw
+
+
+def test_logged_task_emits_generic_event_for_other_failures(monkeypatch):
+    """Non-NotRegistered exceptions still go to ``task_failed``."""
+    from app.worker.celery_app import LoggedTask
+
+    captured: list[tuple[str, dict]] = []
+
+    class StubLogger:
+        def error(self, event: str, **kw):
+            captured.append((event, kw))
+
+    monkeypatch.setattr("structlog.get_logger", lambda: StubLogger())
+
+    task = LoggedTask()
+    task.name = "real.task"
+    task.on_failure(ValueError("boom"), "task-456", (), {}, None)
+
+    assert captured == [(
+        "task_failed",
+        {
+            "task_id": "task-456",
+            "task_name": "real.task",
+            "error": "boom",
+            "args": (),
+            "kwargs": {},
+        },
+    )]

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -1,0 +1,59 @@
+"""Unit tests for the shared worker task runner.
+
+The headline test (`test_two_sequential_calls_do_not_share_loop`) is the
+regression guard for the 2026-05-24 event-loop bug: two tasks running on
+the same worker process must each get a clean loop so cached httpx /
+asyncpg primitives from a previous loop cannot leak in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from app.worker._runner import run_task
+
+
+def _make_factory(probe: dict) -> Callable[[], Awaitable[int]]:
+    async def coro() -> int:
+        probe["loop"] = asyncio.get_running_loop()
+        return 42
+
+    return coro
+
+
+def test_run_task_returns_coroutine_result() -> None:
+    probe: dict = {}
+    assert run_task(_make_factory(probe)) == 42
+    assert probe["loop"] is not None
+
+
+def test_two_sequential_calls_do_not_share_loop() -> None:
+    probe_a: dict = {}
+    probe_b: dict = {}
+    run_task(_make_factory(probe_a))
+    run_task(_make_factory(probe_b))
+    assert probe_a["loop"] is not None
+    assert probe_b["loop"] is not None
+    assert probe_a["loop"] is not probe_b["loop"], (
+        "run_task must use a fresh event loop per invocation — "
+        "loop reuse is the root cause of the 2026-05-24 export bug."
+    )
+
+
+def test_run_task_propagates_exceptions() -> None:
+    async def coro() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        run_task(coro)
+
+
+def test_run_task_rejects_a_bare_coroutine() -> None:
+    async def coro() -> int:
+        return 1
+
+    with pytest.raises(TypeError, match="callable"):
+        run_task(coro())  # type: ignore[arg-type]

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -33,6 +33,40 @@ All three Railway services + the Redis plugin live in the same project, region *
 | `worker` | `backend/Dockerfile` | `celery -A app.worker.celery_app worker --loglevel=info --queues=extractions,imports,exports,celery` (Railway custom start command — overrides Dockerfile CMD) | no | none |
 | `Redis` | Railway managed plugin | n/a | private network only (`redis.railway.internal`) | n/a |
 
+## Worker — task runner
+
+Every Celery task in `backend/app/worker/tasks/` delegates to a single
+shared runner:
+
+```python
+from app.worker._runner import run_task
+
+@celery_app.task
+def my_task(self, ...):
+    async def run():
+        async with AsyncSessionLocal() as db:
+            ...
+    return run_task(run)
+```
+
+`run_task` calls `asyncio.run(coro_factory())` — a fresh loop per task.
+**Do not** cache event loops in module globals (we tried; see the
+2026-05-24 incident). **Do not** cache the Supabase client at module
+scope; `get_supabase_client()` returns a new instance per call, so the
+httpx connection pool stays bound to the current loop.
+
+## Observability — task-registry alerts
+
+`LoggedTask.on_failure` emits two distinct structlog events:
+
+| Event | Meaning | Recommended alert |
+|---|---|---|
+| `task_failed` | Generic task crash (business error, retry exhausted). | Aggregate; alert above baseline rate. |
+| `celery.task_unregistered` | The worker received a task name it has no handler for. **P1** — always caused by `celery_app.include` drift or a routing typo. | Page on first occurrence. |
+
+The drift guard at `backend/tests/unit/test_celery_app_task_registry.py`
+prevents this in CI, but the log event is the runtime safety net.
+
 ## Environment variables
 
 There is no tracked env template — env files match `.gitignore` line 21 (`.env.*`). This table is the canonical reference; paste the values into the Railway dashboard or use the Railway CLI to set them.


### PR DESCRIPTION
## Summary

Closes the 2026-05-24 `Future attached to a different loop` worker bug surfaced during smoke-testing the extraction Excel export on Railway. Centralises every Celery task on a shared `run_task` runner, kills the cached event loop, replaces the cached Supabase client + pooled DB engine with per-task constructions, gives `app/worker/*` real test coverage (was 0% / `omit`-ed), and adds a CI smoke job that boots a real Redis+worker and proves both PRs' regression guards.

## What's in the box

| Layer | Change |
|---|---|
| **Runtime fix** | `app/worker/_runner.py:run_task(coro_factory)` — fresh `asyncio.run` per task. `app/worker/_session.py:worker_session()` — per-task SQLAlchemy engine + `NullPool` (no pool state crosses loops). All 4 task modules (`extraction_export`, `extraction`, `export`, `import`) refactored to use both. `get_supabase_client` lost `@lru_cache`. |
| **Tests** | `test_worker_runner.py` (8 tests, incl. loop-isolation + engine-isolation regressions + signal handler). `test_worker_eager_mode.py` (4 tests, eager-mode coverage per task with mocked services). `test_celery_routes_drift.py` (parses `railway.toml`, asserts every routed queue is consumed). `test_celery_app_task_registry.py` extended with explicit-route requirement. |
| **Observability** | `LoggedTask.on_failure` emits `celery.task_unregistered` (P1 alertable) for `NotRegistered`. `@task_unknown.connect` signal handler covers the actual Celery routing path (the `on_failure` branch is dead in production but kept as defense in depth). |
| **CI gate** | `.github/workflows/worker-smoke.yml` spins up Redis 7 as a service container, boots a real Celery worker, dispatches 2 sequential tasks, asserts the worker log contains no `attached to a different loop` and no `NotRegistered`, and `sys.exit(1)`s if any task is still PENDING after the deadline (so a worker crash can't pass silently). |
| **Coverage** | `app/worker/*` removed from coverage omit. Worker coverage now real-measured. |
| **Hygiene** | English-only sweep across `app/worker/`, `app/core/deps.py` (CLAUDE.md §1). Documentation updates in `docs/architecture/deployment.md` (runner pattern + observability events). |

## How it was proved

Local smoke test against the worktree branch with REAL workload (3 sequential `export_extraction_task` invocations, valid project_id, `include_ai_metadata=True` so it exercises template fetch + AI metadata + Storage upload):

- ✅ All 3 transitioned `SUCCESS` and returned signed URLs
- ✅ Zero `attached to a different loop` in worker log
- ✅ Worker log shows the second and third tasks reuse the worker's Celery context but use **fresh** SQLAlchemy engine + connection per task (visible in `sqlalchemy.engine.Engine` lines)

Without the fix, dispatching a second task with a real template_id reliably explodes on the second DB query inside `resolve_layout`.

## Test plan

- [x] `cd backend && uv run pytest tests/unit/test_worker_runner.py tests/integration/test_worker_eager_mode.py tests/unit/test_celery_routes_drift.py tests/unit/test_celery_app_task_registry.py -v` → **22 passed**
- [x] `make test-backend` → **567 passed**, 4 pre-existing integration failures unchanged
- [x] `make lint-backend` → green
- [x] Local worker smoke: 3 sequential `export_extraction_task` with real fixtures → all SUCCESS
- [x] Sabotage on drift test (add fake `ghost` queue) → test fails with the expected message
- [ ] CI worker-smoke workflow (new — first PR run is the validation)

## Commits

```
800f606 fix(worker): per-task engine with NullPool to seal the loop bug
60e1d23 fix(worker): rewire NotRegistered to celery signal + harden CI gate
9e8e5ca feat(worker): NotRegistered alert + CI smoke test for runner
b8a65e3 test(worker): tighten eager-mode commit guard + document drift regex
09d461f test(worker): close coverage gap + add route/queue drift guards
20c8df8 chore(core): translate deps.py docstrings/comments to English
45a47ae chore(worker): translate worker package __init__ docstring to English
e820acb chore(worker): translate celery_app.py comments/docstrings to English
5c87bc1 fix(worker): tighten runner guard + translate worker tasks to English
4051b48 fix(worker): per-call event loop + lazy clients via shared runner
```

Total: +1183 / −184 across 17 files. See `docs/superpowers/plans/2026-05-24-worker-hardening.md` for the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core worker async/DB/Supabase lifecycle for all background jobs (exports, imports, extractions); mitigated by targeted regression tests and a real-worker CI smoke gate, but production behavior still depends on Railway queue config staying in sync with routes.
> 
> **Overview**
> Fixes the **2026-05-24** Celery worker failure where a second task could raise **Future attached to a different loop** during extraction exports.
> 
> **Runtime:** All background tasks now go through shared **`run_task`**, which runs **`asyncio.run`** once per invocation with a coroutine **factory** (not a pre-built coroutine). Workers use **`worker_session()`** — a per-task SQLAlchemy engine with **`NullPool`** — instead of the app-wide pooled engine. **`get_supabase_client`** no longer uses **`@lru_cache`**, so httpx/Supabase clients are created per task or per HTTP request.
> 
> **Celery ops:** **`export_tasks.*`** gets an explicit **`celery`** queue route. **`LoggedTask`** and a **`task_unknown`** signal emit **`celery.task_unregistered`** for missing handlers. Unit tests assert every included task module has a route and that routed queues match **`railway.toml`** worker **`--queues`**.
> 
> **Testing & CI:** New unit/integration tests cover loop isolation, eager-mode task contracts, and registry/drift guards. **`app/worker/*`** is removed from coverage omit. **`.github/workflows/worker-smoke.yml`** boots Redis + a real worker, runs two sequential **`export_extraction_task`** jobs, and fails on loop-reuse or **`NotRegistered`** in logs.
> 
> **Docs/hygiene:** **`deployment.md`** documents the runner pattern and alert events; worker/deps comments translated to English.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c292ee60f44ad6ad3366b291556947c23f7861f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->