### PR TITLE
fix(types): wave 2.2 type-arg + no-untyped-def cleanup (176 → 134 errors)

### DIFF
--- a/backend/app/api/v1/endpoints/extraction_export.py
+++ b/backend/app/api/v1/endpoints/extraction_export.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import uuid
+from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Request, Response, status
@@ -299,7 +300,7 @@ async def start_extraction_export(
 
 @router.get(
     "/{project_id}/extraction-export/reviewers",
-    response_model=ApiResponse[list[dict]],
+    response_model=ApiResponse[list[dict[str, Any]]],
     summary="List reviewers with non-reject decisions for the picker (US2 / FR-028)",
 )
 @limiter.limit("30/minute")
@@ -310,7 +311,7 @@ async def list_extraction_export_reviewers(
     db: DbSession,
     user: CurrentUser,
     supabase: SupabaseClient,
-) -> ApiResponse[list[dict]]:
+) -> ApiResponse[list[dict[str, Any]]]:
     """Return reviewers who have ≥ 1 non-reject decision on this template.
 
     Non-managers see only themselves (when they have decisions); managers

--- a/backend/app/api/v1/endpoints/extraction_runs.py
+++ b/backend/app/api/v1/endpoints/extraction_runs.py
@@ -10,6 +10,7 @@ the ones that drive consensus + publish later.
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps.security import ensure_project_member, get_current_user_sub
 from app.core.deps import DbSession
@@ -68,7 +69,9 @@ def _trace(request: Request) -> str | None:
     return getattr(request.state, "trace_id", None)
 
 
-async def _load_run_and_check_member(db, run_id: UUID, user_sub: UUID) -> RunSummaryResponse:
+async def _load_run_and_check_member(
+    db: AsyncSession, run_id: UUID, user_sub: UUID
+) -> RunSummaryResponse:
     """Load a Run by id, 404 when missing, 403 when caller is not a member.
 
     Returns the Run as a RunSummaryResponse schema (not the ORM type) so

--- a/backend/app/api/v1/endpoints/hitl_configs.py
+++ b/backend/app/api/v1/endpoints/hitl_configs.py
@@ -16,6 +16,7 @@ Response semantics
   resolve up the chain and report ``inherited=true``.
 """
 
+from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -34,7 +35,7 @@ from app.services.hitl_config_service import (
 router = APIRouter()
 
 
-def _to_read(snapshot: dict) -> HitlConfigRead:
+def _to_read(snapshot: dict[str, Any]) -> HitlConfigRead:
     """Convert a service snapshot dict into the API response model."""
     scope_id = snapshot.get("scope_id")
     return HitlConfigRead(

--- a/backend/app/repositories/article_author_repository.py
+++ b/backend/app/repositories/article_author_repository.py
@@ -2,6 +2,7 @@
 Article author repository.
 """
 
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import delete, select
@@ -33,7 +34,7 @@ class ArticleAuthorRepository(BaseRepository[ArticleAuthor]):
         display_name: str,
         *,
         orcid: str | None = None,
-        source_hint: dict | None = None,
+        source_hint: dict[str, Any] | None = None,
     ) -> ArticleAuthor:
         normalized_name = normalize_author_name(display_name)
         existing = await self.get_by_identity(normalized_name, orcid)

--- a/backend/app/repositories/article_repository.py
+++ b/backend/app/repositories/article_repository.py
@@ -5,6 +5,7 @@ Article and file persistence layer.
 """
 
 from datetime import UTC, datetime
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -190,7 +191,7 @@ class ArticleRepository(BaseRepository[Article]):
         self,
         *,
         project_id: UUID,
-        payload: dict,
+        payload: dict[str, Any],
         canonical_identity: dict[str, str | None],
     ) -> tuple[Article, bool]:
         existing = await self.get_by_canonical_identity(
@@ -309,7 +310,7 @@ class ArticleSyncEventRepository(BaseRepository[ArticleSyncEvent]):
         authority_rule_applied: str | None = None,
         error_code: str | None = None,
         error_message: str | None = None,
-        event_payload: dict | None = None,
+        event_payload: dict[str, Any] | None = None,
     ) -> ArticleSyncEvent:
         event = ArticleSyncEvent(
             project_id=project_id,

--- a/backend/app/repositories/extraction_published_state_repository.py
+++ b/backend/app/repositories/extraction_published_state_repository.py
@@ -1,5 +1,6 @@
 """Repository for ExtractionPublishedState with optimistic concurrency."""
 
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import func, select, update
@@ -35,7 +36,7 @@ class ExtractionPublishedStateRepository:
         run_id: UUID,
         instance_id: UUID,
         field_id: UUID,
-        value: dict,
+        value: dict[str, Any],
         published_by: UUID,
     ) -> ExtractionPublishedState | None:
         """INSERT ... ON CONFLICT DO NOTHING — returns the row on insert, else None.
@@ -72,7 +73,7 @@ class ExtractionPublishedStateRepository:
         run_id: UUID,
         instance_id: UUID,
         field_id: UUID,
-        value: dict,
+        value: dict[str, Any],
         published_by: UUID,
         expected_version: int,
     ) -> int:

--- a/backend/app/repositories/project_repository.py
+++ b/backend/app/repositories/project_repository.py
@@ -4,6 +4,7 @@ Project Repository.
 Project and membership persistence layer.
 """
 
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
@@ -99,7 +100,7 @@ class ProjectRepository(BaseRepository[Project]):
         )
         return result.scalar_one_or_none()
 
-    async def get_summary(self, project_id: UUID | str) -> dict:
+    async def get_summary(self, project_id: UUID | str) -> dict[str, Any]:
         """
         Fetch project summary data for AI context.
 

--- a/backend/app/repositories/unit_of_work.py
+++ b/backend/app/repositories/unit_of_work.py
@@ -65,6 +65,7 @@ WITHOUT UoW (not recommended):
     await session.commit()  # Voce controla o commit
 """
 
+from types import TracebackType
 from typing import Self
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -215,7 +216,12 @@ class UnitOfWork:
         """
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """
         Sai do contexto async.
 

--- a/backend/app/services/articles_export_service.py
+++ b/backend/app/services/articles_export_service.py
@@ -10,7 +10,10 @@ import io
 import re
 import zipfile
 from datetime import UTC, datetime
+from typing import Any
 from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import LoggerMixin
 from app.infrastructure.storage.base import StorageAdapter
@@ -138,11 +141,11 @@ class ArticlesExportService(LoggerMixin):
 
     def __init__(
         self,
-        db,
+        db: AsyncSession,
         user_id: str,
         storage: StorageAdapter,
         trace_id: str | None = None,
-    ):
+    ) -> None:
         self.db = db
         self.user_id = user_id
         self.storage = storage
@@ -176,7 +179,7 @@ class ArticlesExportService(LoggerMixin):
         formats: list[str],
         file_scope: str,
         job_id: str | None = None,  # noqa: ARG002
-    ) -> tuple[bytes, str, str, list[dict]]:
+    ) -> tuple[bytes, str, str, list[dict[str, Any]]]:
         """
         Executa export sincrono: gera conteudo (CSV/RIS/RDF and optionalmente ZIP with files).
         Return (content_bytes, content_type, suggested_filename, skipped_files).
@@ -189,7 +192,7 @@ class ArticlesExportService(LoggerMixin):
         if not articles:
             return b"", "application/octet-stream", "export.bin", []
 
-        skipped: list[dict] = []
+        skipped: list[dict[str, Any]] = []
         bucket = "articles"
 
         if file_scope == "none":
@@ -291,7 +294,7 @@ class ArticlesExportService(LoggerMixin):
         formats: list[str],
         file_scope: str,
         job_id: str,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """
         Executa export and faz upload do ZIP for storage; retorna download_url, expires_at, skipped_files.
         """

--- a/backend/app/services/extraction_consensus_service.py
+++ b/backend/app/services/extraction_consensus_service.py
@@ -1,5 +1,6 @@
 """Service: consensus decisions + publish with optimistic concurrency."""
 
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -53,7 +54,7 @@ class ExtractionConsensusService:
         consensus_user_id: UUID,
         mode: ExtractionConsensusMode | str,
         selected_decision_id: UUID | None = None,
-        value: dict | None = None,
+        value: dict[str, Any] | None = None,
         rationale: str | None = None,
     ) -> tuple[ExtractionConsensusDecision, ExtractionPublishedState]:
         run = await load_run_for_update(self.db, run_id)
@@ -148,7 +149,7 @@ class ExtractionConsensusService:
         run_id: UUID,
         instance_id: UUID,
         field_id: UUID,
-        value: dict,
+        value: dict[str, Any],
         published_by: UUID,
         expected_version: int,
     ) -> ExtractionPublishedState:
@@ -186,7 +187,7 @@ class ExtractionConsensusService:
         run_id: UUID,
         instance_id: UUID,
         field_id: UUID,
-        value: dict,
+        value: dict[str, Any],
         published_by: UUID,
     ) -> ExtractionPublishedState:
         # Race-free first publish: INSERT ... ON CONFLICT DO NOTHING. If a row

--- a/backend/app/services/extraction_proposal_service.py
+++ b/backend/app/services/extraction_proposal_service.py
@@ -1,5 +1,6 @@
 """Service: validate + record proposals append-only."""
 
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,7 +35,7 @@ class ExtractionProposalService:
         instance_id: UUID,
         field_id: UUID,
         source: ExtractionProposalSource | str,
-        proposed_value: dict,
+        proposed_value: dict[str, Any],
         source_user_id: UUID | None = None,
         confidence_score: float | None = None,
         rationale: str | None = None,

--- a/backend/app/services/extraction_review_service.py
+++ b/backend/app/services/extraction_review_service.py
@@ -1,5 +1,6 @@
 """Service: validate reviewer decisions, write append-only, upsert ReviewerState."""
 
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -44,7 +45,7 @@ class ExtractionReviewService:
         reviewer_id: UUID,
         decision: ExtractionReviewerDecisionType | str,
         proposal_record_id: UUID | None = None,
-        value: dict | None = None,
+        value: dict[str, Any] | None = None,
         rationale: str | None = None,
     ) -> ExtractionReviewerDecision:
         run = await load_run_for_update(self.db, run_id)

--- a/backend/app/services/pdf_processor.py
+++ b/backend/app/services/pdf_processor.py
@@ -76,7 +76,7 @@ class PDFProcessor(LoggerMixin):
         r"^(?:\d+\.?\s*)?supplementary",
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._compiled_patterns = [
             re.compile(p, re.IGNORECASE | re.MULTILINE) for p in self.SECTION_PATTERNS
         ]

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -1337,7 +1337,7 @@ Example response format:
 
             confidence_score: float | None = None
             reasoning: str | None = None
-            evidence_meta: dict | None = None
+            evidence_meta: dict[str, Any] | None = None
 
             if isinstance(value, dict):
                 confidence_score = value.get("confidence")

--- a/backend/app/services/template_clone_service.py
+++ b/backend/app/services/template_clone_service.py
@@ -2,6 +2,7 @@
 
 from collections import deque
 from datetime import UTC, datetime
+from typing import Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import select, text, update
@@ -415,7 +416,7 @@ class TemplateCloneService:
         )
         return (await self.db.execute(stmt)).scalar_one_or_none()
 
-    async def _snapshot(self, project_template_id: UUID) -> dict:
+    async def _snapshot(self, project_template_id: UUID) -> dict[str, Any]:
         from sqlalchemy import text
 
         result = await self.db.execute(

--- a/backend/app/services/zotero_import_service.py
+++ b/backend/app/services/zotero_import_service.py
@@ -579,7 +579,7 @@ class ZoteroImportService(LoggerMixin):
         status_filter: str | None,
         offset: int,
         limit: int,
-    ) -> tuple[list, int]:
+    ) -> tuple[list[Any], int]:
         return await self._sync_events.list_run_events(
             sync_run_id=sync_run_id,
             status_filter=status_filter,

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -5,6 +5,7 @@ Configures Celery with Redis as broker and result backend.
 """
 
 import os
+from typing import Any
 
 from celery import Celery
 
@@ -71,7 +72,14 @@ celery_app.conf.update(
 class LoggedTask(celery_app.Task):
     """Task base class with structured logging."""
 
-    def on_failure(self, exc, task_id, args, kwargs, _einfo):
+    def on_failure(
+        self,
+        exc: Exception,
+        task_id: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        _einfo: Any,
+    ) -> None:
         """Log on failure."""
         import structlog
         from celery.exceptions import NotRegistered
@@ -103,7 +111,13 @@ class LoggedTask(celery_app.Task):
             kwargs=kwargs,
         )
 
-    def on_success(self, _retval, task_id, _args, _kwargs):
+    def on_success(
+        self,
+        _retval: Any,
+        task_id: str,
+        _args: tuple[Any, ...],
+        _kwargs: dict[str, Any],
+    ) -> None:
         """Log on success."""
         import structlog
 
@@ -114,7 +128,14 @@ class LoggedTask(celery_app.Task):
             task_name=self.name,
         )
 
-    def on_retry(self, exc, task_id, _args, _kwargs, _einfo):
+    def on_retry(
+        self,
+        exc: Exception,
+        task_id: str,
+        _args: tuple[Any, ...],
+        _kwargs: dict[str, Any],
+        _einfo: Any,
+    ) -> None:
         """Log on retry."""
         import structlog
 
@@ -143,12 +164,12 @@ from celery.signals import task_unknown  # noqa: E402
 
 @task_unknown.connect
 def _on_task_unknown(
-    sender=None,  # noqa: ARG001
+    sender: Any = None,  # noqa: ARG001
     name: str | None = None,
     id: str | None = None,  # noqa: A002 — Celery signal kwarg name
-    message=None,  # noqa: ARG001
+    message: Any = None,  # noqa: ARG001
     exc: Exception | None = None,  # noqa: ARG001
-    **_kwargs,
+    **_kwargs: Any,
 ) -> None:
     """Log unregistered-task events as a P1 incident.
 

--- a/backend/app/worker/tasks/export_tasks.py
+++ b/backend/app/worker/tasks/export_tasks.py
@@ -9,7 +9,10 @@ module's docstring for the event-loop rationale.
 
 from __future__ import annotations
 
+from typing import Any
 from uuid import UUID
+
+from celery import Task
 
 from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
@@ -21,13 +24,13 @@ from app.worker.celery_app import celery_app
     rate_limit="5/m",
 )
 def export_articles_task(
-    self,
+    self: Task[Any, Any],
     project_id: str,
     article_ids: list[str],
     formats: list[str],
     file_scope: str,
     user_id: str,
-) -> dict:
+) -> dict[str, Any]:
     """Export a set of articles in the background.
 
     Builds a ZIP with metadata (CSV/RIS/RDF) and optionally the article
@@ -44,7 +47,7 @@ def export_articles_task(
         Dict with download_url, expires_at, skipped_files, user_id.
     """
 
-    async def run() -> dict:
+    async def run() -> dict[str, Any]:
         from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.articles_export_service import ArticlesExportService

--- a/backend/app/worker/tasks/extraction_export_tasks.py
+++ b/backend/app/worker/tasks/extraction_export_tasks.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from uuid import UUID
+
+from celery import Task
 
 from app.core.logging import get_logger
 from app.worker._runner import run_task
@@ -35,7 +38,7 @@ _STORAGE_PREFIX = "exports/extraction"
     rate_limit="5/m",
 )
 def export_extraction_task(
-    self,
+    self: Task[Any, Any],
     project_id: str,
     template_id: str,
     mode: str,
@@ -45,14 +48,14 @@ def export_extraction_task(
     reviewer_id: str | None = None,
     include_ai_metadata: bool = False,
     anonymize_reviewer_names: bool = False,
-) -> dict:
+) -> dict[str, Any]:
     """Async extraction export job.
 
     Builds the workbook via ``ExtractionExportService``, uploads bytes
     to Supabase Storage, returns ``{download_url, expires_at, user_id}``.
     """
 
-    async def run() -> dict:
+    async def run() -> dict[str, Any]:
         # Lazy imports + lazy client construction.
         from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter

--- a/backend/app/worker/tasks/extraction_tasks.py
+++ b/backend/app/worker/tasks/extraction_tasks.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
+from celery import Task
+
 from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
 
@@ -23,7 +25,7 @@ from app.worker.celery_app import celery_app
     rate_limit="5/m",
 )
 def extract_section_task(
-    self,
+    self: Task[Any, Any],
     project_id: str,
     article_id: str,
     template_id: str,
@@ -49,7 +51,7 @@ def extract_section_task(
         Dict with the extraction result summary.
     """
 
-    async def run():
+    async def run() -> dict[str, Any]:
         from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.api_key_service import APIKeyService
@@ -108,7 +110,7 @@ def extract_section_task(
     rate_limit="5/m",
 )
 def extract_models_task(
-    self,
+    self: Task[Any, Any],
     project_id: str,
     article_id: str,
     template_id: str,
@@ -129,7 +131,7 @@ def extract_models_task(
         Dict with the extracted models summary.
     """
 
-    async def run():
+    async def run() -> dict[str, Any]:
         from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.api_key_service import APIKeyService
@@ -204,7 +206,7 @@ def extract_models_task(
     rate_limit="1/m",
 )
 def batch_extract_task(
-    self,  # noqa: ARG001
+    self: Task[Any, Any],  # noqa: ARG001
     project_id: str,
     article_ids: list[str],
     template_id: str,

--- a/backend/app/worker/tasks/import_tasks.py
+++ b/backend/app/worker/tasks/import_tasks.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
+from celery import Task
+
 from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
 
@@ -23,7 +25,7 @@ from app.worker.celery_app import celery_app
     rate_limit="2/m",
 )
 def import_zotero_collection_task(
-    self,
+    self: Task[Any, Any],
     project_id: str,
     collection_key: str,
     user_id: str,
@@ -47,7 +49,7 @@ def import_zotero_collection_task(
         Dict with the import result summary.
     """
 
-    async def run():
+    async def run() -> dict[str, Any]:
         from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.zotero_import_service import ZoteroImportService
@@ -114,14 +116,14 @@ def import_zotero_collection_task(
     rate_limit="2/m",
 )
 def retry_failed_zotero_sync_task(
-    self,
+    self: Task[Any, Any],
     project_id: str,
     source_sync_run_id: str,
     user_id: str,
     sync_run_id: str,
     limit: int = 100,
 ) -> dict[str, Any]:
-    async def run():
+    async def run() -> dict[str, Any]:
         from app.core.deps import get_supabase_client
         from app.core.factories import create_storage_adapter
         from app.services.zotero_import_service import ZoteroImportService
@@ -169,8 +171,8 @@ def retry_failed_zotero_sync_task(
     rate_limit="1/m",
 )
 def sync_zotero_library_task(
-    self,
-    user_id: str,
+    self: Task[Any, Any],
+    user_id: str,  # noqa: ARG001
 ) -> dict[str, Any]:
     """Sync the user's full Zotero library metadata.
 
@@ -181,7 +183,7 @@ def sync_zotero_library_task(
         Dict with the sync result summary.
     """
 
-    async def run():
+    async def run() -> dict[str, Any]:
         from app.services.zotero_service import ZoteroService
         from app.worker._session import worker_session
 


### PR DESCRIPTION
## Summary

> Re-opens [#147](https://github.com/raphaelfh/prumo/pull/147), which was auto-closed when its stacked base (wave-2) was deleted after merge of #148. Rebased onto `dev`; commit unchanged.

Onda 2.2: **42 mypy --strict errors eliminated** via two mechanical sweeps across 21 files.

## Sweep 1 — \`type-arg\` codemod (~25 errors)

Bare \`dict\` / \`list\` parameterized as \`dict[str, Any]\` / \`list[Any]\` across services, repositories, endpoints, and worker tasks. Extends the same discipline wave 1 applied to \`models/\` so \`Mapped[dict[str, Any]]\` is consistent end-to-end.

**Files touched**: repositories (\`extraction_published_state\`, \`project\`, \`article\`, \`article_author\`), services (\`template_clone\`, \`extraction_review\`, \`extraction_proposal\`, \`extraction_consensus\`, \`articles_export\`, \`zotero_import\`, \`section_extraction\`), endpoints (\`hitl_configs\`, \`extraction_export\`), worker tasks (\`extraction_export_tasks\`, \`export_tasks\`).

## Sweep 2 — \`no-untyped-def\` annotations (~17 errors)

### Worker layer
- **\`app/worker/celery_app.py\`**: \`LoggedTask.on_failure / on_success / on_retry\` signatures now match the [celery-types](https://pypi.org/project/celery-types/) Task hooks (\`exc: Exception, task_id: str, args: tuple[Any, ...], kwargs: dict[str, Any], _einfo: Any\`). The \`task_unknown\` signal handler annotates \`sender / message / **kwargs\`.
- **\`app/worker/tasks/*.py\`**: every \`@celery_app.task\` function gets \`self: Task[Any, Any]\` (the 2-param Generic from \`celery-types\`) and inner \`async def run()\` helpers get \`-> dict[str, Any]\`.

### Service / repository / endpoint layer
- \`pdf_processor.py\`: \`PDFProcessor.__init__ -> None\`.
- \`articles_export_service.py\`: \`db: AsyncSession\`.
- \`unit_of_work.py\`: \`__aexit__\` params typed (\`type[BaseException] | None / BaseException | None / TracebackType | None\`).
- \`extraction_runs.py\`: \`_load_run_and_check_member\`'s \`db\` typed.

## Architectural notes

- \`Task\` from \`celery-types\` is generic in \`[P, R]\` (ParamSpec + return type). \`Task[Any, Any]\` is the pragmatic anonymous form; concrete tasks could narrow to \`Task[..., dict[str, Any]]\` in future PRs if precise typing is wanted.
- Pre-existing bugs surfaced now that parent \`no-untyped-def\` errors are gone are **deliberately out of scope** for this PR:
  - \`trace_id: str | None\` passed where \`str\` expected (worker tasks)
  - \`batch_extract_task\` \`results\` dict mistyped as \`dict[str, object]\`
  - \`StorageAdapter.get_signed_url\` missing (real method-rename drift in \`extraction_export_tasks.py:100\`)
  - \`job_id: str | None\` passed where \`str\` expected (\`export_tasks.py:70\`)

  These need per-service fixes; bundling them into a "typing PR" would muddy the review.

## Test plan

- [x] \`uv run mypy app\` — 176 → 134 errors
- [x] \`uv run ruff check app\` — clean
- [x] \`uv run pytest tests/unit -x -q\` — 604 passed
- [x] Zero new \`# type: ignore\` comments
- [x] No runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)