### PR TITLE
test(integration): self-healing seed + sentinel-coherent lifecycle tests

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -93,6 +93,18 @@ PRIMARY_FIELD_ID = UUID("ffffffff-9999-0005-0000-000000000001")
 
 PRIMARY_INSTANCE_ID = UUID("ffffffff-9999-0006-0000-000000000001")
 
+# Obsolete sentinel rows from prior conftest revisions that the current
+# seed no longer creates. The cross-project template at id ending in
+# ``...0002`` was seeded by an earlier version with
+# ``kind='quality_assessment'`` + ``global_template_id=NULL`` — a shape that
+# now violates the invariant tested by
+# ``test_existing_templates_backfilled_to_extraction_kind`` (every
+# non-extraction project template must point at a QA global). When a
+# sentinel ID is dropped from the seed, leaving the stale row behind also
+# leaves stale-data constraint failures behind; add the retired ID here so
+# the seed garbage-collects it on next run.
+_OBSOLETE_SENTINEL_TEMPLATE_IDS: tuple[UUID, ...] = (UUID("ffffffff-9999-0003-0000-000000000002"),)
+
 
 class IntegrationSeedIds(NamedTuple):
     """Stable IDs for the rows seeded by ``seeded_integration_db``.
@@ -156,13 +168,62 @@ async def _seed_minimum_graph(session: AsyncSession) -> None:
     - One article + one template + one entity_type + one field + one
       instance covers the run/proposal/consensus suite that queries the
       full chain.
+
+    No early-return guard: every INSERT below uses ``ON CONFLICT (id) DO
+    NOTHING`` so running on a partially-populated DB is safe and converges
+    to the intended shape. An earlier revision short-circuited on
+    "PRIMARY_PROFILE exists" and skipped the rest of the seed, which left
+    the dev DB stuck in a state where the profile was present but the
+    template + article + entity-type chain wasn't — fine for CI (empty
+    DB), broken for a developer DB that had accumulated rows from manual
+    usage.
     """
-    already_seeded = await session.execute(
-        text("SELECT 1 FROM public.profiles WHERE id = :id"),
-        {"id": str(PRIMARY_PROFILE_ID)},
+    # Garbage-collect any obsolete sentinel rows from prior seed revisions
+    # before re-inserting. CASCADE handles downstream tables
+    # (entity_types, versions, runs, instances) that depend on the dropped
+    # template.
+    if _OBSOLETE_SENTINEL_TEMPLATE_IDS:
+        await session.execute(
+            text("DELETE FROM public.project_extraction_templates WHERE id = ANY(:ids)"),
+            {"ids": [str(i) for i in _OBSOLETE_SENTINEL_TEMPLATE_IDS]},
+        )
+
+    # Sentinel projects belong wholly to the seed — the sentinel UUID
+    # namespace cannot collide with real data. Drop any non-sentinel
+    # extraction templates committed into the sentinel projects by prior
+    # test runs (commonly ``test_run_lifecycle_concurrency`` fixtures
+    # that committed an extra template, then panicked before cleanup).
+    # Without this, the partial unique index
+    # ``uq_one_active_extraction_template_per_project`` rejects the seed's
+    # active extraction template because a stale non-sentinel one also
+    # claims the slot. CASCADE handles entity types, versions, runs, etc.
+    await session.execute(
+        text(
+            "DELETE FROM public.project_extraction_templates "
+            "WHERE project_id = ANY(:pids) "
+            "AND id::text NOT LIKE 'ffffffff-9999-%'"
+        ),
+        {"pids": [str(PRIMARY_PROJECT_ID), str(SECONDARY_PROJECT_ID)]},
     )
-    if already_seeded.scalar() is not None:
-        return
+
+    # Drop any non-sentinel ``extraction_instances`` that collide with
+    # the sentinel slot. The cardinality trigger on
+    # ``(entity_type_id, article_id, parent_instance_id)`` blocks the
+    # sentinel INSERT below if a prior test left an orphan instance for
+    # the sentinel article + entity_type with a non-sentinel id.
+    # ``ON CONFLICT (id)`` only protects against id collisions; the
+    # cardinality constraint fires before that.
+    await session.execute(
+        text(
+            "DELETE FROM public.extraction_instances "
+            "WHERE article_id = :aid AND entity_type_id = :etid "
+            "AND id::text NOT LIKE 'ffffffff-9999-%'"
+        ),
+        {
+            "aid": str(PRIMARY_ARTICLE_ID),
+            "etid": str(PRIMARY_ENTITY_TYPE_ID),
+        },
+    )
 
     # --- Profiles ---
     # Insert via auth.users to fire the ``handle_new_user`` trigger
@@ -319,24 +380,32 @@ async def _seed_minimum_graph(session: AsyncSession) -> None:
         },
     )
 
-    await session.execute(
-        text(
-            "INSERT INTO public.extraction_instances "
-            "(id, project_id, template_id, entity_type_id, article_id, "
-            " label, status, created_by) "
-            "VALUES (:id, :pid, :tid, :etid, :aid, "
-            " 'Integration Test Instance', 'pending', :created_by) "
-            "ON CONFLICT (id) DO NOTHING"
-        ),
-        {
-            "id": str(PRIMARY_INSTANCE_ID),
-            "pid": str(PRIMARY_PROJECT_ID),
-            "tid": str(PRIMARY_TEMPLATE_ID),
-            "etid": str(PRIMARY_ENTITY_TYPE_ID),
-            "aid": str(PRIMARY_ARTICLE_ID),
-            "created_by": str(PRIMARY_PROFILE_ID),
-        },
+    # The cardinality trigger on ``extraction_instances`` is BEFORE
+    # INSERT, so it fires before the ``ON CONFLICT (id) DO NOTHING``
+    # clause can short-circuit a no-op re-insert of the same sentinel.
+    # Guard with an explicit existence check.
+    existing_instance = await session.execute(
+        text("SELECT 1 FROM public.extraction_instances WHERE id = :id"),
+        {"id": str(PRIMARY_INSTANCE_ID)},
     )
+    if existing_instance.scalar() is None:
+        await session.execute(
+            text(
+                "INSERT INTO public.extraction_instances "
+                "(id, project_id, template_id, entity_type_id, article_id, "
+                " label, status, created_by) "
+                "VALUES (:id, :pid, :tid, :etid, :aid, "
+                " 'Integration Test Instance', 'pending', :created_by)"
+            ),
+            {
+                "id": str(PRIMARY_INSTANCE_ID),
+                "pid": str(PRIMARY_PROJECT_ID),
+                "tid": str(PRIMARY_TEMPLATE_ID),
+                "etid": str(PRIMARY_ENTITY_TYPE_ID),
+                "aid": str(PRIMARY_ARTICLE_ID),
+                "created_by": str(PRIMARY_PROFILE_ID),
+            },
+        )
 
     await session.commit()
 

--- a/backend/tests/integration/test_run_lifecycle_service.py
+++ b/backend/tests/integration/test_run_lifecycle_service.py
@@ -12,24 +12,36 @@ from app.services.run_lifecycle_service import (
     InvalidStageTransitionError,
     RunLifecycleService,
 )
+from tests.integration.conftest import SEED
 
 
 async def _fixtures(db: AsyncSession) -> tuple[UUID, UUID, UUID, UUID] | None:
-    """Return (project_id, article_id, project_template_id, profile_id) or None."""
-    project_id = (await db.execute(text("SELECT id FROM public.projects LIMIT 1"))).scalar()
-    article_id = (await db.execute(text("SELECT id FROM public.articles LIMIT 1"))).scalar()
-    template_id = (
+    """Return the seeded coherent (project, article, template, profile) tuple.
+
+    Uses the sentinel rows seeded by ``seeded_integration_db`` instead of
+    independent ``LIMIT 1`` picks. Independent picks happily returned
+    project=A / article=A / template=B on a dev DB with mixed-origin rows,
+    making ``RunLifecycleService.create_run`` raise ``TemplateNotFoundError``
+    because the template's ``project_id`` did not match the request. The
+    sentinel rows always form a coherent graph rooted at
+    ``primary_profile → primary_project → primary_article + primary_template``.
+
+    Returns ``None`` only if the seed has not run (e.g., a session that
+    skipped the autouse fixture); tests fall back to ``pytest.skip(...)``.
+    """
+    if (
         await db.execute(
-            text(
-                "SELECT id FROM public.project_extraction_templates "
-                "WHERE kind = 'extraction' LIMIT 1"
-            )
+            text("SELECT 1 FROM public.profiles WHERE id = :id"),
+            {"id": str(SEED.primary_profile)},
         )
-    ).scalar()
-    profile_id = (await db.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if not all((project_id, article_id, template_id, profile_id)):
+    ).scalar() is None:
         return None
-    return project_id, article_id, template_id, profile_id
+    return (
+        SEED.primary_project,
+        SEED.primary_article,
+        SEED.primary_template,
+        SEED.primary_profile,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The integration seed in `backend/tests/integration/conftest.py` short-circuited on "PRIMARY_PROFILE exists" and skipped the rest. Fine for CI's empty DB, but on a developer DB that had accumulated rows from manual usage, the profile was present while the template + article + entity-type chain was not, leaving the seed half-applied and the suite mostly red.

This PR makes the seed self-healing:

- Drops the all-or-nothing early-return guard.
- Adds `_OBSOLETE_SENTINEL_TEMPLATE_IDS` — a tuple of retired sentinel UUIDs. The seed garbage-collects them before re-inserting (CASCADE handles dependents).
- Deletes non-sentinel `project_extraction_templates` from sentinel projects (leaked by some lifecycle/concurrency tests).
- Deletes non-sentinel `extraction_instances` for the sentinel article + entity_type. The cardinality trigger on `(entity_type_id, article_id, parent_instance_id)` is BEFORE INSERT so it blocks the no-op re-insert; orphan rows must go first.
- Guards the sentinel-instance INSERT with an explicit `EXISTS` check (BEFORE INSERT triggers fire before `ON CONFLICT (id)`).

Also refactors `tests/integration/test_run_lifecycle_service.py` to use the sentinel `SEED` tuple instead of `SELECT ... LIMIT 1` discovery. The previous shape happily returned `project=A / article=A / template=B` on a dev DB with mixed-origin rows, making `RunLifecycleService.create_run` raise `TemplateNotFoundError` because the template's `project_id` did not match the request.

## Test plan

- [x] Backend suite green: **929 passed, 29 skipped, 0 failures** on a developer DB that previously produced 12+ integration failures + 376 fixture-level errors.
- [x] `make lint-backend` green.
- [x] `make test-backend` runs cleanly on a fresh (CI-like) DB too — every cleanup step is idempotent + no-op on empty schema.

## Context

Sequel to PRs #128 (worker hardening), #131 (extraction-export tests), #132 (drop dead repo methods). Closes the local-dev coverage gap those PRs surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)