### PR TITLE
fix(repos): drop dead extraction-repo methods referencing missing schema

### DIFF
--- a/backend/app/repositories/extraction_repository.py
+++ b/backend/app/repositories/extraction_repository.py
@@ -96,18 +96,6 @@ class GlobalTemplateRepository(BaseRepository[ExtractionTemplateGlobal]):
     def __init__(self, db: AsyncSession):
         super().__init__(db, ExtractionTemplateGlobal)
 
-    async def get_active(self) -> list[ExtractionTemplateGlobal]:
-        """
-        List active global templates.
-
-        Returns:
-            Active template list.
-        """
-        result = await self.db.execute(
-            select(ExtractionTemplateGlobal).where(ExtractionTemplateGlobal.is_active.is_(True))
-        )
-        return list(result.scalars().all())
-
 
 class ExtractionEntityTypeRepository(BaseRepository[ExtractionEntityType]):
     """Repository for extraction entity types."""
@@ -338,26 +326,3 @@ class ExtractionInstanceRepository(BaseRepository[ExtractionInstance]):
             db_duration_ms=(perf_counter() - query_start) * 1000,
         )
         return list(result.scalars().all())
-
-    async def get_with_values(
-        self,
-        instance_id: UUID | str,
-    ) -> ExtractionInstance | None:
-        """
-        Fetch instance with extracted values loaded.
-
-        Args:
-            instance_id: Instance ID.
-
-        Returns:
-            Instance with values or None.
-        """
-        if isinstance(instance_id, str):
-            instance_id = UUID(instance_id)
-
-        result = await self.db.execute(
-            select(ExtractionInstance)
-            .options(selectinload(ExtractionInstance.values))
-            .where(ExtractionInstance.id == instance_id)
-        )
-        return result.scalar_one_or_none()

--- a/backend/tests/unit/test_extraction_repository.py
+++ b/backend/tests/unit/test_extraction_repository.py
@@ -13,14 +13,12 @@ import pytest
 from app.models.extraction import (
     ExtractionEntityType,
     ExtractionInstance,
-    ExtractionTemplateGlobal,
     ProjectExtractionTemplate,
 )
 from app.repositories.extraction_repository import (
     ExtractionEntityTypeRepository,
     ExtractionInstanceRepository,
     ExtractionTemplateRepository,
-    GlobalTemplateRepository,
 )
 
 # ---------------------------------------------------------------------------
@@ -84,7 +82,6 @@ def make_instance(
     inst.entity_type_id = entity_type_id or ENTITY_TYPE_ID
     inst.parent_instance_id = parent_instance_id
     inst.sort_order = 0
-    inst.values = []
     return inst
 
 
@@ -145,49 +142,6 @@ class TestExtractionTemplateRepository:
         result = await repo.get_with_entity_types(str(TEMPLATE_ID))
 
         assert result is None
-
-
-# ---------------------------------------------------------------------------
-# GlobalTemplateRepository
-# ---------------------------------------------------------------------------
-
-
-class TestGlobalTemplateRepository:
-    # NOTE: ExtractionTemplateGlobal.is_active does not exist on the ORM model.
-    # GlobalTemplateRepository.get_active() references this missing column, which
-    # makes the WHERE clause raise AttributeError at query-build time.
-    # Bug documented in DONE_WITH_CONCERNS. Tests are xfail to capture intent.
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionTemplateGlobal has no is_active column; "
-            "get_active() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_active_returns_active_templates(self) -> None:
-        db = make_db()
-        tmpl = MagicMock(spec=ExtractionTemplateGlobal)
-        db.execute = AsyncMock(return_value=make_scalars_result([tmpl]))
-        repo = GlobalTemplateRepository(db)
-        result = await repo.get_active()
-        assert result == [tmpl]
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionTemplateGlobal has no is_active column; "
-            "get_active() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_active_returns_empty_when_none(self) -> None:
-        db = make_db()
-        db.execute = AsyncMock(return_value=make_scalars_result([]))
-        repo = GlobalTemplateRepository(db)
-        result = await repo.get_active()
-        assert result == []
 
 
 # ---------------------------------------------------------------------------
@@ -380,53 +334,3 @@ class TestExtractionInstanceRepository:
         result = await repo.get_children(str(INSTANCE_ID))
 
         assert result == []
-
-    # NOTE: ExtractionInstance.values relationship does not exist on the ORM model.
-    # ExtractionInstanceRepository.get_with_values() calls selectinload(ExtractionInstance.values)
-    # which raises AttributeError at query-build time. Bug documented in DONE_WITH_CONCERNS.
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionInstance has no 'values' relationship; "
-            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_with_values_returns_instance(self) -> None:
-        db = make_db()
-        inst = make_instance()
-        db.execute = AsyncMock(return_value=make_scalar_one_or_none(inst))
-        repo = ExtractionInstanceRepository(db)
-        result = await repo.get_with_values(INSTANCE_ID)
-        assert result is inst
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionInstance has no 'values' relationship; "
-            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_with_values_returns_none(self) -> None:
-        db = make_db()
-        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
-        repo = ExtractionInstanceRepository(db)
-        result = await repo.get_with_values(INSTANCE_ID)
-        assert result is None
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionInstance has no 'values' relationship; "
-            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_with_values_accepts_string_id(self) -> None:
-        db = make_db()
-        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
-        repo = ExtractionInstanceRepository(db)
-        result = await repo.get_with_values(str(INSTANCE_ID))
-        assert result is None


### PR DESCRIPTION
## Summary

Deletes two repository methods that have **zero production callers** and raise `AttributeError` at query-build time because they reference schema that doesn't exist:

- `GlobalTemplateRepository.get_active()` filtered on `ExtractionTemplateGlobal.is_active`, but that column has never existed on the model or the table (see `baseline_v1.sql:960-971` — `extraction_templates_global` has `is_global` only).
- `ExtractionInstanceRepository.get_with_values()` called `selectinload(ExtractionInstance.values)`, but that relationship was removed when the `extracted_values` table was dropped in migration `0002_drop_extracted_values`. Canonical values now live in `extraction_published_states` / `extraction_reviewer_decisions`.

Both methods plus the 5 `xfail(strict=True)` tests covering them (added in #124 alongside the test sweep that surfaced the bugs) are deleted rather than rewritten. Adding an `is_active` column + migration or a `published_states` relationship just to support unused methods would be architectural churn for no caller benefit.

## Verification

- `make lint-backend` → `All checks passed!`
- `make test-backend` on `test_extraction_repository.py` → `22 passed` (was `22 passed, 5 xfailed`).
- Full backend suite: 13 unrelated pre-existing failures in `test_run_lifecycle_*` / `test_hitl_session` / `test_kind_discriminator` (all `TemplateNotFoundError` from a fixture issue on `dev` — confirmed identical on clean tree pre-change). Not introduced by this PR.

## Test plan

- [x] `make lint-backend`
- [x] `make test-backend` (targeted file)
- [x] Confirmed pre-existing unrelated failures exist on clean `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)