### PR TITLE
Merge dev → main: resolve cursor/* orphan PRs (#129 + #111)

### DIFF
--- a/backend/app/api/v1/endpoints/model_extraction.py
+++ b/backend/app/api/v1/endpoints/model_extraction.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 
-from app.api.deps.security import get_current_user_sub
+from app.api.deps.security import ensure_project_member, get_current_user_sub
 from app.core.deps import CurrentUser, DbSession, SupabaseClient
 from app.core.factories import create_storage_adapter
 from app.core.logging import get_logger
@@ -54,6 +54,8 @@ async def create_manual_model_hierarchy(
 ) -> ApiResponse[CreateModelHierarchyResponse]:
     trace_id = getattr(request.state, "trace_id", None) or "missing-trace-id"
     service = ModelHierarchyService(db)
+
+    await ensure_project_member(db, payload.project_id, current_user_sub)
 
     try:
         result = await service.create_model_hierarchy(
@@ -116,6 +118,7 @@ async def extract_models(
     db: DbSession,
     user: CurrentUser,
     supabase: SupabaseClient,
+    current_user_sub: UUID = Depends(get_current_user_sub),
 ) -> ApiResponse[dict[str, Any]]:
     """
     Run prediction model extraction for an article.
@@ -147,6 +150,8 @@ async def extract_models(
         template_id=str(payload.template_id),
         model=payload.model,
     )
+
+    await ensure_project_member(db, payload.project_id, current_user_sub)
 
     try:
         # Create storage adapter via factory

--- a/backend/app/api/v1/endpoints/section_extraction.py
+++ b/backend/app/api/v1/endpoints/section_extraction.py
@@ -7,10 +7,12 @@ Suporta extraction individual or em batch de todas as sections.
 
 from time import perf_counter
 from typing import Any
+from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
 
+from app.api.deps.security import ensure_project_member, get_current_user_sub
 from app.core.deps import CurrentUser, DbSession, SupabaseClient
 from app.core.factories import create_storage_adapter
 from app.core.logging import get_logger
@@ -21,6 +23,7 @@ from app.schemas.extraction import (
     SingleSectionResult,
 )
 from app.services.api_key_service import APIKeyService
+from app.services.extraction_run_read_service import RunNotFoundError, get_run_or_raise
 from app.services.run_lifecycle_service import (
     CreateRunInputError,
     TemplateNotFoundError,
@@ -31,6 +34,32 @@ from app.utils.rate_limiter import limiter
 
 router = APIRouter()
 logger = get_logger(__name__)
+
+
+async def _check_request_scope(
+    db: DbSession,
+    payload: SectionExtractionRequest,
+    current_user_sub: UUID,
+) -> None:
+    if payload.run_id is None:
+        await ensure_project_member(db, payload.project_id, current_user_sub)
+        return
+
+    try:
+        run = await get_run_or_raise(db, payload.run_id)
+    except RunNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    await ensure_project_member(db, run.project_id, current_user_sub)
+    if (
+        payload.project_id != run.project_id
+        or payload.article_id != run.article_id
+        or payload.template_id != run.template_id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="runId does not match projectId, articleId, and templateId",
+        )
 
 
 @router.post(
@@ -46,6 +75,7 @@ async def extract_section(
     db: DbSession,
     user: CurrentUser,
     supabase: SupabaseClient,
+    current_user_sub: UUID = Depends(get_current_user_sub),
 ) -> ApiResponse[dict[str, Any]]:
     """
     Executa extraction de section(oes) de um template.
@@ -77,6 +107,8 @@ async def extract_section(
         extract_all_sections=payload.extract_all_sections,
         model=payload.model,
     )
+
+    await _check_request_scope(db, payload, current_user_sub)
 
     try:
         # Create storage adapter via factory

--- a/backend/app/services/extraction_export_service.py
+++ b/backend/app/services/extraction_export_service.py
@@ -501,7 +501,7 @@ class ExtractionExportService(LoggerMixin):
             .all()
         )
 
-        runs_by_article: dict[UUID, ExtractionRun] = {r.article_id: r for r in run_rows}
+        runs_by_article = _select_current_runs_by_article(run_rows)
         omitted: dict[str, int] = {}
         kept_run_ids: list[UUID] = []
         kept_articles: list[UUID] = []
@@ -707,7 +707,7 @@ class ExtractionExportService(LoggerMixin):
             .scalars()
             .all()
         )
-        runs_by_article: dict[UUID, ExtractionRun] = {r.article_id: r for r in run_rows}
+        runs_by_article = _select_current_runs_by_article(run_rows)
 
         if not runs_by_article:
             return [], {"no_run": len(candidate_ids)}
@@ -948,7 +948,7 @@ class ExtractionExportService(LoggerMixin):
             .scalars()
             .all()
         )
-        runs_by_article: dict[UUID, ExtractionRun] = {r.article_id: r for r in run_rows}
+        runs_by_article = _select_current_runs_by_article(run_rows)
 
         omitted: dict[str, int] = {}
         kept_article_ids: list[UUID] = []
@@ -1378,6 +1378,57 @@ def _infer_reviewer_outcome(
     if proposal_id != latest_id:
         return "superseded"
     return "pending"
+
+
+_ACTIVE_EXPORT_RUN_STAGES = {
+    ExtractionRunStage.PENDING.value,
+    ExtractionRunStage.PROPOSAL.value,
+    ExtractionRunStage.REVIEW.value,
+    ExtractionRunStage.CONSENSUS.value,
+}
+
+
+def _select_current_runs_by_article(
+    run_rows: list[ExtractionRun],
+) -> dict[UUID, ExtractionRun]:
+    """Choose the same current run the HITL session path exposes.
+
+    Reopen creates multiple runs for the same article/template. Export must
+    never let PostgreSQL row order decide whether it sees the old finalized
+    run or the active revision. Prefer the latest non-terminal run, otherwise
+    the latest finalized run, otherwise the latest cancelled run for omission
+    accounting.
+    """
+
+    active_by_article: dict[UUID, ExtractionRun] = {}
+    finalized_by_article: dict[UUID, ExtractionRun] = {}
+    cancelled_by_article: dict[UUID, ExtractionRun] = {}
+
+    for run in sorted(run_rows, key=_run_recency_key, reverse=True):
+        if run.stage in _ACTIVE_EXPORT_RUN_STAGES:
+            active_by_article.setdefault(run.article_id, run)
+        elif run.stage == ExtractionRunStage.FINALIZED.value:
+            finalized_by_article.setdefault(run.article_id, run)
+        elif run.stage == ExtractionRunStage.CANCELLED.value:
+            cancelled_by_article.setdefault(run.article_id, run)
+
+    selected: dict[UUID, ExtractionRun] = {}
+    for article_id in {
+        *active_by_article.keys(),
+        *finalized_by_article.keys(),
+        *cancelled_by_article.keys(),
+    }:
+        selected[article_id] = (
+            active_by_article.get(article_id)
+            or finalized_by_article.get(article_id)
+            or cancelled_by_article[article_id]
+        )
+    return selected
+
+
+def _run_recency_key(run: ExtractionRun) -> tuple[datetime, str]:
+    created_at = run.created_at or datetime.min.replace(tzinfo=UTC)
+    return created_at, str(run.id)
 
 
 def _normalize_allowed_values(raw: Any) -> tuple[str, ...]:

--- a/backend/app/services/model_hierarchy_service.py
+++ b/backend/app/services/model_hierarchy_service.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.article import Article
 from app.models.extraction import (
     ExtractionCardinality,
     ExtractionEntityRole,
@@ -67,6 +68,10 @@ class ModelHierarchyService:
             raise ValueError("Template not found in project")
         if template.kind != TemplateKind.EXTRACTION.value:
             raise ValueError("Template kind must be extraction")
+
+        article = await self.db.get(Article, article_id)
+        if article is None or article.project_id != project_id:
+            raise ValueError("Article not found in project")
 
         model_entity_type = await self._prediction_models_entity_type(template_id)
         if model_entity_type is None:

--- a/backend/tests/integration/test_extraction_endpoints.py
+++ b/backend/tests/integration/test_extraction_endpoints.py
@@ -2,6 +2,7 @@
 Extraction Endpoints Integration Tests.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -59,9 +60,15 @@ class TestSectionExtractionEndpoints:
         """Test extraction with valid request."""
         from app.services.section_extraction_service import SectionExtractionResult
 
-        with patch(
-            "app.api.v1.endpoints.section_extraction.SectionExtractionService"
-        ) as mock_service_class:
+        with (
+            patch(
+                "app.api.v1.endpoints.section_extraction.SectionExtractionService"
+            ) as mock_service_class,
+            patch(
+                "app.api.v1.endpoints.section_extraction.ensure_project_member",
+                new_callable=AsyncMock,
+            ) as guard,
+        ):
             mock_service = mock_service_class.return_value
             mock_service.extract_section = AsyncMock(
                 return_value=SectionExtractionResult(
@@ -93,6 +100,7 @@ class TestSectionExtractionEndpoints:
             assert data.get("trace_id") == trace_id
             assert response.headers.get("X-Trace-Id") == trace_id
             assert mock_service_class.call_args.kwargs["trace_id"] == trace_id
+            guard.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_section_extraction_batch_valid_request(
@@ -102,9 +110,15 @@ class TestSectionExtractionEndpoints:
         """Test batch extraction with valid request."""
         from app.services.section_extraction_service import BatchExtractionResult
 
-        with patch(
-            "app.api.v1.endpoints.section_extraction.SectionExtractionService"
-        ) as mock_service_class:
+        with (
+            patch(
+                "app.api.v1.endpoints.section_extraction.SectionExtractionService"
+            ) as mock_service_class,
+            patch(
+                "app.api.v1.endpoints.section_extraction.ensure_project_member",
+                new_callable=AsyncMock,
+            ) as guard,
+        ):
             mock_service = mock_service_class.return_value
             mock_service.extract_all_sections = AsyncMock(
                 return_value=BatchExtractionResult(
@@ -137,6 +151,7 @@ class TestSectionExtractionEndpoints:
             assert data.get("ok") is True
             assert data.get("trace_id") == trace_id
             assert mock_service_class.call_args.kwargs["trace_id"] == trace_id
+            guard.assert_awaited_once()
 
 
 class TestModelExtractionEndpoints:
@@ -164,9 +179,15 @@ class TestModelExtractionEndpoints:
         """Test model extraction with valid request."""
         from app.services.model_extraction_service import ModelExtractionResult
 
-        with patch(
-            "app.api.v1.endpoints.model_extraction.ModelExtractionService"
-        ) as mock_service_class:
+        with (
+            patch(
+                "app.api.v1.endpoints.model_extraction.ModelExtractionService"
+            ) as mock_service_class,
+            patch(
+                "app.api.v1.endpoints.model_extraction.ensure_project_member",
+                new_callable=AsyncMock,
+            ) as guard,
+        ):
             mock_service = mock_service_class.return_value
             mock_service.extract = AsyncMock(
                 return_value=ModelExtractionResult(
@@ -198,6 +219,7 @@ class TestModelExtractionEndpoints:
             assert data.get("trace_id") == trace_id
             assert response.headers.get("X-Trace-Id") == trace_id
             assert mock_service_class.call_args.kwargs["trace_id"] == trace_id
+            guard.assert_awaited_once()
 
 
 class TestManualModelHierarchyEndpoints:
@@ -224,7 +246,13 @@ class TestManualModelHierarchyEndpoints:
             ModelHierarchyResult,
         )
 
-        with patch("app.api.v1.endpoints.model_extraction.ModelHierarchyService") as svc_cls:
+        with (
+            patch("app.api.v1.endpoints.model_extraction.ModelHierarchyService") as svc_cls,
+            patch(
+                "app.api.v1.endpoints.model_extraction.ensure_project_member",
+                new_callable=AsyncMock,
+            ) as guard,
+        ):
             svc = svc_cls.return_value
             svc.create_model_hierarchy = AsyncMock(
                 return_value=ModelHierarchyResult(
@@ -259,3 +287,34 @@ class TestManualModelHierarchyEndpoints:
             assert payload["data"]["modelLabel"] == "Cox Model"
             assert len(payload["data"]["childInstances"]) == 1
             svc.create_model_hierarchy.assert_awaited_once()
+            guard.assert_awaited_once()
+
+
+class TestManualModelHierarchyService:
+    """Regression tests for cross-project model hierarchy invariants."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_article_from_another_project(self) -> None:
+        from app.services.model_hierarchy_service import ModelHierarchyService
+
+        project_id = uuid4()
+        article_id = uuid4()
+        template_id = uuid4()
+        db = AsyncMock()
+        db.get = AsyncMock(
+            side_effect=[
+                SimpleNamespace(project_id=project_id, kind="extraction"),
+                SimpleNamespace(project_id=uuid4()),
+            ]
+        )
+
+        service = ModelHierarchyService(db)
+
+        with pytest.raises(ValueError, match="Article not found in project"):
+            await service.create_model_hierarchy(
+                project_id=project_id,
+                article_id=article_id,
+                template_id=template_id,
+                user_id=uuid4(),
+                model_name="Cox Model",
+            )

--- a/backend/tests/integration/test_membership_guards.py
+++ b/backend/tests/integration/test_membership_guards.py
@@ -132,6 +132,29 @@ async def _pick_template_for_outsider(
     return UUID(str(row[0])), UUID(str(row[1]))
 
 
+async def _pick_extraction_article_template_for_outsider(
+    db: AsyncSession, outsider_id: UUID
+) -> tuple[UUID, UUID, UUID] | None:
+    row = (
+        await db.execute(
+            text(
+                """
+                SELECT t.project_id, a.id, t.id
+                FROM public.project_extraction_templates t
+                JOIN public.articles a ON a.project_id = t.project_id
+                WHERE t.kind = 'extraction'
+                  AND NOT public.is_project_member(t.project_id, :uid)
+                LIMIT 1
+                """
+            ),
+            {"uid": str(outsider_id)},
+        )
+    ).first()
+    if row is None:
+        return None
+    return UUID(str(row[0])), UUID(str(row[1])), UUID(str(row[2]))
+
+
 # =================== #57: GET /runs/{id} ===================
 
 
@@ -263,6 +286,121 @@ async def test_open_hitl_session_403_for_non_member(
             "project_id": str(project_id),
             "article_id": str(article_id),
             "project_template_id": str(template_id),
+        },
+    )
+    assert res.status_code == 403, res.text
+
+
+# =================== Extraction AI endpoints ===================
+
+
+@pytest.mark.asyncio
+async def test_section_extraction_403_for_non_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    outsider_user: UUID,
+) -> None:
+    fx = await _pick_extraction_article_template_for_outsider(db_session, outsider_user)
+    if fx is None:
+        pytest.skip(
+            "Need an extraction article/template in a project the outsider does not belong to"
+        )
+    project_id, article_id, template_id = fx
+
+    res = await db_client.post(
+        "/api/v1/extraction/sections",
+        json={
+            "projectId": str(project_id),
+            "articleId": str(article_id),
+            "templateId": str(template_id),
+            "entityTypeId": str(uuid.uuid4()),
+        },
+    )
+    assert res.status_code == 403, res.text
+
+
+@pytest.mark.asyncio
+async def test_section_extraction_run_id_403_for_non_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    outsider_user: UUID,
+) -> None:
+    fx = await _pick_run_for_outsider(db_session, outsider_user)
+    if fx is None:
+        pytest.skip("Need a run in a project the outsider does not belong to")
+    run_id, _, _, _ = fx
+    row = (
+        await db_session.execute(
+            text(
+                """
+                SELECT project_id, article_id, template_id
+                FROM public.extraction_runs
+                WHERE id = :rid
+                """
+            ),
+            {"rid": str(run_id)},
+        )
+    ).first()
+    if row is None:
+        pytest.skip("Run disappeared before request")
+    project_id, article_id, template_id = row
+
+    res = await db_client.post(
+        "/api/v1/extraction/sections",
+        json={
+            "projectId": str(project_id),
+            "articleId": str(article_id),
+            "templateId": str(template_id),
+            "runId": str(run_id),
+        },
+    )
+    assert res.status_code == 403, res.text
+
+
+@pytest.mark.asyncio
+async def test_model_extraction_403_for_non_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    outsider_user: UUID,
+) -> None:
+    fx = await _pick_extraction_article_template_for_outsider(db_session, outsider_user)
+    if fx is None:
+        pytest.skip(
+            "Need an extraction article/template in a project the outsider does not belong to"
+        )
+    project_id, article_id, template_id = fx
+
+    res = await db_client.post(
+        "/api/v1/extraction/models",
+        json={
+            "projectId": str(project_id),
+            "articleId": str(article_id),
+            "templateId": str(template_id),
+        },
+    )
+    assert res.status_code == 403, res.text
+
+
+@pytest.mark.asyncio
+async def test_manual_model_hierarchy_403_for_non_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    outsider_user: UUID,
+) -> None:
+    fx = await _pick_extraction_article_template_for_outsider(db_session, outsider_user)
+    if fx is None:
+        pytest.skip(
+            "Need an extraction article/template in a project the outsider does not belong to"
+        )
+    project_id, article_id, template_id = fx
+
+    res = await db_client.post(
+        "/api/v1/extraction/models/manual",
+        json={
+            "projectId": str(project_id),
+            "articleId": str(article_id),
+            "templateId": str(template_id),
+            "modelName": "Outsider model",
         },
     )
     assert res.status_code == 403, res.text

--- a/backend/tests/unit/test_extraction_export_service.py
+++ b/backend/tests/unit/test_extraction_export_service.py
@@ -1,0 +1,58 @@
+"""Unit coverage for extraction export service helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.models.extraction import ExtractionRunStage
+from app.services.extraction_export_service import _select_current_runs_by_article
+
+
+def _run(article_id, stage: ExtractionRunStage, created_at: datetime):
+    return SimpleNamespace(
+        id=uuid4(),
+        article_id=article_id,
+        stage=stage.value,
+        created_at=created_at,
+    )
+
+
+def test_select_current_run_prefers_active_revision_over_old_finalized_run():
+    article_id = uuid4()
+    base = datetime(2026, 5, 24, 10, 0, tzinfo=UTC)
+    old_finalized = _run(article_id, ExtractionRunStage.FINALIZED, base)
+    reopened_review = _run(article_id, ExtractionRunStage.REVIEW, base + timedelta(minutes=5))
+
+    selected = _select_current_runs_by_article([old_finalized, reopened_review])
+
+    assert selected[article_id].id == reopened_review.id
+
+
+def test_select_current_run_prefers_latest_finalized_revision_when_no_active_run():
+    article_id = uuid4()
+    base = datetime(2026, 5, 24, 10, 0, tzinfo=UTC)
+    old_finalized = _run(article_id, ExtractionRunStage.FINALIZED, base)
+    latest_finalized = _run(
+        article_id,
+        ExtractionRunStage.FINALIZED,
+        base + timedelta(minutes=5),
+    )
+
+    selected = _select_current_runs_by_article([latest_finalized, old_finalized])
+
+    assert selected[article_id].id == latest_finalized.id
+
+
+def test_select_current_run_keeps_cancelled_run_for_omission_accounting():
+    article_id = uuid4()
+    cancelled = _run(
+        article_id,
+        ExtractionRunStage.CANCELLED,
+        datetime(2026, 5, 24, 10, 0, tzinfo=UTC),
+    )
+
+    selected = _select_current_runs_by_article([cancelled])
+
+    assert selected[article_id].stage == ExtractionRunStage.CANCELLED.value

--- a/frontend/components/navigation/NotificationCenter.tsx
+++ b/frontend/components/navigation/NotificationCenter.tsx
@@ -25,9 +25,15 @@ import {useBackgroundJobPolling} from '@/hooks/useBackgroundJobPolling';
 import {cn} from '@/lib/utils';
 import {toast} from 'sonner';
 import {useNavigate} from 'react-router-dom';
-import type {ArticlesExportJob, BackgroundJob, ZoteroImportJob} from '@/types/background-jobs';
+import type {
+    ArticlesExportJob,
+    BackgroundJob,
+    ExtractionExportJob,
+    ZoteroImportJob,
+} from '@/types/background-jobs';
 import {t} from '@/lib/copy';
-import {getExportStatus} from '@/services/articlesExportService';
+import {getExportStatus as getArticlesExportStatus} from '@/services/articlesExportService';
+import {getExportStatus as getExtractionExportStatus} from '@/services/extractionExportService';
 
 export function NotificationCenter() {
   const navigate = useNavigate();
@@ -48,16 +54,22 @@ export function NotificationCenter() {
                     .getState()
                     .jobs.filter(
                         (job) =>
-                            job.type === 'articles-export' &&
+                            (job.type === 'articles-export' || job.type === 'extraction-export') &&
                             (job.status === 'pending' || job.status === 'running')
-                    ) as ArticlesExportJob[];
+                    ) as Array<ArticlesExportJob | ExtractionExportJob>;
 
                 if (exportJobs.length === 0) return;
 
                 await Promise.all(
                     exportJobs.map(async (job) => {
                         try {
-                            const status = await getExportStatus(job.metadata.backendJobId);
+                            const status =
+                                job.type === 'articles-export'
+                                    ? await getArticlesExportStatus(job.metadata.backendJobId)
+                                    : await getExtractionExportStatus(
+                                        job.metadata.projectId,
+                                        job.metadata.backendJobId,
+                                    );
                             const nextStatus = status.status === 'pending' ? 'running' : status.status;
                             updateJob(job.id, {
                                 status: nextStatus,
@@ -69,7 +81,7 @@ export function NotificationCenter() {
                                         ? Date.now()
                                         : undefined,
                                 error: status.error,
-                                progress: status.progress
+                                progress: 'progress' in status && status.progress
                                     ? {
                                         phase: status.progress.stage,
                                         current: status.progress.current,
@@ -82,7 +94,9 @@ export function NotificationCenter() {
                                     downloadUrl: status.download_url ?? job.metadata.downloadUrl,
                                 },
                                 stats:
-                                    status.skipped_files && status.skipped_files.length > 0
+                                    'skipped_files' in status &&
+                                    status.skipped_files &&
+                                    status.skipped_files.length > 0
                                         ? {skipped: status.skipped_files.length}
                                         : undefined,
                             });
@@ -125,11 +139,14 @@ export function NotificationCenter() {
                           navigate(`/projects/${zoteroJob.metadata.projectId}`);
                       },
                   }
-                  : job.type === 'articles-export'
+                  : job.type === 'articles-export' || job.type === 'extraction-export'
                       ? {
-                          label: t('articles', 'exportDownload'),
+                          label:
+                              job.type === 'articles-export'
+                                  ? t('articles', 'exportDownload')
+                                  : t('extraction', 'exportButton'),
                           onClick: () => {
-                              const exportJob = job as ArticlesExportJob;
+                              const exportJob = job as ArticlesExportJob | ExtractionExportJob;
                               if (exportJob.metadata.downloadUrl) {
                                   window.open(exportJob.metadata.downloadUrl, '_blank', 'noopener,noreferrer');
                               }
@@ -184,8 +201,11 @@ export function NotificationCenter() {
       setOpen(false);
         return;
     }
-      if (job.type === 'articles-export' && job.status === 'completed') {
-          const exportJob = job as ArticlesExportJob;
+      if (
+          (job.type === 'articles-export' || job.type === 'extraction-export') &&
+          job.status === 'completed'
+      ) {
+          const exportJob = job as ArticlesExportJob | ExtractionExportJob;
           if (exportJob.metadata.downloadUrl) {
               window.open(exportJob.metadata.downloadUrl, '_blank', 'noopener,noreferrer');
           }
@@ -281,7 +301,10 @@ interface NotificationItemProps {
 function NotificationItem({ job, onRemove, onClick }: NotificationItemProps) {
   const icon = getJobIcon(job);
     const isClickable =
-        job.status === 'completed' && (job.type === 'zotero-import' || job.type === 'articles-export');
+        job.status === 'completed' &&
+        (job.type === 'zotero-import' ||
+            job.type === 'articles-export' ||
+            job.type === 'extraction-export');
 
   return (
     <div
@@ -387,6 +410,9 @@ function getJobTitle(job: BackgroundJob): string {
     if (job.type === 'articles-export') {
         return t('articles', 'exportTitle');
     }
+    if (job.type === 'extraction-export') {
+        return t('extraction', 'exportDialogTitle');
+    }
     return t('navigation', 'backgroundTask');
 }
 
@@ -423,6 +449,22 @@ function getJobDescription(job: BackgroundJob): string {
             return t('articles', 'exportCancelled');
         }
     }
+    if (job.type === 'extraction-export') {
+        const metadata = (job as ExtractionExportJob).metadata;
+        const templateName = metadata.templateName || t('extraction', 'exportDialogTitle');
+        if (job.status === 'running' || job.status === 'pending') {
+            return `${t('extraction', 'exportGenerating')} (${metadata.articleCount} articles, ${templateName})`;
+        }
+        if (job.status === 'completed') {
+            return t('extraction', 'exportSuccessToast');
+        }
+        if (job.status === 'failed') {
+            return job.error || t('extraction', 'exportFailedToast');
+        }
+        if (job.status === 'cancelled') {
+            return t('extraction', 'exportCancel');
+        }
+    }
 
     return job.status === 'completed' ? t('navigation', 'statusCompleted') : job.error || t('navigation', 'statusInProgress');
 }
@@ -442,6 +484,9 @@ function getCompletionMessage(job: BackgroundJob): string {
   }
     if (job.type === 'articles-export') {
         return t('articles', 'exportDownloadReady');
+    }
+    if (job.type === 'extraction-export') {
+        return t('extraction', 'exportSuccessToast');
     }
 
     return t('navigation', 'taskCompleteSuccess');

--- a/frontend/hooks/extraction/useExtractedValues.ts
+++ b/frontend/hooks/extraction/useExtractedValues.ts
@@ -25,7 +25,14 @@
  * autosave is the single writer.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { toast } from 'sonner';
 
 import { supabase } from '@/integrations/supabase/client';
@@ -62,12 +69,47 @@ interface UseExtractedValuesReturn {
 
 const REVIEWER_STATE_STAGES = new Set(['review', 'consensus', 'finalized']);
 
+function resetValuesIfNeeded(
+  setValues: Dispatch<SetStateAction<Record<string, any>>>,
+) {
+  setValues((prev) => (Object.keys(prev).length > 0 ? {} : prev));
+}
+
 function unwrapProposalValue(raw: unknown): unknown {
   if (raw === null || raw === undefined) return null;
   if (typeof raw === 'object' && raw !== null && 'value' in raw) {
     return (raw as { value: unknown }).value ?? null;
   }
   return raw;
+}
+
+function mergeValuesById(
+  prev: Record<string, any>,
+  next: Record<string, any>,
+): Record<string, any> {
+  // Local edits are authoritative. ``useAutoSaveProposals`` is the
+  // sole writer that flips ``proposed_value`` on the backend; any
+  // diff between ``prev[key]`` and ``next[key]`` for a key the user
+  // has touched means the autosave POST simply hasn't landed yet (or
+  // a TanStack ``useRun`` refetch raced ahead of it). Overwriting in
+  // that window erased the keystroke before autosave's debounce
+  // fired — the autosave then saw "no dirty entries" and skipped the
+  // POST, silently dropping the input. We only adopt backend-shaped
+  // entries for coords absent from local state (initial hydration +
+  // AI proposals that introduce brand-new fields).
+  let changed = false;
+  const addedKeys: string[] = [];
+  const out = { ...prev };
+  for (const [key, value] of Object.entries(next)) {
+    if (key in prev) continue;
+    out[key] = value;
+    changed = true;
+    addedKeys.push(key);
+  }
+  if (addedKeys.length > 0) {
+    requestAnimationFrame(() => dispatchValueUpdates(addedKeys));
+  }
+  return changed ? out : prev;
 }
 
 export function useExtractedValues(
@@ -79,6 +121,24 @@ export function useExtractedValues(
   const [loading, setLoading] = useState(true);
   const [initialized, setInitialized] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const hydratedRunIdRef = useRef<string | null>(null);
+
+  const applyLoadedValues = useCallback(
+    (valuesMap: Record<string, any>) => {
+      setValues((prev) => {
+        if (hydratedRunIdRef.current !== runId) {
+          hydratedRunIdRef.current = runId ?? null;
+          const addedKeys = Object.keys(valuesMap);
+          if (addedKeys.length > 0) {
+            requestAnimationFrame(() => dispatchValueUpdates(addedKeys));
+          }
+          return valuesMap;
+        }
+        return mergeValuesById(prev, valuesMap);
+      });
+    },
+    [runId],
+  );
 
   const loadValues = useCallback(
     async (silent = false) => {
@@ -87,7 +147,8 @@ export function useExtractedValues(
 
       try {
         if (!runId || !stage) {
-          setValues({});
+          hydratedRunIdRef.current = null;
+          resetValuesIfNeeded(setValues);
           setInitialized(true);
           return;
         }
@@ -108,7 +169,7 @@ export function useExtractedValues(
                 : null;
             valuesMap[key] = extractValueFromDb({ value: unwrapped, unit });
           }
-          setValues((prev) => mergeValuesById(prev, valuesMap));
+          applyLoadedValues(valuesMap);
           setInitialized(true);
           return;
         }
@@ -124,7 +185,8 @@ export function useExtractedValues(
           if (userRes.error) throw userRes.error;
           const user = userRes.data.user;
           if (!user) {
-            setValues({});
+            hydratedRunIdRef.current = runId;
+            resetValuesIfNeeded(setValues);
             return;
           }
 
@@ -144,13 +206,14 @@ export function useExtractedValues(
                 : null;
             valuesMap[key] = extractValueFromDb({ value: row.value, unit });
           }
-          setValues((prev) => mergeValuesById(prev, valuesMap));
+          applyLoadedValues(valuesMap);
           setInitialized(true);
           return;
         }
 
         // PENDING / CANCELLED / unknown — no values to show.
-        setValues({});
+        hydratedRunIdRef.current = runId;
+        resetValuesIfNeeded(setValues);
         setInitialized(true);
       } catch (err: any) {
         console.error('Erro ao carregar valores extraídos:', err);
@@ -160,7 +223,7 @@ export function useExtractedValues(
         if (!silent) setLoading(false);
       }
     },
-    [runId, stage, proposals],
+    [runId, stage, proposals, applyLoadedValues],
   );
 
   useEffect(() => {
@@ -174,41 +237,14 @@ export function useExtractedValues(
       // ``if (loading || valuesLoading) → spinner`` gate doesn't sit on
       // the spinner forever. Treat ``initialized = true`` here as
       // "we know there are no values to show" (the empty map below).
+      hydratedRunIdRef.current = runId ?? null;
+      resetValuesIfNeeded(setValues);
       setLoading(false);
       setInitialized(true);
       return;
     }
     void loadValues();
   }, [enabled, loadValues]);
-
-  function mergeValuesById(
-    prev: Record<string, any>,
-    next: Record<string, any>,
-  ): Record<string, any> {
-    // Local edits are authoritative. ``useAutoSaveProposals`` is the
-    // sole writer that flips ``proposed_value`` on the backend; any
-    // diff between ``prev[key]`` and ``next[key]`` for a key the user
-    // has touched means the autosave POST simply hasn't landed yet (or
-    // a TanStack ``useRun`` refetch raced ahead of it). Overwriting in
-    // that window erased the keystroke before autosave's debounce
-    // fired — the autosave then saw "no dirty entries" and skipped the
-    // POST, silently dropping the input. We only adopt backend-shaped
-    // entries for coords absent from local state (initial hydration +
-    // AI proposals that introduce brand-new fields).
-    let changed = false;
-    const addedKeys: string[] = [];
-    const out = { ...prev };
-    for (const [key, value] of Object.entries(next)) {
-      if (key in prev) continue;
-      out[key] = value;
-      changed = true;
-      addedKeys.push(key);
-    }
-    if (addedKeys.length > 0) {
-      requestAnimationFrame(() => dispatchValueUpdates(addedKeys));
-    }
-    return changed ? out : prev;
-  }
 
   const updateValue = useCallback((instanceId: string, fieldId: string, value: any) => {
     const key = `${instanceId}_${fieldId}`;

--- a/frontend/hooks/runs/useAutoSaveProposals.ts
+++ b/frontend/hooks/runs/useAutoSaveProposals.ts
@@ -28,9 +28,9 @@
  * ``extraction_proposal_records`` table doesn't accumulate one
  * duplicate row per debounce tick.
  *
- * Concurrent ``performSave`` invocations are serialized via a
- * ref-based mutex; a save triggered while another is in flight is a
- * silent no-op (the in-flight one already has the latest values).
+ * Concurrent ``performSave`` invocations are serialized: a save triggered
+ * while another is in flight waits for the first batch, recomputes the
+ * dirty diff, and writes any trailing edits.
  *
  * Goes straight to ``apiClient`` rather than wrapping a TanStack Query
  * mutation: invalidating ``runs.detail(runId)`` on every debounced
@@ -88,10 +88,9 @@ export function useAutoSaveProposals(
   // Stringified last successful write per `${instanceId}_${fieldId}` —
   // the diff check against the current values map.
   const lastSavedByKeyRef = useRef<Record<string, string>>({});
-  // Mutual-exclusion guard. React state is async, so ``saveState ===
-  // 'saving'`` cannot be used as a synchronous lock across overlapping
-  // ``performSave`` invocations.
-  const isSavingRef = useRef(false);
+  // React state is async, so ``saveState === 'saving'`` cannot be used
+  // as a synchronous lock across overlapping ``performSave`` invocations.
+  const activeSavePromiseRef = useRef<Promise<void> | null>(null);
 
   const computeDirtyEntries = useCallback((): Array<[string, unknown]> => {
     const dirty: Array<[string, unknown]> = [];
@@ -109,18 +108,25 @@ export function useAutoSaveProposals(
   }, []);
 
   const performSave = useCallback(async (): Promise<void> => {
+    while (activeSavePromiseRef.current) {
+      try {
+        await activeSavePromiseRef.current;
+      } catch {
+        // The owner call surfaces the error state/toast; queued calls can
+        // still retry any dirty values that were not acknowledged.
+      }
+    }
+
     const currentRunId = runIdRef.current;
     if (!currentRunId || !enabledRef.current) return;
-    if (isSavingRef.current) return;
 
     const dirty = computeDirtyEntries();
     if (dirty.length === 0) return;
 
-    isSavingRef.current = true;
     setSaveState('saving');
     setError(null);
 
-    try {
+    const savePromise = (async () => {
       // ``Promise.allSettled`` so a single failed write does not abort
       // the others mid-flight; otherwise their ``lastSavedByKeyRef``
       // updates race the catch block and leave the diff map
@@ -170,6 +176,12 @@ export function useAutoSaveProposals(
 
       setLastSavedAt(new Date());
       setSaveState('saved');
+    })();
+
+    activeSavePromiseRef.current = savePromise;
+
+    try {
+      await savePromise;
     } catch (err) {
       const message =
         err instanceof Error
@@ -180,7 +192,9 @@ export function useAutoSaveProposals(
       setSaveState('error');
       toast.error(t('extraction', 'errors_autoSaveFailed'));
     } finally {
-      isSavingRef.current = false;
+      if (activeSavePromiseRef.current === savePromise) {
+        activeSavePromiseRef.current = null;
+      }
     }
   }, [computeDirtyEntries]);
 

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -208,7 +208,10 @@ export default function QualityAssessmentFullScreen() {
     useAutoSaveProposals({
       runId: session?.runId ?? null,
       values,
-      enabled: !!session && !!runDetail && runDetail.run.stage === "proposal",
+      enabled:
+        !!session &&
+        !!runDetail &&
+        (runDetail.run.stage === "proposal" || runDetail.run.stage === "review"),
     });
 
   // AI suggestions wiring — kind-agnostic hooks reused from Data

--- a/frontend/test/hooks/useAutoSaveProposals.test.tsx
+++ b/frontend/test/hooks/useAutoSaveProposals.test.tsx
@@ -185,7 +185,7 @@ describe('useAutoSaveProposals — basic write semantics', () => {
 });
 
 describe('useAutoSaveProposals — mutex + error handling', () => {
-  it('concurrent saveNow invocations do not double-write (mutex)', async () => {
+  it('concurrent saveNow invocations do not double-write unchanged values', async () => {
     let release!: () => void;
     const block = new Promise<void>((resolve) => {
       release = resolve;
@@ -210,6 +210,60 @@ describe('useAutoSaveProposals — mutex + error handling', () => {
     });
 
     expect(apiClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('queues a trailing save when values change during an in-flight save', async () => {
+    let releaseFirst!: () => void;
+    const firstRequest = new Promise<typeof PROPOSAL_RESPONSE>((resolve) => {
+      releaseFirst = () => resolve(PROPOSAL_RESPONSE);
+    });
+    apiClientMock
+      .mockReturnValueOnce(firstRequest)
+      .mockResolvedValueOnce(PROPOSAL_RESPONSE);
+
+    const { result, rerender } = renderHook(
+      ({ values }) =>
+        useAutoSaveProposals({
+          runId: 'run-1',
+          values,
+        }),
+      {
+        initialProps: {
+          values: { 'inst-1_field-1': 'first' } as Record<string, unknown>,
+        },
+      },
+    );
+
+    let firstSave!: Promise<void>;
+    await act(async () => {
+      firstSave = result.current.saveNow();
+      await Promise.resolve();
+    });
+    expect(apiClientMock).toHaveBeenCalledTimes(1);
+
+    rerender({ values: { 'inst-1_field-1': 'second' } });
+
+    let trailingSave!: Promise<void>;
+    await act(async () => {
+      trailingSave = result.current.saveNow();
+      await Promise.resolve();
+    });
+    expect(apiClientMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      releaseFirst();
+      await Promise.all([firstSave, trailingSave]);
+    });
+
+    expect(apiClientMock).toHaveBeenCalledTimes(2);
+    expect(apiClientMock).toHaveBeenLastCalledWith(
+      '/api/v1/runs/run-1/proposals',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          proposed_value: { value: 'second' },
+        }),
+      }),
+    );
   });
 
   it('surfaces partial failures and retries only the failed coord', async () => {

--- a/frontend/test/hooks/useExtractedValues.test.tsx
+++ b/frontend/test/hooks/useExtractedValues.test.tsx
@@ -13,7 +13,7 @@
  * writer.
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/integrations/supabase/client', () => ({
@@ -275,7 +275,9 @@ describe('useExtractedValues — local update', () => {
       }),
     );
     await waitFor(() => expect(result.current.initialized).toBe(true));
-    result.current.updateValue('inst-1', 'field-1', 'typed');
+    act(() => {
+      result.current.updateValue('inst-1', 'field-1', 'typed');
+    });
     await waitFor(() =>
       expect(result.current.values['inst-1_field-1']).toBe('typed'),
     );
@@ -322,7 +324,9 @@ describe('useExtractedValues — local-edits-win on backend refetch', () => {
     expect(result.current.values['inst-1_field-1']).toBe('old');
 
     // User types a new value (in-flight, autosave POST not yet flushed).
-    result.current.updateValue('inst-1', 'field-1', 'user-typed');
+    act(() => {
+      result.current.updateValue('inst-1', 'field-1', 'user-typed');
+    });
     await waitFor(() =>
       expect(result.current.values['inst-1_field-1']).toBe('user-typed'),
     );
@@ -407,5 +411,64 @@ describe('useExtractedValues — local-edits-win on backend refetch', () => {
     );
     // Pre-existing key still wins.
     expect(result.current.values['inst-1_field-1']).toBe('mine');
+  });
+});
+
+describe('useExtractedValues — run boundary reset', () => {
+  it('replaces preserved local values when the active run changes', async () => {
+    const run1Proposals = [
+      {
+        id: 'p-run-1',
+        run_id: 'run-1',
+        instance_id: 'inst-1',
+        field_id: 'field-1',
+        source: 'human' as const,
+        source_user_id: 'user-1',
+        proposed_value: { value: 'old-run-value' },
+        confidence_score: null,
+        rationale: null,
+        created_at: '2026-04-28T10:00:00Z',
+      },
+    ];
+    const run2Proposals = [
+      {
+        id: 'p-run-2',
+        run_id: 'run-2',
+        instance_id: 'inst-1',
+        field_id: 'field-1',
+        source: 'human' as const,
+        source_user_id: 'user-1',
+        proposed_value: { value: 'new-run-value' },
+        confidence_score: null,
+        rationale: null,
+        created_at: '2026-04-28T11:00:00Z',
+      },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ runId, proposals }) =>
+        useExtractedValues({
+          runId,
+          stage: 'proposal',
+          proposals,
+        }),
+      { initialProps: { runId: 'run-1', proposals: run1Proposals } },
+    );
+
+    await waitFor(() => expect(result.current.initialized).toBe(true));
+    expect(result.current.values['inst-1_field-1']).toBe('old-run-value');
+
+    act(() => {
+      result.current.updateValue('inst-1', 'field-1', 'unsaved-run-1-edit');
+    });
+    await waitFor(() =>
+      expect(result.current.values['inst-1_field-1']).toBe('unsaved-run-1-edit'),
+    );
+
+    rerender({ runId: 'run-2', proposals: run2Proposals });
+
+    await waitFor(() =>
+      expect(result.current.values['inst-1_field-1']).toBe('new-run-value'),
+    );
   });
 });


### PR DESCRIPTION
Promotes both resolved cursor orphan PRs from dev → main:

- **#129** (rebased from #104) — BOLA/IDOR guards on extraction AI endpoints + autosave trailing-write queueing.
- **#111** — Stale extraction run state after reopen + export job polling in NotificationCenter.

Both were originally opened by cursor agent, had stale CI failures (lint format + coverage gate from before F1), and were unblocked by merging current main into them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)