### PR TITLE
Merge dev → main: integration seed self-healing + drop dead repo methods

### DIFF
--- a/backend/app/repositories/extraction_repository.py
+++ b/backend/app/repositories/extraction_repository.py
@@ -96,18 +96,6 @@ class GlobalTemplateRepository(BaseRepository[ExtractionTemplateGlobal]):
     def __init__(self, db: AsyncSession):
         super().__init__(db, ExtractionTemplateGlobal)
 
-    async def get_active(self) -> list[ExtractionTemplateGlobal]:
-        """
-        List active global templates.
-
-        Returns:
-            Active template list.
-        """
-        result = await self.db.execute(
-            select(ExtractionTemplateGlobal).where(ExtractionTemplateGlobal.is_active.is_(True))
-        )
-        return list(result.scalars().all())
-
 
 class ExtractionEntityTypeRepository(BaseRepository[ExtractionEntityType]):
     """Repository for extraction entity types."""
@@ -338,26 +326,3 @@ class ExtractionInstanceRepository(BaseRepository[ExtractionInstance]):
             db_duration_ms=(perf_counter() - query_start) * 1000,
         )
         return list(result.scalars().all())
-
-    async def get_with_values(
-        self,
-        instance_id: UUID | str,
-    ) -> ExtractionInstance | None:
-        """
-        Fetch instance with extracted values loaded.
-
-        Args:
-            instance_id: Instance ID.
-
-        Returns:
-            Instance with values or None.
-        """
-        if isinstance(instance_id, str):
-            instance_id = UUID(instance_id)
-
-        result = await self.db.execute(
-            select(ExtractionInstance)
-            .options(selectinload(ExtractionInstance.values))
-            .where(ExtractionInstance.id == instance_id)
-        )
-        return result.scalar_one_or_none()

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -93,6 +93,18 @@ PRIMARY_FIELD_ID = UUID("ffffffff-9999-0005-0000-000000000001")
 
 PRIMARY_INSTANCE_ID = UUID("ffffffff-9999-0006-0000-000000000001")
 
+# Obsolete sentinel rows from prior conftest revisions that the current
+# seed no longer creates. The cross-project template at id ending in
+# ``...0002`` was seeded by an earlier version with
+# ``kind='quality_assessment'`` + ``global_template_id=NULL`` — a shape that
+# now violates the invariant tested by
+# ``test_existing_templates_backfilled_to_extraction_kind`` (every
+# non-extraction project template must point at a QA global). When a
+# sentinel ID is dropped from the seed, leaving the stale row behind also
+# leaves stale-data constraint failures behind; add the retired ID here so
+# the seed garbage-collects it on next run.
+_OBSOLETE_SENTINEL_TEMPLATE_IDS: tuple[UUID, ...] = (UUID("ffffffff-9999-0003-0000-000000000002"),)
+
 
 class IntegrationSeedIds(NamedTuple):
     """Stable IDs for the rows seeded by ``seeded_integration_db``.
@@ -156,13 +168,62 @@ async def _seed_minimum_graph(session: AsyncSession) -> None:
     - One article + one template + one entity_type + one field + one
       instance covers the run/proposal/consensus suite that queries the
       full chain.
+
+    No early-return guard: every INSERT below uses ``ON CONFLICT (id) DO
+    NOTHING`` so running on a partially-populated DB is safe and converges
+    to the intended shape. An earlier revision short-circuited on
+    "PRIMARY_PROFILE exists" and skipped the rest of the seed, which left
+    the dev DB stuck in a state where the profile was present but the
+    template + article + entity-type chain wasn't — fine for CI (empty
+    DB), broken for a developer DB that had accumulated rows from manual
+    usage.
     """
-    already_seeded = await session.execute(
-        text("SELECT 1 FROM public.profiles WHERE id = :id"),
-        {"id": str(PRIMARY_PROFILE_ID)},
+    # Garbage-collect any obsolete sentinel rows from prior seed revisions
+    # before re-inserting. CASCADE handles downstream tables
+    # (entity_types, versions, runs, instances) that depend on the dropped
+    # template.
+    if _OBSOLETE_SENTINEL_TEMPLATE_IDS:
+        await session.execute(
+            text("DELETE FROM public.project_extraction_templates WHERE id = ANY(:ids)"),
+            {"ids": [str(i) for i in _OBSOLETE_SENTINEL_TEMPLATE_IDS]},
+        )
+
+    # Sentinel projects belong wholly to the seed — the sentinel UUID
+    # namespace cannot collide with real data. Drop any non-sentinel
+    # extraction templates committed into the sentinel projects by prior
+    # test runs (commonly ``test_run_lifecycle_concurrency`` fixtures
+    # that committed an extra template, then panicked before cleanup).
+    # Without this, the partial unique index
+    # ``uq_one_active_extraction_template_per_project`` rejects the seed's
+    # active extraction template because a stale non-sentinel one also
+    # claims the slot. CASCADE handles entity types, versions, runs, etc.
+    await session.execute(
+        text(
+            "DELETE FROM public.project_extraction_templates "
+            "WHERE project_id = ANY(:pids) "
+            "AND id::text NOT LIKE 'ffffffff-9999-%'"
+        ),
+        {"pids": [str(PRIMARY_PROJECT_ID), str(SECONDARY_PROJECT_ID)]},
     )
-    if already_seeded.scalar() is not None:
-        return
+
+    # Drop any non-sentinel ``extraction_instances`` that collide with
+    # the sentinel slot. The cardinality trigger on
+    # ``(entity_type_id, article_id, parent_instance_id)`` blocks the
+    # sentinel INSERT below if a prior test left an orphan instance for
+    # the sentinel article + entity_type with a non-sentinel id.
+    # ``ON CONFLICT (id)`` only protects against id collisions; the
+    # cardinality constraint fires before that.
+    await session.execute(
+        text(
+            "DELETE FROM public.extraction_instances "
+            "WHERE article_id = :aid AND entity_type_id = :etid "
+            "AND id::text NOT LIKE 'ffffffff-9999-%'"
+        ),
+        {
+            "aid": str(PRIMARY_ARTICLE_ID),
+            "etid": str(PRIMARY_ENTITY_TYPE_ID),
+        },
+    )
 
     # --- Profiles ---
     # Insert via auth.users to fire the ``handle_new_user`` trigger
@@ -319,24 +380,32 @@ async def _seed_minimum_graph(session: AsyncSession) -> None:
         },
     )
 
-    await session.execute(
-        text(
-            "INSERT INTO public.extraction_instances "
-            "(id, project_id, template_id, entity_type_id, article_id, "
-            " label, status, created_by) "
-            "VALUES (:id, :pid, :tid, :etid, :aid, "
-            " 'Integration Test Instance', 'pending', :created_by) "
-            "ON CONFLICT (id) DO NOTHING"
-        ),
-        {
-            "id": str(PRIMARY_INSTANCE_ID),
-            "pid": str(PRIMARY_PROJECT_ID),
-            "tid": str(PRIMARY_TEMPLATE_ID),
-            "etid": str(PRIMARY_ENTITY_TYPE_ID),
-            "aid": str(PRIMARY_ARTICLE_ID),
-            "created_by": str(PRIMARY_PROFILE_ID),
-        },
+    # The cardinality trigger on ``extraction_instances`` is BEFORE
+    # INSERT, so it fires before the ``ON CONFLICT (id) DO NOTHING``
+    # clause can short-circuit a no-op re-insert of the same sentinel.
+    # Guard with an explicit existence check.
+    existing_instance = await session.execute(
+        text("SELECT 1 FROM public.extraction_instances WHERE id = :id"),
+        {"id": str(PRIMARY_INSTANCE_ID)},
     )
+    if existing_instance.scalar() is None:
+        await session.execute(
+            text(
+                "INSERT INTO public.extraction_instances "
+                "(id, project_id, template_id, entity_type_id, article_id, "
+                " label, status, created_by) "
+                "VALUES (:id, :pid, :tid, :etid, :aid, "
+                " 'Integration Test Instance', 'pending', :created_by)"
+            ),
+            {
+                "id": str(PRIMARY_INSTANCE_ID),
+                "pid": str(PRIMARY_PROJECT_ID),
+                "tid": str(PRIMARY_TEMPLATE_ID),
+                "etid": str(PRIMARY_ENTITY_TYPE_ID),
+                "aid": str(PRIMARY_ARTICLE_ID),
+                "created_by": str(PRIMARY_PROFILE_ID),
+            },
+        )
 
     await session.commit()
 

--- a/backend/tests/integration/test_run_lifecycle_service.py
+++ b/backend/tests/integration/test_run_lifecycle_service.py
@@ -12,24 +12,36 @@ from app.services.run_lifecycle_service import (
     InvalidStageTransitionError,
     RunLifecycleService,
 )
+from tests.integration.conftest import SEED
 
 
 async def _fixtures(db: AsyncSession) -> tuple[UUID, UUID, UUID, UUID] | None:
-    """Return (project_id, article_id, project_template_id, profile_id) or None."""
-    project_id = (await db.execute(text("SELECT id FROM public.projects LIMIT 1"))).scalar()
-    article_id = (await db.execute(text("SELECT id FROM public.articles LIMIT 1"))).scalar()
-    template_id = (
+    """Return the seeded coherent (project, article, template, profile) tuple.
+
+    Uses the sentinel rows seeded by ``seeded_integration_db`` instead of
+    independent ``LIMIT 1`` picks. Independent picks happily returned
+    project=A / article=A / template=B on a dev DB with mixed-origin rows,
+    making ``RunLifecycleService.create_run`` raise ``TemplateNotFoundError``
+    because the template's ``project_id`` did not match the request. The
+    sentinel rows always form a coherent graph rooted at
+    ``primary_profile → primary_project → primary_article + primary_template``.
+
+    Returns ``None`` only if the seed has not run (e.g., a session that
+    skipped the autouse fixture); tests fall back to ``pytest.skip(...)``.
+    """
+    if (
         await db.execute(
-            text(
-                "SELECT id FROM public.project_extraction_templates "
-                "WHERE kind = 'extraction' LIMIT 1"
-            )
+            text("SELECT 1 FROM public.profiles WHERE id = :id"),
+            {"id": str(SEED.primary_profile)},
         )
-    ).scalar()
-    profile_id = (await db.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if not all((project_id, article_id, template_id, profile_id)):
+    ).scalar() is None:
         return None
-    return project_id, article_id, template_id, profile_id
+    return (
+        SEED.primary_project,
+        SEED.primary_article,
+        SEED.primary_template,
+        SEED.primary_profile,
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_extraction_repository.py
+++ b/backend/tests/unit/test_extraction_repository.py
@@ -13,14 +13,12 @@ import pytest
 from app.models.extraction import (
     ExtractionEntityType,
     ExtractionInstance,
-    ExtractionTemplateGlobal,
     ProjectExtractionTemplate,
 )
 from app.repositories.extraction_repository import (
     ExtractionEntityTypeRepository,
     ExtractionInstanceRepository,
     ExtractionTemplateRepository,
-    GlobalTemplateRepository,
 )
 
 # ---------------------------------------------------------------------------
@@ -84,7 +82,6 @@ def make_instance(
     inst.entity_type_id = entity_type_id or ENTITY_TYPE_ID
     inst.parent_instance_id = parent_instance_id
     inst.sort_order = 0
-    inst.values = []
     return inst
 
 
@@ -145,49 +142,6 @@ class TestExtractionTemplateRepository:
         result = await repo.get_with_entity_types(str(TEMPLATE_ID))
 
         assert result is None
-
-
-# ---------------------------------------------------------------------------
-# GlobalTemplateRepository
-# ---------------------------------------------------------------------------
-
-
-class TestGlobalTemplateRepository:
-    # NOTE: ExtractionTemplateGlobal.is_active does not exist on the ORM model.
-    # GlobalTemplateRepository.get_active() references this missing column, which
-    # makes the WHERE clause raise AttributeError at query-build time.
-    # Bug documented in DONE_WITH_CONCERNS. Tests are xfail to capture intent.
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionTemplateGlobal has no is_active column; "
-            "get_active() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_active_returns_active_templates(self) -> None:
-        db = make_db()
-        tmpl = MagicMock(spec=ExtractionTemplateGlobal)
-        db.execute = AsyncMock(return_value=make_scalars_result([tmpl]))
-        repo = GlobalTemplateRepository(db)
-        result = await repo.get_active()
-        assert result == [tmpl]
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionTemplateGlobal has no is_active column; "
-            "get_active() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_active_returns_empty_when_none(self) -> None:
-        db = make_db()
-        db.execute = AsyncMock(return_value=make_scalars_result([]))
-        repo = GlobalTemplateRepository(db)
-        result = await repo.get_active()
-        assert result == []
 
 
 # ---------------------------------------------------------------------------
@@ -380,53 +334,3 @@ class TestExtractionInstanceRepository:
         result = await repo.get_children(str(INSTANCE_ID))
 
         assert result == []
-
-    # NOTE: ExtractionInstance.values relationship does not exist on the ORM model.
-    # ExtractionInstanceRepository.get_with_values() calls selectinload(ExtractionInstance.values)
-    # which raises AttributeError at query-build time. Bug documented in DONE_WITH_CONCERNS.
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionInstance has no 'values' relationship; "
-            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_with_values_returns_instance(self) -> None:
-        db = make_db()
-        inst = make_instance()
-        db.execute = AsyncMock(return_value=make_scalar_one_or_none(inst))
-        repo = ExtractionInstanceRepository(db)
-        result = await repo.get_with_values(INSTANCE_ID)
-        assert result is inst
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionInstance has no 'values' relationship; "
-            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_with_values_returns_none(self) -> None:
-        db = make_db()
-        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
-        repo = ExtractionInstanceRepository(db)
-        result = await repo.get_with_values(INSTANCE_ID)
-        assert result is None
-
-    @pytest.mark.xfail(
-        reason=(
-            "BUG: ExtractionInstance has no 'values' relationship; "
-            "get_with_values() raises AttributeError — see DONE_WITH_CONCERNS"
-        ),
-        strict=True,
-    )
-    @pytest.mark.asyncio
-    async def test_get_with_values_accepts_string_id(self) -> None:
-        db = make_db()
-        db.execute = AsyncMock(return_value=make_scalar_one_or_none(None))
-        repo = ExtractionInstanceRepository(db)
-        result = await repo.get_with_values(str(INSTANCE_ID))
-        assert result is None


### PR DESCRIPTION
## Summary

Promotes two coherent backend cleanups that have been sitting on dev with all checks green:

- **#132** `fix(repos): drop dead extraction-repo methods referencing missing schema` — removes `GlobalTemplateRepository.get_active()` (filtered on non-existent `is_active` column) and `ExtractionInstanceRepository.get_with_values()` (eager-loaded relationship removed when `extracted_values` was dropped in migration 0002). Both methods had zero production callers and raised `AttributeError` at query-build time. Five xfail tests deleted with them.
- **#137** `test(integration): self-healing seed + sentinel-coherent lifecycle tests` — refactors `backend/tests/integration/conftest.py` so a developer DB polluted by prior test runs converges back to the seeded sentinel shape. Adds obsolete-sentinel garbage collection, drops non-sentinel collisions in sentinel projects, and guards the sentinel-instance INSERT against the BEFORE-INSERT cardinality trigger. Refactors `test_run_lifecycle_service.py` to use the sentinel `SEED` tuple instead of `SELECT ... LIMIT 1` discovery that returned mismatched (project, template) pairs on dirty DBs.

Neither change ships application behavior; both are quality wins (drop dead code, make the integration suite robust to local DB pollution).

## Test plan

- [x] Dev CI green for #132 and #137 (all gates).
- [x] Local backend suite: **929 passed, 29 skipped, 0 failed** on a developer DB.
- [ ] Post-merge: Railway auto-deploys; deploy is a no-op for runtime (only test files + deletes of unused methods). Worker + web log boot should be identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)