### PR TITLE
ci(coverage): backport diff-coverage + critical-path gates from main (PR #136)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # diff-cover needs the merge-base between origin/<base_ref> and
+          # HEAD to compute the diff. The default shallow checkout
+          # (fetch-depth=1) leaves git with no common ancestor, breaking
+          # the "Diff coverage gate (PR only)" step below with
+          # `fatal: origin/<base>...HEAD: no merge base`. Full history is
+          # the simplest fix; the repo is small enough that the bandwidth
+          # cost is negligible.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -205,6 +214,15 @@ jobs:
       #
       # Hard rule: never lower this once raised. If a PR drops coverage,
       # the PR adds tests, not the gate that gets relaxed.
+      #
+      # The global gate is the FLOOR. Two finer-grained gates run on top
+      # of it (see steps below):
+      #   - Diff coverage gate: lines touched by a PR must hit 80% (PR-only).
+      #     Catches "PR ships new code without tests" even when the global
+      #     ratchet wouldn't notice the dip yet.
+      #   - Critical-path coverage gate: aggregate over backend/.coverage_critical
+      #     must hit 85%. Modules where bug = data loss / BOLA / HITL state
+      #     corruption cannot regress even by a percentage point.
       - name: Run tests with coverage
         run: |
           uv run pytest tests/ \
@@ -212,6 +230,57 @@ jobs:
             --cov-report=xml \
             --cov-report=term-missing \
             --cov-fail-under=62
+
+      # Diff coverage gate (PR-only, hard fail).
+      # Why: a PR that adds 500 LOC with 200 tested still passes the 62%
+      # global ratchet, but degrades quality. Gating on diff coverage forces
+      # the new code to carry its own weight.
+      #
+      # `origin/${base_ref}` is the merge target (main or dev). For push
+      # events (already in trunk) the step is skipped — diff would be empty.
+      #
+      # PRUMO_DIFF_COVERAGE_MIN can be overridden via repo variables when
+      # iterating on the threshold; default 80 mirrors what most quality
+      # gates settle on (SonarCloud "Clean as You Code", Codecov defaults).
+      - name: Diff coverage gate (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          PRUMO_DIFF_COVERAGE_MIN: ${{ vars.PRUMO_DIFF_COVERAGE_MIN || '80' }}
+        run: |
+          # Belt-and-braces: the job's `actions/checkout` step sets
+          # `fetch-depth: 0` so the local clone already has full history,
+          # but refetch the base ref explicitly in case a self-hosted
+          # runner or future cache rewrite ships a partial tree.
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          uv run diff-cover coverage.xml \
+            --compare-branch="origin/${{ github.base_ref }}" \
+            --fail-under="${PRUMO_DIFF_COVERAGE_MIN}" \
+            --format "markdown:diff-coverage.md"
+          echo "## Diff coverage" >> "$GITHUB_STEP_SUMMARY"
+          cat diff-coverage.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Critical-path coverage gate (every run, hard fail).
+      # Why: the modules in backend/.coverage_critical have a no-regression
+      # contract — bug there means data loss, BOLA, or HITL state corruption.
+      # We measure their AGGREGATE (not per-file) so a single trim doesn't
+      # need its own justification, but the surface as a whole can never
+      # drift below the 85% floor. See backend/.coverage_critical for the
+      # current coverage snapshot and the rationale per file.
+      - name: Critical-path coverage gate
+        env:
+          PRUMO_CRITICAL_COVERAGE_MIN: ${{ vars.PRUMO_CRITICAL_COVERAGE_MIN || '85' }}
+        run: |
+          # Build a comma-separated include pattern from the curated list,
+          # stripping comments + blanks.
+          INCLUDE=$(grep -Ev '^\s*(#|$)' .coverage_critical | paste -sd, -)
+          if [[ -z "${INCLUDE}" ]]; then
+            echo "::error::backend/.coverage_critical is empty — refusing to soft-pass critical paths"
+            exit 1
+          fi
+          echo "Critical-path modules: ${INCLUDE}"
+          uv run coverage report \
+            --include="${INCLUDE}" \
+            --fail-under="${PRUMO_CRITICAL_COVERAGE_MIN}"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,8 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
+diff-coverage.md
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/backend/.coverage_critical
+++ b/backend/.coverage_critical
@@ -1,0 +1,36 @@
+# Critical-path coverage gate.
+#
+# Modules listed here are aggregated and must stay above the threshold set in
+# .github/workflows/ci.yml (Critical-path coverage gate step). A regression
+# in any of these — even when global coverage is healthy — bounces the PR.
+#
+# Selection rule: "bug here = data loss, BOLA, or HITL state corruption".
+# This is the smallest blast-radius surface that absolutely cannot drift.
+#
+# Adding to this list: only with a clear rationale in the same PR.
+# Removing from this list: never.
+#
+# Coverage measured 2026-05-24 (commit 87ab794):
+#   _extraction_run_lock.py            100.0%  TOCTOU lock helper
+#   hitl_session_service.py             94.7%  session opener (auth-critical)
+#   run_lifecycle_service.py            92.1%  stage transitions
+#   extraction_review_service.py        89.2%  reviewer-decision writes
+#   coordinate_coherence.py             87.5%  (run,instance,field) triplet validator
+#   extraction_proposal_repository.py   82.6%  proposal persistence
+#   extraction_proposal_service.py      80.6%  autosave write path
+#   api/deps/security.py                64.0%  auth dependency
+#   ------------------------------------------------------------------
+#   aggregate                           89.1%  current; gate set at 85 (-4pt margin)
+#
+# TODO(post-coverage-debt): once extraction_consensus_service.py climbs from
+# 34.2% to 80%+ via a dedicated test PR, add it here. Today its coverage
+# would crater the aggregate; the gate's purpose is preventing regression,
+# not papering over an outlier that needs its own remediation.
+app/services/_extraction_run_lock.py
+app/services/run_lifecycle_service.py
+app/services/hitl_session_service.py
+app/services/extraction_proposal_service.py
+app/services/extraction_review_service.py
+app/services/coordinate_coherence.py
+app/api/deps/security.py
+app/repositories/extraction_proposal_repository.py

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -76,6 +76,12 @@ dev = [
     "ruff>=0.8.0",
     "mypy>=1.13.0",
     "pre-commit>=4.0.0",
+    # CI diff coverage gate (see .github/workflows/ci.yml "Diff coverage gate"
+    # step). PR-only check: lines touched by the PR must hit
+    # PRUMO_DIFF_COVERAGE_MIN (default 80%). Coexists with the global ratchet
+    # `--cov-fail-under=62` — diff coverage catches "PR drops new code without
+    # tests" before the global gate notices the dip.
+    "diff-cover>=10.0",
 ]
 
 [build-system]

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -136,18 +136,51 @@ on the head commit passes).
 - Push to `dev` → no deploy. Use `dev` for staging-style integration;
   promote to `main` to ship.
 
-### Current constraint (2026-05-24)
+### What CI gates the deploy on
 
-The backend `--cov-fail-under=60` gate in `.github/workflows/ci.yml`
-is failing on `main` (current coverage 58.77%, threshold 60%). Until
-that is resolved — either by adding tests for the excel-export feature
-or by ratcheting the threshold down — every `main` push will SKIP the
-Railway auto-deploy. The fallback is a manual deploy:
+The Railway "Wait for CI" gate waits for every required check on the
+head commit. As of 2026-05-24 the relevant ones for backend code:
+
+1. **`backend-lint`** — ruff lint + ruff format (mypy advisory).
+2. **`fitness`** — every fitness function in `scripts/fitness/`
+   (migration boundaries, layered architecture, ApiResponse envelope,
+   TanStack query keys, glossary sync, RLS coverage, legacy concept
+   blacklist). Baselines are empty as of 2026-05-20; any new violation
+   blocks merge with no grandfathering.
+3. **`backend-test`** — pytest with three coverage gates:
+   - **Global ratchet** (`--cov-fail-under=62`): floor that only ever
+     goes up. Current `main` coverage is **71%**. Bumped from 60→62
+     on 2026-05-24 after F1/F2; next target 70% after F4 lands.
+     **Never lower this once raised** — if a PR drops coverage, the
+     PR adds tests, not a relaxed gate.
+   - **Diff coverage** (`PRUMO_DIFF_COVERAGE_MIN`, default 80%, PR-only):
+     the lines a PR introduces must be ≥80% covered. Catches "new code
+     without tests" before the global ratchet notices the dip.
+   - **Critical-path aggregate** (`PRUMO_CRITICAL_COVERAGE_MIN`,
+     default 85%): the modules listed in `backend/.coverage_critical`
+     (autosave write path, run lifecycle, HITL session opener, auth
+     deps, coord coherence, run lock, review service, proposal repo)
+     aggregate to ≥85%. Bug there = data loss / BOLA / HITL state
+     corruption. Snapshot today is 89%.
+4. **`backend-e2e`** — `pytest -m e2e`.
+5. **`backend-build`** — Docker image build.
+6. **`frontend-lint`** + **`frontend-build`** + the E2E gates when the
+   corresponding secrets are configured.
+
+Override the env-driven thresholds via repo variables
+(`PRUMO_DIFF_COVERAGE_MIN`, `PRUMO_CRITICAL_COVERAGE_MIN`) when
+deliberately experimenting; do not edit `ci.yml` for one-off tweaks.
+
+### Manual deploy fallback
+
+When CI is red for a known reason — e.g. a long-running migration PR
+where coverage temporarily dips while the spec is in flight — manual
+deploys remain available:
 
 ```bash
 railway up backend --path-as-root --service web --detach -m "<msg>"
 railway up backend --path-as-root --service worker --detach -m "<msg>"
 ```
 
-After the coverage debt is paid down and CI is green, no extra config
-is needed — Railway will resume auto-deploying.
+Use this sparingly. Manual deploys bypass the gates; if you are
+shipping past a red CI, document why in the deploy message.


### PR DESCRIPTION
## Summary

Backport of PR #136 (currently only on `main`) to `dev`.

PR #136 was merged directly to `main`, leaving `dev` without the critical-path coverage gate or the `backend/.coverage_critical` file. Any PR opened against `dev` (where all feature work targets) skips both gates entirely; the divergence also blocks the next planned change — adding `extraction_consensus_service.py` to the critical-path list once its coverage climbs to ≥80%.

This brings the two new gates and the supporting docs to `dev` so they apply to every future PR.

## What this brings

- **Diff coverage gate** — PR-only; lines touched must hit `PRUMO_DIFF_COVERAGE_MIN` (default 80%). Uses `diff-cover` against `origin/${base_ref}`.
- **Critical-path coverage gate** — every run; modules in `backend/.coverage_critical` must aggregate ≥ `PRUMO_CRITICAL_COVERAGE_MIN` (default 85%).
- `backend/.coverage_critical` curated list (8 modules; bug = data loss / BOLA / HITL state corruption).
- `backend/pyproject.toml` — adds `pytest-cov>=5.0.0`, `diff-cover>=10.0`.
- `.gitignore` — coverage artefacts.
- `docs/architecture/deployment.md` — "What CI gates the deploy on" section.

## Verification on dev

Ran locally on this branch (`73791ef`):

```
uv run pytest tests/ -q --cov=app --cov-report=
→ 957 passed, 1 skipped
uv run coverage report --fail-under=62
→ TOTAL 76% (passes — gate 62)
uv run coverage report --include=$(<.coverage_critical) --fail-under=85
→ TOTAL 93% (passes — gate 85)
```

Per-file critical-path snapshot on dev (slightly different from main's 89% snapshot because dev has the worker-hardening changes that lifted hitl_session_service.py and run_lifecycle_service.py):

| Module | Coverage |
| --- | --- |
| `_extraction_run_lock.py` | 100% |
| `coordinate_coherence.py` | 100% |
| `extraction_proposal_repository.py` | 100% |
| `extraction_proposal_service.py` | 97% |
| `extraction_review_service.py` | 97% |
| `hitl_session_service.py` | 96% |
| `run_lifecycle_service.py` | 93% |
| `api/deps/security.py` | 64% |
| **aggregate** | **93%** |

## Follow-ups (separate PRs)

1. `extraction_consensus_service.py` (34%) → dedicated test PR to lift to ≥80%, then add to `.coverage_critical`.
2. Deterministic fixture resolution in `tests/integration/test_extraction_runs_endpoints.py` so the `_resolve_fixtures` helper does not silently skip when stale non-sentinel rows are present.

## Test plan

- [x] `uv run pytest tests/ -q --cov=app` → 957 passed.
- [x] Critical-path gate at 85% → passes (93% aggregate).
- [x] Global gate at 62% → passes (76%).
- [ ] CI runs both gates on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)