### PR TITLE
fix(types): parameterize ApiResponse.failure() in T (wave 2.1)

### DIFF
--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -103,8 +103,15 @@ class ApiResponse(BaseModel, Generic[T]):
         message: str,
         details: dict[str, Any] | None = None,
         trace_id: str | None = None,
-    ) -> "ApiResponse[None]":
-        """Create error response."""
+    ) -> "ApiResponse[T]":
+        """Create error response.
+
+        Generic in ``T`` so callers can do
+        ``return ApiResponse.failure(...)`` inside an endpoint typed
+        ``-> ApiResponse[SomeModel]`` without a type error: an envelope
+        without ``data`` satisfies ``ApiResponse[T]`` because
+        ``data: T | None = None`` accepts the implicit ``None``.
+        """
         return cls(
             ok=False,
             error=ErrorDetail(code=code, message=message, details=details),


### PR DESCRIPTION
## Summary

Onda 2 sub-step 1: **16 mypy --strict return-value errors eliminated** with a single-line typing change (192 → 176 errors total).

> **Base branch**: stacked on [#145](https://github.com/raphaelfh/prumo/pull/145). Merge that first, then rebase this onto `dev`.

## Root cause

`ApiResponse.failure()` was declared as `-> ApiResponse[None]`, so every endpoint that returned it inline failed mypy:

```python
async def start(...) -> ApiResponse[ExportStartedResponse]:
    if not formats:
        return ApiResponse.failure(...)  # ApiResponse[None] ≠ ApiResponse[T]
```

The hybrid error model documented in `app/schemas/common.py:8-26` is **intentional**:
- Business validation past Pydantic → HTTP 200 + `{ok: false, error: ...}` envelope
- Protocol/auth failures (401/403/404/422/429) → 4xx via `raise <DomainError>` + central handler

The model itself is correct — only the typing was forcing the mismatch.

## Fix

Declare `failure()` generic in `T`:

```python
@classmethod
def failure(...) -> "ApiResponse[T]":
    return cls(ok=False, error=..., trace_id=trace_id)
```

Because `data: T | None = None` accepts the implicit `None`, an envelope without `data` satisfies `ApiResponse[T]` for any `T` inferred from the endpoint's return type.

**Zero runtime change.** `ApiResponse.failure()` still emits the same `{ok: false, error: {...}}` payload. Only the static type signature becomes context-inferred.

## Test plan

- [x] `uv run mypy app` — 192 → 176 errors (return-value: 19 → 3, remaining 3 are unrelated)
- [x] `uv run pytest tests/unit -x -q` — 604 passed
- [x] `scripts/fitness/check_api_response_envelope.py` — `OK (baseline matched: 9 grandfathered)`
- [ ] CI critical-path coverage gate (≥85%) holds — no new code paths

## What's deliberately *not* in this PR

- **Migrating `FORBIDDEN`/`NOT_FOUND` from `return ApiResponse.failure(...)` to `raise <DomainError>`**: would change runtime HTTP status (200 → 403/404), needs frontend confirmation. The hybrid model docs explicitly allow either choice per case — current code is fine.
- **`type-arg` codemod for bare `dict`/`list`** (~24 errors in services/repositories/worker): separate concern, mechanical, follow-up PR.
- **camelCase alias removal in Pydantic schemas** (~73 errors): wave 2 sub-step 2, requires frontend RFC and coordinated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)