### PR TITLE
test(integration): sentinel-coherent lifecycle helpers + run purge in seed

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -225,6 +225,20 @@ async def _seed_minimum_graph(session: AsyncSession) -> None:
         },
     )
 
+    # Purge ``extraction_runs`` left by previous test sessions inside the
+    # sentinel projects. Tests that exercise the lifecycle commit runs
+    # against the sentinel article+template, and ``ON CONFLICT (id) DO
+    # NOTHING`` does not clean those up — they accumulate across sessions
+    # and bleed state into downstream tables. CASCADE on
+    # ``extraction_proposal_records`` / ``extraction_reviewer_decisions`` /
+    # ``extraction_reviewer_states`` / ``extraction_consensus_decisions`` /
+    # ``extraction_published_states`` handles the rest. Sentinel projects
+    # belong entirely to the seed, so a project-scoped DELETE is safe.
+    await session.execute(
+        text("DELETE FROM public.extraction_runs WHERE project_id = ANY(:pids)"),
+        {"pids": [str(PRIMARY_PROJECT_ID), str(SECONDARY_PROJECT_ID)]},
+    )
+
     # --- Profiles ---
     # Insert via auth.users to fire the ``handle_new_user`` trigger
     # (which materialises ``public.profiles``). Fall back to a direct

--- a/backend/tests/integration/test_extraction_runs_endpoints.py
+++ b/backend/tests/integration/test_extraction_runs_endpoints.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 API_PREFIX = "/api/v1/runs"
 
@@ -34,54 +35,26 @@ API_PREFIX = "/api/v1/runs"
 
 
 async def _resolve_fixtures(
-    db: AsyncSession,
+    db: AsyncSession,  # noqa: ARG001
 ) -> tuple[UUID, UUID, UUID, UUID, UUID, UUID] | None:
-    """Resolve (project, article, template, profile, instance, field) IDs from the
-    test database, picking instance + field that share the same template/entity_type.
+    """Return the seeded sentinel (project, article, template, profile, instance, field).
 
-    Queries article and template under the same project so the BOLA ownership
-    checks in create_run pass (article.project_id == project_id, and
-    template.project_id == project_id).
+    Pinning to the seed sentinels (vs ``LIMIT 1``) keeps the BOLA-ownership
+    chain coherent — previous revisions of this helper picked any
+    project/article/template row at random, which could resolve to a stale,
+    half-orphaned trio committed by a previous test session and silently
+    skip the whole file with ``Missing fixtures``. The return type stays
+    ``... | None`` so every caller's ``if fx is None`` guard remains a
+    valid no-op without churn; with the seed always present, it never fires.
     """
-    profile_id = (await db.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    # Find a project that has both an article and an extraction template so the
-    # ownership invariant is satisfied without the test having to set up its own data.
-    row = (
-        await db.execute(
-            text(
-                """
-                SELECT p.id AS project_id, a.id AS article_id, t.id AS template_id
-                FROM public.projects p
-                JOIN public.articles a ON a.project_id = p.id
-                JOIN public.project_extraction_templates t
-                    ON t.project_id = p.id AND t.kind = 'extraction'
-                LIMIT 1
-                """
-            )
-        )
-    ).first()
-    if row is None or profile_id is None:
-        return None
-    project_id, article_id, template_id = row
-
-    row = await db.execute(
-        text(
-            """
-            SELECT i.id AS iid, f.id AS fid
-            FROM public.extraction_instances i
-            JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
-            JOIN public.extraction_fields f ON f.entity_type_id = et.id
-            WHERE i.template_id = :tid
-            LIMIT 1
-            """
-        ),
-        {"tid": template_id},
+    return (
+        SEED.primary_project,
+        SEED.primary_article,
+        SEED.primary_template,
+        SEED.primary_profile,
+        SEED.primary_instance,
+        SEED.primary_field,
     )
-    pair = row.first()
-    if pair is None:
-        return None
-    instance_id, field_id = pair
-    return project_id, article_id, template_id, profile_id, instance_id, field_id
 
 
 @pytest_asyncio.fixture
@@ -92,14 +65,12 @@ async def auth_as_profile(
 
     Must be requested AFTER ``db_client`` (or alongside, since FastAPI just
     checks the override map at request time). Yielding the UUID lets each test
-    assert against the same id used by the API.
+    assert against the same id used by the API. Pinned to the seed sentinel
+    so the chosen profile is guaranteed to be a manager of both seed projects
+    (see conftest topology).
     """
-    profile_id_raw = (
-        await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))
-    ).scalar()
-    if profile_id_raw is None:
-        pytest.skip("No profile rows available in test database")
-    profile_id = UUID(str(profile_id_raw))
+    del db_session  # kept for fixture-dependency ordering against ``db_client``
+    profile_id = SEED.primary_profile
 
     async def override_get_current_user() -> TokenPayload:
         return TokenPayload(

--- a/backend/tests/integration/test_runs_endpoint_lifecycle.py
+++ b/backend/tests/integration/test_runs_endpoint_lifecycle.py
@@ -22,7 +22,6 @@ from uuid import UUID
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user

--- a/backend/tests/integration/test_runs_endpoint_lifecycle.py
+++ b/backend/tests/integration/test_runs_endpoint_lifecycle.py
@@ -27,17 +27,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 
 @pytest_asyncio.fixture
 async def auth_as_profile(
-    db_session: AsyncSession,
+    db_session: AsyncSession,  # noqa: ARG001 — kept for fixture-dep ordering
 ) -> AsyncGenerator[UUID, None]:
-    """Override get_current_user so JWT sub is a real profile UUID."""
-    raw = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if raw is None:
-        pytest.skip("No profile rows available in test database")
-    profile_id = UUID(str(raw))
+    """Override get_current_user so JWT sub is the seeded primary profile.
+
+    Pinned to ``SEED.primary_profile`` so the chosen subject is always a
+    project manager of the seed projects — regardless of any stale rows the
+    test DB might have accumulated from previous sessions.
+    """
+    profile_id = SEED.primary_profile
 
     async def override_get_current_user() -> TokenPayload:
         return TokenPayload(
@@ -51,45 +54,23 @@ async def auth_as_profile(
     yield profile_id
 
 
-async def _pick_fixtures(db: AsyncSession) -> tuple[str, str, str, str, str] | None:
-    """Pick (project_id, article_id, template_id, instance_id, field_id) where
-    instance + field both belong to the same template/entity_type chain."""
-    project_id = (await db.execute(text("SELECT id FROM public.projects LIMIT 1"))).scalar()
-    article_id = (await db.execute(text("SELECT id FROM public.articles LIMIT 1"))).scalar()
-    template_id = (
-        await db.execute(
-            text(
-                "SELECT id FROM public.project_extraction_templates "
-                "WHERE kind = 'extraction' LIMIT 1"
-            )
-        )
-    ).scalar()
-    if not (project_id and article_id and template_id):
-        return None
-    pair = (
-        await db.execute(
-            text(
-                """
-                SELECT i.id, f.id
-                FROM public.extraction_instances i
-                JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
-                JOIN public.extraction_fields f ON f.entity_type_id = et.id
-                WHERE i.template_id = :tid
-                LIMIT 1
-                """
-            ),
-            {"tid": template_id},
-        )
-    ).first()
-    if pair is None:
-        return None
-    instance_id, field_id = pair
+async def _pick_fixtures(
+    db: AsyncSession,  # noqa: ARG001 — kept for signature stability with callers
+) -> tuple[str, str, str, str, str] | None:
+    """Return the seeded sentinel chain (project, article, template, instance, field).
+
+    Pinned to the sentinels (previous revisions used ``LIMIT 1``) so the
+    helper does not silently pick a stale, half-orphaned trio committed by
+    a prior test session and skip the three lifecycle tests with
+    ``Need fixtures.`` The return type stays ``... | None`` so each
+    caller's ``if fx is None`` guard remains a valid (now dead) no-op.
+    """
     return (
-        str(project_id),
-        str(article_id),
-        str(template_id),
-        str(instance_id),
-        str(field_id),
+        str(SEED.primary_project),
+        str(SEED.primary_article),
+        str(SEED.primary_template),
+        str(SEED.primary_instance),
+        str(SEED.primary_field),
     )
 
 


### PR DESCRIPTION
## Summary

Three tests in [test_runs_endpoint_lifecycle.py](backend/tests/integration/test_runs_endpoint_lifecycle.py) were the user-reported \"3 integration tests falhando localmente por state stale do Supabase remoto\":

- `test_full_hitl_lifecycle`
- `test_invalid_stage_transition_returns_400`
- `test_proposal_outside_proposal_stage_returns_400`

All three depend on a local `_pick_fixtures()` helper that ran **three independent `LIMIT 1` lookups** (any project, any article, any extraction template). On a fresh DB those happen to be coherent — only one graph exists. On a developer DB carrying leftovers from previous sessions, the picks split across projects and the create-run BOLA guard rejects with 400 / 403, or the (instance, field) chain comes back empty and the test silently skips with `Need fixtures.`

This PR is the next step after [#137](https://github.com/raphaelfh/prumo/pull/137) (self-healing seed) and is **complementary to [#141](https://github.com/raphaelfh/prumo/pull/141)** (which pins SEED in `test_run_lifecycle_concurrency` + `test_hitl_session`); the two changes are orthogonal and can land in either order.

## Changes

- **`test_runs_endpoint_lifecycle.py`** — `_pick_fixtures` + `auth_as_profile` now return the `SEED` sentinels directly. The `... | None` return type is kept so existing `if fx is None: pytest.skip(...)` guards remain valid (now dead) no-ops without churning every caller.
- **`test_extraction_runs_endpoints.py`** — same fix in its `_resolve_fixtures` + `auth_as_profile`. This was the worst offender — silently skipping **25 tests** in the same way.
- **`tests/integration/conftest.py`** — purge `extraction_runs` in the sentinel projects at session start. Lifecycle tests commit runs against the sentinel article+template; `ON CONFLICT (id) DO NOTHING` does not clean those up, and they accumulate across sessions, bleeding state into proposal / decision / state tables. CASCADE handles the rest.

## Verification

Run on `fix/integration-fixture-determinism`:

\`\`\`
=== Before this PR (dev @ b52a34f) ===
$ pytest tests/integration/ -q --tb=no
341 passed, 35 skipped
(19–44 intermittent failures depending on accumulated state)

=== After this PR ===
Run 1: 370 passed, 6 skipped
Run 2: 370 passed, 6 skipped
Run 3: 370 passed, 6 skipped
Run 4: 370 passed, 6 skipped
Run 5: 370 passed, 6 skipped
\`\`\`

The three named lifecycle tests pass 3 / 3 consecutive runs in isolation as well.

The remaining 6 skips are tests gated on optional resources (e.g. `test_extraction_manual_only_flow` needing specific extraction templates) and do not regress.

## Test plan

- [x] `pytest tests/integration/test_runs_endpoint_lifecycle.py` — 4 passed, 0 skipped (3 consecutive runs).
- [x] `pytest tests/integration/` — 370 passed, 6 skipped (5 consecutive runs, no flake).
- [ ] CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)