### PR TITLE
Merge dev → main: worker hardening (event-loop fix + CI guards)

### DIFF
--- a/.github/workflows/worker-smoke.yml
+++ b/.github/workflows/worker-smoke.yml
@@ -45,7 +45,10 @@ jobs:
         run: pip install uv
       - name: Install backend deps
         working-directory: backend
-        run: uv sync --frozen
+        # NOTE: `--frozen` is intentionally omitted because `backend/uv.lock`
+        # is in `.gitignore`. If the project ever starts tracking the
+        # lockfile, add `--frozen` here for reproducible CI installs.
+        run: uv sync
       - name: Boot worker in background
         working-directory: backend
         run: |

--- a/.github/workflows/worker-smoke.yml
+++ b/.github/workflows/worker-smoke.yml
@@ -45,7 +45,7 @@ jobs:
         run: pip install uv
       - name: Install backend deps
         working-directory: backend
-        run: uv sync
+        run: uv sync --frozen
       - name: Boot worker in background
         working-directory: backend
         run: |
@@ -92,6 +92,20 @@ jobs:
               if all(s not in ("PENDING", "STARTED") for s in states):
                   break
               time.sleep(2)
+          final_states = [AsyncResult(i, app=celery_app).state for i in ids]
+          still_pending = [
+              (i, s) for i, s in zip(ids, final_states)
+              if s in ("PENDING", "STARTED")
+          ]
+          if still_pending:
+              import sys
+              print(
+                  f"ERROR: {len(still_pending)} tasks never reached a "
+                  f"terminal state after 45s. States: {final_states}. "
+                  f"This usually means the worker crashed or never picked "
+                  f"up the message. See worker.log."
+              )
+              sys.exit(1)
           PY
       - name: Assert no loop-reuse error in worker log
         working-directory: backend

--- a/.github/workflows/worker-smoke.yml
+++ b/.github/workflows/worker-smoke.yml
@@ -1,0 +1,120 @@
+name: Worker Smoke Test
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/worker/**"
+      - "backend/app/services/exports/**"
+      - "backend/app/services/extraction_export_service.py"
+      - "backend/app/services/articles_export_service.py"
+      - "backend/tests/integration/test_worker_eager_mode.py"
+      - ".github/workflows/worker-smoke.yml"
+
+jobs:
+  worker-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      REDIS_URL: redis://localhost:6379/0
+      # Stub Supabase / OPENAI / encryption — the smoke test mocks the
+      # heavy services and only exercises the task <-> worker contract.
+      SUPABASE_URL: http://localhost:54321
+      SUPABASE_ANON_KEY: stub-anon
+      SUPABASE_SERVICE_ROLE_KEY: stub-service-role
+      ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+      DATABASE_URL: postgresql+asyncpg://stub
+      DIRECT_DATABASE_URL: postgresql://stub
+      OPENAI_API_KEY: sk-stub
+      DEBUG: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        run: pip install uv
+      - name: Install backend deps
+        working-directory: backend
+        run: uv sync
+      - name: Boot worker in background
+        working-directory: backend
+        run: |
+          uv run celery -A app.worker.celery_app worker \
+            --loglevel=info \
+            --queues=extractions,imports,exports,celery \
+            --pool=solo \
+            > worker.log 2>&1 &
+          echo $! > worker.pid
+          for i in {1..30}; do
+            grep -q "celery@.*ready" worker.log && break
+            sleep 1
+          done
+          grep -q "celery@.*ready" worker.log || (echo "Worker never became ready"; cat worker.log; exit 1)
+      - name: Dispatch two sequential extraction_export tasks
+        working-directory: backend
+        run: |
+          uv run python <<'PY'
+          import time
+          from celery.result import AsyncResult
+          from app.worker.celery_app import celery_app
+          ids = []
+          for i in range(2):
+              r = celery_app.send_task(
+                  "app.worker.tasks.extraction_export_tasks.export_extraction_task",
+                  kwargs={
+                      "project_id": "00000000-0000-0000-0000-000000000000",
+                      "template_id": "00000000-0000-0000-0000-000000000000",
+                      "mode": "consensus",
+                      "article_ids": ["00000000-0000-0000-0000-000000000000"],
+                      "article_scope": "current_list",
+                      "user_id": "00000000-0000-0000-0000-000000000000",
+                      "reviewer_id": None,
+                      "include_ai_metadata": False,
+                      "anonymize_reviewer_names": False,
+                  },
+              )
+              ids.append(r.id)
+              print(f"Dispatched #{i}: {r.id}")
+          deadline = time.time() + 45
+          while time.time() < deadline:
+              states = [AsyncResult(i, app=celery_app).state for i in ids]
+              print("States:", states)
+              if all(s not in ("PENDING", "STARTED") for s in states):
+                  break
+              time.sleep(2)
+          PY
+      - name: Assert no loop-reuse error in worker log
+        working-directory: backend
+        run: |
+          if grep -q "attached to a different loop" worker.log; then
+            echo "Loop-reuse bug returned — see worker.log"
+            cat worker.log
+            exit 1
+          fi
+      - name: Assert no NotRegistered in worker log
+        working-directory: backend
+        run: |
+          if grep -q "NotRegistered\|celery.task_unregistered" worker.log; then
+            echo "A task was unregistered — celery_app.include drift"
+            cat worker.log
+            exit 1
+          fi
+      - name: Tail worker log on failure
+        if: failure()
+        working-directory: backend
+        run: tail -200 worker.log
+      - name: Stop worker
+        if: always()
+        working-directory: backend
+        run: |
+          [ -f worker.pid ] && kill "$(cat worker.pid)" || true

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,7 +1,7 @@
 """
 Dependencies Module.
 
-Contem todas as dependencies compartilhadas da aplicacao:
+Contains all shared application dependencies:
 - Database session
 - Supabase client
 - Current user
@@ -23,9 +23,9 @@ logger = get_logger(__name__)
 # =================== DATABASE ===================
 
 # Engine async for PostgreSQL
-# NOTA: O workaround de ::VARCHAR for ENUMs foi REMOVIDO.
-# Agora usamos PostgreSQLEnumType (em app.models.base) que resolve o problema
-# de forma declarativa diretamente nos models SQLAlchemy.
+# NOTE: The ::VARCHAR workaround for ENUMs was REMOVED.
+# We now use PostgreSQLEnumType (in app.models.base), which resolves
+# the problem declaratively at the SQLAlchemy model level.
 engine = create_async_engine(
     settings.async_database_url,
     echo=settings.DEBUG,
@@ -33,9 +33,9 @@ engine = create_async_engine(
     pool_size=10,
     max_overflow=20,
     connect_args={
-        "statement_cache_size": 0,  # ✅ Desabilita prepared statements (compativel with pgbouncer)
+        "statement_cache_size": 0,  # Disable prepared statements (compatible with pgbouncer)
         "server_settings": {
-            "jit": "off",  # Desabilita JIT for melhor performance em queries complexas
+            "jit": "off",  # Disable JIT for better performance on complex queries
         },
     },
 )

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -51,12 +51,12 @@ AsyncSessionLocal = async_sessionmaker(
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     """
-    Dependency que fornece uma sessao de banco de data.
+    Dependency that provides a database session.
 
-    A sessao e automaticamente fechada ao final da request.
+    The session is automatically closed at the end of the request.
 
     Yields:
-        AsyncSession: Sessao do SQLAlchemy.
+        AsyncSession: SQLAlchemy async session.
     """
     async with AsyncSessionLocal() as session:
         try:
@@ -65,7 +65,7 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
             await session.close()
 
 
-# Type alias for uso nas rotas
+# Type alias for use in routes
 DbSession = Annotated[AsyncSession, Depends(get_db)]
 
 
@@ -90,7 +90,7 @@ def get_supabase_client() -> Client:
 
 
 def get_supabase() -> Client:
-    """Dependency for obter Supabase client."""
+    """Dependency to obtain a Supabase client."""
     return get_supabase_client()
 
 
@@ -107,9 +107,9 @@ CurrentUser = Annotated[TokenPayload, Depends(get_current_user)]
 
 class RequestContext:
     """
-    Contexto da requisicao with todas as dependencies comuns.
+    Request context grouping all common dependencies.
 
-    Agrupa db, user and supabase for facilitar passagem for services.
+    Bundles db, user, and supabase to simplify passing them to services.
     """
 
     def __init__(
@@ -124,7 +124,7 @@ class RequestContext:
 
     @property
     def user_id(self) -> str:
-        """user atual."""
+        """Current user id."""
         return self.user.sub
 
 
@@ -134,9 +134,9 @@ async def get_request_context(
     supabase: SupabaseClient,
 ) -> RequestContext:
     """
-    Dependency que fornece contexto completo da requisicao.
+    Dependency that provides the complete request context.
 
-    Util for services que precisam de multiplas dependencies.
+    Useful for services that need multiple dependencies.
     """
     return RequestContext(db=db, user=user, supabase=supabase)
 

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -8,7 +8,6 @@ Contem todas as dependencies compartilhadas da aplicacao:
 """
 
 from collections.abc import AsyncGenerator
-from functools import lru_cache
 from typing import Annotated
 
 from fastapi import Depends
@@ -73,17 +72,16 @@ DbSession = Annotated[AsyncSession, Depends(get_db)]
 # =================== SUPABASE CLIENT ===================
 
 
-@lru_cache
 def get_supabase_client() -> Client:
-    """
-    Return cliente Supabase configurado with service role.
+    """Return a fresh Supabase service-role client.
 
-    Usado for operacoes que precisam de acesso elevado:
-    - Storage operations
-    - Bypass RLS quando necessario
-
-    Returns:
-        Client: Supabase client configurado.
+    NOT cached. The cached version was the root cause of the 2026-05-24
+    event-loop reuse bug — the underlying httpx client binds its
+    connection pool to the loop active at construction time, so reusing
+    one across loops raises ``RuntimeError: <Future ...> attached to a
+    different loop``. Worker tasks construct one per invocation via
+    ``app.worker._runner.run_task``; FastAPI request handlers construct
+    one per request via ``get_supabase`` in this module.
     """
     return create_client(
         settings.SUPABASE_URL,

--- a/backend/app/worker/__init__.py
+++ b/backend/app/worker/__init__.py
@@ -1,9 +1,9 @@
 """
 Celery Worker.
 
-Processamento assincrono de tarefas longas:
-- Extracoes em lote
-- Importacoes do Zotero
+Asynchronous processing of long-running tasks:
+- Batch extractions
+- Zotero imports
 """
 
 from app.worker.celery_app import celery_app

--- a/backend/app/worker/_runner.py
+++ b/backend/app/worker/_runner.py
@@ -1,0 +1,50 @@
+"""Shared async runner for Celery tasks.
+
+Every Celery task in this codebase is a synchronous entry point that
+delegates real work to an async coroutine. This module provides the one
+correct way to bridge the two:
+
+    @celery_app.task
+    def my_task(...):
+        async def run() -> dict:
+            async with AsyncSessionLocal() as db:
+                ...
+        return run_task(run)
+
+Why a fresh ``asyncio.run()`` per invocation:
+
+- A previous iteration of this codebase cached one event loop in a
+  module global and reused it across all task invocations. Combined
+  with ``@lru_cache`` on ``get_supabase_client``, that meant the
+  Supabase httpx client's connection-pool futures were bound to
+  whichever loop ran first — any subsequent task on a different loop
+  raised ``RuntimeError: <Future ...> attached to a different loop``.
+  The bug surfaced on 2026-05-24 against ``export_extraction_task``.
+
+Why the runner takes a *factory*, not a coroutine:
+
+- Coroutines created at import time bind to whichever loop happens to
+  be running when the module is imported (or ``None``). Requiring
+  callers to pass a zero-arg callable defers coroutine construction
+  until ``asyncio.run`` is already running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def run_task(coro_factory: Callable[[], Awaitable[T]]) -> T:
+    """Run an async coroutine in a fresh event loop and return its result."""
+    if not callable(coro_factory):
+        raise TypeError(
+            f"run_task requires a zero-arg callable, got "
+            f"{type(coro_factory).__name__}. Pass the coroutine function "
+            f"itself (e.g. run_task(run)), not the coroutine "
+            f"(e.g. run_task(run()))."
+        )
+    return asyncio.run(coro_factory())

--- a/backend/app/worker/_runner.py
+++ b/backend/app/worker/_runner.py
@@ -7,7 +7,7 @@ correct way to bridge the two:
     @celery_app.task
     def my_task(...):
         async def run() -> dict:
-            async with AsyncSessionLocal() as db:
+            async with worker_session() as db:
                 ...
         return run_task(run)
 

--- a/backend/app/worker/_runner.py
+++ b/backend/app/worker/_runner.py
@@ -32,6 +32,7 @@ Why the runner takes a *factory*, not a coroutine:
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
@@ -39,12 +40,25 @@ T = TypeVar("T")
 
 
 def run_task(coro_factory: Callable[[], Awaitable[T]]) -> T:
-    """Run an async coroutine in a fresh event loop and return its result."""
+    """Run an async coroutine in a fresh event loop and return its result.
+
+    Args:
+        coro_factory: Zero-argument callable that returns the coroutine
+            to run. Must be a callable — passing a coroutine directly
+            defeats the per-call loop guarantee.
+
+    Raises:
+        TypeError: if ``coro_factory`` is a coroutine object or not callable.
+        Exception: re-raises any exception raised by the coroutine.
+    """
+    if inspect.iscoroutine(coro_factory):
+        raise TypeError(
+            "run_task requires a zero-arg callable, got a coroutine object. "
+            "Pass the function itself (e.g. run_task(run)), not the result "
+            "of calling it (e.g. run_task(run()))."
+        )
     if not callable(coro_factory):
         raise TypeError(
-            f"run_task requires a zero-arg callable, got "
-            f"{type(coro_factory).__name__}. Pass the coroutine function "
-            f"itself (e.g. run_task(run)), not the coroutine "
-            f"(e.g. run_task(run()))."
+            f"run_task requires a zero-arg callable, got {type(coro_factory).__name__}."
         )
     return asyncio.run(coro_factory())

--- a/backend/app/worker/_session.py
+++ b/backend/app/worker/_session.py
@@ -1,0 +1,73 @@
+"""Per-task SQLAlchemy session for Celery workers.
+
+The application-wide engine in ``app/core/deps.py`` is a module-level
+global with a pooled connection set bound to the event loop active on
+first checkout. The Celery worker calls ``asyncio.run(...)`` per task
+(via ``app.worker._runner.run_task``), so loops are short-lived; reusing
+the global engine across loops triggers ``RuntimeError: <Future ...>
+attached to a different loop`` on any operation that touches the pool's
+internal waiters.
+
+This module exposes ``worker_session()`` — an async context manager that
+builds a fresh engine with ``NullPool`` (no pooling), yields a session,
+then disposes the engine. Cost: one extra TCP connection per task.
+That's irrelevant for the worker's task rates and eliminates the
+cross-loop hazard at the root.
+
+Usage inside a Celery task:
+
+    @celery_app.task
+    def my_task(...):
+        async def run():
+            async with worker_session() as db:
+                ...
+        return run_task(run)
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
+
+from app.core.config import settings
+
+
+@asynccontextmanager
+async def worker_session() -> AsyncIterator[AsyncSession]:
+    """Yield a SQLAlchemy AsyncSession backed by a per-call engine.
+
+    The engine uses ``NullPool`` — every connection is opened on demand
+    and closed when the session ends. The engine itself is disposed
+    when the context exits, releasing the underlying asyncpg
+    connection. This guarantees no event-loop primitive survives past
+    the task's ``asyncio.run`` boundary.
+    """
+    engine = create_async_engine(
+        settings.async_database_url,
+        echo=settings.DEBUG,
+        poolclass=NullPool,
+        connect_args={
+            "statement_cache_size": 0,  # Compatible with pgbouncer
+            "server_settings": {
+                "jit": "off",  # Better performance for complex queries
+            },
+        },
+    )
+    factory = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+    try:
+        async with factory() as session:
+            yield session
+    finally:
+        await engine.dispose()

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -74,8 +74,26 @@ class LoggedTask(celery_app.Task):
     def on_failure(self, exc, task_id, args, kwargs, _einfo):
         """Log on failure."""
         import structlog
+        from celery.exceptions import NotRegistered
 
         logger = structlog.get_logger()
+        if isinstance(exc, NotRegistered):
+            # P1-class incident: an enqueued task has no handler. Always
+            # caused by a module missing from celery_app.include or a
+            # routing typo. Surface separately so dashboards can alert.
+            logger.error(
+                "celery.task_unregistered",
+                task_id=task_id,
+                task_name=self.name,
+                args=args,
+                kwargs=kwargs,
+                remediation=(
+                    "Check celery_app.include for the missing module and "
+                    "tests/unit/test_celery_app_task_registry.py for the "
+                    "regression guard."
+                ),
+            )
+            return
         logger.error(
             "task_failed",
             task_id=task_id,

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -1,17 +1,17 @@
 """
 Celery Application Configuration.
 
-Configura Celery with Redis como broker and result backend.
+Configures Celery with Redis as broker and result backend.
 """
 
 import os
 
 from celery import Celery
 
-# Configuracao do broker Redis
+# Redis broker configuration
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
-# Criar app Celery
+# Create the Celery app
 celery_app = Celery(
     "review_hub",
     broker=REDIS_URL,
@@ -24,7 +24,7 @@ celery_app = Celery(
     ],
 )
 
-# Configuracoes
+# Configuration
 celery_app.conf.update(
     # Task settings
     task_serializer="json",
@@ -33,19 +33,19 @@ celery_app.conf.update(
     timezone="UTC",
     enable_utc=True,
     # Result settings
-    result_expires=3600,  # 1 hora
+    result_expires=3600,  # 1 hour
     # Task execution
     task_acks_late=True,
     task_reject_on_worker_lost=True,
     # Rate limiting
-    task_default_rate_limit="10/m",  # 10 tasks por minuto por default
+    task_default_rate_limit="10/m",  # 10 tasks per minute by default
     # Retry settings
-    task_default_retry_delay=60,  # 1 minuto entre retries
+    task_default_retry_delay=60,  # 1 minute between retries
     task_max_retries=3,
     # Concurrency
     worker_concurrency=4,
     worker_prefetch_multiplier=2,
-    # Task routes (filas separadas por tipo)
+    # Task routes (queues separated by type)
     task_routes={
         "app.worker.tasks.extraction_tasks.*": {"queue": "extractions"},
         "app.worker.tasks.import_tasks.*": {"queue": "imports"},
@@ -58,10 +58,10 @@ celery_app.conf.update(
 
 # Task base class with logging
 class LoggedTask(celery_app.Task):
-    """Task base with logging estruturado."""
+    """Task base class with structured logging."""
 
     def on_failure(self, exc, task_id, args, kwargs, _einfo):
-        """Log em caso de falha."""
+        """Log on failure."""
         import structlog
 
         logger = structlog.get_logger()
@@ -75,7 +75,7 @@ class LoggedTask(celery_app.Task):
         )
 
     def on_success(self, _retval, task_id, _args, _kwargs):
-        """Log em caso de sucesso."""
+        """Log on success."""
         import structlog
 
         logger = structlog.get_logger()
@@ -86,7 +86,7 @@ class LoggedTask(celery_app.Task):
         )
 
     def on_retry(self, exc, task_id, _args, _kwargs, _einfo):
-        """Log em caso de retry."""
+        """Log on retry."""
         import structlog
 
         logger = structlog.get_logger()
@@ -99,5 +99,5 @@ class LoggedTask(celery_app.Task):
         )
 
 
-# Registrar task base
+# Register the base task class
 celery_app.Task = LoggedTask

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -45,13 +45,24 @@ celery_app.conf.update(
     # Concurrency
     worker_concurrency=4,
     worker_prefetch_multiplier=2,
-    # Task routes (queues separated by type)
+    # Task routes (queues separated by type). Every module in
+    # ``include=`` MUST appear here explicitly — the registry test in
+    # ``tests/unit/test_celery_app_task_registry.py`` enforces this so
+    # new task modules cannot silently fall back to the default
+    # ``celery`` queue (which the Railway worker may or may not be
+    # consuming). The drift guard
+    # ``tests/unit/test_celery_routes_drift.py`` then asserts every
+    # queue named here is in the worker ``--queues=...`` list.
     task_routes={
         "app.worker.tasks.extraction_tasks.*": {"queue": "extractions"},
         "app.worker.tasks.import_tasks.*": {"queue": "imports"},
         # Keep CPU-bound XLSX builds off the LLM-heavy `extractions` queue
         # so a long-running extraction can't starve a user-initiated export.
         "app.worker.tasks.extraction_export_tasks.*": {"queue": "exports"},
+        # Article exports (CSV/RIS/RDF + ZIP) — explicit `celery` queue so
+        # the drift guard has a clean baseline. The Railway worker
+        # consumes `celery` alongside the three named queues.
+        "app.worker.tasks.export_tasks.*": {"queue": "celery"},
     },
 )
 

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -130,3 +130,46 @@ class LoggedTask(celery_app.Task):
 
 # Register the base task class
 celery_app.Task = LoggedTask
+
+
+# Register a signal handler for tasks that the worker receives but
+# cannot find in its registry. Celery routes this through the consumer
+# (signals.task_unknown), not the task instance's on_failure callback —
+# so a NotRegistered branch in on_failure alone would be dead code in
+# production. Keep both paths: the signal is the runtime hook, the
+# on_failure branch is defense in depth in case Celery changes routing.
+from celery.signals import task_unknown  # noqa: E402
+
+
+@task_unknown.connect
+def _on_task_unknown(
+    sender=None,  # noqa: ARG001
+    name: str | None = None,
+    id: str | None = None,  # noqa: A002 — Celery signal kwarg name
+    message=None,  # noqa: ARG001
+    exc: Exception | None = None,  # noqa: ARG001
+    **_kwargs,
+) -> None:
+    """Log unregistered-task events as a P1 incident.
+
+    Triggered by Celery when a worker pops a message whose ``task``
+    header does not match any entry in ``celery_app.tasks``. Always
+    caused by a module missing from ``celery_app.include`` or a routing
+    typo. The regression guard at
+    ``tests/unit/test_celery_app_task_registry.py`` prevents this at CI,
+    and the drift guard at ``tests/unit/test_celery_routes_drift.py``
+    prevents queue/route mismatches; this signal is the runtime safety
+    net.
+    """
+    import structlog
+
+    structlog.get_logger().error(
+        "celery.task_unregistered",
+        task_id=id,
+        task_name=name,
+        remediation=(
+            "Check celery_app.include for the missing module and "
+            "tests/unit/test_celery_app_task_registry.py for the "
+            "regression guard."
+        ),
+    )

--- a/backend/app/worker/tasks/__init__.py
+++ b/backend/app/worker/tasks/__init__.py
@@ -1,5 +1,5 @@
 """
 Celery Tasks.
 
-Tasks assincronas for processamento em background.
+Async tasks for background processing.
 """

--- a/backend/app/worker/tasks/export_tasks.py
+++ b/backend/app/worker/tasks/export_tasks.py
@@ -1,11 +1,13 @@
-"""
-Export Tasks.
+"""Export Celery tasks.
 
-Tasks Celery for exportacao de articles (CSV, RIS, RDF + files).
+Celery tasks that export articles (CSV, RIS, RDF) plus optional PDFs as
+a single ZIP, upload the bundle to storage, and return a signed URL.
 
 The async bridge is via ``app.worker._runner.run_task`` — see that
 module's docstring for the event-loop rationale.
 """
+
+from __future__ import annotations
 
 from uuid import UUID
 
@@ -26,18 +28,17 @@ def export_articles_task(
     file_scope: str,
     user_id: str,
 ) -> dict:
-    """
-    Task for exportacao de articles em background.
+    """Export a set of articles in the background.
 
-    Gera ZIP with metadata (CSV/RIS/RDF) and optionalmente files;
-    faz upload for storage and retorna URL assinada.
+    Builds a ZIP with metadata (CSV/RIS/RDF) and optionally the article
+    files; uploads the bundle to storage and returns a signed URL.
 
     Args:
-        project_id: project.
-        article_ids: List de IDs of the articles (UUID strings).
-        formats: List de formatos: csv, ris, rdf.
-        file_scope: none, main_only, all.
-        user_id: user (para ownership do job).
+        project_id: Project UUID.
+        article_ids: List of article UUIDs to export.
+        formats: List of metadata formats: csv, ris, rdf.
+        file_scope: One of none, main_only, all.
+        user_id: User UUID owning the export job.
 
     Returns:
         Dict with download_url, expires_at, skipped_files, user_id.

--- a/backend/app/worker/tasks/export_tasks.py
+++ b/backend/app/worker/tasks/export_tasks.py
@@ -45,11 +45,12 @@ def export_articles_task(
     """
 
     async def run() -> dict:
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.articles_export_service import ArticlesExportService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             supabase = get_supabase_client()
             storage = create_storage_adapter(supabase)
             service = ArticlesExportService(

--- a/backend/app/worker/tasks/export_tasks.py
+++ b/backend/app/worker/tasks/export_tasks.py
@@ -2,22 +2,15 @@
 Export Tasks.
 
 Tasks Celery for exportacao de articles (CSV, RIS, RDF + files).
+
+The async bridge is via ``app.worker._runner.run_task`` — see that
+module's docstring for the event-loop rationale.
 """
 
-import asyncio
 from uuid import UUID
 
+from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
-
-_WORKER_LOOP: asyncio.AbstractEventLoop | None = None
-
-
-def _run_in_worker_loop(coro):
-    global _WORKER_LOOP
-    if _WORKER_LOOP is None or _WORKER_LOOP.is_closed():
-        _WORKER_LOOP = asyncio.new_event_loop()
-        asyncio.set_event_loop(_WORKER_LOOP)
-    return _WORKER_LOOP.run_until_complete(coro)
 
 
 @celery_app.task(
@@ -49,11 +42,12 @@ def export_articles_task(
     Returns:
         Dict with download_url, expires_at, skipped_files, user_id.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.articles_export_service import ArticlesExportService
 
     async def run() -> dict:
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.articles_export_service import ArticlesExportService
+
         async with AsyncSessionLocal() as session:
             supabase = get_supabase_client()
             storage = create_storage_adapter(supabase)
@@ -73,4 +67,4 @@ def export_articles_task(
             result["user_id"] = user_id
             return result
 
-    return _run_in_worker_loop(run())
+    return run_task(run)

--- a/backend/app/worker/tasks/extraction_export_tasks.py
+++ b/backend/app/worker/tasks/extraction_export_tasks.py
@@ -2,38 +2,30 @@
 
 Background-export worker. Opens its own DB session + storage adapter,
 runs the export service, uploads bytes, returns a signed URL.
+
+The async bridge is via ``app.worker._runner.run_task`` — see that
+module's docstring for the event-loop rationale.
 """
 
 from __future__ import annotations
 
-import asyncio
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from app.core.logging import get_logger
+from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
 
 logger = get_logger(__name__)
 
-_WORKER_LOOP: asyncio.AbstractEventLoop | None = None
-
-#: Signed-URL TTL for the generated `.xlsx`. Matches the articles_export
+#: Signed-URL TTL for the generated ``.xlsx``. Matches the articles_export
 #: convention so users see consistent expiry windows across export types.
 _DOWNLOAD_URL_TTL_SECONDS = 3600
 
-#: Supabase Storage bucket. We reuse the existing `articles` bucket
-#: under a dedicated `exports/extraction/` prefix (research.md §2).
+#: Supabase Storage bucket. We reuse the existing ``articles`` bucket
+#: under a dedicated ``exports/extraction/`` prefix (research.md §2).
 _STORAGE_BUCKET = "articles"
 _STORAGE_PREFIX = "exports/extraction"
-
-
-def _run_in_worker_loop(coro):
-    """Reuse a worker-local event loop across task invocations."""
-    global _WORKER_LOOP
-    if _WORKER_LOOP is None or _WORKER_LOOP.is_closed():
-        _WORKER_LOOP = asyncio.new_event_loop()
-        asyncio.set_event_loop(_WORKER_LOOP)
-    return _WORKER_LOOP.run_until_complete(coro)
 
 
 @celery_app.task(
@@ -47,7 +39,7 @@ def export_extraction_task(
     template_id: str,
     mode: str,
     article_ids: list[str],
-    article_scope: str,  # noqa: ARG001 — currently informational; carried for audit/log
+    article_scope: str,  # noqa: ARG001 — informational; carried for audit/log
     user_id: str,
     reviewer_id: str | None = None,
     include_ai_metadata: bool = False,
@@ -58,15 +50,19 @@ def export_extraction_task(
     Builds the workbook via ``ExtractionExportService``, uploads bytes
     to Supabase Storage, returns ``{download_url, expires_at, user_id}``.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.exports.extraction_xlsx_builder import build_workbook
-    from app.services.extraction_export_service import (
-        ExportMode,
-        ExtractionExportService,
-    )
 
     async def run() -> dict:
+        # Lazy imports + lazy client construction.
+        import asyncio
+
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.exports.extraction_xlsx_builder import build_workbook
+        from app.services.extraction_export_service import (
+            ExportMode,
+            ExtractionExportService,
+        )
+
         async with AsyncSessionLocal() as session:
             supabase = get_supabase_client()
             storage = create_storage_adapter(supabase)
@@ -110,4 +106,4 @@ def export_extraction_task(
                 "user_id": user_id,
             }
 
-    return _run_in_worker_loop(run())
+    return run_task(run)

--- a/backend/app/worker/tasks/extraction_export_tasks.py
+++ b/backend/app/worker/tasks/extraction_export_tasks.py
@@ -9,6 +9,7 @@ module's docstring for the event-loop rationale.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
@@ -53,8 +54,6 @@ def export_extraction_task(
 
     async def run() -> dict:
         # Lazy imports + lazy client construction.
-        import asyncio
-
         from app.core.deps import AsyncSessionLocal, get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.exports.extraction_xlsx_builder import build_workbook

--- a/backend/app/worker/tasks/extraction_export_tasks.py
+++ b/backend/app/worker/tasks/extraction_export_tasks.py
@@ -54,15 +54,16 @@ def export_extraction_task(
 
     async def run() -> dict:
         # Lazy imports + lazy client construction.
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.exports.extraction_xlsx_builder import build_workbook
         from app.services.extraction_export_service import (
             ExportMode,
             ExtractionExportService,
         )
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             supabase = get_supabase_client()
             storage = create_storage_adapter(supabase)
             service = ExtractionExportService(

--- a/backend/app/worker/tasks/extraction_tasks.py
+++ b/backend/app/worker/tasks/extraction_tasks.py
@@ -50,12 +50,13 @@ def extract_section_task(
     """
 
     async def run():
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.api_key_service import APIKeyService
         from app.services.section_extraction_service import SectionExtractionService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 supabase = get_supabase_client()
                 storage = create_storage_adapter(supabase)
@@ -129,12 +130,13 @@ def extract_models_task(
     """
 
     async def run():
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.api_key_service import APIKeyService
         from app.services.model_extraction_service import ModelExtractionService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 supabase = get_supabase_client()
                 storage = create_storage_adapter(supabase)

--- a/backend/app/worker/tasks/extraction_tasks.py
+++ b/backend/app/worker/tasks/extraction_tasks.py
@@ -2,12 +2,15 @@
 Extraction Tasks.
 
 Tasks Celery for processamento de extractions.
+
+The async bridge is via ``app.worker._runner.run_task`` — see that
+module's docstring for the event-loop rationale.
 """
 
-import asyncio
 from typing import Any
 from uuid import UUID
 
+from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
 
 
@@ -42,12 +45,13 @@ def extract_section_task(
     Returns:
         Dict with resultado da extraction.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.api_key_service import APIKeyService
-    from app.services.section_extraction_service import SectionExtractionService
 
     async def run():
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.api_key_service import APIKeyService
+        from app.services.section_extraction_service import SectionExtractionService
+
         async with AsyncSessionLocal() as session:
             try:
                 supabase = get_supabase_client()
@@ -88,7 +92,7 @@ def extract_section_task(
                 raise
 
     try:
-        return asyncio.run(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)
 
@@ -120,12 +124,13 @@ def extract_models_task(
     Returns:
         Dict with modelos extraidos.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.api_key_service import APIKeyService
-    from app.services.model_extraction_service import ModelExtractionService
 
     async def run():
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.api_key_service import APIKeyService
+        from app.services.model_extraction_service import ModelExtractionService
+
         async with AsyncSessionLocal() as session:
             try:
                 supabase = get_supabase_client()
@@ -182,7 +187,7 @@ def extract_models_task(
                 raise
 
     try:
-        return asyncio.run(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)
 

--- a/backend/app/worker/tasks/extraction_tasks.py
+++ b/backend/app/worker/tasks/extraction_tasks.py
@@ -1,11 +1,13 @@
-"""
-Extraction Tasks.
+"""Extraction Celery tasks.
 
-Tasks Celery for processamento de extractions.
+Celery tasks that drive AI-assisted extraction (single-section and
+prediction-model extraction) plus a small batch-fanout helper.
 
 The async bridge is via ``app.worker._runner.run_task`` — see that
 module's docstring for the event-loop rationale.
 """
+
+from __future__ import annotations
 
 from typing import Any
 from uuid import UUID
@@ -30,20 +32,21 @@ def extract_section_task(
     parent_instance_id: str | None = None,
     openai_api_key: str | None = None,
 ) -> dict[str, Any]:
-    """
-    Task for extraction de uma section.
+    """Run AI extraction for a single section of an article.
 
     Args:
-        project_id: project.
-        article_id: article.
-        template_id: template.
-        entity_type_id: entity type.
-        user_id: user.
-        parent_instance_id: instance pai (optional).
-        openai_api_key: API key customizada (BYOK). Se None, busca do user or usa global.
+        project_id: Project UUID.
+        article_id: Article UUID.
+        template_id: Project template UUID.
+        entity_type_id: Entity type UUID to extract.
+        user_id: User UUID owning the run.
+        parent_instance_id: Parent instance UUID, when extracting a child
+            section under a model container (optional).
+        openai_api_key: BYOK override. If ``None``, the user's stored key
+            is resolved; falls back to the global service key.
 
     Returns:
-        Dict with resultado da extraction.
+        Dict with the extraction result summary.
     """
 
     async def run():
@@ -111,18 +114,18 @@ def extract_models_task(
     user_id: str,
     openai_api_key: str | None = None,
 ) -> dict[str, Any]:
-    """
-    Task for extraction de modelos de predicao.
+    """Run AI extraction for prediction models in an article.
 
     Args:
-        project_id: project.
-        article_id: article.
-        template_id: template.
-        user_id: user.
-        openai_api_key: API key customizada (BYOK). Se None, busca do user or usa global.
+        project_id: Project UUID.
+        article_id: Article UUID.
+        template_id: Project template UUID.
+        user_id: User UUID owning the run.
+        openai_api_key: BYOK override. If ``None``, the user's stored key
+            is resolved; falls back to the global service key.
 
     Returns:
-        Dict with modelos extraidos.
+        Dict with the extracted models summary.
     """
 
     async def run():
@@ -205,17 +208,16 @@ def batch_extract_task(
     template_id: str,
     user_id: str,
 ) -> dict[str, Any]:
-    """
-    Task for extraction em batch de multiplos articles.
+    """Fan out model extraction across a batch of articles.
 
     Args:
-        project_id: project.
-        article_ids: List de IDs de articles.
-        template_id: template.
-        user_id: user.
+        project_id: Project UUID.
+        article_ids: List of article UUIDs to extract.
+        template_id: Project template UUID.
+        user_id: User UUID owning the runs.
 
     Returns:
-        Dict with estatisticas do batch.
+        Dict with per-article queue stats for the batch.
     """
     results = {
         "total": len(article_ids),

--- a/backend/app/worker/tasks/import_tasks.py
+++ b/backend/app/worker/tasks/import_tasks.py
@@ -48,11 +48,12 @@ def import_zotero_collection_task(
     """
 
     async def run():
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.zotero_import_service import ZoteroImportService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 supabase = get_supabase_client()
                 storage = create_storage_adapter(supabase)
@@ -121,11 +122,12 @@ def retry_failed_zotero_sync_task(
     limit: int = 100,
 ) -> dict[str, Any]:
     async def run():
-        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.zotero_import_service import ZoteroImportService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 supabase = get_supabase_client()
                 storage = create_storage_adapter(supabase)
@@ -180,10 +182,10 @@ def sync_zotero_library_task(
     """
 
     async def run():
-        from app.core.deps import AsyncSessionLocal
         from app.services.zotero_service import ZoteroService
+        from app.worker._session import worker_session
 
-        async with AsyncSessionLocal() as session:
+        async with worker_session() as session:
             try:
                 zotero = ZoteroService(
                     db=session,

--- a/backend/app/worker/tasks/import_tasks.py
+++ b/backend/app/worker/tasks/import_tasks.py
@@ -2,23 +2,16 @@
 Import Tasks.
 
 Tasks Celery for importacao de data externos.
+
+The async bridge is via ``app.worker._runner.run_task`` — see that
+module's docstring for the event-loop rationale.
 """
 
-import asyncio
 from typing import Any
 from uuid import UUID
 
+from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
-
-_WORKER_LOOP: asyncio.AbstractEventLoop | None = None
-
-
-def _run_in_worker_loop(coro):
-    global _WORKER_LOOP
-    if _WORKER_LOOP is None or _WORKER_LOOP.is_closed():
-        _WORKER_LOOP = asyncio.new_event_loop()
-        asyncio.set_event_loop(_WORKER_LOOP)
-    return _WORKER_LOOP.run_until_complete(coro)
 
 
 @celery_app.task(
@@ -50,11 +43,12 @@ def import_zotero_collection_task(
     Returns:
         Dict with resultado da importacao.
     """
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.zotero_import_service import ZoteroImportService
 
     async def run():
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.zotero_import_service import ZoteroImportService
+
         async with AsyncSessionLocal() as session:
             try:
                 supabase = get_supabase_client()
@@ -104,7 +98,7 @@ def import_zotero_collection_task(
                 raise
 
     try:
-        return _run_in_worker_loop(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)
 
@@ -123,11 +117,11 @@ def retry_failed_zotero_sync_task(
     sync_run_id: str,
     limit: int = 100,
 ) -> dict[str, Any]:
-    from app.core.deps import AsyncSessionLocal, get_supabase_client
-    from app.core.factories import create_storage_adapter
-    from app.services.zotero_import_service import ZoteroImportService
-
     async def run():
+        from app.core.deps import AsyncSessionLocal, get_supabase_client
+        from app.core.factories import create_storage_adapter
+        from app.services.zotero_import_service import ZoteroImportService
+
         async with AsyncSessionLocal() as session:
             try:
                 supabase = get_supabase_client()
@@ -159,7 +153,7 @@ def retry_failed_zotero_sync_task(
                 raise
 
     try:
-        return _run_in_worker_loop(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)
 
@@ -182,10 +176,11 @@ def sync_zotero_library_task(
     Returns:
         Dict with resultado da sincronizacao.
     """
-    from app.core.deps import AsyncSessionLocal
-    from app.services.zotero_service import ZoteroService
 
     async def run():
+        from app.core.deps import AsyncSessionLocal
+        from app.services.zotero_service import ZoteroService
+
         async with AsyncSessionLocal() as session:
             try:
                 zotero = ZoteroService(
@@ -222,6 +217,6 @@ def sync_zotero_library_task(
                 raise
 
     try:
-        return _run_in_worker_loop(run())
+        return run_task(run)
     except Exception as exc:
         self.retry(exc=exc)

--- a/backend/app/worker/tasks/import_tasks.py
+++ b/backend/app/worker/tasks/import_tasks.py
@@ -1,11 +1,13 @@
-"""
-Import Tasks.
+"""Import Celery tasks.
 
-Tasks Celery for importacao de data externos.
+Celery tasks that import external data (currently Zotero collections
+and Zotero library sync) into a project.
 
 The async bridge is via ``app.worker._runner.run_task`` — see that
 module's docstring for the event-loop rationale.
 """
+
+from __future__ import annotations
 
 from typing import Any
 from uuid import UUID
@@ -30,18 +32,19 @@ def import_zotero_collection_task(
     update_existing: bool = True,
     sync_run_id: str | None = None,
 ) -> dict[str, Any]:
-    """
-    Task for importacao de collection do Zotero.
+    """Import a Zotero collection into the project.
 
     Args:
-        project_id: project.
-        collection_key: Key da collection in the Zotero.
-        user_id: user.
-        import_pdfs: Se deve importar PDFs.
-        max_items: Maximo de items a importar.
+        project_id: Project UUID.
+        collection_key: Zotero collection key.
+        user_id: User UUID owning the import.
+        import_pdfs: Whether to also import attached PDFs.
+        max_items: Max items to import.
+        update_existing: Whether to update items that already exist.
+        sync_run_id: Existing sync-run UUID to attach to (optional).
 
     Returns:
-        Dict with resultado da importacao.
+        Dict with the import result summary.
     """
 
     async def run():
@@ -167,14 +170,13 @@ def sync_zotero_library_task(
     self,
     user_id: str,
 ) -> dict[str, Any]:
-    """
-    Task for sincronizacao completa da biblioteca Zotero.
+    """Sync the user's full Zotero library metadata.
 
     Args:
-        user_id: user.
+        user_id: User UUID whose Zotero library should be synced.
 
     Returns:
-        Dict with resultado da sincronizacao.
+        Dict with the sync result summary.
     """
 
     async def run():
@@ -188,7 +190,7 @@ def sync_zotero_library_task(
                     user_id=user_id,
                 )
 
-                # Testar conexao
+                # Test the connection
                 connection_result = await zotero.test_connection()
 
                 if not connection_result.get("success"):
@@ -197,7 +199,7 @@ def sync_zotero_library_task(
                         "error": connection_result.get("error"),
                     }
 
-                # Listar collections
+                # List collections
                 collections_result = await zotero.list_collections()
 
                 return {
@@ -209,7 +211,7 @@ def sync_zotero_library_task(
                             "key": c.get("key"),
                             "name": c.get("data", {}).get("name"),
                         }
-                        for c in collections_result.get("collections", [])[:20]  # Limitar
+                        for c in collections_result.get("collections", [])[:20]  # Cap response size
                     ],
                 }
             except Exception:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -137,11 +137,13 @@ markers = [
 
 
 [tool.coverage.run]
-# KISS/DRY: focar coverage no código que está sendo efetivamente exercitado e mantido.
-# Estes diretórios estão atualmente sem testes (0%) e puxam a cobertura para baixo no CI.
+# Focus coverage on code that is actually exercised and maintained.
+# Directories listed here are intentionally excluded — `app/worker/*`
+# was previously here but PR 2 of the worker-hardening plan added real
+# tests (loop-isolation regression + eager-mode integration + drift
+# guard), so it has real coverage numbers now.
 omit = [
     "app/schemas/read_models/*",
-    "app/worker/*",
 ]
 
 [dependency-groups]

--- a/backend/tests/integration/test_worker_eager_mode.py
+++ b/backend/tests/integration/test_worker_eager_mode.py
@@ -10,7 +10,7 @@ on the pytest event loop, so loop reuse is impossible by construction.
 For loop coverage see the CI smoke job added in PR 3.
 
 Each test patches the *imports inside the task closure* (the task
-module imports ``AsyncSessionLocal``, ``get_supabase_client`` and the
+module imports ``worker_session``, ``get_supabase_client`` and the
 service classes lazily inside ``async def run``), then triggers the
 task via ``.apply(kwargs=...)`` which exercises the kwargs serialiser
 and the ``run_task`` async bridge.
@@ -44,7 +44,7 @@ class _FakeAsyncSession:
     """Drop-in for an SQLAlchemy ``AsyncSession`` that records lifecycle.
 
     Tasks call ``await session.commit()`` / ``await session.rollback()``
-    on the result of ``async with AsyncSessionLocal() as session``. We
+    on the result of ``async with worker_session() as session``. We
     don't need real SQL — just need awaitable no-ops so ``async with``
     and the commit/rollback calls succeed without raising.
     """
@@ -58,9 +58,9 @@ class _FakeAsyncSession:
 
 
 def _session_factory_returning(session: _FakeAsyncSession) -> Any:
-    """Return a callable that mimics ``AsyncSessionLocal()``.
+    """Return a callable that mimics ``worker_session()``.
 
-    ``AsyncSessionLocal()`` returns an async context manager whose
+    ``worker_session()`` returns an async context manager whose
     ``__aenter__`` yields the session. We can't use ``MagicMock`` here
     because ``async with`` requires ``__aenter__``/``__aexit__`` to be
     real coroutines.
@@ -106,7 +106,7 @@ def test_export_extraction_task_signature_and_kwargs_alignment() -> None:
             return_value=b"PK\x03\x04minimal-xlsx-bytes",
         ),
         patch(
-            "app.core.deps.AsyncSessionLocal",
+            "app.worker._session.worker_session",
             new=_session_factory_returning(session),
         ),
         patch(
@@ -166,7 +166,7 @@ def test_export_articles_task_signature_and_kwargs_alignment() -> None:
             return_value=MagicMock(),
         ),
         patch(
-            "app.core.deps.AsyncSessionLocal",
+            "app.worker._session.worker_session",
             new=_session_factory_returning(session),
         ),
         patch(
@@ -244,7 +244,7 @@ def test_import_zotero_collection_task_signature_and_kwargs_alignment() -> None:
             return_value=MagicMock(),
         ),
         patch(
-            "app.core.deps.AsyncSessionLocal",
+            "app.worker._session.worker_session",
             new=_session_factory_returning(session),
         ),
         patch(
@@ -316,7 +316,7 @@ def test_extract_section_task_signature_and_kwargs_alignment() -> None:
             return_value=MagicMock(),
         ),
         patch(
-            "app.core.deps.AsyncSessionLocal",
+            "app.worker._session.worker_session",
             new=_session_factory_returning(session),
         ),
         patch(

--- a/backend/tests/integration/test_worker_eager_mode.py
+++ b/backend/tests/integration/test_worker_eager_mode.py
@@ -1,0 +1,340 @@
+"""Eager-mode coverage for every Celery task.
+
+Runs each task synchronously via ``task_always_eager`` +
+``task_eager_propagates``. Validates serialisation (UUIDs come in as
+strings, parse correctly), kwargs alignment, and per-task client
+construction.
+
+Does NOT validate the event-loop bug — eager mode runs the coroutine
+on the pytest event loop, so loop reuse is impossible by construction.
+For loop coverage see the CI smoke job added in PR 3.
+
+Each test patches the *imports inside the task closure* (the task
+module imports ``AsyncSessionLocal``, ``get_supabase_client`` and the
+service classes lazily inside ``async def run``), then triggers the
+task via ``.apply(kwargs=...)`` which exercises the kwargs serialiser
+and the ``run_task`` async bridge.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.worker.celery_app import celery_app
+
+# ----------------------------------------------------------------------
+# Shared fixtures / helpers
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def eager_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run every Celery task synchronously in the pytest process."""
+    monkeypatch.setattr(celery_app.conf, "task_always_eager", True)
+    monkeypatch.setattr(celery_app.conf, "task_eager_propagates", True)
+
+
+class _FakeAsyncSession:
+    """Drop-in for an SQLAlchemy ``AsyncSession`` that records lifecycle.
+
+    Tasks call ``await session.commit()`` / ``await session.rollback()``
+    on the result of ``async with AsyncSessionLocal() as session``. We
+    don't need real SQL — just need awaitable no-ops so ``async with``
+    and the commit/rollback calls succeed without raising.
+    """
+
+    def __init__(self) -> None:
+        self.commit = AsyncMock()
+        self.rollback = AsyncMock()
+        self.close = AsyncMock()
+        self.flush = AsyncMock()
+        self.refresh = AsyncMock()
+
+
+def _session_factory_returning(session: _FakeAsyncSession) -> Any:
+    """Return a callable that mimics ``AsyncSessionLocal()``.
+
+    ``AsyncSessionLocal()`` returns an async context manager whose
+    ``__aenter__`` yields the session. We can't use ``MagicMock`` here
+    because ``async with`` requires ``__aenter__``/``__aexit__`` to be
+    real coroutines.
+    """
+
+    @asynccontextmanager
+    async def _cm() -> AsyncIterator[_FakeAsyncSession]:
+        yield session
+
+    def _factory() -> Any:
+        return _cm()
+
+    return _factory
+
+
+# ----------------------------------------------------------------------
+# 1. extraction_export_tasks.export_extraction_task
+# ----------------------------------------------------------------------
+
+
+def test_export_extraction_task_signature_and_kwargs_alignment() -> None:
+    """The 9 task kwargs must align with what the endpoint passes."""
+    from app.worker.tasks.extraction_export_tasks import export_extraction_task
+
+    session = _FakeAsyncSession()
+    fake_service = MagicMock()
+    fake_service.resolve_layout = AsyncMock(return_value=object())
+    fake_storage = MagicMock()
+    fake_storage.upload = AsyncMock(return_value=None)
+    fake_storage.get_signed_url = AsyncMock(return_value="https://signed.example/url")
+
+    with (
+        patch(
+            "app.services.extraction_export_service.ExtractionExportService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.core.factories.create_storage_adapter",
+            return_value=fake_storage,
+        ),
+        patch(
+            "app.services.exports.extraction_xlsx_builder.build_workbook",
+            return_value=b"PK\x03\x04minimal-xlsx-bytes",
+        ),
+        patch(
+            "app.core.deps.AsyncSessionLocal",
+            new=_session_factory_returning(session),
+        ),
+        patch(
+            "app.core.deps.get_supabase_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = export_extraction_task.apply(
+            kwargs={
+                "project_id": str(uuid4()),
+                "template_id": str(uuid4()),
+                "mode": "consensus",
+                "article_ids": [str(uuid4())],
+                "article_scope": "current_list",
+                "user_id": str(uuid4()),
+                "reviewer_id": None,
+                "include_ai_metadata": False,
+                "anonymize_reviewer_names": False,
+            }
+        ).get(timeout=5)
+
+    assert result["download_url"] == "https://signed.example/url"
+    assert "expires_at" in result
+    assert "user_id" in result
+    # Layout resolved, workbook built, bytes uploaded, signed URL returned.
+    fake_service.resolve_layout.assert_awaited_once()
+    fake_storage.upload.assert_awaited_once()
+    fake_storage.get_signed_url.assert_awaited_once()
+
+
+# ----------------------------------------------------------------------
+# 2. export_tasks.export_articles_task
+# ----------------------------------------------------------------------
+
+
+def test_export_articles_task_signature_and_kwargs_alignment() -> None:
+    """Mirror of the extraction export — but for the articles ZIP path."""
+    from app.worker.tasks.export_tasks import export_articles_task
+
+    session = _FakeAsyncSession()
+    fake_service = MagicMock()
+    fake_service.run_export_async = AsyncMock(
+        return_value={
+            "download_url": "https://signed.example/zip",
+            "expires_at": "2026-05-24T12:00:00+00:00",
+            "skipped_files": [],
+        }
+    )
+
+    with (
+        patch(
+            "app.services.articles_export_service.ArticlesExportService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.core.factories.create_storage_adapter",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.core.deps.AsyncSessionLocal",
+            new=_session_factory_returning(session),
+        ),
+        patch(
+            "app.core.deps.get_supabase_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = export_articles_task.apply(
+            kwargs={
+                "project_id": str(uuid4()),
+                "article_ids": [str(uuid4()), str(uuid4())],
+                "formats": ["csv", "ris"],
+                "file_scope": "none",
+                "user_id": str(uuid4()),
+            }
+        ).get(timeout=5)
+
+    assert result["download_url"] == "https://signed.example/zip"
+    assert result["skipped_files"] == []
+    # The task augments the service result with ``user_id`` on the way out.
+    assert "user_id" in result
+    fake_service.run_export_async.assert_awaited_once()
+
+
+# ----------------------------------------------------------------------
+# 3. import_tasks.import_zotero_collection_task
+# ----------------------------------------------------------------------
+
+
+def test_import_zotero_collection_task_signature_and_kwargs_alignment() -> None:
+    """The Zotero collection import — service returns a dataclass with
+    a ``results`` list; the task flattens it into a JSON-safe dict.
+    """
+    from app.services.zotero_import_service import (
+        ZoteroImportItemResult,
+        ZoteroImportResult,
+    )
+    from app.worker.tasks.import_tasks import import_zotero_collection_task
+
+    session = _FakeAsyncSession()
+    fake_service = MagicMock()
+    fake_service.import_collection = AsyncMock(
+        return_value=ZoteroImportResult(
+            total_items=1,
+            imported=1,
+            failed=0,
+            skipped=0,
+            updated=0,
+            removed_at_source=0,
+            reactivated=0,
+            results=[
+                ZoteroImportItemResult(
+                    zotero_key="KEY1",
+                    title="Sample article",
+                    success=True,
+                    article_id=str(uuid4()),
+                    pdf_imported=False,
+                ),
+            ],
+            sync_run_id=str(uuid4()),
+        )
+    )
+
+    with (
+        patch(
+            "app.services.zotero_import_service.ZoteroImportService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.core.factories.create_storage_adapter",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.core.deps.AsyncSessionLocal",
+            new=_session_factory_returning(session),
+        ),
+        patch(
+            "app.core.deps.get_supabase_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = import_zotero_collection_task.apply(
+            kwargs={
+                "project_id": str(uuid4()),
+                "collection_key": "ABCD1234",
+                "user_id": str(uuid4()),
+                "import_pdfs": False,
+                "max_items": 10,
+                "update_existing": True,
+                "sync_run_id": str(uuid4()),
+            }
+        ).get(timeout=5)
+
+    assert result["total_items"] == 1
+    assert result["imported"] == 1
+    assert result["results"][0]["zotero_key"] == "KEY1"
+    fake_service.import_collection.assert_awaited_once()
+    session.commit.assert_awaited()  # task commits on the happy path
+
+
+# ----------------------------------------------------------------------
+# 4. extraction_tasks.extract_section_task
+# ----------------------------------------------------------------------
+
+
+def test_extract_section_task_signature_and_kwargs_alignment() -> None:
+    """The section extractor with BYOK fallback — when ``openai_api_key``
+    is ``None`` the task constructs an APIKeyService and resolves it
+    from the user's stored key.
+    """
+    from app.services.section_extraction_service import SectionExtractionResult
+    from app.worker.tasks.extraction_tasks import extract_section_task
+
+    session = _FakeAsyncSession()
+
+    fake_extraction_service = MagicMock()
+    fake_extraction_service.extract_section = AsyncMock(
+        return_value=SectionExtractionResult(
+            extraction_run_id=str(uuid4()),
+            entity_type_id=str(uuid4()),
+            suggestions_created=3,
+            tokens_prompt=120,
+            tokens_completion=80,
+            tokens_total=200,
+            duration_ms=1234.5,
+        )
+    )
+
+    fake_api_key_service = MagicMock()
+    fake_api_key_service.get_key_for_provider = AsyncMock(return_value="resolved-from-user-keys")
+
+    with (
+        patch(
+            "app.services.section_extraction_service.SectionExtractionService",
+            return_value=fake_extraction_service,
+        ),
+        patch(
+            "app.services.api_key_service.APIKeyService",
+            return_value=fake_api_key_service,
+        ),
+        patch(
+            "app.core.factories.create_storage_adapter",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "app.core.deps.AsyncSessionLocal",
+            new=_session_factory_returning(session),
+        ),
+        patch(
+            "app.core.deps.get_supabase_client",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = extract_section_task.apply(
+            kwargs={
+                "project_id": str(uuid4()),
+                "article_id": str(uuid4()),
+                "template_id": str(uuid4()),
+                "entity_type_id": str(uuid4()),
+                "user_id": str(uuid4()),
+                "parent_instance_id": None,
+                # No openai_api_key -> task must resolve via APIKeyService.
+                "openai_api_key": None,
+            }
+        ).get(timeout=5)
+
+    assert result["suggestions_created"] == 3
+    assert result["duration_ms"] == 1234
+    fake_api_key_service.get_key_for_provider.assert_awaited_once_with("openai")
+    fake_extraction_service.extract_section.assert_awaited_once()
+    session.commit.assert_awaited()

--- a/backend/tests/integration/test_worker_eager_mode.py
+++ b/backend/tests/integration/test_worker_eager_mode.py
@@ -189,6 +189,10 @@ def test_export_articles_task_signature_and_kwargs_alignment() -> None:
     # The task augments the service result with ``user_id`` on the way out.
     assert "user_id" in result
     fake_service.run_export_async.assert_awaited_once()
+    # Transaction management belongs to the service — the task body must
+    # not perform a raw commit. Catches a future regression where someone
+    # adds an `await session.commit()` to the task wrapper.
+    session.commit.assert_not_awaited()
 
 
 # ----------------------------------------------------------------------

--- a/backend/tests/unit/test_api_key_service.py
+++ b/backend/tests/unit/test_api_key_service.py
@@ -312,8 +312,8 @@ class TestGetGlobalKey:
         svc = make_service()
         # settings.OPENAI_API_KEY is "x" in test env
         result = svc._get_global_key("openai")
-        # Acceptable: either "x" or None (depending on env), but no exception
-        assert result is not None or result is None
+        # Should return the settings key when configured
+        assert result is not None
 
     def test_unknown_provider_returns_none(self) -> None:
         svc = make_service()

--- a/backend/tests/unit/test_celery_app_task_registry.py
+++ b/backend/tests/unit/test_celery_app_task_registry.py
@@ -41,3 +41,23 @@ def test_celery_module_is_included(module: str, sample_task: str) -> None:
         f"the worker will reject {sample_task!r} as NotRegistered. "
         f"Add it to the include=[...] list in app/worker/celery_app.py."
     )
+
+
+@pytest.mark.parametrize(("module", "_sample_task"), EXPECTED_TASK_MODULES)
+def test_module_has_explicit_task_route(module: str, _sample_task: str) -> None:
+    """Every task module must have an explicit route — no falling back
+    to the default ``celery`` queue. Prevents future tasks from silently
+    landing on a queue that may or may not be consumed by the worker.
+
+    Pairs with ``tests/unit/test_celery_routes_drift.py`` which then
+    asserts every routed queue is actually consumed by the Railway
+    worker. Together they form a two-step guard: routes must exist
+    (this test) AND must map to a real queue (drift test).
+    """
+    pattern = f"{module}.*"
+    routes = celery_app.conf.task_routes or {}
+    assert pattern in routes, (
+        f"Module {module!r} is in include= but has no entry in "
+        f"task_routes. Add e.g. `{pattern!r}: {{'queue': 'celery'}}` "
+        f"explicitly so the test guarantees no drift."
+    )

--- a/backend/tests/unit/test_celery_routes_drift.py
+++ b/backend/tests/unit/test_celery_routes_drift.py
@@ -31,6 +31,14 @@ SOURCE_FILE = REPO_ROOT / "railway.toml"
 
 #: Pattern matching ``--queues=a,b,c`` in the Railway worker start
 #: command. Allows letters, digits and underscores in queue names.
+#:
+#: NOTE: ``[\w,]+`` is intentionally strict — the captured group stops
+#: at the first character outside ``[A-Za-z0-9_,]``. This means the
+#: queue list in ``railway.toml`` MUST be a contiguous CSV with no
+#: whitespace and no line continuations: ``--queues=a,b,c`` works,
+#: ``--queues=a, b, c`` does NOT (the regex captures only ``a``).
+#: If a future format change introduces spaces or wraps the line,
+#: relax this pattern and add a test that documents the new format.
 QUEUES_PATTERN = re.compile(r"--queues=([\w,]+)")
 
 

--- a/backend/tests/unit/test_celery_routes_drift.py
+++ b/backend/tests/unit/test_celery_routes_drift.py
@@ -1,0 +1,67 @@
+"""Drift guard between task routes and the deployed worker's queue list.
+
+``celery_app.conf.task_routes`` decides which queue each task lands in.
+The Railway worker boots with ``--queues=<csv>`` (set in the Railway
+dashboard; mirrored in ``railway.toml`` for documentation). If the two
+diverge, tasks are enqueued to queues nobody consumes — silent failure.
+
+This test parses the worker start command out of the canonical source
+(``railway.toml`` at the repo root — see the inventory comment block
+in that file) and asserts every queue named in ``task_routes`` is in
+that list.
+
+If the queue list ever moves out of ``railway.toml`` (e.g. into a
+GitHub Actions workflow), update ``SOURCE_FILE`` and ``QUEUES_PATTERN``
+accordingly. The Railway dashboard remains the runtime source of truth;
+this test guards against drift between the dashboard and the in-repo
+documentation, both of which must be updated together.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.worker.celery_app import celery_app
+
+# ``__file__`` -> backend/tests/unit/test_celery_routes_drift.py
+# parents[0] = unit/, [1] = tests/, [2] = backend/, [3] = repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SOURCE_FILE = REPO_ROOT / "railway.toml"
+
+#: Pattern matching ``--queues=a,b,c`` in the Railway worker start
+#: command. Allows letters, digits and underscores in queue names.
+QUEUES_PATTERN = re.compile(r"--queues=([\w,]+)")
+
+
+def _railway_worker_queues() -> set[str]:
+    """Parse the worker ``--queues=<csv>`` flag from the canonical file."""
+    text = SOURCE_FILE.read_text(encoding="utf-8")
+    match = QUEUES_PATTERN.search(text)
+    if not match:
+        raise AssertionError(
+            f"Could not find '--queues=...' in {SOURCE_FILE}. "
+            f"The drift test relies on the worker start command being "
+            f"present there. If you moved the canonical location, "
+            f"update SOURCE_FILE in this test."
+        )
+    return set(match.group(1).split(","))
+
+
+def test_every_routed_queue_is_consumed_by_the_railway_worker() -> None:
+    """Every queue routed in code MUST be consumed by the worker.
+
+    If this fails, either:
+      - add the missing queue to the worker ``--queues`` list in
+        ``railway.toml`` AND in the Railway dashboard, or
+      - drop the route in ``app/worker/celery_app.py``.
+    """
+    routed = {entry["queue"] for entry in celery_app.conf.task_routes.values()}
+    consumed = _railway_worker_queues()
+    missing = routed - consumed
+    assert not missing, (
+        f"Queues routed in celery_app.conf.task_routes but NOT in the "
+        f"Railway worker --queues list: {sorted(missing)}. Either add "
+        f"them to the worker start command in railway.toml (and update "
+        f"the Railway dashboard) or drop the route in celery_app.py."
+    )

--- a/backend/tests/unit/test_extraction_export_service.py
+++ b/backend/tests/unit/test_extraction_export_service.py
@@ -1,58 +1,2193 @@
-"""Unit coverage for extraction export service helpers."""
+"""Unit tests for ExtractionExportService.
+
+Pure-mock tests that drive the service to ≥80% coverage. No real DB
+session is used — all repository calls and SQLAlchemy execute() chains
+are replaced with AsyncMock / MagicMock instances.
+
+Coverage targets (in priority order):
+  T1  assert_can_export             — auth gate (4 paths)
+  T2  _build_consensus_value_map    — 3-tuple keys, JSONB unwrap
+  T3  _resolve_articles_for_consensus — stage filtering + omit tracking
+  T4  _infer_reviewer_outcome        — pure function, 5 outcomes
+  T5  _load_ai_proposal_rows         — 8-query orchestration
+  T6  _build_all_users_value_map     — 4-tuple keys, decision precedence
+  T7  list_eligible_reviewers_for_picker — manager vs non-manager
+"""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
-from types import SimpleNamespace
-from uuid import uuid4
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
 
-from app.models.extraction import ExtractionRunStage
-from app.services.extraction_export_service import _select_current_runs_by_article
+import pytest
+
+from app.core.error_handler import AuthorizationError
+from app.models.extraction import (
+    ExtractionEntityRole,
+    ExtractionFieldType,
+    ExtractionInstance,
+    ExtractionRun,
+    ExtractionRunStage,
+)
+from app.models.project import ProjectMemberRole
+from app.services.extraction_export_service import (
+    ArticleDescriptor,
+    ExportMode,
+    ExtractionExportService,
+    FieldDescriptor,
+    SectionDescriptor,
+    _build_header_label,
+    _infer_reviewer_outcome,
+    _letter_for,
+    _normalize_allowed_values,
+    _short_id,
+    _unwrap_value,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
 
 
-def _run(article_id, stage: ExtractionRunStage, created_at: datetime):
-    return SimpleNamespace(
-        id=uuid4(),
-        article_id=article_id,
-        stage=stage.value,
-        created_at=created_at,
+def _make_service(user_id: str | None = None) -> ExtractionExportService:
+    """Return a service wired to a no-op async session and storage."""
+    db = AsyncMock()
+    storage = MagicMock()
+    return ExtractionExportService(
+        db=db,
+        user_id=user_id or str(uuid4()),
+        storage=storage,
     )
 
 
-def test_select_current_run_prefers_active_revision_over_old_finalized_run():
-    article_id = uuid4()
-    base = datetime(2026, 5, 24, 10, 0, tzinfo=UTC)
-    old_finalized = _run(article_id, ExtractionRunStage.FINALIZED, base)
-    reopened_review = _run(article_id, ExtractionRunStage.REVIEW, base + timedelta(minutes=5))
-
-    selected = _select_current_runs_by_article([old_finalized, reopened_review])
-
-    assert selected[article_id].id == reopened_review.id
+def _scalars_result(items: list) -> MagicMock:
+    """Return a fake SQLAlchemy Result whose .scalars().all() yields *items*."""
+    scalars_obj = MagicMock()
+    scalars_obj.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars_obj
+    return result
 
 
-def test_select_current_run_prefers_latest_finalized_revision_when_no_active_run():
-    article_id = uuid4()
-    base = datetime(2026, 5, 24, 10, 0, tzinfo=UTC)
-    old_finalized = _run(article_id, ExtractionRunStage.FINALIZED, base)
-    latest_finalized = _run(
-        article_id,
-        ExtractionRunStage.FINALIZED,
-        base + timedelta(minutes=5),
+def _rows_result(rows: list) -> MagicMock:
+    """Return a fake Result whose .all() yields *rows* (row-tuple queries)."""
+    result = MagicMock()
+    result.all.return_value = rows
+    return result
+
+
+def _make_run(
+    *,
+    article_id: UUID | None = None,
+    stage: str = ExtractionRunStage.FINALIZED.value,
+    template_id: UUID | None = None,
+    project_id: UUID | None = None,
+    kind: str = "extraction",
+    created_at: datetime | None = None,
+) -> ExtractionRun:
+    """Construct an ExtractionRun-shaped object without a DB session.
+
+    ``created_at`` is required by ``_run_recency_key`` (added by PR #111 to
+    deterministically pick the current run per article after reopen). We
+    default to a stable timestamp so sort comparisons against a
+    MagicMock-typed datetime don't blow up — tests that care about
+    recency ordering pass an explicit ``created_at``.
+    """
+    run = MagicMock(spec=ExtractionRun)
+    run.id = uuid4()
+    run.article_id = article_id or uuid4()
+    run.stage = stage
+    run.template_id = template_id or uuid4()
+    run.project_id = project_id or uuid4()
+    run.kind = kind
+    run.created_at = created_at or datetime(2026, 1, 1, tzinfo=UTC)
+    return run
+
+
+def _make_instance(
+    *,
+    article_id: UUID | None = None,
+    entity_type_id: UUID | None = None,
+    template_id: UUID | None = None,
+) -> ExtractionInstance:
+    inst = MagicMock(spec=ExtractionInstance)
+    inst.id = uuid4()
+    inst.article_id = article_id or uuid4()
+    inst.entity_type_id = entity_type_id or uuid4()
+    inst.template_id = template_id or uuid4()
+    inst.sort_order = 0
+    return inst
+
+
+def _make_field(label: str, parent: UUID) -> FieldDescriptor:
+    return FieldDescriptor(
+        field_id=uuid4(),
+        label=label,
+        type=ExtractionFieldType.TEXT,
+        allowed_values=(),
+        parent_section_id=parent,
     )
 
-    selected = _select_current_runs_by_article([latest_finalized, old_finalized])
 
-    assert selected[article_id].id == latest_finalized.id
-
-
-def test_select_current_run_keeps_cancelled_run_for_omission_accounting():
-    article_id = uuid4()
-    cancelled = _run(
-        article_id,
-        ExtractionRunStage.CANCELLED,
-        datetime(2026, 5, 24, 10, 0, tzinfo=UTC),
+def _make_section(label: str, role: ExtractionEntityRole) -> SectionDescriptor:
+    eid = uuid4()
+    return SectionDescriptor(
+        entity_type_id=eid,
+        label=label,
+        role=role,
+        parent_entity_type_id=None,
+        fields=(_make_field(f"{label} F1", eid),),
     )
 
-    selected = _select_current_runs_by_article([cancelled])
 
-    assert selected[article_id].stage == ExtractionRunStage.CANCELLED.value
+# ===========================================================================
+# T1 — assert_can_export
+# ===========================================================================
+
+
+class TestAssertCanExport:
+    """Auth gate: membership + manager checks (FR-003 / FR-004).
+
+    Mocking strategy: monkeypatch ProjectMemberRepository at the
+    module import name so the lazy accessor `_project_members_repo()`
+    returns the mock repo.
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_member_raises_authorization_error(self, monkeypatch):
+        """User is not a project member → AuthorizationError."""
+        svc = _make_service()
+        project_id = uuid4()
+
+        member_repo = AsyncMock()
+        member_repo.is_member = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+
+        with pytest.raises(AuthorizationError):
+            await svc.assert_can_export(project_id, ExportMode.CONSENSUS, None)
+
+    @pytest.mark.asyncio
+    async def test_member_consensus_mode_no_raise(self, monkeypatch):
+        """Member requesting CONSENSUS export → no error raised."""
+        svc = _make_service()
+        project_id = uuid4()
+
+        member_repo = AsyncMock()
+        member_repo.is_member = AsyncMock(return_value=True)
+        member_repo.has_role = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+
+        # Should not raise
+        await svc.assert_can_export(project_id, ExportMode.CONSENSUS, None)
+        member_repo.has_role.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_manager_single_user_other_reviewer_raises(self, monkeypatch):
+        """Non-manager trying to export another reviewer's decisions → AuthorizationError."""
+        user_id = uuid4()
+        svc = _make_service(user_id=str(user_id))
+        project_id = uuid4()
+        other_reviewer_id = uuid4()
+
+        member_repo = AsyncMock()
+        member_repo.is_member = AsyncMock(return_value=True)
+        member_repo.has_role = AsyncMock(return_value=False)  # not a manager
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+
+        with pytest.raises(AuthorizationError):
+            await svc.assert_can_export(project_id, ExportMode.SINGLE_USER, other_reviewer_id)
+
+    @pytest.mark.asyncio
+    async def test_manager_all_users_mode_no_raise(self, monkeypatch):
+        """Manager requesting ALL_USERS export → no error raised."""
+        svc = _make_service()
+        project_id = uuid4()
+
+        member_repo = AsyncMock()
+        member_repo.is_member = AsyncMock(return_value=True)
+        member_repo.has_role = AsyncMock(return_value=True)  # is a manager
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+
+        await svc.assert_can_export(project_id, ExportMode.ALL_USERS, None)
+        member_repo.has_role.assert_called_once_with(
+            project_id, UUID(svc.user_id), ProjectMemberRole.MANAGER
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_user_id_raises_authorization_error(self, monkeypatch):
+        """Service with non-UUID user_id raises AuthorizationError early."""
+        svc = _make_service(user_id="not-a-uuid")
+
+        member_repo = AsyncMock()
+        member_repo.is_member = AsyncMock(return_value=True)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+
+        with pytest.raises(AuthorizationError):
+            await svc.assert_can_export(uuid4(), ExportMode.CONSENSUS, None)
+
+    @pytest.mark.asyncio
+    async def test_non_manager_single_user_own_reviewer_no_raise(self, monkeypatch):
+        """Non-manager exporting their own decisions → no error (self-export allowed)."""
+        user_id = uuid4()
+        svc = _make_service(user_id=str(user_id))
+        project_id = uuid4()
+
+        member_repo = AsyncMock()
+        member_repo.is_member = AsyncMock(return_value=True)
+        member_repo.has_role = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+
+        # target_reviewer_id == caller_id → no manager check required
+        await svc.assert_can_export(project_id, ExportMode.SINGLE_USER, user_id)
+        member_repo.has_role.assert_not_called()
+
+
+# ===========================================================================
+# T2 — _build_consensus_value_map
+# ===========================================================================
+
+
+class TestBuildConsensusValueMap:
+    """3-tuple keyed value map from ExtractionPublishedState rows.
+
+    Mocking strategy: mock svc.db.execute(...).all() to return fake row
+    tuples (run_id, instance_id, field_id, value).
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_run_ids_returns_empty_dict(self):
+        """No run_ids → short-circuits to empty dict without hitting DB."""
+        svc = _make_service()
+        result = await svc._build_consensus_value_map(run_ids=[])
+        assert result == {}
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_multiple_published_states_correct_keys(self):
+        """Multiple rows → each 3-tuple key maps to the unwrapped value."""
+        svc = _make_service()
+
+        run_id = uuid4()
+        instance_id1 = uuid4()
+        instance_id2 = uuid4()
+        field_id1 = uuid4()
+        field_id2 = uuid4()
+
+        rows = [
+            (run_id, instance_id1, field_id1, "value_a"),
+            (run_id, instance_id2, field_id2, "value_b"),
+        ]
+        svc.db.execute = AsyncMock(return_value=_rows_result(rows))
+
+        result = await svc._build_consensus_value_map(run_ids=[run_id])
+
+        assert result[(run_id, instance_id1, field_id1)] == "value_a"
+        assert result[(run_id, instance_id2, field_id2)] == "value_b"
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_jsonb_wrapper_is_unwrapped(self):
+        """Value stored as {"value": "actual"} is unwrapped to "actual"."""
+        svc = _make_service()
+
+        run_id = uuid4()
+        instance_id = uuid4()
+        field_id = uuid4()
+
+        rows = [(run_id, instance_id, field_id, {"value": "actual_string"})]
+        svc.db.execute = AsyncMock(return_value=_rows_result(rows))
+
+        result = await svc._build_consensus_value_map(run_ids=[run_id])
+
+        assert result[(run_id, instance_id, field_id)] == "actual_string"
+
+    @pytest.mark.asyncio
+    async def test_non_wrapper_dict_value_kept_as_is(self):
+        """A dict with multiple keys is NOT unwrapped — kept raw."""
+        svc = _make_service()
+
+        run_id = uuid4()
+        instance_id = uuid4()
+        field_id = uuid4()
+        raw = {"value": "x", "extra": "y"}
+
+        rows = [(run_id, instance_id, field_id, raw)]
+        svc.db.execute = AsyncMock(return_value=_rows_result(rows))
+
+        result = await svc._build_consensus_value_map(run_ids=[run_id])
+        assert result[(run_id, instance_id, field_id)] == raw
+
+
+# ===========================================================================
+# T3 — _resolve_articles_for_consensus
+# ===========================================================================
+
+
+class TestResolveArticlesForConsensus:
+    """Stage filtering + omit tracking for consensus export (FR-013).
+
+    Mocking strategy: mock svc.db.execute (for run queries), then also
+    mock the helper methods _load_instances_for_runs,
+    _load_entity_type_role_map, and _load_article_headers to return
+    controlled data so we isolate the filtering logic.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_candidate_ids_returns_empty(self):
+        """No candidate_ids → short-circuits before DB access."""
+        svc = _make_service()
+        articles, omitted = await svc._resolve_articles_for_consensus(
+            template_id=uuid4(),
+            project_id=uuid4(),
+            candidate_ids=[],
+        )
+        assert articles == []
+        assert omitted == {}
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_all_finalized_articles_kept(self):
+        """All FINALIZED runs → all articles kept, no omissions."""
+        svc = _make_service()
+        project_id = uuid4()
+        template_id = uuid4()
+
+        aid1 = uuid4()
+        aid2 = uuid4()
+        run1 = _make_run(article_id=aid1, stage=ExtractionRunStage.FINALIZED.value)
+        run2 = _make_run(article_id=aid2, stage=ExtractionRunStage.FINALIZED.value)
+        run1.template_id = template_id
+        run2.template_id = template_id
+
+        svc.db.execute = AsyncMock(return_value=_scalars_result([run1, run2]))
+
+        # Mock the three helpers called after filtering
+        svc._load_instances_for_runs = AsyncMock(return_value={run1.id: [], run2.id: []})
+        svc._load_entity_type_role_map = AsyncMock(return_value={})
+        svc._load_article_headers = AsyncMock(
+            return_value={aid1: "Author1, 2021", aid2: "Author2, 2022"}
+        )
+
+        articles, omitted = await svc._resolve_articles_for_consensus(
+            template_id=template_id,
+            project_id=project_id,
+            candidate_ids=[aid1, aid2],
+        )
+
+        assert len(articles) == 2
+        assert omitted == {}
+        article_ids_out = {a.article_id for a in articles}
+        assert article_ids_out == {aid1, aid2}
+
+    @pytest.mark.asyncio
+    async def test_mixed_stages_only_finalized_kept(self):
+        """FINALIZED kept; REVIEW + PROPOSAL → omitted with stage key."""
+        svc = _make_service()
+        template_id = uuid4()
+        project_id = uuid4()
+
+        aid_fin = uuid4()
+        aid_rev = uuid4()
+        aid_prop = uuid4()
+
+        run_fin = _make_run(article_id=aid_fin, stage=ExtractionRunStage.FINALIZED.value)
+        run_rev = _make_run(article_id=aid_rev, stage=ExtractionRunStage.REVIEW.value)
+        run_prop = _make_run(article_id=aid_prop, stage=ExtractionRunStage.PROPOSAL.value)
+
+        svc.db.execute = AsyncMock(return_value=_scalars_result([run_fin, run_rev, run_prop]))
+        svc._load_instances_for_runs = AsyncMock(return_value={run_fin.id: []})
+        svc._load_entity_type_role_map = AsyncMock(return_value={})
+        svc._load_article_headers = AsyncMock(return_value={aid_fin: "Smith, 2020"})
+
+        articles, omitted = await svc._resolve_articles_for_consensus(
+            template_id=template_id,
+            project_id=project_id,
+            candidate_ids=[aid_fin, aid_rev, aid_prop],
+        )
+
+        assert len(articles) == 1
+        assert articles[0].article_id == aid_fin
+        assert omitted[ExtractionRunStage.REVIEW.value] == 1
+        assert omitted[ExtractionRunStage.PROPOSAL.value] == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_run_counted_as_no_run(self):
+        """Article without a run → counted in omitted["no_run"]."""
+        svc = _make_service()
+        template_id = uuid4()
+        project_id = uuid4()
+
+        aid_exists = uuid4()
+        aid_missing = uuid4()  # no run in DB
+
+        run = _make_run(article_id=aid_exists, stage=ExtractionRunStage.FINALIZED.value)
+        svc.db.execute = AsyncMock(return_value=_scalars_result([run]))
+        svc._load_instances_for_runs = AsyncMock(return_value={run.id: []})
+        svc._load_entity_type_role_map = AsyncMock(return_value={})
+        svc._load_article_headers = AsyncMock(return_value={aid_exists: "Jones, 2019"})
+
+        articles, omitted = await svc._resolve_articles_for_consensus(
+            template_id=template_id,
+            project_id=project_id,
+            candidate_ids=[aid_exists, aid_missing],
+        )
+
+        assert len(articles) == 1
+        assert omitted.get("no_run") == 1
+
+    @pytest.mark.asyncio
+    async def test_model_and_study_instances_resolved(self):
+        """An article with both study + model instances populates both lists."""
+        svc = _make_service()
+        template_id = uuid4()
+        project_id = uuid4()
+
+        aid = uuid4()
+        run = _make_run(article_id=aid, stage=ExtractionRunStage.FINALIZED.value)
+
+        study_entity_id = uuid4()
+        model_entity_id = uuid4()
+
+        inst_study = _make_instance(article_id=aid, entity_type_id=study_entity_id)
+        inst_model1 = _make_instance(article_id=aid, entity_type_id=model_entity_id)
+        inst_model2 = _make_instance(article_id=aid, entity_type_id=model_entity_id)
+
+        svc.db.execute = AsyncMock(return_value=_scalars_result([run]))
+        svc._load_instances_for_runs = AsyncMock(
+            return_value={run.id: [inst_study, inst_model1, inst_model2]}
+        )
+        svc._load_entity_type_role_map = AsyncMock(
+            return_value={
+                study_entity_id: ExtractionEntityRole.STUDY_SECTION,
+                model_entity_id: ExtractionEntityRole.MODEL_SECTION,
+            }
+        )
+        svc._load_article_headers = AsyncMock(return_value={aid: "Test, 2023"})
+
+        articles, omitted = await svc._resolve_articles_for_consensus(
+            template_id=template_id,
+            project_id=project_id,
+            candidate_ids=[aid],
+        )
+
+        assert len(articles) == 1
+        desc = articles[0]
+        assert len(desc.model_instances) == 2
+        assert study_entity_id in desc.study_instances
+        assert omitted == {}
+
+
+# ===========================================================================
+# T4 — _infer_reviewer_outcome  (pure function, no mocking)
+# ===========================================================================
+
+
+class TestInferReviewerOutcome:
+    """Parameterized tests for the module-level pure helper.
+
+    Uses ExtractionReviewerDecision-shaped tuples (decision, proposal_id).
+    """
+
+    def test_accept_proposal_exact_match_returns_accepted(self):
+        """accept_proposal decision with matching proposal_id → 'accepted'."""
+        pid = uuid4()
+        decisions = [("accept_proposal", pid)]
+        result = _infer_reviewer_outcome(
+            proposal_id=pid,
+            key=(uuid4(), uuid4(), uuid4()),
+            latest_id=pid,
+            decisions=decisions,
+        )
+        assert result == "accepted"
+
+    def test_reject_decision_returns_rejected(self):
+        """reject decision present → 'rejected' (before edit check)."""
+        pid = uuid4()
+        decisions = [("reject", None)]
+        result = _infer_reviewer_outcome(
+            proposal_id=pid,
+            key=(uuid4(), uuid4(), uuid4()),
+            latest_id=pid,
+            decisions=decisions,
+        )
+        assert result == "rejected"
+
+    def test_edit_decision_returns_edited(self):
+        """edit decision present (no accept/reject) → 'edited (best-effort)'."""
+        pid = uuid4()
+        decisions = [("edit", None)]
+        result = _infer_reviewer_outcome(
+            proposal_id=pid,
+            key=(uuid4(), uuid4(), uuid4()),
+            latest_id=pid,
+            decisions=decisions,
+        )
+        assert result == "edited (best-effort)"
+
+    def test_newer_proposal_exists_returns_superseded(self):
+        """This proposal_id != latest_id and no decisions → 'superseded'."""
+        pid = uuid4()
+        latest_id = uuid4()  # different from pid
+        result = _infer_reviewer_outcome(
+            proposal_id=pid,
+            key=(uuid4(), uuid4(), uuid4()),
+            latest_id=latest_id,
+            decisions=[],
+        )
+        assert result == "superseded"
+
+    def test_no_decisions_returns_pending(self):
+        """No decisions and this is the latest proposal → 'pending'."""
+        pid = uuid4()
+        result = _infer_reviewer_outcome(
+            proposal_id=pid,
+            key=(uuid4(), uuid4(), uuid4()),
+            latest_id=pid,
+            decisions=[],
+        )
+        assert result == "pending"
+
+    def test_accept_proposal_wrong_pid_falls_through_to_pending(self):
+        """accept_proposal for a different proposal → falls through to 'pending'."""
+        pid = uuid4()
+        other_pid = uuid4()
+        decisions = [("accept_proposal", other_pid)]
+        result = _infer_reviewer_outcome(
+            proposal_id=pid,
+            key=(uuid4(), uuid4(), uuid4()),
+            latest_id=pid,  # pid is latest
+            decisions=decisions,
+        )
+        # accept_proposal does not match pid; no reject/edit; pid == latest → pending
+        assert result == "pending"
+
+    @pytest.mark.parametrize(
+        "decisions,expected",
+        [
+            ([("accept_proposal", None)], "pending"),  # accept but wrong pid (None vs real)
+            ([("reject", None), ("edit", None)], "rejected"),  # reject wins over edit
+            ([("edit", None), ("reject", None)], "rejected"),  # order doesn't matter for reject
+        ],
+    )
+    def test_decision_precedence(self, decisions, expected):
+        """Precedence: accept_proposal (exact) > reject > edit > superseded > pending."""
+        pid = uuid4()
+        result = _infer_reviewer_outcome(
+            proposal_id=pid,
+            key=(uuid4(), uuid4(), uuid4()),
+            latest_id=pid,
+            decisions=decisions,
+        )
+        assert result == expected
+
+
+# ===========================================================================
+# T5 — _load_ai_proposal_rows
+# ===========================================================================
+
+
+class TestLoadAiProposalRows:
+    """AI metadata sheet loader (FR-036 – FR-040).
+
+    This method issues 5 separate db.execute() calls for the main path.
+    We use side_effect on db.execute to return controlled results in order.
+
+    Query order (from reading the implementation):
+      1. ExtractionInstance (inst_rows) — instance meta
+      2. ExtractionProposalRecord (proposal_rows) — AI proposals
+      3. ExtractionEvidence (evidence_rows) — evidence
+      4. ExtractionReviewerState+Decision (decision_rows) — reviewer outcomes
+      5. ExtractionEntityType (ent_label_rows) — section labels
+      (6. ExtractionField fallback — only when missing field ids)
+    """
+
+    def _make_article(
+        self,
+        run_id: UUID | None = None,
+        article_id: UUID | None = None,
+        model_instances: tuple[UUID, ...] = (),
+        study_instances: dict | None = None,
+    ) -> ArticleDescriptor:
+        return ArticleDescriptor(
+            article_id=article_id or uuid4(),
+            header_label="Test Article",
+            run_id=run_id or uuid4(),
+            run_stage=ExtractionRunStage.FINALIZED,
+            model_instances=model_instances,
+            study_instances=study_instances or {},
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_run_ids_returns_empty_tuple(self):
+        """Articles with no run_id → no DB calls, returns ()."""
+        svc = _make_service()
+        articles = (
+            ArticleDescriptor(
+                article_id=uuid4(),
+                header_label="No Run",
+                run_id=None,
+                run_stage=None,
+                model_instances=(),
+                study_instances={},
+            ),
+        )
+        result = await svc._load_ai_proposal_rows(
+            articles=articles,
+            sections=(),
+            value_map={},
+            mode=ExportMode.CONSENSUS,
+        )
+        assert result == ()
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_proposals_returns_empty_tuple(self):
+        """Run has no AI proposals → returns () after first two queries."""
+        svc = _make_service()
+        run_id = uuid4()
+        article_id = uuid4()
+        instance_id = uuid4()
+        entity_type_id = uuid4()
+
+        article = self._make_article(run_id=run_id, article_id=article_id)
+
+        # Query order: inst_rows, then proposal_rows (empty) → short-circuit
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                # 1. instance meta
+                _rows_result([(instance_id, entity_type_id, article_id)]),
+                # 2. proposal_rows — empty
+                _rows_result([]),
+            ]
+        )
+
+        result = await svc._load_ai_proposal_rows(
+            articles=(article,),
+            sections=(),
+            value_map={},
+            mode=ExportMode.CONSENSUS,
+        )
+        assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_single_proposal_no_decisions_pending(self):
+        """Single AI proposal with no reviewer decisions → outcome='pending'."""
+        svc = _make_service()
+        run_id = uuid4()
+        article_id = uuid4()
+        instance_id = uuid4()
+        entity_type_id = uuid4()
+        field_id = uuid4()
+        proposal_id = uuid4()
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+
+        # Build section with a controlled entity_type_id so we can match it.
+        section_with_id = SectionDescriptor(
+            entity_type_id=entity_type_id,
+            label="Demographics",
+            role=ExtractionEntityRole.STUDY_SECTION,
+            parent_entity_type_id=None,
+            fields=(
+                FieldDescriptor(
+                    field_id=field_id,
+                    label="Age",
+                    type=ExtractionFieldType.TEXT,
+                    allowed_values=(),
+                    parent_section_id=entity_type_id,
+                ),
+            ),
+        )
+
+        article = self._make_article(
+            run_id=run_id,
+            article_id=article_id,
+            study_instances={entity_type_id: instance_id},
+        )
+
+        # proposal row: (id, run_id, instance_id, field_id, proposed_value, confidence, rationale, created_at)
+        proposal_row = (
+            proposal_id,
+            run_id,
+            instance_id,
+            field_id,
+            "some_value",
+            0.9,
+            "Rationale",
+            ts,
+        )
+        # evidence rows: (proposal_record_id, text_content, page_number)
+        evidence_row = (proposal_id, "Evidence text", 42)
+        # decision rows: empty (no reviewer decisions)
+        # entity label rows: (entity_type_id, label)
+        ent_label_row = (entity_type_id, "Demographics")
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                # 1. instance meta
+                _rows_result([(instance_id, entity_type_id, article_id)]),
+                # 2. proposal_rows
+                _rows_result([proposal_row]),
+                # 3. evidence_rows
+                _rows_result([evidence_row]),
+                # 4. decision_rows
+                _rows_result([]),
+                # 5. ent_label_rows
+                _rows_result([ent_label_row]),
+                # (no field fallback — field_id is in field_label_by_id from sections)
+            ]
+        )
+
+        result = await svc._load_ai_proposal_rows(
+            articles=(article,),
+            sections=(section_with_id,),
+            value_map={},
+            mode=ExportMode.CONSENSUS,
+        )
+
+        assert len(result) == 1
+        row = result[0]
+        assert row.reviewer_outcome == "pending"
+        assert row.final_value_used is None
+        assert row.ai_proposed_value == "some_value"
+        assert row.section_label == "Demographics"
+        assert row.field_label == "Age"
+        assert row.evidence_text == "Evidence text"
+        assert row.evidence_pages == "42"
+        assert row.confidence == 0.9
+        assert row.rationale == "Rationale"
+
+    @pytest.mark.asyncio
+    async def test_single_proposal_accept_decision_consensus_mode(self):
+        """Accepted proposal in CONSENSUS mode → outcome='accepted', 3-tuple key for final value."""
+        svc = _make_service()
+        run_id = uuid4()
+        article_id = uuid4()
+        instance_id = uuid4()
+        entity_type_id = uuid4()
+        field_id = uuid4()
+        proposal_id = uuid4()
+        ts = datetime(2024, 2, 1, tzinfo=UTC)
+
+        article = self._make_article(
+            run_id=run_id,
+            article_id=article_id,
+            study_instances={entity_type_id: instance_id},
+        )
+
+        proposal_row = (
+            proposal_id,
+            run_id,
+            instance_id,
+            field_id,
+            {"value": "consensus_val"},
+            0.95,
+            None,
+            ts,
+        )
+        # decision row: (run_id, instance_id, field_id, decision, proposal_record_id)
+        decision_row = (run_id, instance_id, field_id, "accept_proposal", proposal_id)
+
+        # value_map uses 3-tuple for CONSENSUS mode
+        value_map = {(run_id, instance_id, field_id): "consensus_val"}
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([(instance_id, entity_type_id, article_id)]),
+                _rows_result([proposal_row]),
+                _rows_result([]),  # no evidence
+                _rows_result([decision_row]),
+                _rows_result([(entity_type_id, "Section Label")]),
+                # 6th query: field label fallback (field_id not in sections=())
+                _rows_result([(field_id, "Field Label")]),
+            ]
+        )
+
+        result = await svc._load_ai_proposal_rows(
+            articles=(article,),
+            sections=(),
+            value_map=value_map,
+            mode=ExportMode.CONSENSUS,
+        )
+
+        assert len(result) == 1
+        row = result[0]
+        assert row.reviewer_outcome == "accepted"
+        assert row.final_value_used == "consensus_val"
+        assert row.ai_proposed_value == "consensus_val"  # unwrapped from {"value": ...}
+
+    @pytest.mark.asyncio
+    async def test_all_users_mode_uses_4_tuple_key_with_none(self):
+        """ALL_USERS mode uses (run, instance, field, None) key for consensus sub-column.
+
+        Regression guard for raphaelfh's fix in aa9b288: ALL_USERS was
+        previously using the 3-tuple key which missed the consensus value.
+        """
+        svc = _make_service()
+        run_id = uuid4()
+        article_id = uuid4()
+        instance_id = uuid4()
+        entity_type_id = uuid4()
+        field_id = uuid4()
+        proposal_id = uuid4()
+        ts = datetime(2024, 3, 1, tzinfo=UTC)
+
+        article = self._make_article(
+            run_id=run_id,
+            article_id=article_id,
+            study_instances={entity_type_id: instance_id},
+        )
+
+        proposal_row = (proposal_id, run_id, instance_id, field_id, "val", None, None, ts)
+
+        # ALL_USERS value_map has 4-tuple keys (None = consensus sub-column)
+        value_map_4tuple = {(run_id, instance_id, field_id, None): "consensus_for_all_users"}
+        # But also the 3-tuple key should NOT be picked up in ALL_USERS mode
+        value_map_4tuple[(run_id, instance_id, field_id)] = "wrong_3tuple_value"
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([(instance_id, entity_type_id, article_id)]),
+                _rows_result([proposal_row]),
+                _rows_result([]),
+                _rows_result([]),
+                _rows_result([(entity_type_id, "Section")]),
+                # 6th: field fallback (field_id not in sections=())
+                _rows_result([(field_id, "Field Label")]),
+            ]
+        )
+
+        result = await svc._load_ai_proposal_rows(
+            articles=(article,),
+            sections=(),
+            value_map=value_map_4tuple,
+            mode=ExportMode.ALL_USERS,
+        )
+
+        assert len(result) == 1
+        row = result[0]
+        # Must use 4-tuple key lookup (None for consensus), NOT 3-tuple
+        assert row.final_value_used == "consensus_for_all_users"
+
+    @pytest.mark.asyncio
+    async def test_consensus_mode_uses_3_tuple_key(self):
+        """CONSENSUS mode uses (run, instance, field) 3-tuple key for final value.
+
+        Complement to the ALL_USERS regression test — ensures CONSENSUS
+        still reads from the 3-tuple key correctly.
+        """
+        svc = _make_service()
+        run_id = uuid4()
+        article_id = uuid4()
+        instance_id = uuid4()
+        entity_type_id = uuid4()
+        field_id = uuid4()
+        proposal_id = uuid4()
+        ts = datetime(2024, 3, 15, tzinfo=UTC)
+
+        article = self._make_article(
+            run_id=run_id,
+            article_id=article_id,
+            study_instances={entity_type_id: instance_id},
+        )
+
+        proposal_row = (proposal_id, run_id, instance_id, field_id, "pval", None, None, ts)
+
+        # Only 3-tuple key in value_map
+        value_map = {(run_id, instance_id, field_id): "3tuple_value"}
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([(instance_id, entity_type_id, article_id)]),
+                _rows_result([proposal_row]),
+                _rows_result([]),
+                _rows_result([]),
+                _rows_result([(entity_type_id, "Section")]),
+                # 6th: field fallback (field_id not in sections=())
+                _rows_result([(field_id, "Field Label")]),
+            ]
+        )
+
+        result = await svc._load_ai_proposal_rows(
+            articles=(article,),
+            sections=(),
+            value_map=value_map,
+            mode=ExportMode.CONSENSUS,
+        )
+
+        assert len(result) == 1
+        assert result[0].final_value_used == "3tuple_value"
+
+    @pytest.mark.asyncio
+    async def test_unknown_section_falls_back_to_entity_label(self):
+        """When entity_type is not in sections, falls back to ent_label_rows."""
+        svc = _make_service()
+        run_id = uuid4()
+        article_id = uuid4()
+        instance_id = uuid4()
+        entity_type_id = uuid4()  # NOT in sections
+        field_id = uuid4()
+        proposal_id = uuid4()
+        ts = datetime(2024, 4, 1, tzinfo=UTC)
+
+        article = self._make_article(
+            run_id=run_id,
+            article_id=article_id,
+            study_instances={entity_type_id: instance_id},
+        )
+
+        proposal_row = (proposal_id, run_id, instance_id, field_id, "v", None, None, ts)
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([(instance_id, entity_type_id, article_id)]),
+                _rows_result([proposal_row]),
+                _rows_result([]),
+                _rows_result([]),
+                # ent_label_rows provides fallback label
+                _rows_result([(entity_type_id, "Fallback Section Label")]),
+                # 6th: field fallback (field_id not in sections=())
+                _rows_result([(field_id, "Field Label")]),
+            ]
+        )
+
+        result = await svc._load_ai_proposal_rows(
+            articles=(article,),
+            sections=(),  # empty sections → triggers fallback
+            value_map={},
+            mode=ExportMode.CONSENSUS,
+        )
+
+        assert len(result) == 1
+        assert result[0].section_label == "Fallback Section Label"
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_triggers_fallback_query(self):
+        """Field not in sections triggers an additional DB query for field label."""
+        svc = _make_service()
+        run_id = uuid4()
+        article_id = uuid4()
+        instance_id = uuid4()
+        entity_type_id = uuid4()
+        field_id = uuid4()  # NOT in any section
+        proposal_id = uuid4()
+        ts = datetime(2024, 5, 1, tzinfo=UTC)
+
+        article = self._make_article(
+            run_id=run_id,
+            article_id=article_id,
+            study_instances={entity_type_id: instance_id},
+        )
+
+        proposal_row = (proposal_id, run_id, instance_id, field_id, "v", None, None, ts)
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([(instance_id, entity_type_id, article_id)]),
+                _rows_result([proposal_row]),
+                _rows_result([]),
+                _rows_result([]),
+                _rows_result([(entity_type_id, "Section Label")]),
+                # 6th query: field label fallback
+                _rows_result([(field_id, "Fallback Field Label")]),
+            ]
+        )
+
+        result = await svc._load_ai_proposal_rows(
+            articles=(article,),
+            sections=(),
+            value_map={},
+            mode=ExportMode.CONSENSUS,
+        )
+
+        assert len(result) == 1
+        assert result[0].field_label == "Fallback Field Label"
+
+
+# ===========================================================================
+# T6 — _build_all_users_value_map
+# ===========================================================================
+
+
+class TestBuildAllUsersValueMap:
+    """4-tuple keyed value map for All-users mode (FR-015).
+
+    Mocking strategy: svc.db.execute side_effect — first call returns
+    consensus rows (ExtractionPublishedState), second call returns
+    reviewer decision rows.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_run_ids_returns_empty(self):
+        """No run_ids → short-circuit to empty dict."""
+        svc = _make_service()
+        result = await svc._build_all_users_value_map(run_ids=[], reviewer_ids=[])
+        assert result == {}
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_consensus_only_no_reviewer_ids(self):
+        """Consensus rows with no reviewer_ids → only (run, inst, field, None) keys."""
+        svc = _make_service()
+        run_id = uuid4()
+        instance_id = uuid4()
+        field_id = uuid4()
+
+        consensus_row = (run_id, instance_id, field_id, "published_value")
+        svc.db.execute = AsyncMock(return_value=_rows_result([consensus_row]))
+
+        result = await svc._build_all_users_value_map(run_ids=[run_id], reviewer_ids=[])
+
+        assert result[(run_id, instance_id, field_id, None)] == "published_value"
+        assert len(result) == 1
+        # Should only have called execute once (consensus only, no reviewer ids)
+        svc.db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_accept_proposal_uses_proposed_value(self):
+        """accept_proposal decision → uses proposed_value in 4-tuple key."""
+        svc = _make_service()
+        run_id = uuid4()
+        instance_id = uuid4()
+        field_id = uuid4()
+        reviewer_id = uuid4()
+
+        consensus_row = (run_id, instance_id, field_id, None)  # no consensus value
+        # reviewer row: (run_id, instance_id, field_id, reviewer_id, decision, value, proposed_value)
+        reviewer_row = (
+            run_id,
+            instance_id,
+            field_id,
+            reviewer_id,
+            "accept_proposal",
+            None,
+            "proposed_val",
+        )
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([consensus_row]),
+                _rows_result([reviewer_row]),
+            ]
+        )
+
+        result = await svc._build_all_users_value_map(run_ids=[run_id], reviewer_ids=[reviewer_id])
+
+        assert result[(run_id, instance_id, field_id, None)] is None
+        assert result[(run_id, instance_id, field_id, reviewer_id)] == "proposed_val"
+
+    @pytest.mark.asyncio
+    async def test_edit_decision_uses_decision_value(self):
+        """edit decision → uses decision.value in 4-tuple key."""
+        svc = _make_service()
+        run_id = uuid4()
+        instance_id = uuid4()
+        field_id = uuid4()
+        reviewer_id = uuid4()
+
+        reviewer_row = (
+            run_id,
+            instance_id,
+            field_id,
+            reviewer_id,
+            "edit",
+            {"value": "edited_val"},
+            None,
+        )
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([]),  # no consensus
+                _rows_result([reviewer_row]),
+            ]
+        )
+
+        result = await svc._build_all_users_value_map(run_ids=[run_id], reviewer_ids=[reviewer_id])
+
+        assert result[(run_id, instance_id, field_id, reviewer_id)] == "edited_val"
+
+    @pytest.mark.asyncio
+    async def test_reject_decision_absent_from_map(self):
+        """reject decision → key NOT added to value map (renders blank)."""
+        svc = _make_service()
+        run_id = uuid4()
+        instance_id = uuid4()
+        field_id = uuid4()
+        reviewer_id = uuid4()
+
+        reviewer_row = (run_id, instance_id, field_id, reviewer_id, "reject", None, None)
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([]),
+                _rows_result([reviewer_row]),
+            ]
+        )
+
+        result = await svc._build_all_users_value_map(run_ids=[run_id], reviewer_ids=[reviewer_id])
+
+        assert (run_id, instance_id, field_id, reviewer_id) not in result
+
+    @pytest.mark.asyncio
+    async def test_consensus_and_reviewer_both_present(self):
+        """Both consensus and reviewer decisions populate separate keys."""
+        svc = _make_service()
+        run_id = uuid4()
+        instance_id = uuid4()
+        field_id = uuid4()
+        reviewer_id = uuid4()
+
+        consensus_row = (run_id, instance_id, field_id, "consensus_val")
+        reviewer_row = (
+            run_id,
+            instance_id,
+            field_id,
+            reviewer_id,
+            "edit",
+            {"value": "reviewer_val"},
+            None,
+        )
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _rows_result([consensus_row]),
+                _rows_result([reviewer_row]),
+            ]
+        )
+
+        result = await svc._build_all_users_value_map(run_ids=[run_id], reviewer_ids=[reviewer_id])
+
+        assert result[(run_id, instance_id, field_id, None)] == "consensus_val"
+        assert result[(run_id, instance_id, field_id, reviewer_id)] == "reviewer_val"
+
+
+# ===========================================================================
+# T7 — list_eligible_reviewers_for_picker
+# ===========================================================================
+
+
+class TestListEligibleReviewersForPicker:
+    """Picker dropdown for SINGLE_USER mode — manager vs non-manager.
+
+    Mocking strategy: mock list_reviewers_with_decisions (sister method)
+    and _project_members_repo().has_role.
+    """
+
+    @pytest.mark.asyncio
+    async def test_manager_sees_all_reviewers(self, monkeypatch):
+        """Manager → all reviewers from list_reviewers_with_decisions."""
+        user_id = uuid4()
+        svc = _make_service(user_id=str(user_id))
+
+        all_reviewers = [
+            {"id": str(uuid4()), "name": "Alice"},
+            {"id": str(uuid4()), "name": "Bob"},
+        ]
+
+        member_repo = AsyncMock()
+        member_repo.has_role = AsyncMock(return_value=True)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+        svc.list_reviewers_with_decisions = AsyncMock(return_value=all_reviewers)
+
+        result = await svc.list_eligible_reviewers_for_picker(
+            project_id=uuid4(), template_id=uuid4()
+        )
+
+        assert result == all_reviewers
+
+    @pytest.mark.asyncio
+    async def test_non_manager_sees_only_self(self, monkeypatch):
+        """Non-manager → only their own entry."""
+        user_id = uuid4()
+        svc = _make_service(user_id=str(user_id))
+
+        self_entry = {"id": str(user_id), "name": "Self"}
+        other_entry = {"id": str(uuid4()), "name": "Other"}
+        all_reviewers = [self_entry, other_entry]
+
+        member_repo = AsyncMock()
+        member_repo.has_role = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+        svc.list_reviewers_with_decisions = AsyncMock(return_value=all_reviewers)
+
+        result = await svc.list_eligible_reviewers_for_picker(
+            project_id=uuid4(), template_id=uuid4()
+        )
+
+        assert result == [self_entry]
+
+    @pytest.mark.asyncio
+    async def test_invalid_user_id_returns_empty_list(self, monkeypatch):
+        """Non-UUID user_id → returns [] without raising."""
+        svc = _make_service(user_id="not-a-uuid")
+
+        member_repo = AsyncMock()
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+        svc.list_reviewers_with_decisions = AsyncMock(return_value=[])
+
+        result = await svc.list_eligible_reviewers_for_picker(
+            project_id=uuid4(), template_id=uuid4()
+        )
+
+        assert result == []
+        # has_role should not have been called since UUID() raised
+        member_repo.has_role.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_manager_empty_reviewer_list(self, monkeypatch):
+        """Non-manager when no reviewers exist → returns []."""
+        user_id = uuid4()
+        svc = _make_service(user_id=str(user_id))
+
+        member_repo = AsyncMock()
+        member_repo.has_role = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectMemberRepository",
+            lambda _: member_repo,
+        )
+        svc.list_reviewers_with_decisions = AsyncMock(return_value=[])
+
+        result = await svc.list_eligible_reviewers_for_picker(
+            project_id=uuid4(), template_id=uuid4()
+        )
+
+        assert result == []
+
+
+# ===========================================================================
+# Bonus: _unwrap_value (pure helper, complements T2 coverage)
+# ===========================================================================
+
+
+class TestUnwrapValue:
+    """Unit tests for the module-level _unwrap_value helper."""
+
+    def test_single_key_dict_is_unwrapped(self):
+        assert _unwrap_value({"value": "hello"}) == "hello"
+
+    def test_multi_key_dict_not_unwrapped(self):
+        raw = {"value": "x", "other": "y"}
+        assert _unwrap_value(raw) is raw
+
+    def test_string_returned_as_is(self):
+        assert _unwrap_value("plain") == "plain"
+
+    def test_none_returned_as_is(self):
+        assert _unwrap_value(None) is None
+
+    def test_number_returned_as_is(self):
+        assert _unwrap_value(42) == 42
+
+    def test_empty_dict_not_unwrapped(self):
+        raw = {}
+        assert _unwrap_value(raw) is raw
+
+
+# ===========================================================================
+# Pure helpers: _normalize_allowed_values
+# ===========================================================================
+
+
+class TestNormalizeAllowedValues:
+    """Unit tests for the allowed_values JSONB normalizer."""
+
+    def test_none_returns_empty_tuple(self):
+        assert _normalize_allowed_values(None) == ()
+
+    def test_plain_string_list(self):
+        assert _normalize_allowed_values(["a", "b", "c"]) == ("a", "b", "c")
+
+    def test_dict_items_with_label(self):
+        raw = [{"label": "Yes", "value": "yes"}, {"label": "No", "value": "no"}]
+        assert _normalize_allowed_values(raw) == ("Yes", "No")
+
+    def test_dict_items_fallback_to_value_when_no_label(self):
+        raw = [{"value": "yes"}, {"value": "no"}]
+        assert _normalize_allowed_values(raw) == ("yes", "no")
+
+    def test_dict_items_without_label_or_value_skipped(self):
+        raw = [{"other": "x"}, {"value": "y"}]
+        assert _normalize_allowed_values(raw) == ("y",)
+
+    def test_nested_options_key(self):
+        raw = {"options": ["a", "b"]}
+        assert _normalize_allowed_values(raw) == ("a", "b")
+
+    def test_unknown_type_returns_empty_tuple(self):
+        assert _normalize_allowed_values(42) == ()
+
+    def test_empty_list_returns_empty_tuple(self):
+        assert _normalize_allowed_values([]) == ()
+
+    def test_mixed_string_and_dict_items(self):
+        raw = ["plain", {"label": "From dict"}]
+        assert _normalize_allowed_values(raw) == ("plain", "From dict")
+
+
+# ===========================================================================
+# Pure helpers: _build_header_label
+# ===========================================================================
+
+
+class TestBuildHeaderLabel:
+    """Unit tests for the FR-012 article header label builder."""
+
+    def test_author_with_year_comma_format(self):
+        """'Smith, John' author + year → 'Smith, 2021'."""
+        result = _build_header_label("Title", ["Smith, John"], 2021, uuid4())
+        assert result == "Smith, 2021"
+
+    def test_author_with_year_space_format(self):
+        """'John Smith' author (no comma) → 'Smith, 2021'."""
+        result = _build_header_label("Title", ["John Smith"], 2021, uuid4())
+        assert result == "Smith, 2021"
+
+    def test_author_without_year_returns_surname(self):
+        """Author with no year → just the surname."""
+        result = _build_header_label("Title", ["Jones, Alice"], None, uuid4())
+        assert result == "Jones"
+
+    def test_empty_author_falls_through_to_title(self):
+        """Empty author string → falls through to title[:60]."""
+        result = _build_header_label("A Good Title", [""], 2020, uuid4())
+        assert result == "A Good Title"
+
+    def test_no_authors_uses_title(self):
+        """No authors list → uses title[:60]."""
+        result = _build_header_label("My Title", None, 2020, uuid4())
+        assert result == "My Title"
+
+    def test_title_truncated_to_60_chars(self):
+        """Title longer than 60 chars is truncated."""
+        long_title = "A" * 80
+        result = _build_header_label(long_title, None, None, uuid4())
+        assert result == "A" * 60
+
+    def test_no_authors_no_title_uses_short_id(self):
+        """No authors, no title → short UUID prefix."""
+        article_id = UUID("12345678-abcd-4000-8000-000000000000")
+        result = _build_header_label(None, None, None, article_id)
+        assert result == "12345678"
+
+    def test_empty_authors_list_falls_through_to_title(self):
+        """Empty authors list (not None) → falls through to title."""
+        result = _build_header_label("Fallback Title", [], None, uuid4())
+        assert result == "Fallback Title"
+
+
+# ===========================================================================
+# Pure helpers: _short_id and _letter_for
+# ===========================================================================
+
+
+class TestShortId:
+    def test_returns_first_segment_of_uuid(self):
+        uid = UUID("abcdef01-1234-4000-8000-000000000000")
+        assert _short_id(uid) == "abcdef01"
+
+
+class TestLetterFor:
+    def test_negative_returns_question_mark(self):
+        assert _letter_for(-1) == "?"
+
+    def test_zero_returns_a(self):
+        assert _letter_for(0) == "A"
+
+    def test_25_returns_z(self):
+        assert _letter_for(25) == "Z"
+
+    def test_26_returns_aa(self):
+        assert _letter_for(26) == "AA"
+
+    def test_51_returns_az(self):
+        assert _letter_for(51) == "AZ"
+
+    def test_52_returns_ba(self):
+        assert _letter_for(52) == "BA"
+
+
+# ===========================================================================
+# Service: format_filename (static method)
+# ===========================================================================
+
+
+class TestFormatFilename:
+    """Tests for the static format_filename method."""
+
+    def test_basic_filename_format(self):
+        ts = datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC)
+        result = ExtractionExportService.format_filename(
+            "My Project",
+            "CHARMS Template",
+            ExportMode.CONSENSUS,
+            generated_at=ts,
+        )
+        assert result == "My_Project_CHARMS_Template_consensus_20240115-103045.xlsx"
+
+    def test_special_chars_replaced_with_underscore(self):
+        ts = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
+        result = ExtractionExportService.format_filename(
+            "Project: Alpha/Beta",
+            "Template (v1)",
+            ExportMode.SINGLE_USER,
+            generated_at=ts,
+        )
+        # Special chars become underscores
+        assert result.endswith(".xlsx")
+        assert "single_user" in result
+        # No raw special chars
+        assert ":" not in result
+        assert "/" not in result
+        assert "(" not in result
+
+    def test_empty_project_name_falls_back_to_project(self):
+        ts = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
+        result = ExtractionExportService.format_filename(
+            "   ",  # only spaces → sanitise strips to empty
+            "Template",
+            ExportMode.CONSENSUS,
+            generated_at=ts,
+        )
+        # The sanitizer replaces spaces with _ then strip("_") leaves empty,
+        # so "project" fallback fires
+        assert result.startswith("project_")
+
+    def test_no_generated_at_uses_current_time(self):
+        """Without generated_at, result still matches expected pattern."""
+        result = ExtractionExportService.format_filename(
+            "Proj",
+            "Templ",
+            ExportMode.ALL_USERS,
+        )
+        assert result.endswith(".xlsx")
+        assert "all_users" in result
+        assert result.startswith("Proj_Templ_all_users_")
+
+
+# ===========================================================================
+# Service: _resolve_project_name
+# ===========================================================================
+
+
+class TestResolveProjectName:
+    @pytest.mark.asyncio
+    async def test_project_with_name_returns_name(self, monkeypatch):
+        """Project row with name → returns the name string."""
+        svc = _make_service()
+        project_id = uuid4()
+
+        project_mock = MagicMock()
+        project_mock.name = "Research Project Alpha"
+
+        repo_mock = AsyncMock()
+        repo_mock.get_by_id = AsyncMock(return_value=project_mock)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectRepository",
+            lambda _: repo_mock,
+        )
+
+        result = await svc._resolve_project_name(project_id)
+        assert result == "Research Project Alpha"
+
+    @pytest.mark.asyncio
+    async def test_project_not_found_returns_short_id(self, monkeypatch):
+        """Project not found → falls back to first UUID segment."""
+        svc = _make_service()
+        project_id = UUID("abcdef01-1234-4000-8000-000000000000")
+
+        repo_mock = AsyncMock()
+        repo_mock.get_by_id = AsyncMock(return_value=None)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectRepository",
+            lambda _: repo_mock,
+        )
+
+        result = await svc._resolve_project_name(project_id)
+        assert result == "abcdef01"
+
+    @pytest.mark.asyncio
+    async def test_project_with_empty_name_returns_short_id(self, monkeypatch):
+        """Project found but name is empty string → short_id fallback."""
+        svc = _make_service()
+        project_id = UUID("12345678-0000-4000-8000-000000000000")
+
+        project_mock = MagicMock()
+        project_mock.name = ""
+
+        repo_mock = AsyncMock()
+        repo_mock.get_by_id = AsyncMock(return_value=project_mock)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ProjectRepository",
+            lambda _: repo_mock,
+        )
+
+        result = await svc._resolve_project_name(project_id)
+        assert result == "12345678"
+
+
+# ===========================================================================
+# Service: _load_active_template_version
+# ===========================================================================
+
+
+class TestLoadActiveTemplateVersion:
+    @pytest.mark.asyncio
+    async def test_template_not_found_raises_not_found_error(self):
+        """No template row → NotFoundError raised."""
+        from app.core.error_handler import NotFoundError
+
+        svc = _make_service()
+        template_id = uuid4()
+
+        # scalar_one_or_none returns None (template not found)
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = None
+        svc.db.execute = AsyncMock(return_value=result_mock)
+
+        with pytest.raises(NotFoundError):
+            await svc._load_active_template_version(template_id)
+
+    @pytest.mark.asyncio
+    async def test_template_found_no_version_raises_not_found_error(self, monkeypatch):
+        """Template found but no active version → NotFoundError."""
+        from app.core.error_handler import NotFoundError
+
+        svc = _make_service()
+        template_id = uuid4()
+
+        template_mock = MagicMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = template_mock
+        svc.db.execute = AsyncMock(return_value=result_mock)
+
+        version_repo_mock = AsyncMock()
+        version_repo_mock.get_active = AsyncMock(return_value=None)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ExtractionTemplateVersionRepository",
+            lambda _: version_repo_mock,
+        )
+
+        with pytest.raises(NotFoundError):
+            await svc._load_active_template_version(template_id)
+
+    @pytest.mark.asyncio
+    async def test_template_and_version_found_returns_tuple(self, monkeypatch):
+        """Template + active version found → returns (template, version)."""
+        svc = _make_service()
+        template_id = uuid4()
+
+        template_mock = MagicMock()
+        version_mock = MagicMock()
+
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = template_mock
+        svc.db.execute = AsyncMock(return_value=result_mock)
+
+        version_repo_mock = AsyncMock()
+        version_repo_mock.get_active = AsyncMock(return_value=version_mock)
+
+        monkeypatch.setattr(
+            "app.services.extraction_export_service.ExtractionTemplateVersionRepository",
+            lambda _: version_repo_mock,
+        )
+
+        template, version = await svc._load_active_template_version(template_id)
+        assert template is template_mock
+        assert version is version_mock
+
+
+# ===========================================================================
+# Service: _load_sections
+# ===========================================================================
+
+
+class TestLoadSections:
+    @pytest.mark.asyncio
+    async def test_no_entity_types_returns_empty_tuple(self):
+        """No entity types in template → returns empty tuple."""
+        svc = _make_service()
+        svc.db.execute = AsyncMock(return_value=_scalars_result([]))
+
+        result = await svc._load_sections(uuid4())
+        assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_entity_types_with_fields_returns_sections(self):
+        """Entity types + fields → SectionDescriptors with FieldDescriptors."""
+        svc = _make_service()
+        template_id = uuid4()
+
+        entity_id = uuid4()
+        entity = MagicMock()
+        entity.id = entity_id
+        entity.label = "Demographics"
+        entity.role = ExtractionEntityRole.STUDY_SECTION.value
+        entity.parent_entity_type_id = None
+
+        field_id = uuid4()
+        field = MagicMock()
+        field.id = field_id
+        field.label = "Age"
+        field.field_type = ExtractionFieldType.NUMBER.value
+        field.allowed_values = None
+        field.entity_type_id = entity_id
+        field.sort_order = 0
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _scalars_result([entity]),
+                _scalars_result([field]),
+            ]
+        )
+
+        result = await svc._load_sections(template_id)
+
+        assert len(result) == 1
+        section = result[0]
+        assert section.entity_type_id == entity_id
+        assert section.label == "Demographics"
+        assert section.role == ExtractionEntityRole.STUDY_SECTION
+        assert len(section.fields) == 1
+        assert section.fields[0].label == "Age"
+        assert section.fields[0].type == ExtractionFieldType.NUMBER
+
+
+# ===========================================================================
+# Service: _load_instances_for_runs
+# ===========================================================================
+
+
+class TestLoadInstancesForRuns:
+    @pytest.mark.asyncio
+    async def test_empty_run_ids_returns_empty(self):
+        """Empty run_ids → short-circuit."""
+        svc = _make_service()
+        result = await svc._load_instances_for_runs([])
+        assert result == {}
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_not_found_returns_empty(self):
+        """Run ids provided but no runs found in DB → {}."""
+        svc = _make_service()
+        svc.db.execute = AsyncMock(return_value=_scalars_result([]))
+
+        result = await svc._load_instances_for_runs([uuid4()])
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_instances_grouped_by_run(self):
+        """Instances loaded and correctly grouped by run_id."""
+        svc = _make_service()
+
+        template_id = uuid4()
+        article_id = uuid4()
+
+        run = _make_run(article_id=article_id, template_id=template_id)
+        run.id = uuid4()
+        run.article_id = article_id
+        run.template_id = template_id
+
+        inst = _make_instance(article_id=article_id, template_id=template_id)
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _scalars_result([run]),  # load runs
+                _scalars_result([inst]),  # load instances
+            ]
+        )
+
+        result = await svc._load_instances_for_runs([run.id])
+        assert run.id in result
+        assert inst in result[run.id]
+
+
+# ===========================================================================
+# Service: _load_entity_type_role_map
+# ===========================================================================
+
+
+class TestLoadEntityTypeRoleMap:
+    @pytest.mark.asyncio
+    async def test_returns_correct_role_map(self):
+        """Rows are mapped to entity_type_id → ExtractionEntityRole."""
+        svc = _make_service()
+        eid = uuid4()
+        svc.db.execute = AsyncMock(
+            return_value=_rows_result([(eid, ExtractionEntityRole.STUDY_SECTION.value)])
+        )
+
+        result = await svc._load_entity_type_role_map(uuid4())
+        assert result[eid] == ExtractionEntityRole.STUDY_SECTION
+
+
+# ===========================================================================
+# Service: _load_article_headers
+# ===========================================================================
+
+
+class TestLoadArticleHeaders:
+    @pytest.mark.asyncio
+    async def test_empty_article_ids_returns_empty(self):
+        """Empty list → no DB call, returns {}."""
+        svc = _make_service()
+        result = await svc._load_article_headers([])
+        assert result == {}
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_builds_headers_from_db_rows(self):
+        """DB rows → header labels built via _build_header_label."""
+        svc = _make_service()
+        aid = uuid4()
+
+        svc.db.execute = AsyncMock(
+            return_value=_rows_result([(aid, "A Title", ["Smith, John"], 2022)])
+        )
+
+        result = await svc._load_article_headers([aid])
+        assert result[aid] == "Smith, 2022"
+
+
+# ===========================================================================
+# Service: _resolve_articles_for_single_user
+# ===========================================================================
+
+
+class TestResolveArticlesForSingleUser:
+    """Stage filtering for single-user mode.
+
+    Mocking strategy: two db.execute() calls — one for run_rows, one for
+    eligible_run_rows. Then helper mocks for instances/roles/headers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_candidate_ids_returns_empty(self):
+        svc = _make_service()
+        articles, omitted = await svc._resolve_articles_for_single_user(
+            template_id=uuid4(),
+            project_id=uuid4(),
+            candidate_ids=[],
+            reviewer_id=uuid4(),
+        )
+        assert articles == []
+        assert omitted == {}
+
+    @pytest.mark.asyncio
+    async def test_no_runs_found_returns_no_run_omission(self):
+        """No runs in DB → all articles count as no_run."""
+        svc = _make_service()
+        candidate_ids = [uuid4(), uuid4()]
+
+        svc.db.execute = AsyncMock(return_value=_scalars_result([]))
+
+        articles, omitted = await svc._resolve_articles_for_single_user(
+            template_id=uuid4(),
+            project_id=uuid4(),
+            candidate_ids=candidate_ids,
+            reviewer_id=uuid4(),
+        )
+
+        assert articles == []
+        assert omitted["no_run"] == len(candidate_ids)
+
+    @pytest.mark.asyncio
+    async def test_cancelled_run_omitted(self):
+        """CANCELLED stage → counted in omitted['cancelled']."""
+        svc = _make_service()
+        aid = uuid4()
+        reviewer_id = uuid4()
+
+        run = _make_run(article_id=aid, stage=ExtractionRunStage.CANCELLED.value)
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _scalars_result([run]),  # run_rows
+                _rows_result([]),  # eligible_run_rows (empty)
+            ]
+        )
+
+        articles, omitted = await svc._resolve_articles_for_single_user(
+            template_id=uuid4(),
+            project_id=uuid4(),
+            candidate_ids=[aid],
+            reviewer_id=reviewer_id,
+        )
+        assert articles == []
+        assert omitted.get("cancelled") == 1
+
+    @pytest.mark.asyncio
+    async def test_run_not_eligible_omitted(self):
+        """Run not in eligible_run_ids → no_decisions_from_reviewer."""
+        svc = _make_service()
+        aid = uuid4()
+        reviewer_id = uuid4()
+
+        run = _make_run(article_id=aid, stage=ExtractionRunStage.REVIEW.value)
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _scalars_result([run]),
+                _rows_result([]),  # eligible_run_ids empty → not eligible
+            ]
+        )
+
+        articles, omitted = await svc._resolve_articles_for_single_user(
+            template_id=uuid4(),
+            project_id=uuid4(),
+            candidate_ids=[aid],
+            reviewer_id=reviewer_id,
+        )
+        assert articles == []
+        assert omitted.get("no_decisions_from_reviewer") == 1
+
+    @pytest.mark.asyncio
+    async def test_eligible_run_returns_article_descriptor(self):
+        """Eligible run → article descriptor returned."""
+        svc = _make_service()
+        aid = uuid4()
+        reviewer_id = uuid4()
+
+        run = _make_run(article_id=aid, stage=ExtractionRunStage.REVIEW.value)
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                _scalars_result([run]),
+                _rows_result([(run.id,)]),  # eligible_run_ids includes this run
+            ]
+        )
+
+        svc._load_instances_for_runs = AsyncMock(return_value={run.id: []})
+        svc._load_entity_type_role_map = AsyncMock(return_value={})
+        svc._load_article_headers = AsyncMock(return_value={aid: "Author, 2020"})
+
+        articles, omitted = await svc._resolve_articles_for_single_user(
+            template_id=uuid4(),
+            project_id=uuid4(),
+            candidate_ids=[aid],
+            reviewer_id=reviewer_id,
+        )
+        assert len(articles) == 1
+        assert articles[0].article_id == aid
+        assert omitted == {}
+
+
+# ===========================================================================
+# Service: _build_single_user_value_map
+# ===========================================================================
+
+
+class TestBuildSingleUserValueMap:
+    """3-tuple keyed value map for single-user mode."""
+
+    @pytest.mark.asyncio
+    async def test_empty_run_ids_returns_empty(self):
+        svc = _make_service()
+        result = await svc._build_single_user_value_map(run_ids=[], reviewer_id=uuid4())
+        assert result == {}
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_accept_proposal_uses_proposed_value(self):
+        svc = _make_service()
+        run_id, instance_id, field_id = uuid4(), uuid4(), uuid4()
+        row = (run_id, instance_id, field_id, "accept_proposal", None, "proposed_val")
+        svc.db.execute = AsyncMock(return_value=_rows_result([row]))
+
+        result = await svc._build_single_user_value_map(run_ids=[run_id], reviewer_id=uuid4())
+        assert result[(run_id, instance_id, field_id)] == "proposed_val"
+
+    @pytest.mark.asyncio
+    async def test_edit_decision_uses_decision_value(self):
+        svc = _make_service()
+        run_id, instance_id, field_id = uuid4(), uuid4(), uuid4()
+        row = (run_id, instance_id, field_id, "edit", {"value": "edited"}, None)
+        svc.db.execute = AsyncMock(return_value=_rows_result([row]))
+
+        result = await svc._build_single_user_value_map(run_ids=[run_id], reviewer_id=uuid4())
+        assert result[(run_id, instance_id, field_id)] == "edited"
+
+    @pytest.mark.asyncio
+    async def test_reject_key_absent(self):
+        svc = _make_service()
+        run_id, instance_id, field_id = uuid4(), uuid4(), uuid4()
+        row = (run_id, instance_id, field_id, "reject", None, None)
+        svc.db.execute = AsyncMock(return_value=_rows_result([row]))
+
+        result = await svc._build_single_user_value_map(run_ids=[run_id], reviewer_id=uuid4())
+        assert (run_id, instance_id, field_id) not in result
+
+
+# ===========================================================================
+# Service: list_reviewers_with_decisions
+# ===========================================================================
+
+
+class TestListReviewersWithDecisions:
+    """Tests for list_reviewers_with_decisions."""
+
+    @pytest.mark.asyncio
+    async def test_returns_sorted_reviewer_list(self):
+        """Rows with name → returns sorted list by name."""
+        svc = _make_service()
+        rid1 = uuid4()
+        rid2 = uuid4()
+        svc.db.execute = AsyncMock(
+            return_value=_rows_result(
+                [
+                    (rid1, "Bob Smith", "bob@example.com"),
+                    (rid2, "Alice Jones", "alice@example.com"),
+                ]
+            )
+        )
+
+        result = await svc.list_reviewers_with_decisions(project_id=uuid4(), template_id=uuid4())
+
+        # Sorted alphabetically by name (lowercase)
+        assert result[0]["name"] == "Alice Jones"
+        assert result[1]["name"] == "Bob Smith"
+        assert result[0]["id"] == str(rid2)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_email_when_no_name(self):
+        """No full_name → falls back to email."""
+        svc = _make_service()
+        rid = uuid4()
+        svc.db.execute = AsyncMock(return_value=_rows_result([(rid, None, "reviewer@example.com")]))
+
+        result = await svc.list_reviewers_with_decisions(project_id=uuid4(), template_id=uuid4())
+        assert result[0]["name"] == "reviewer@example.com"
+
+    @pytest.mark.asyncio
+    async def test_no_rows_returns_empty_list(self):
+        svc = _make_service()
+        svc.db.execute = AsyncMock(return_value=_rows_result([]))
+
+        result = await svc.list_reviewers_with_decisions(project_id=uuid4(), template_id=uuid4())
+        assert result == []
+
+
+# ===========================================================================
+# Service: _resolve_articles_for_all_users
+# ===========================================================================
+
+
+class TestResolveArticlesForAllUsers:
+    """Stage filtering for all-users mode — excludes cancelled/pending/proposal."""
+
+    @pytest.mark.asyncio
+    async def test_empty_candidate_ids_returns_empty(self):
+        svc = _make_service()
+        articles, omitted = await svc._resolve_articles_for_all_users(
+            template_id=uuid4(), project_id=uuid4(), candidate_ids=[]
+        )
+        assert articles == []
+        assert omitted == {}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_proposal_pending_omitted(self):
+        """CANCELLED, PROPOSAL, PENDING → all omitted."""
+        svc = _make_service()
+        aid1, aid2, aid3 = uuid4(), uuid4(), uuid4()
+
+        run1 = _make_run(article_id=aid1, stage=ExtractionRunStage.CANCELLED.value)
+        run2 = _make_run(article_id=aid2, stage=ExtractionRunStage.PROPOSAL.value)
+        run3 = _make_run(article_id=aid3, stage=ExtractionRunStage.PENDING.value)
+
+        svc.db.execute = AsyncMock(return_value=_scalars_result([run1, run2, run3]))
+
+        articles, omitted = await svc._resolve_articles_for_all_users(
+            template_id=uuid4(),
+            project_id=uuid4(),
+            candidate_ids=[aid1, aid2, aid3],
+        )
+        assert articles == []
+        assert omitted[ExtractionRunStage.CANCELLED.value] == 1
+        assert omitted[ExtractionRunStage.PROPOSAL.value] == 1
+        assert omitted[ExtractionRunStage.PENDING.value] == 1
+
+    @pytest.mark.asyncio
+    async def test_review_and_finalized_kept(self):
+        """REVIEW and FINALIZED stages → kept for all-users."""
+        svc = _make_service()
+        aid1, aid2 = uuid4(), uuid4()
+
+        run1 = _make_run(article_id=aid1, stage=ExtractionRunStage.REVIEW.value)
+        run2 = _make_run(article_id=aid2, stage=ExtractionRunStage.FINALIZED.value)
+
+        svc.db.execute = AsyncMock(return_value=_scalars_result([run1, run2]))
+        svc._load_instances_for_runs = AsyncMock(return_value={run1.id: [], run2.id: []})
+        svc._load_entity_type_role_map = AsyncMock(return_value={})
+        svc._load_article_headers = AsyncMock(return_value={aid1: "A1, 2021", aid2: "A2, 2022"})
+
+        articles, omitted = await svc._resolve_articles_for_all_users(
+            template_id=uuid4(),
+            project_id=uuid4(),
+            candidate_ids=[aid1, aid2],
+        )
+        assert len(articles) == 2
+        assert omitted == {}
+
+
+# ===========================================================================
+# Service: _list_reviewers_for_runs
+# ===========================================================================
+
+
+class TestListReviewersForRuns:
+    """Tests for _list_reviewers_for_runs with anonymize flag."""
+
+    @pytest.mark.asyncio
+    async def test_empty_run_ids_returns_empty_tuple(self):
+        svc = _make_service()
+        result = await svc._list_reviewers_for_runs(run_ids=[], anonymize=False)
+        assert result == ()
+
+    @pytest.mark.asyncio
+    async def test_anonymize_false_returns_named_reviewers(self):
+        """anonymize=False → reviewers sorted by name."""
+        svc = _make_service()
+        rid1, rid2 = uuid4(), uuid4()
+        svc.db.execute = AsyncMock(
+            return_value=_rows_result(
+                [
+                    (rid1, "Charlie", None),
+                    (rid2, "Alice", None),
+                ]
+            )
+        )
+
+        result = await svc._list_reviewers_for_runs(run_ids=[uuid4()], anonymize=False)
+
+        assert len(result) == 2
+        assert result[0].display_label == "Alice"
+        assert result[1].display_label == "Charlie"
+
+    @pytest.mark.asyncio
+    async def test_anonymize_true_returns_letter_labels(self):
+        """anonymize=True → reviewers labeled Reviewer A, B, etc."""
+        svc = _make_service()
+        rid1 = uuid4()
+        rid2 = uuid4()
+        svc.db.execute = AsyncMock(
+            return_value=_rows_result(
+                [
+                    (rid1, "Alice", None),
+                    (rid2, "Bob", None),
+                ]
+            )
+        )
+
+        result = await svc._list_reviewers_for_runs(run_ids=[uuid4()], anonymize=True)
+
+        assert len(result) == 2
+        labels = {r.display_label for r in result}
+        assert "Reviewer A" in labels
+        assert "Reviewer B" in labels
+
+    @pytest.mark.asyncio
+    async def test_email_fallback_when_no_name(self):
+        """No name → email used as display label."""
+        svc = _make_service()
+        rid = uuid4()
+        svc.db.execute = AsyncMock(return_value=_rows_result([(rid, None, "r@example.com")]))
+
+        result = await svc._list_reviewers_for_runs(run_ids=[uuid4()], anonymize=False)
+        assert result[0].display_label == "r@example.com"
+
+
+# ===========================================================================
+# Service: _load_ai_proposal_rows — model_instances index coverage
+# ===========================================================================
+
+
+class TestAiProposalRowsModelInstances:
+    """Tests for the model_instances indexing path in _load_ai_proposal_rows."""
+
+    @pytest.mark.asyncio
+    async def test_model_instance_index_assigned_correctly(self):
+        """model_instances are indexed 1-based in instance_index_by_id."""
+        svc = _make_service()
+        run_id = uuid4()
+        article_id = uuid4()
+        entity_type_id = uuid4()
+        model_instance_id1 = uuid4()
+        model_instance_id2 = uuid4()
+        field_id = uuid4()
+        proposal_id = uuid4()
+        ts = datetime(2024, 6, 1, tzinfo=UTC)
+
+        # Article with 2 model_instances
+        article = ArticleDescriptor(
+            article_id=article_id,
+            header_label="Test Article",
+            run_id=run_id,
+            run_stage=ExtractionRunStage.FINALIZED,
+            model_instances=(model_instance_id1, model_instance_id2),
+            study_instances={},
+        )
+
+        proposal_row = (proposal_id, run_id, model_instance_id1, field_id, "v", None, None, ts)
+
+        svc.db.execute = AsyncMock(
+            side_effect=[
+                # inst_rows: instance_id, entity_type_id, article_id
+                _rows_result([(model_instance_id1, entity_type_id, article_id)]),
+                _rows_result([proposal_row]),
+                _rows_result([]),
+                _rows_result([]),
+                _rows_result([(entity_type_id, "Model Section")]),
+                _rows_result([(field_id, "Field")]),  # field fallback
+            ]
+        )
+
+        result = await svc._load_ai_proposal_rows(
+            articles=(article,),
+            sections=(),
+            value_map={},
+            mode=ExportMode.CONSENSUS,
+        )
+
+        assert len(result) == 1
+        # model_instance_id1 is first → instance_index = 1
+        assert result[0].instance_index == 1

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -921,9 +921,17 @@ class TestGenerateExtractionSummary:
 
     def test_truncates_at_200_chars(self, service):
         et = self._make_entity_type("Section")
-        data = {"field": "X" * 300}
+        # Create multiple fields with long names to push summary over 200 chars
+        # Format: "Section: longfieldname1: X*50, longfieldname2: X*50, longfieldname3: X*50"
+        data = {
+            "very_long_field_name_number_one": "X" * 300,
+            "very_long_field_name_number_two": "Y" * 300,
+            "very_long_field_name_number_three": "Z" * 300,
+        }
         result = service._generate_extraction_summary(et, data)
-        assert len(result) <= 200
+        # Should truncate and append "..."
+        assert len(result) == 200
+        assert result.endswith("...")
 
     def test_more_indicator_when_more_than_three_fields(self, service):
         et = self._make_entity_type("Section")

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -105,13 +105,50 @@ def test_logged_task_emits_generic_event_for_other_failures(monkeypatch):
     task.name = "real.task"
     task.on_failure(ValueError("boom"), "task-456", (), {}, None)
 
-    assert captured == [(
-        "task_failed",
-        {
-            "task_id": "task-456",
-            "task_name": "real.task",
-            "error": "boom",
-            "args": (),
-            "kwargs": {},
-        },
-    )]
+    assert captured == [
+        (
+            "task_failed",
+            {
+                "task_id": "task-456",
+                "task_name": "real.task",
+                "error": "boom",
+                "args": (),
+                "kwargs": {},
+            },
+        )
+    ]
+
+
+def test_task_unknown_signal_emits_structured_event(monkeypatch):
+    """The runtime hook for NotRegistered is the celery signal — not the
+    task's on_failure callback. Verify the signal handler emits the
+    correct structlog event when fired.
+    """
+    from celery.signals import task_unknown
+
+    captured: list[tuple[str, dict]] = []
+
+    class StubLogger:
+        def error(self, event: str, **kw):
+            captured.append((event, kw))
+
+    monkeypatch.setattr("structlog.get_logger", lambda: StubLogger())
+
+    # Import the celery_app module so the @task_unknown.connect handler
+    # is registered as a side effect.
+    import app.worker.celery_app  # noqa: F401
+
+    task_unknown.send(
+        sender=None,
+        name="ghost.task",
+        id="task-789",
+        message=None,
+        exc=None,
+    )
+
+    matches = [kw for event, kw in captured if event == "celery.task_unregistered"]
+    assert matches, f"Expected celery.task_unregistered event from signal handler, got {captured!r}"
+    kw = matches[-1]
+    assert kw["task_id"] == "task-789"
+    assert kw["task_name"] == "ghost.task"
+    assert "remediation" in kw

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -152,3 +152,32 @@ def test_task_unknown_signal_emits_structured_event(monkeypatch):
     assert kw["task_id"] == "task-789"
     assert kw["task_name"] == "ghost.task"
     assert "remediation" in kw
+
+
+def test_worker_session_uses_fresh_engine_each_call() -> None:
+    """Each worker_session() must construct + dispose its own engine.
+
+    The 2026-05-24 incident root cause was a module-global engine whose
+    asyncpg connection pool bound its waiters to the first event loop
+    that touched it. ``worker_session`` MUST build a per-call engine so
+    no pool state ever crosses ``asyncio.run`` boundaries.
+    """
+    import asyncio
+
+    from app.worker._session import worker_session
+
+    engines_seen: list[int] = []
+
+    async def grab_engine_id() -> None:
+        async with worker_session() as session:
+            engines_seen.append(id(session.bind))
+
+    asyncio.run(grab_engine_id())
+    asyncio.run(grab_engine_id())
+
+    assert len(engines_seen) == 2
+    assert engines_seen[0] != engines_seen[1], (
+        "worker_session must construct a fresh engine per call — "
+        "engine identity reuse is the root cause of the 2026-05-24 "
+        "cross-loop bug."
+    )

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -55,5 +55,10 @@ def test_run_task_rejects_a_bare_coroutine() -> None:
     async def coro() -> int:
         return 1
 
-    with pytest.raises(TypeError, match="callable"):
+    with pytest.raises(TypeError, match="coroutine object"):
         run_task(coro())  # type: ignore[arg-type]
+
+
+def test_run_task_rejects_a_non_callable_non_coroutine() -> None:
+    with pytest.raises(TypeError, match="run_task requires a zero-arg callable"):
+        run_task(42)  # type: ignore[arg-type]

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -62,3 +62,56 @@ def test_run_task_rejects_a_bare_coroutine() -> None:
 def test_run_task_rejects_a_non_callable_non_coroutine() -> None:
     with pytest.raises(TypeError, match="run_task requires a zero-arg callable"):
         run_task(42)  # type: ignore[arg-type]
+
+
+def test_logged_task_emits_specific_event_for_not_registered(monkeypatch):
+    from celery.exceptions import NotRegistered
+
+    from app.worker.celery_app import LoggedTask
+
+    captured: list[tuple[str, dict]] = []
+
+    class StubLogger:
+        def error(self, event: str, **kw):
+            captured.append((event, kw))
+
+    monkeypatch.setattr("structlog.get_logger", lambda: StubLogger())
+
+    task = LoggedTask()
+    task.name = "ghost.task"
+    task.on_failure(NotRegistered("ghost.task"), "task-123", (), {"a": 1}, None)
+
+    assert captured, "on_failure should have logged"
+    event, kw = captured[0]
+    assert event == "celery.task_unregistered"
+    assert kw["task_id"] == "task-123"
+    assert kw["task_name"] == "ghost.task"
+    assert "remediation" in kw
+
+
+def test_logged_task_emits_generic_event_for_other_failures(monkeypatch):
+    """Non-NotRegistered exceptions still go to ``task_failed``."""
+    from app.worker.celery_app import LoggedTask
+
+    captured: list[tuple[str, dict]] = []
+
+    class StubLogger:
+        def error(self, event: str, **kw):
+            captured.append((event, kw))
+
+    monkeypatch.setattr("structlog.get_logger", lambda: StubLogger())
+
+    task = LoggedTask()
+    task.name = "real.task"
+    task.on_failure(ValueError("boom"), "task-456", (), {}, None)
+
+    assert captured == [(
+        "task_failed",
+        {
+            "task_id": "task-456",
+            "task_name": "real.task",
+            "error": "boom",
+            "args": (),
+            "kwargs": {},
+        },
+    )]

--- a/backend/tests/unit/test_worker_runner.py
+++ b/backend/tests/unit/test_worker_runner.py
@@ -1,0 +1,59 @@
+"""Unit tests for the shared worker task runner.
+
+The headline test (`test_two_sequential_calls_do_not_share_loop`) is the
+regression guard for the 2026-05-24 event-loop bug: two tasks running on
+the same worker process must each get a clean loop so cached httpx /
+asyncpg primitives from a previous loop cannot leak in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from app.worker._runner import run_task
+
+
+def _make_factory(probe: dict) -> Callable[[], Awaitable[int]]:
+    async def coro() -> int:
+        probe["loop"] = asyncio.get_running_loop()
+        return 42
+
+    return coro
+
+
+def test_run_task_returns_coroutine_result() -> None:
+    probe: dict = {}
+    assert run_task(_make_factory(probe)) == 42
+    assert probe["loop"] is not None
+
+
+def test_two_sequential_calls_do_not_share_loop() -> None:
+    probe_a: dict = {}
+    probe_b: dict = {}
+    run_task(_make_factory(probe_a))
+    run_task(_make_factory(probe_b))
+    assert probe_a["loop"] is not None
+    assert probe_b["loop"] is not None
+    assert probe_a["loop"] is not probe_b["loop"], (
+        "run_task must use a fresh event loop per invocation — "
+        "loop reuse is the root cause of the 2026-05-24 export bug."
+    )
+
+
+def test_run_task_propagates_exceptions() -> None:
+    async def coro() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        run_task(coro)
+
+
+def test_run_task_rejects_a_bare_coroutine() -> None:
+    async def coro() -> int:
+        return 1
+
+    with pytest.raises(TypeError, match="callable"):
+        run_task(coro())  # type: ignore[arg-type]

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -33,6 +33,40 @@ All three Railway services + the Redis plugin live in the same project, region *
 | `worker` | `backend/Dockerfile` | `celery -A app.worker.celery_app worker --loglevel=info --queues=extractions,imports,exports,celery` (Railway custom start command — overrides Dockerfile CMD) | no | none |
 | `Redis` | Railway managed plugin | n/a | private network only (`redis.railway.internal`) | n/a |
 
+## Worker — task runner
+
+Every Celery task in `backend/app/worker/tasks/` delegates to a single
+shared runner:
+
+```python
+from app.worker._runner import run_task
+
+@celery_app.task
+def my_task(self, ...):
+    async def run():
+        async with AsyncSessionLocal() as db:
+            ...
+    return run_task(run)
+```
+
+`run_task` calls `asyncio.run(coro_factory())` — a fresh loop per task.
+**Do not** cache event loops in module globals (we tried; see the
+2026-05-24 incident). **Do not** cache the Supabase client at module
+scope; `get_supabase_client()` returns a new instance per call, so the
+httpx connection pool stays bound to the current loop.
+
+## Observability — task-registry alerts
+
+`LoggedTask.on_failure` emits two distinct structlog events:
+
+| Event | Meaning | Recommended alert |
+|---|---|---|
+| `task_failed` | Generic task crash (business error, retry exhausted). | Aggregate; alert above baseline rate. |
+| `celery.task_unregistered` | The worker received a task name it has no handler for. **P1** — always caused by `celery_app.include` drift or a routing typo. | Page on first occurrence. |
+
+The drift guard at `backend/tests/unit/test_celery_app_task_registry.py`
+prevents this in CI, but the log event is the runtime safety net.
+
 ## Environment variables
 
 There is no tracked env template — env files match `.gitignore` line 21 (`.env.*`). This table is the canonical reference; paste the values into the Railway dashboard or use the Railway CLI to set them.

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -151,9 +151,3 @@ railway up backend --path-as-root --service worker --detach -m "<msg>"
 
 After the coverage debt is paid down and CI is green, no extra config
 is needed — Railway will resume auto-deploying.
-
-## Rollback fast paths
-
-(See "Rollback" section above for details.)
-
-(This mirrors the previous Render behavior — see the memory entry `reference_railway_deploys_from_main`.)


### PR DESCRIPTION
## Summary

Promotes the worker-hardening branch (PR #128) plus all other `dev` work to `main`, triggering the Railway auto-deploy.

### Worker hardening (PR #128)

- Seals the 2026-05-24 `Future attached to a different loop` worker bug. All four task modules now use a shared `run_task` runner (`asyncio.run` per call) and `worker_session()` (per-task SQLAlchemy engine + `NullPool`). Removes `@lru_cache` from `get_supabase_client`.
- Adds eager-mode integration tests per task, drift detection between `task_routes` and `railway.toml` worker `--queues=`, explicit-route requirement, and lifts `app/worker/*` out of the coverage omit list.
- `LoggedTask.on_failure` + `@task_unknown.connect` signal handler emit `celery.task_unregistered` as a P1-alertable structlog event.
- New `.github/workflows/worker-smoke.yml` boots a real Redis + Celery worker on PR, dispatches 2 sequential tasks, asserts no `attached to a different loop` and no `NotRegistered`.
- Locally smoke-tested with 3 sequential `export_extraction_task` invocations against real fixtures: all SUCCESS, zero loop bugs.

### Test plan

- [x] All `dev` CI green on PR #128 (Backend Lint/Tests/E2E/Docker Build, Frontend Lint/Build, Architectural Fitness, worker-smoke, Vercel)
- [ ] Post-merge: Railway auto-deploys `web` + `worker`; confirm `/health` returns 200 and worker logs show `celery@... ready`.
- [ ] Post-merge: smoke test `extraction_export` from the frontend (consensus + AI metadata) end-to-end against prod and confirm signed-URL download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)