### PR TITLE
ci(automation): routine-dispatch workflows (zero API consumption)

### DIFF
--- a/.github/workflows/bug-watch-write-dispatch.yml
+++ b/.github/workflows/bug-watch-write-dispatch.yml
@@ -1,0 +1,53 @@
+name: Bug Watch Write Dispatch
+
+# Thin dispatcher: on issues:labeled with `auto-fix-approved` AND issue already `auto-found`,
+# fire the `bug-watch-write` routine.
+# No Anthropic API consumption — the routine runs on Pro/Max plan quota.
+#
+# Setup (one-time, by repo owner):
+#   1. https://claude.ai/code/routines → edit `bug-watch-write (API-triggered via GH Action, label auto-fix-approved)`
+#   2. Add an API trigger → generate token → copy
+#   3. `gh secret set CLAUDE_ROUTINE_BUGFIX_TOKEN -R raphaelfh/prumo`
+#
+# Routine ID: trig_0157uwfRoXA6RTFvWqg8VKPd
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: none
+
+concurrency:
+  group: bugfix-dispatch-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: >-
+      github.event.label.name == 'auto-fix-approved'
+      && contains(github.event.issue.labels.*.name, 'auto-found')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Fire bug-watch-write routine
+        env:
+          ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_BUGFIX_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$ROUTINE_TOKEN" ]; then
+            echo "::error::Missing secret CLAUDE_ROUTINE_BUGFIX_TOKEN. See workflow header for setup." >&2
+            exit 1
+          fi
+          curl -fsSL --max-time 30 -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/trig_0157uwfRoXA6RTFvWqg8VKPd/fire" \
+            -H "Authorization: Bearer $ROUTINE_TOKEN" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg t "issue:${ISSUE_NUMBER} repo:${REPO}" '{text:$t}')" \
+            | tee /tmp/routine_response.json
+          echo "Routine fired. Session URL:"
+          jq -r '.claude_code_session_url // "(no URL in response)"' /tmp/routine_response.json

--- a/.github/workflows/cleanup-on-demand-dispatch.yml
+++ b/.github/workflows/cleanup-on-demand-dispatch.yml
@@ -1,0 +1,50 @@
+name: Cleanup On Demand Dispatch
+
+# Thin dispatcher: on issues:labeled with `tech-debt`, fire the `cleanup-on-demand` routine.
+# No Anthropic API consumption — the routine runs on Pro/Max plan quota.
+#
+# Setup (one-time, by repo owner):
+#   1. https://claude.ai/code/routines → edit `cleanup-on-demand (API-triggered via GH Action, label tech-debt)`
+#   2. Add an API trigger → generate token → copy
+#   3. `gh secret set CLAUDE_ROUTINE_CLEANUP_TOKEN -R raphaelfh/prumo`
+#
+# Routine ID: trig_01Jt9AvtB4aN8YXMkVd4jqW1
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: none
+
+concurrency:
+  group: cleanup-dispatch-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: github.event.label.name == 'tech-debt'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Fire cleanup-on-demand routine
+        env:
+          ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_CLEANUP_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$ROUTINE_TOKEN" ]; then
+            echo "::error::Missing secret CLAUDE_ROUTINE_CLEANUP_TOKEN. See workflow header for setup." >&2
+            exit 1
+          fi
+          curl -fsSL --max-time 30 -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/trig_01Jt9AvtB4aN8YXMkVd4jqW1/fire" \
+            -H "Authorization: Bearer $ROUTINE_TOKEN" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg t "issue:${ISSUE_NUMBER} repo:${REPO}" '{text:$t}')" \
+            | tee /tmp/routine_response.json
+          echo "Routine fired. Session URL:"
+          jq -r '.claude_code_session_url // "(no URL in response)"' /tmp/routine_response.json

--- a/.github/workflows/issue-triage-dispatch.yml
+++ b/.github/workflows/issue-triage-dispatch.yml
@@ -1,0 +1,53 @@
+name: Issue Triage Dispatch
+
+# Thin dispatcher: on issues:opened/reopened, fire the `issue-triage` routine.
+# No Anthropic API consumption — the routine runs on Pro/Max plan quota.
+#
+# Setup (one-time, by repo owner):
+#   1. https://claude.ai/code/routines → edit `issue-triage (API-triggered via GH Action)`
+#   2. Add an API trigger → generate token → copy
+#   3. `gh secret set CLAUDE_ROUTINE_TRIAGE_TOKEN -R raphaelfh/prumo`
+#
+# Routine ID: trig_01AjKuPTrn75HGZVnepoHTH2
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: none
+
+concurrency:
+  group: triage-dispatch-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: >-
+      github.event.issue.user.type != 'Bot'
+      && !contains(github.event.issue.labels.*.name, 'triaged')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Fire issue-triage routine
+        env:
+          ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_TRIAGE_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ACTION: ${{ github.event.action }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$ROUTINE_TOKEN" ]; then
+            echo "::error::Missing secret CLAUDE_ROUTINE_TRIAGE_TOKEN. See workflow header for setup." >&2
+            exit 1
+          fi
+          curl -fsSL --max-time 30 -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/trig_01AjKuPTrn75HGZVnepoHTH2/fire" \
+            -H "Authorization: Bearer $ROUTINE_TOKEN" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg t "issue:${ISSUE_NUMBER} action:${ACTION} repo:${REPO}" '{text:$t}')" \
+            | tee /tmp/routine_response.json
+          echo "Routine fired. Session URL:"
+          jq -r '.claude_code_session_url // "(no URL in response)"' /tmp/routine_response.json


### PR DESCRIPTION
## Summary

Replaces #150 and #154 — both used `anthropics/claude-code-action` with `ANTHROPIC_API_KEY` (pay-per-token API billing). This PR uses the **correct architecture** for event-driven Claude work on a Pro/Max plan:

```
GitHub webhook (issues:opened / issues:labeled)
        ↓
GH Action (~50 lines, curl-only — NO claude-code-action)
        ↓
POST https://api.anthropic.com/v1/claude_code/routines/<id>/fire
  Authorization: Bearer <OAuth token from claude.ai>
        ↓
Routine runs on Pro/Max plan quota (zero API consumption)
```

3 workflows × 3 routines:

| Workflow file | Trigger | Routine ID | Secret needed |
|---|---|---|---|
| `issue-triage-dispatch.yml` | `issues:opened/reopened` | `trig_01AjKuPTrn75HGZVnepoHTH2` | `CLAUDE_ROUTINE_TRIAGE_TOKEN` |
| `cleanup-on-demand-dispatch.yml` | `issues:labeled` filter `tech-debt` | `trig_01Jt9AvtB4aN8YXMkVd4jqW1` | `CLAUDE_ROUTINE_CLEANUP_TOKEN` |
| `bug-watch-write-dispatch.yml` | `issues:labeled` filter `auto-fix-approved` AND issue already `auto-found` | `trig_0157uwfRoXA6RTFvWqg8VKPd` | `CLAUDE_ROUTINE_BUGFIX_TOKEN` |

Each workflow has:
- `permissions: contents: none` (workflows themselves don't touch the repo; the routine does, using your GitHub identity)
- 2-minute timeout (dispatch only — actual work is async on the routine)
- Guard rejecting bot-authored issues / missing secrets
- `concurrency: group` to avoid double-firing on rapid label flips

## Required setup (one-time, by you — cannot do via API)

For each of the 3 routines:

1. Open https://claude.ai/code/routines and edit the routine
2. Under **Select a trigger**, click **Add another trigger** → **API**
3. **Generate token** and copy it (shown only once)
4. Set the matching repo secret:
   ```bash
   gh secret set CLAUDE_ROUTINE_TRIAGE_TOKEN  -R raphaelfh/prumo  # paste token
   gh secret set CLAUDE_ROUTINE_CLEANUP_TOKEN -R raphaelfh/prumo
   gh secret set CLAUDE_ROUTINE_BUGFIX_TOKEN  -R raphaelfh/prumo
   ```

Optionally: remove the placeholder `run_once_at: 2099-01-01` from each routine (it was set during creation because the API requires at least one trigger; once the API trigger is added, you can delete the one-off).

## Test plan

After secrets are set + merge:

- [ ] Open a test issue — `issue-triage-dispatch.yml` fires within seconds, look in the **Actions** tab and check the curl response shows a `claude_code_session_url`
- [ ] Open the linked session URL on claude.ai/code — routine ran, posted comment + labels on the issue
- [ ] Apply label `tech-debt` to an issue with body `module: backend/app/utils/datetime` — `cleanup-on-demand-dispatch` fires; routine either opens draft PR or comments "Blocked by N PRs"
- [ ] Pick an existing `auto-found` issue and apply `auto-fix-approved` — `bug-watch-write-dispatch` fires; routine respects severity gate, opens draft PR with regression test
- [ ] Verify zero API consumption in Anthropic Console billing page during the test

## Why this matters

The routines were already created and waiting. The cron-based ones (`bug-watch`, `weekly-cleanup-sweep`, `prod-health-pulse`, `dep-vuln-sweep`, `migration-drift-detector`) never used API — only the event-driven companions were wrong. This PR fixes that without changing any of the cron routines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)