### PR TITLE
test(integration): finish sentinel-coherence pass on concurrency + hitl_session

### DIFF
--- a/backend/tests/integration/test_hitl_session.py
+++ b/backend/tests/integration/test_hitl_session.py
@@ -19,8 +19,40 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 _SESSION_URL = "/api/v1/hitl/sessions"
+
+
+@pytest_asyncio.fixture
+async def auth_as_seed_primary(
+    db_session: AsyncSession,  # noqa: ARG001 — fixture order: seed runs first
+) -> AsyncGenerator[UUID, None]:
+    """Override auth to ``SEED.primary_profile`` — the conftest-seeded
+    profile that manages ``SEED.primary_project`` (owner of
+    ``SEED.primary_article`` and ``SEED.primary_template``).
+
+    Use this instead of ``auth_as_profile`` when the test also pins
+    project/article/template to the seeded sentinel rows; ``LIMIT 1`` on
+    ``profiles`` is non-deterministic on a polluted dev DB and can return
+    a profile that doesn't manage the sentinel project, leading to 403
+    on writes against ``primary_project``.
+    """
+    profile_id = SEED.primary_profile
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="primary@integration-test.prumo.local",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield profile_id
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
 
 
 @pytest_asyncio.fixture
@@ -867,14 +899,17 @@ async def test_extraction_session_requires_project_template_id(
 @pytest.mark.asyncio
 async def test_extraction_session_opens_run_for_existing_project_template(
     db_client: AsyncClient,
-    db_session: AsyncSession,
-    auth_as_profile: UUID,  # noqa: ARG001
+    db_session: AsyncSession,  # noqa: ARG001 — kept for seed-fixture ordering
+    auth_as_seed_primary: UUID,  # noqa: ARG001
 ) -> None:
-    article = await _pick_article(db_session)
-    template_id = await _pick_extraction_project_template(db_session)
-    if article is None or template_id is None:
-        pytest.skip("Need an article + an extraction project template")
-    article_id, project_id = article
+    # Pin to the sentinel triple: ``_pick_article`` and
+    # ``_pick_extraction_project_template`` each ``LIMIT 1`` independently
+    # and could land in different projects on a polluted dev DB, surfacing
+    # as "project_template_id … not found in project" (400) instead of
+    # the 201/200 contract this test asserts.
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
 
     res = await db_client.post(
         _SESSION_URL,
@@ -982,19 +1017,18 @@ async def test_patch_template_active_toggles_qa_template(
 async def test_patch_template_active_rejects_disabling_only_extraction_template(
     db_client: AsyncClient,
     db_session: AsyncSession,
-    auth_as_profile: UUID,  # noqa: ARG001
+    auth_as_seed_primary: UUID,  # noqa: ARG001
 ) -> None:
     """Disabling the project's only active extraction template must 400 —
     extraction's article-table view assumes a single active template."""
-    template_id = await _pick_extraction_project_template(db_session)
-    if template_id is None:
-        pytest.skip("Need an extraction project template")
-    project_id = (
-        await db_session.execute(
-            text("SELECT project_id FROM public.project_extraction_templates WHERE id = :tid"),
-            {"tid": str(template_id)},
-        )
-    ).scalar()
+    # Pin to the sentinel template + project so the auth principal
+    # (``SEED.primary_profile``, manager of ``SEED.primary_project``) is
+    # guaranteed to have write access. ``_pick_extraction_project_template``
+    # used to LIMIT 1 over all extraction templates and could return one
+    # from a project the auth principal does not manage, surfacing as
+    # 403 "Manager role required" instead of the 400 this test asserts.
+    project_id = SEED.primary_project
+    template_id = SEED.primary_template
 
     other_active = (
         await db_session.execute(

--- a/backend/tests/integration/test_run_lifecycle_concurrency.py
+++ b/backend/tests/integration/test_run_lifecycle_concurrency.py
@@ -27,6 +27,7 @@ from app.services.run_lifecycle_service import (
     InvalidStageTransitionError,
     RunLifecycleService,
 )
+from tests.integration.conftest import SEED
 
 
 @pytest_asyncio.fixture
@@ -39,12 +40,25 @@ async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], 
 
 
 async def _pick_basic_fixtures(db: AsyncSession) -> tuple[UUID, UUID, UUID] | None:
-    project_id = (await db.execute(text("SELECT id FROM public.projects LIMIT 1"))).scalar()
-    article_id = (await db.execute(text("SELECT id FROM public.articles LIMIT 1"))).scalar()
-    profile_id = (await db.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if not all((project_id, article_id, profile_id)):
+    """Return the seeded coherent ``(project_id, article_id, profile_id)`` tuple.
+
+    Replaces three independent ``LIMIT 1`` lookups that, on a dev DB with
+    rows from several projects, happily returned project=A / article=B /
+    profile=C — incoherent, so ``RunLifecycleService.create_run`` raised
+    ``TemplateNotFoundError`` because the chosen template's
+    ``project_id`` did not match the chosen project. The sentinel tuple
+    seeded by ``seeded_integration_db`` always forms a coherent graph
+    (``primary_profile`` manages ``primary_project`` which owns
+    ``primary_article``).
+    """
+    if (
+        await db.execute(
+            text("SELECT 1 FROM public.profiles WHERE id = :id"),
+            {"id": str(SEED.primary_profile)},
+        )
+    ).scalar() is None:
         return None
-    return UUID(str(project_id)), UUID(str(article_id)), UUID(str(profile_id))
+    return SEED.primary_project, SEED.primary_article, SEED.primary_profile
 
 
 async def _create_fresh_extraction_template(
@@ -257,20 +271,16 @@ async def test_concurrent_advance_stage_serialises_via_row_lock(
         if fx is None:
             pytest.skip("Missing project/article/profile fixtures")
         project_id, article_id, profile_id = fx
-        template_id = (
-            await setup_session.execute(
-                text(
-                    "SELECT id FROM public.project_extraction_templates "
-                    "WHERE kind = 'extraction' LIMIT 1"
-                )
-            )
-        ).scalar()
-        if template_id is None:
-            pytest.skip("No extraction template available")
+        # Use the seeded sentinel template so it stays coherent with the
+        # project/article picked above. An earlier ``LIMIT 1`` over
+        # ``project_extraction_templates`` could land on a template from
+        # a different project on a polluted dev DB and trip
+        # ``TemplateNotFoundError`` inside ``create_run``.
+        template_id = SEED.primary_template
         run = await RunLifecycleService(setup_session).create_run(
             project_id=project_id,
             article_id=article_id,
-            project_template_id=UUID(str(template_id)),
+            project_template_id=template_id,
             user_id=profile_id,
         )
         await setup_session.commit()
@@ -339,20 +349,15 @@ async def test_concurrent_reopen_does_not_fork_multiple_children(
         if fx is None:
             pytest.skip("Missing fixtures")
         project_id, article_id, profile_id = fx
-        template_id = (
-            await setup_session.execute(
-                text(
-                    "SELECT id FROM public.project_extraction_templates "
-                    "WHERE kind = 'extraction' LIMIT 1"
-                )
-            )
-        ).scalar()
-        if template_id is None:
-            pytest.skip("No extraction template")
+        # Use the sentinel template so it stays coherent with the seeded
+        # project/article (see _pick_basic_fixtures). The previous
+        # ``LIMIT 1`` could land on a different project's template on a
+        # polluted dev DB.
+        template_id = SEED.primary_template
         run = await RunLifecycleService(setup_session).create_run(
             project_id=project_id,
             article_id=article_id,
-            project_template_id=UUID(str(template_id)),
+            project_template_id=template_id,
             user_id=profile_id,
         )
         # Drive directly to FINALIZED — no consensus needed for this test.

--- a/docs/superpowers/plans/2026-05-24-integration-test-pollution-cleanup.md
+++ b/docs/superpowers/plans/2026-05-24-integration-test-pollution-cleanup.md
@@ -1,0 +1,135 @@
+# Integration Test DB-Pollution Cleanup
+
+> **Status:** open. Follow-up to PRs [#137](https://github.com/raphaelfh/prumo/pull/137) and [#141](https://github.com/raphaelfh/prumo/pull/141), which made `tests/integration/conftest.py` self-healing and switched four test files from `LIMIT 1` lottery to seeded `SEED.*` constants.
+>
+> **For agentic workers:** read this in full before touching anything in `backend/tests/integration/`. Use `superpowers:systematic-debugging` for the bisect phase and `superpowers:test-driven-development` for the rollback-fixture phase.
+
+## TL;DR
+
+After [#137](https://github.com/raphaelfh/prumo/pull/137) + [#141](https://github.com/raphaelfh/prumo/pull/141):
+
+- **CI:** 0 failures. Every check on #141 green (8/8). CI starts with an empty DB, the conftest seeds the sentinel graph, all tests pass.
+- **Local `make test-backend` on a dev DB with accumulated rows:** ~22 failures, all in **4 specific files** and all driven by cross-file DB-state pollution from earlier tests in the same run. None of them fail in isolation or when those four files are run as a contiguous group.
+
+This document scopes the remaining cleanup work.
+
+## What's done
+
+| PR | Files | Effect |
+|---|---|---|
+| #137 | `conftest.py`, `test_run_lifecycle_service.py` | Conftest is now self-healing (drops the early-return guard, GCs obsolete sentinel rows, deletes non-sentinel templates from sentinel projects). `_fixtures()` uses `SEED` directly. |
+| #141 | `test_run_lifecycle_concurrency.py`, `test_hitl_session.py` | `_pick_basic_fixtures` + the 2 inline template `LIMIT 1`s switched to `SEED.primary_template`. New local `auth_as_seed_primary` fixture for the 2 extraction-template hitl tests. |
+
+The originally-reported 13 failures are all green. Verified by running the four affected files together: 38/38 pass.
+
+## What's left
+
+### Symptom
+
+`make test-backend` on a developer DB produces ~22 failures, exclusively from:
+
+- `tests/integration/test_qa_publish_flow.py` — 15 tests
+- `tests/integration/test_session_backfill_extensive.py` — 1 test
+- `tests/integration/test_single_active_extraction_invariant.py` — 3 tests
+- `tests/integration/test_template_clone_extraction.py` — 3 tests
+
+**Confirmed not real bugs:** running those four files together (`pytest tests/integration/test_qa_publish_flow.py tests/integration/test_session_backfill_extensive.py tests/integration/test_single_active_extraction_invariant.py tests/integration/test_template_clone_extraction.py`) → 77/77 pass. CI passes them too (empty DB). They only fail when the full suite runs earlier files first.
+
+### Why it happens (hypothesis)
+
+`backend/tests/conftest.py::db_session` yields a real `AsyncSession` without wrapping the test body in a transaction:
+
+```python
+@pytest_asyncio.fixture(scope="function")
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine(...)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+    await engine.dispose()
+```
+
+So when an integration test calls `await db_session.commit()` (and many do — `home_project_fixture`, `_create_fresh_extraction_template`, the BOLA fabricators in `test_hitl_session.py`, etc.), the row stays in the DB forever. If a `try/finally` cleanup is skipped — assertion failure inside `try`, KeyboardInterrupt, a previous flaky run leaving the test halfway — the row leaks. The next test that picks `LIMIT 1` or relies on the partial unique index `uq_one_active_extraction_template_per_project` then trips on the leftover.
+
+This matches the failure surface: every failing test deals with `project_extraction_templates`, the table where active-template-per-project + sentinel cleanup intersect.
+
+## Goal
+
+Make `make test-backend` go green on a polluted dev DB, matching CI.
+
+Two complementary tracks:
+
+### Track A — bisect & patch the actual pollution sources (smaller change)
+
+1. Run `pytest --collect-only -q tests/integration/` to get the order pytest will execute.
+2. Bisect: run the suite halving the set of earlier-running files until you find which one(s) leak. Likely candidates by content: anything in `test_hitl_session.py`, `test_run_*.py`, `test_extraction_*.py`, `test_template_*.py` that does `await db_session.commit()` and inserts into `project_extraction_templates`, `extraction_template_versions`, or `extraction_runs`.
+3. For each leak: convert the test's setup-then-commit pattern to either (a) bracket it with explicit cleanup in a `try/finally`, or (b) drop the commit if the assertion does not require visibility across sessions.
+
+Pros: targeted, no fixture churn.
+Cons: every new test that needs to commit risks re-introducing the same class of bug.
+
+### Track B — transactional `db_session` fixture (bigger, but fixes the class)
+
+Convert `backend/tests/conftest.py::db_session` to begin a SAVEPOINT and roll back on teardown, so tests that "commit" actually commit into the savepoint and the outer transaction rolls back cleanly. SQLAlchemy 2.0 pattern:
+
+```python
+@pytest_asyncio.fixture(scope="function")
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine(settings.async_database_url)
+    async with engine.connect() as connection:
+        trans = await connection.begin()
+        async_session = async_sessionmaker(bind=connection, ...)
+        async with async_session() as session:
+            # Nested savepoint so calls to session.commit() inside the test
+            # don't end the outer transaction.
+            await session.begin_nested()
+
+            @event.listens_for(session.sync_session, "after_transaction_end")
+            def restart_savepoint(sess, transaction):
+                if transaction.nested and not transaction._parent.nested:
+                    sess.begin_nested()
+
+            yield session
+        await trans.rollback()
+    await engine.dispose()
+```
+
+Caveats this introduces:
+
+- The HTTP endpoints under test get the test session via `dependency_overrides[get_db]`. The endpoint's own `await db.commit()` calls now hit the savepoint and survive *within* the test — but the outer rollback wipes them after the test ends, so cross-test isolation is restored.
+- Tests that genuinely need *cross-session* visibility (like `test_run_lifecycle_concurrency.py`, which opens two sessions on the same engine to exercise row locks) cannot use this pattern — they must keep their per-test `session_factory` and own their own cleanup. The concurrency file already does this; double-check that no other file silently relies on cross-session commits.
+- Deferred constraints (e.g., migration 0004's "every active template has an active version") fire at `COMMIT`. With nested savepoints, they fire at the *outer* commit, which never happens — so the trigger never runs, and a malformed write that would have failed in prod silently succeeds in the test. Need either `SET CONSTRAINTS ALL IMMEDIATE` at fixture start, or accept the gap and rely on a small number of "real commit" smoke tests.
+
+Pros: structural fix; new tests don't have to think about cleanup.
+Cons: bigger change; some tests need explicit opt-out; deferred-constraint surface area shrinks.
+
+### Recommendation
+
+Do **Track A first** (mechanical, low risk, fixes today's red). When the test suite is green locally, evaluate Track B as a separate piece of work — the value is preventive (saves future writes from re-introducing the same class of bug), not corrective.
+
+## Reproducer
+
+```bash
+# Repro the polluted run (from project root)
+make test-backend
+# → 22 failures across 4 files
+
+# Same 4 files in isolation pass
+.venv/bin/python -m pytest tests/integration/test_qa_publish_flow.py \
+  tests/integration/test_session_backfill_extensive.py \
+  tests/integration/test_single_active_extraction_invariant.py \
+  tests/integration/test_template_clone_extraction.py
+# → 77 passed
+```
+
+## Out of scope
+
+- The `LIMIT 1` lottery in **other** test files (the ones not currently failing). Convert opportunistically when touching them, but don't refactor en masse — the conftest seed already guarantees coherence on a clean DB and the failing-test PR list converges on the SEED pattern.
+- The flaky branch-switching that happened during the PR #137 / #141 sessions (parallel sessions stashing/restoring work). Use git worktrees for any further multi-session AI work on this repo.
+- CI changes. CI is already green and doesn't have this problem.
+
+## Definition of done
+
+- `make test-backend` exits 0 on a developer dev DB that has at least: 1 non-sentinel project with articles + multiple extraction templates + a profile that's its manager.
+- No regression in the 38 tests covered by #137/#141.
+- (If Track B is done) at least one explicit smoke test exercises a deferred-constraint trigger under the new fixture so we know it still fires somewhere.


### PR DESCRIPTION
## Summary

Follow-up to #137. That PR fixed the seed (self-healing on a dirty dev DB) and `_fixtures()` in `test_run_lifecycle_service.py`, but the sibling helpers in `test_run_lifecycle_concurrency.py` and the two extraction-template tests in `test_hitl_session.py` still used three or four independent `LIMIT 1` lookups. On a fresh dev DB those picks happen to be coherent by coincidence (only one coherent project graph exists); as soon as a developer adds an article in a different project or an extra extraction template, the picks split across projects and `TemplateNotFoundError` / 400 / 403 returns.

This PR switches both files to use the `SEED` namedtuple already exported by `tests/integration/conftest.py`.

## Changes

- **`test_run_lifecycle_concurrency.py`**: `_pick_basic_fixtures` returns `(primary_project, primary_article, primary_profile)` directly. The two inline `LIMIT 1` template picks inside the concurrency tests reuse `SEED.primary_template` so the triple stays coherent end-to-end.
- **`test_hitl_session.py`**: new local `auth_as_seed_primary` fixture pins the JWT sub to `SEED.primary_profile` (manager of `SEED.primary_project`). The two failing extraction-template tests use it together with the sentinel article + template.
- **Deliberately NOT changed**: shared `auth_as_profile` / `_pick_article` / `_pick_extraction_project_template` helpers stay untouched because 16 other tests in the same file rely on their LIMIT-1 behaviour (they clone a *global* template into the profile's project, so coherence is irrelevant there).

## Test plan

- [x] Originally-failing 4 test files: 38/38 green (`test_run_lifecycle_service.py`, `test_run_lifecycle_concurrency.py`, `test_hitl_session.py`, `test_kind_discriminator.py`)
- [x] CI: all 8 checks green on this branch
- [x] Full backend suite on a polluted dev DB: 22 failures (down from baseline ~51 without this fix); remaining 22 are pre-existing cross-file DB pollution — same tests pass in isolation and on CI. Documented and scoped for follow-up in [`docs/superpowers/plans/2026-05-24-integration-test-pollution-cleanup.md`](docs/superpowers/plans/2026-05-24-integration-test-pollution-cleanup.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)