### PR TITLE
ci(automation): label-triggered cleanup + bug-fix workflows

### DIFF
--- a/.github/workflows/bug-watch-write.yml
+++ b/.github/workflows/bug-watch-write.yml
@@ -1,0 +1,123 @@
+name: Bug Watch Write Mode
+
+# Event-driven auto-fix. Triggered when a human applies the `auto-fix-approved` label to an
+# `auto-found` issue. The issue already contains the hypothesis and file:line from bug-watch —
+# this workflow applies the minimal correction + regression test and opens a draft PR.
+#
+# Requirements:
+#   - Repo secret ANTHROPIC_API_KEY must be set
+#   - Label `auto-fix-approved` exists
+#   - The issue must already have label `auto-found` (defense in depth — refuses otherwise)
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: bug-watch-write-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  fix:
+    if: >-
+      github.event.label.name == 'auto-fix-approved'
+      && contains(github.event.issue.labels.*.name, 'auto-found')
+    runs-on: ubuntu-latest
+    timeout-minutes: 18
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup git author
+        run: |
+          git config user.name "claude-autofix[bot]"
+          git config user.email "claude-autofix@users.noreply.github.com"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Apply minimal fix with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-6
+          timeout_minutes: "15"
+          allowed_tools: "Bash(gh:*),Bash(git:*),Bash(make:*),Bash(npm:*),Bash(npx:*),Bash(python:*),Bash(uv:*),Bash(pytest:*),Bash(grep:*),Bash(rg:*),Bash(jq:*),Read,Write,Edit,Grep,Glob,Skill"
+          prompt: |
+            You are applying an authorized fix to an `auto-found` issue. The hypothesis, file:line,
+            and verification command are ALREADY in the issue body — your job is the minimum correction.
+
+            Issue: #${{ github.event.issue.number }}
+            Title: ${{ toJSON(github.event.issue.title) }}
+
+            ## Procedure
+
+            1. Read issue body: `gh issue view ${{ github.event.issue.number }} --json title,body,labels`
+            2. Parse from the body:
+               - The H2 `## File & Lines` section → primary file:line target
+               - The H2 `## Verification` section → reproduction / verification command
+               - The H2 `## Severity` section → only act if `high` or `med`. If `low` (lint/type only): comment "This `auto-fix-approved` request targets a low-severity finding — humans usually handle these inline. Aborting auto-fix to keep the queue focused on high-impact issues." Remove the label. Stop.
+            3. Read the cited file:line. Confirm the symptom still exists at HEAD. If not (already fixed): comment "Symptom no longer reproducible at HEAD ${SHORT_SHA}. Closing the issue." then `gh issue close ${{ github.event.issue.number }} --reason completed`. Stop.
+
+            4. Invoke skills (Layer A — in repo `.claude/skills/`):
+               - `systematic-debugging` — confirm the hypothesis maps to the symptom
+               - `root-cause-tracing` — make sure you fix the root cause, not the surface
+               - `defense-in-depth` if it is auth/BOLA/RLS
+               - `verification-before-completion` BEFORE pushing
+               If a skill fails to load, proceed with the explicit logic above (defense in depth fallback).
+
+            5. Apply the MINIMAL correction:
+               - Modify the cited file:line (and only adjacent helpers if strictly needed)
+               - Add ONE regression test that:
+                 (a) reproduces the bug on HEAD WITHOUT the fix (verify with `git stash`)
+                 (b) passes WITH the fix
+               - Do NOT broaden the change to "improve" unrelated code. No `while I'm here`.
+               - FORBIDDEN paths: backend/alembic/versions/ (require a separate migration PR), supabase/migrations/, .env*, lockfiles, .github/workflows/
+
+            6. Verify locally:
+               ```bash
+               # Backend if Python file touched:
+               cd backend && make lint-backend && make test-backend && cd ..
+               # Frontend if TS/TSX touched:
+               cd frontend && npm test && npm run lint && cd ..
+               ```
+               On ANY failure: comment `Tests failed after applying the fix — aborting. See logs.` Remove `auto-fix-approved` label. Stop.
+
+            7. Open draft PR:
+               ```bash
+               git checkout -b autofix/issue-${{ github.event.issue.number }}
+               git add -A
+               git commit -m "fix: <one-line summary>  (closes #${{ github.event.issue.number }})"
+               git push -u origin HEAD
+               gh pr create --draft --base dev \
+                 --title "fix: <one-line summary>" \
+                 --body "Closes #${{ github.event.issue.number }}.\n\n## Root cause\n<from skill output>\n\n## Fix\n<bullets>\n\n## Regression test added\n<file:line + test name>\n\n## Verification\n<paste pytest/vitest output>"
+               ```
+            8. Comment on the issue with the PR URL.
+
+            ## Hard rules
+            - One PR per issue. If the issue was already fixed: close it instead.
+            - Never broaden scope beyond the cited file:line + one regression test.
+            - Severity `low` does NOT get auto-fixed.
+            - Tests must pass before push.
+            - Stay under 15 minutes.
+
+            ## Output
+            Last line MUST be:
+            `bug_watch_write_done issue=#${{ github.event.issue.number }} severity=<high|med|low|n-a> action=<pr-opened|closed-already-fixed|skip|aborted> pr=<#N|none>`

--- a/.github/workflows/cleanup-on-demand.yml
+++ b/.github/workflows/cleanup-on-demand.yml
@@ -1,0 +1,120 @@
+name: Cleanup On Demand
+
+# Event-driven cleanup. Triggered when a human applies the `tech-debt` label to an issue.
+# Reads the issue body to scope the cleanup (module: <path>), then delegates to the
+# code-simplifier plugin via claude-code-action.
+#
+# Requirements:
+#   - Repo secret ANTHROPIC_API_KEY must be set
+#   - Label `tech-debt` exists (created during plan execution)
+# Skip rules: only fires when the label being added is exactly `tech-debt`.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: cleanup-on-demand-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    if: github.event.label.name == 'tech-debt'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup git author
+        run: |
+          git config user.name "claude-cleanup[bot]"
+          git config user.email "claude-cleanup@users.noreply.github.com"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cleanup with Claude (code-simplifier plugin)
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-6
+          timeout_minutes: "12"
+          plugin_marketplaces: '["anthropics/claude-plugins-official"]'
+          plugins: '["code-simplifier"]'
+          allowed_tools: "Bash(gh:*),Bash(git:*),Bash(make:*),Bash(npm:*),Bash(npx:*),Bash(python:*),Bash(uv:*),Bash(grep:*),Bash(rg:*),Bash(jq:*),Bash(ls:*),Bash(cat:*),Read,Write,Edit,Grep,Glob,Skill"
+          prompt: |
+            You are handling a `tech-debt`-labeled issue on prumo. Apply scoped cleanup per the issue body.
+
+            Issue: #${{ github.event.issue.number }}
+            Title: ${{ toJSON(github.event.issue.title) }}
+
+            ## Procedure
+
+            1. Read issue: `gh issue view ${{ github.event.issue.number }} --json title,body,labels`
+            2. Extract MODULE path from issue body. Conventions accepted (in order):
+                - Line matching `module:\s*(\S+)`
+                - Line matching `path:\s*(\S+)`
+                - First markdown code-fence containing a path under backend/ or frontend/
+                If no module can be extracted: comment "Cannot extract a `module:` path from this issue body. Please add a line like `module: backend/app/services/foo` and re-apply the label." Then remove the `tech-debt` label and stop.
+
+            3. Anti-conflict gate (MANDATORY):
+               ```bash
+               OPEN_PRS=$(gh pr list -R raphaelfh/prumo --state open --json files \
+                 | jq "[.[] | select(.files != null) | select(.files[].path | startswith(\"$MODULE\"))] | length")
+               ```
+               If $OPEN_PRS > 0: comment on issue `Blocked by N open PR(s) touching $MODULE — try again once they merge.` and stop.
+
+            4. Invoke skill `code-simplifier:code-simplifier` (Layer B) with scope=$MODULE. Constraints:
+               - net LOC delta ≤ 200
+               - files touched ≤ 15
+               - FORBIDDEN paths: backend/alembic/versions/, supabase/migrations/, .env*, .github/workflows/, package.json, package-lock.json, pyproject.toml, uv.lock
+               - FORBIDDEN changes: API contract, SQLAlchemy model field renames, public symbol renames, new abstractions, "while I'm here"
+               - ALLOWED (max 2 categories): dead-code removal (grep proof, 0 callers), unused imports/vars (lint-driven), `ruff format`/`prettier`, consolidate 2 near-identical helpers ≤30 LOC each
+
+            5. Verify locally BEFORE pushing:
+               ```bash
+               cd backend && make lint-backend && make test-backend && cd ..
+               # if frontend touched:
+               cd frontend && npm test && npm run lint && cd ..
+               ```
+               On ANY failure: comment `Tests/lint failed — aborting. See logs.` and stop without pushing.
+
+            6. Push branch + open draft PR:
+               ```bash
+               git checkout -b cleanup/$(basename $MODULE)-issue-${{ github.event.issue.number }}
+               git add -A
+               git commit -m "cleanup($(basename $MODULE)): <summary>  (refs #${{ github.event.issue.number }})"
+               git push -u origin HEAD
+               gh pr create --draft --base dev \
+                 --title "cleanup($(basename $MODULE)): <summary>" \
+                 --body "Closes #${{ github.event.issue.number }} on review/merge.\n\n## What\n<bullets>\n\n## Evidence\n<grep + tests + lint>"
+               ```
+
+            7. Comment on the issue with the PR URL.
+
+            ## Hard rules
+            - One PR per issue. If you opened one, comment it back and stop.
+            - Never bypass the anti-conflict gate.
+            - Never touch forbidden paths.
+            - Stay under 12 minutes; comment progress + abort if you near the limit.
+
+            ## Output
+            Last line MUST be:
+            `cleanup_on_demand_done issue=#${{ github.event.issue.number }} module=<path|none> action=<pr-opened|skip|aborted> pr=<#N|none>`


### PR DESCRIPTION
## Summary

Two new event-driven GitHub Actions, companions to the routine portfolio reorganization (see [plan](/Users/raphael/.claude/plans/system-reminder-the-git-worktree-hashed-tide.md)):

- **`cleanup-on-demand.yml`** — fires on `issues:labeled` filtering `tech-debt`. Reads the issue body for `module: <path>`, runs the anti-conflict gate (skip if open PR touches it), then delegates to the `code-simplifier` plugin via `plugin_marketplaces` + `plugins` inputs. Same hard limits as the new `weekly-cleanup-sweep` routine (≤200 LOC, ≤15 files, draft PR only).

- **`bug-watch-write.yml`** — fires on `issues:labeled` filtering `auto-fix-approved`, AND requires the issue to also have `auto-found` (defense in depth). Parses `## File & Lines` + `## Verification` + `## Severity` from the bug-watch issue body, refuses severity `low`, applies the minimal correction + ONE regression test, opens a draft PR.

## Context

These complement 3 actions already done in the routine layer (visible via [claude.ai/code/routines](https://claude.ai/code/routines)):
- Created routines `bug-watch` (weekly Sat 06:00 UTC, replaces 2 daily bug-finders) and `weekly-cleanup-sweep` (Tuesday 09:00 UTC, replaces daily-cleanup-pass)
- Disabled `Daily Deep Bug Finder` and `daily-bug-hunt` (consolidated into `bug-watch`)
- Updated `prod-health-pulse` (removed unused `Skill` from allowed_tools) and `dep-vuln-sweep`/`weekly-cleanup-sweep` (clear_mcp_connections)
- Created labels `tech-debt` (#c5def5) and `auto-fix-approved` (#0e8a16)

The PR #150 `issue-triage.yml` is the third event-driven workflow (still open, blocked on unrelated CI red).

## Required before merge

- [ ] Repo secret `ANTHROPIC_API_KEY` must be set: `gh secret set ANTHROPIC_API_KEY -R raphaelfh/prumo` (same secret as #150)
- [x] Labels `tech-debt` + `auto-fix-approved` exist
- [x] New routines `bug-watch` + `weekly-cleanup-sweep` created and enabled

## Test plan

After merge + secret configured:

- [ ] **cleanup-on-demand.yml**: open test issue with body `module: backend/app/utils/datetime` + apply `tech-debt` label. Expected: workflow fires within ~30s, anti-conflict gate runs, either opens draft PR or comments "Blocked by N PR(s)".
- [ ] **bug-watch-write.yml**: pick an existing `auto-found` issue (or wait for next `bug-watch` Saturday run) and apply `auto-fix-approved`. Expected: workflow fires, parses body, opens draft PR with regression test, comments on issue.
- [ ] Severity gating: apply `auto-fix-approved` to a low-severity `auto-found` issue. Expected: workflow refuses with explanatory comment.
- [ ] Verify `plugin_marketplaces` input works: check workflow logs for the `code-simplifier` plugin install line before the action runs.
- [ ] If the `@v1` action ref fails: change to `@beta`.

## Open items (post-merge, documented in plan §13)

- `enabled_plugins` field in the routine API silently accepted `["claude-plugins-official"]` but stored `[]` — sintaxe correta a confirmar empiricamente quando `weekly-cleanup-sweep` rodar pela primeira vez (terça). Possíveis formatos a testar: `["code-simplifier@claude-plugins-official"]`, `[{"plugin": "code-simplifier", "marketplace": "claude-plugins-official"}]`. Camada C (fallback inline) está presente no prompt da routine como salvaguarda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)