### PR TITLE
test: coverage for citations, article-text-blocks, template-active service + Zotero full-pipeline E2E

### DIFF
--- a/backend/tests/integration/test_article_text_blocks_endpoint.py
+++ b/backend/tests/integration/test_article_text_blocks_endpoint.py
@@ -285,7 +285,9 @@ async def test_list_text_blocks_returns_404_for_unknown_file(
     res = await db_client.get(f"/api/v1/article-files/{unknown_id}/text-blocks")
 
     assert res.status_code == 404, res.text
-    assert str(unknown_id) in res.json()["detail"]
+    body = res.json()
+    assert body["ok"] is False
+    assert str(unknown_id) in body["error"]["message"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_article_text_blocks_endpoint.py
+++ b/backend/tests/integration/test_article_text_blocks_endpoint.py
@@ -1,0 +1,307 @@
+"""API contract tests for `GET /api/v1/article-files/{file_id}/text-blocks`.
+
+The endpoint feeds the PDF viewer's typography reader view; population
+of `article_text_blocks` is Phase 6 of the ingestion pipeline. Until
+now there was no integration test asserting:
+- the empty list returned for an unprocessed file
+- the `(page_number, block_index)` ordering contract the viewer relies on
+- the camelCase wire shape
+- 404 for unknown files / 403 for non-members
+
+`article_files` rows are not part of the integration seed, so each test
+inserts its own and cleans up via the SAVEPOINT-isolated `db_session`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from tests.integration.conftest import SEED
+
+
+@pytest_asyncio.fixture
+async def auth_as_primary_member(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Override `get_current_user` so JWT sub matches a real seed profile."""
+    del db_session
+    profile_id = SEED.primary_profile
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="primary@integration-test.prumo.local",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield profile_id
+
+
+@pytest_asyncio.fixture
+async def auth_as_outsider(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Authenticated user with no project memberships."""
+    outsider_id = uuid.uuid4()
+    email = f"outsider-{outsider_id}@text-blocks-test.local"
+
+    await db_session.execute(
+        text(
+            "INSERT INTO auth.users (id, email, instance_id, aud, role) "
+            "VALUES (:id, :email, '00000000-0000-0000-0000-000000000000', "
+            "'authenticated', 'authenticated')"
+        ),
+        {"id": str(outsider_id), "email": email},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO public.profiles (id, email, full_name) "
+            "VALUES (:id, :email, 'Text Blocks Outsider') "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": str(outsider_id), "email": email},
+    )
+    await db_session.commit()
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(outsider_id),
+            email=email,
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield outsider_id
+    finally:
+        await db_session.execute(
+            text("DELETE FROM public.profiles WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.execute(
+            text("DELETE FROM auth.users WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.commit()
+
+
+async def _insert_article_file(
+    db: AsyncSession,
+    *,
+    project_id: UUID,
+    article_id: UUID,
+) -> UUID:
+    file_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": str(file_id),
+            "pid": str(project_id),
+            "aid": str(article_id),
+            "key": f"test/{file_id}.pdf",
+        },
+    )
+    await db.commit()
+    return file_id
+
+
+async def _insert_text_block(
+    db: AsyncSession,
+    *,
+    article_file_id: UUID,
+    page_number: int,
+    block_index: int,
+    text_content: str,
+    char_start: int = 0,
+    char_end: int = 0,
+    block_type: str = "paragraph",
+) -> UUID:
+    block_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.article_text_blocks "
+            "(id, article_file_id, page_number, block_index, text, "
+            " char_start, char_end, bbox, block_type) "
+            "VALUES (:id, :fid, :page, :idx, :txt, :cs, :ce, "
+            ' \'{"x": 0, "y": 0, "width": 100, "height": 20}\'::jsonb, :bt)'
+        ),
+        {
+            "id": str(block_id),
+            "fid": str(article_file_id),
+            "page": page_number,
+            "idx": block_index,
+            "txt": text_content,
+            "cs": char_start,
+            "ce": char_end,
+            "bt": block_type,
+        },
+    )
+    return block_id
+
+
+@pytest.mark.asyncio
+async def test_list_text_blocks_returns_empty_for_unprocessed_file(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_primary_member: UUID,
+) -> None:
+    """Unprocessed (no rows in `article_text_blocks`) returns []."""
+    del auth_as_primary_member
+    file_id = await _insert_article_file(
+        db_session,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+
+    res = await db_client.get(f"/api/v1/article-files/{file_id}/text-blocks")
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_text_blocks_returns_blocks_in_reading_order(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_primary_member: UUID,
+) -> None:
+    """Rows are ordered by (page_number asc, block_index asc).
+
+    Insert deliberately out of order to ensure the ORDER BY clause —
+    not insertion order — drives the response.
+    """
+    del auth_as_primary_member
+    file_id = await _insert_article_file(
+        db_session,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    await _insert_text_block(
+        db_session,
+        article_file_id=file_id,
+        page_number=2,
+        block_index=0,
+        text_content="page2-block0",
+    )
+    await _insert_text_block(
+        db_session,
+        article_file_id=file_id,
+        page_number=1,
+        block_index=1,
+        text_content="page1-block1",
+    )
+    await _insert_text_block(
+        db_session,
+        article_file_id=file_id,
+        page_number=1,
+        block_index=0,
+        text_content="page1-block0",
+    )
+    await db_session.commit()
+
+    res = await db_client.get(f"/api/v1/article-files/{file_id}/text-blocks")
+
+    assert res.status_code == 200, res.text
+    blocks = res.json()["data"]
+    assert [b["text"] for b in blocks] == [
+        "page1-block0",
+        "page1-block1",
+        "page2-block0",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_text_blocks_uses_camelcase_wire_shape(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_primary_member: UUID,
+) -> None:
+    """Response keys match the PDF viewer's runtime types (camelCase)."""
+    del auth_as_primary_member
+    file_id = await _insert_article_file(
+        db_session,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    await _insert_text_block(
+        db_session,
+        article_file_id=file_id,
+        page_number=1,
+        block_index=0,
+        text_content="hello",
+        char_start=0,
+        char_end=5,
+    )
+    await db_session.commit()
+
+    res = await db_client.get(f"/api/v1/article-files/{file_id}/text-blocks")
+
+    block = res.json()["data"][0]
+    assert set(block.keys()) == {
+        "id",
+        "pageNumber",
+        "blockIndex",
+        "text",
+        "charStart",
+        "charEnd",
+        "bbox",
+        "blockType",
+    }
+    assert block["pageNumber"] == 1
+    assert block["blockIndex"] == 0
+    assert block["charStart"] == 0
+    assert block["charEnd"] == 5
+    assert block["blockType"] == "paragraph"
+    assert block["bbox"] == {"x": 0, "y": 0, "width": 100, "height": 20}
+
+
+@pytest.mark.asyncio
+async def test_list_text_blocks_returns_404_for_unknown_file(
+    db_client: AsyncClient,
+    auth_as_primary_member: UUID,
+) -> None:
+    del auth_as_primary_member
+    unknown_id = uuid.uuid4()
+
+    res = await db_client.get(f"/api/v1/article-files/{unknown_id}/text-blocks")
+
+    assert res.status_code == 404, res.text
+    assert str(unknown_id) in res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_list_text_blocks_returns_403_for_non_project_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_outsider: UUID,
+) -> None:
+    """Non-members get 403 even when the file id is valid."""
+    del auth_as_outsider
+    file_id = await _insert_article_file(
+        db_session,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+
+    res = await db_client.get(f"/api/v1/article-files/{file_id}/text-blocks")
+
+    assert res.status_code == 403, res.text

--- a/backend/tests/integration/test_citations_endpoint.py
+++ b/backend/tests/integration/test_citations_endpoint.py
@@ -1,0 +1,149 @@
+"""API contract tests for `GET /api/v1/articles/{article_id}/citations`.
+
+The endpoint surfaces `extraction_evidence` rows with their JSONB
+`position` validated against `PositionV1` so the PDF viewer can render
+them without a translation layer. Before these tests it had zero
+integration coverage — the read service and endpoint were exercised
+only transitively by frontend code, with no gate on the membership
+check or the article-not-found path.
+
+Scoped to the failure surfaces that matter:
+- 200 + [] for an article with no evidence (the legacy empty-`{}`
+  filter is exercised elsewhere; here we lock the "no rows" path)
+- 404 for an unknown article id
+- 403 for an authenticated user who is not a project member
+
+Auth pattern mirrors `test_extraction_runs_endpoints.py`: the `db_client`
+fixture from the root conftest overrides `get_current_user` with a
+stub `sub='test-user-id'` that has no profile FK, so we re-override
+inside the test to point at a real seed profile.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from tests.integration.conftest import SEED
+
+
+@pytest_asyncio.fixture
+async def auth_as_primary_member(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Override `get_current_user` so JWT sub matches a real seed profile."""
+    del db_session  # fixture-ordering dependency only
+    profile_id = SEED.primary_profile
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="primary@integration-test.prumo.local",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield profile_id
+
+
+@pytest_asyncio.fixture
+async def auth_as_outsider(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Authenticated user with no project memberships."""
+    outsider_id = uuid.uuid4()
+    email = f"outsider-{outsider_id}@citations-test.local"
+
+    await db_session.execute(
+        text(
+            "INSERT INTO auth.users (id, email, instance_id, aud, role) "
+            "VALUES (:id, :email, '00000000-0000-0000-0000-000000000000', "
+            "'authenticated', 'authenticated')"
+        ),
+        {"id": str(outsider_id), "email": email},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO public.profiles (id, email, full_name) "
+            "VALUES (:id, :email, 'Citations Outsider') "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": str(outsider_id), "email": email},
+    )
+    await db_session.commit()
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(outsider_id),
+            email=email,
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield outsider_id
+    finally:
+        await db_session.execute(
+            text("DELETE FROM public.profiles WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.execute(
+            text("DELETE FROM auth.users WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_list_citations_returns_empty_for_article_without_evidence(
+    db_client: AsyncClient,
+    auth_as_primary_member: UUID,
+) -> None:
+    """An article with zero ExtractionEvidence rows resolves to an empty list."""
+    del auth_as_primary_member
+
+    res = await db_client.get(f"/api/v1/articles/{SEED.primary_article}/citations")
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is True
+    assert body["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_citations_returns_404_for_unknown_article(
+    db_client: AsyncClient,
+    auth_as_primary_member: UUID,
+) -> None:
+    """Unknown article id surfaces `ArticleNotFoundError` as a 404."""
+    del auth_as_primary_member
+    unknown_id = uuid.uuid4()
+
+    res = await db_client.get(f"/api/v1/articles/{unknown_id}/citations")
+
+    assert res.status_code == 404, res.text
+    assert str(unknown_id) in res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_list_citations_returns_403_for_non_project_member(
+    db_client: AsyncClient,
+    auth_as_outsider: UUID,
+) -> None:
+    """Non-members cannot list citations for a project's article."""
+    del auth_as_outsider
+
+    res = await db_client.get(f"/api/v1/articles/{SEED.primary_article}/citations")
+
+    assert res.status_code == 403, res.text

--- a/backend/tests/integration/test_citations_endpoint.py
+++ b/backend/tests/integration/test_citations_endpoint.py
@@ -133,7 +133,9 @@ async def test_list_citations_returns_404_for_unknown_article(
     res = await db_client.get(f"/api/v1/articles/{unknown_id}/citations")
 
     assert res.status_code == 404, res.text
-    assert str(unknown_id) in res.json()["detail"]
+    body = res.json()
+    assert body["ok"] is False
+    assert str(unknown_id) in body["error"]["message"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_project_template_active_service.py
+++ b/backend/tests/integration/test_project_template_active_service.py
@@ -1,0 +1,199 @@
+"""Unit tests for `project_template_active_service.set_template_active`.
+
+Why this exists
+---------------
+The service owns the single-active-extraction-template invariant: a
+project must always have ≥1 active extraction template, because the
+extraction workflow reads "the" active template at runtime. The same
+invariant is enforced at the DB level by the partial unique index
+`uq_one_active_extraction_template_per_project` (which forbids >1
+active at any moment), so the service is the only place that prevents
+the *lower* bound from being crossed.
+
+Before this file, `set_template_active` had zero direct test coverage —
+it was hit transitively through one router test, so the three branches
+(not-found, cross-project, last-active-guard) had never been
+independently exercised. A bug here is silent: a frontend that
+disables the last active template would leave the project's runs
+unable to resolve a template version, and the failure would surface
+deep inside `TemplateCloneService` / `HitlSessionService` rather than
+at the boundary.
+
+The tests speak directly to the service (no HTTP layer) because the
+invariant is data-shaped, not endpoint-shaped.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.project_template_active_service import (
+    LastActiveExtractionTemplateError,
+    ProjectTemplateNotFoundError,
+    set_template_active,
+)
+from tests.integration.conftest import SEED
+
+
+async def _insert_inactive_extraction_template(
+    db: AsyncSession,
+    *,
+    project_id,
+    created_by,
+) -> uuid.UUID:
+    """Create an additional extraction template (is_active=False).
+
+    The partial unique index `uq_one_active_extraction_template_per_project`
+    forbids two active extraction templates simultaneously, so any
+    "extra" template the test inserts must start inactive. The service
+    can then flip it active.
+    """
+    tpl_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.project_extraction_templates "
+            "(id, project_id, name, description, framework, version, kind, "
+            " schema, is_active, created_by) "
+            "VALUES (:id, :pid, :name, NULL, 'CUSTOM', '1.0', 'extraction', "
+            " '{}'::jsonb, false, :created_by)"
+        ),
+        {
+            "id": str(tpl_id),
+            "pid": str(project_id),
+            "name": f"extra-{tpl_id}",
+            "created_by": str(created_by),
+        },
+    )
+    # Inactive templates still need an active version row to keep the
+    # deferred trigger from migration 0004 from firing on commit if the
+    # template is ever activated. Keeping an inactive template
+    # version-less is fine — the trigger only checks active templates.
+    await db.execute(
+        text(
+            "INSERT INTO public.extraction_template_versions "
+            "(id, project_template_id, version, schema, published_by, is_active) "
+            "VALUES (gen_random_uuid(), :tid, 1, "
+            " '{\"entity_types\": []}'::jsonb, :published_by, true)"
+        ),
+        {
+            "tid": str(tpl_id),
+            "published_by": str(created_by),
+        },
+    )
+    await db.commit()
+    return tpl_id
+
+
+@pytest.mark.asyncio
+async def test_activate_inactive_template_succeeds(
+    db_session: AsyncSession,
+) -> None:
+    """Flipping is_active=False → True on a fresh template works.
+
+    Uses SECONDARY_PROJECT because the seed doesn't put any template
+    there — so there's no `uq_one_active_extraction_template_per_project`
+    collision when we activate this one.
+    """
+    tpl_id = await _insert_inactive_extraction_template(
+        db_session,
+        project_id=SEED.secondary_project,
+        created_by=SEED.primary_profile,
+    )
+
+    response = await set_template_active(
+        db_session,
+        project_id=SEED.secondary_project,
+        template_id=tpl_id,
+        is_active=True,
+    )
+
+    assert response.project_template_id == tpl_id
+    assert response.is_active is True
+
+    # Verify the row actually persisted.
+    db_value = (
+        await db_session.execute(
+            text("SELECT is_active FROM public.project_extraction_templates WHERE id = :id"),
+            {"id": str(tpl_id)},
+        )
+    ).scalar()
+    assert db_value is True
+
+
+@pytest.mark.asyncio
+async def test_set_active_raises_for_unknown_template(
+    db_session: AsyncSession,
+) -> None:
+    """An unknown template_id surfaces as ProjectTemplateNotFoundError."""
+    unknown_id = uuid.uuid4()
+
+    with pytest.raises(ProjectTemplateNotFoundError) as exc:
+        await set_template_active(
+            db_session,
+            project_id=SEED.primary_project,
+            template_id=unknown_id,
+            is_active=True,
+        )
+    assert str(unknown_id) in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_set_active_raises_when_template_belongs_to_other_project(
+    db_session: AsyncSession,
+) -> None:
+    """Cross-project access surfaces as NotFound (BOLA guard).
+
+    The primary template exists, but it doesn't belong to
+    secondary_project — the service must not leak its existence by
+    flipping its flag through a project_id that doesn't own it.
+    """
+    with pytest.raises(ProjectTemplateNotFoundError):
+        await set_template_active(
+            db_session,
+            project_id=SEED.secondary_project,
+            template_id=SEED.primary_template,
+            is_active=False,
+        )
+
+    # Confirm the flag was NOT modified despite the failed call.
+    db_value = (
+        await db_session.execute(
+            text("SELECT is_active FROM public.project_extraction_templates WHERE id = :id"),
+            {"id": str(SEED.primary_template)},
+        )
+    ).scalar()
+    assert db_value is True
+
+
+@pytest.mark.asyncio
+async def test_deactivating_last_active_extraction_template_raises(
+    db_session: AsyncSession,
+) -> None:
+    """Cannot disable the only active extraction template in a project.
+
+    The seed leaves PRIMARY_TEMPLATE as the single active extraction
+    template in PRIMARY_PROJECT. Disabling it would leave the project
+    with zero active extraction templates, which the extraction
+    workflow cannot tolerate.
+    """
+    with pytest.raises(LastActiveExtractionTemplateError) as exc:
+        await set_template_active(
+            db_session,
+            project_id=SEED.primary_project,
+            template_id=SEED.primary_template,
+            is_active=False,
+        )
+    assert "only active extraction template" in str(exc.value)
+
+    # Confirm the template is still active after the failed call.
+    db_value = (
+        await db_session.execute(
+            text("SELECT is_active FROM public.project_extraction_templates WHERE id = :id"),
+            {"id": str(SEED.primary_template)},
+        )
+    ).scalar()
+    assert db_value is True

--- a/frontend/e2e/flows/zotero-full-pipeline.api.e2e.ts
+++ b/frontend/e2e/flows/zotero-full-pipeline.api.e2e.ts
@@ -1,0 +1,167 @@
+import { APIRequestContext, expect, test } from "@playwright/test";
+
+import { authHeaders, parseEnvelope } from "../_fixtures/api";
+import { createTraceId, loadE2EEnv, missingEnvKeys } from "../_fixtures/env";
+
+/**
+ * Zotero **full pipeline** API E2E.
+ *
+ * The existing `zotero.e2e.ts` covers the cheap surfaces (validation 400,
+ * unknown sync-status 404, and the credential save + connection test).
+ * What it does NOT cover — and what this file adds — is the end-to-end
+ * import: save credentials → kick `sync-collection` → poll `sync-status`
+ * until the run reaches a terminal state → assert the counts invariant
+ * and the trace_id propagation.
+ *
+ * This is the path that, when it regresses, silently drops articles on
+ * the floor: the sync request returns 202, the run goes RUNNING, then
+ * an exception swallowed inside the Celery task leaves `counts.failed`
+ * inflated and nobody notices because no surface asserts the
+ * `persisted + updated + skipped + failed + removed_at_source ==
+ * total_received` identity.
+ *
+ * Skips politely when:
+ * - Required env (`E2E_AUTH_TOKEN`, `E2E_PROJECT_ID`,
+ *   `E2E_ZOTERO_USER_ID`, `E2E_ZOTERO_API_KEY`,
+ *   `E2E_ZOTERO_COLLECTION_KEY`) is missing — local dev without Zotero
+ *   credentials, CI without secrets configured.
+ * - The sync-collection POST returns 503 — Redis/Celery isn't available
+ *   to enqueue the task. Same diagnostic the articles-export E2E uses
+ *   so a stack-down state doesn't look like a real failure.
+ * - Polling times out — Celery worker is up but not consuming
+ *   (the queue is wired but the consumer isn't).
+ */
+
+type SyncCounts = {
+  totalReceived: number;
+  persisted: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  removedAtSource: number;
+  reactivated: number;
+};
+
+type SyncStatusBody = {
+  syncRunId: string;
+  status: string;
+  counts: SyncCounts;
+  startedAt: string;
+  completedAt?: string | null;
+  traceId: string;
+};
+
+const INFLIGHT_STATUSES = new Set(["pending", "queued", "running", "in_progress"]);
+const TERMINAL_STATUSES = new Set(["completed", "failed", "partial"]);
+
+async function pollSyncToTerminal(input: {
+  apiUrl: string;
+  token: string;
+  syncRunId: string;
+  request: APIRequestContext;
+}): Promise<SyncStatusBody | { status: "timeout" }> {
+  const maxIters = 20;
+  for (let i = 0; i < maxIters; i += 1) {
+    const res = await input.request.post(`${input.apiUrl}/api/v1/zotero/sync-status`, {
+      headers: authHeaders(input.token, createTraceId(`e2e-zotero-poll-${i}`)),
+      data: { syncRunId: input.syncRunId },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await parseEnvelope<SyncStatusBody>(res);
+    expect(body.ok).toBeTruthy();
+    if (!INFLIGHT_STATUSES.has(body.data.status)) {
+      return body.data;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+  }
+  return { status: "timeout" };
+}
+
+test.describe("Zotero full pipeline (credentials → sync → status)", () => {
+  test("imports a collection end-to-end with consistent counts", async ({ request }) => {
+    const env = loadE2EEnv();
+    const required = missingEnvKeys([
+      "E2E_AUTH_TOKEN",
+      "E2E_PROJECT_ID",
+      "E2E_ZOTERO_USER_ID",
+      "E2E_ZOTERO_API_KEY",
+      "E2E_ZOTERO_COLLECTION_KEY",
+    ]);
+    test.skip(
+      required.length > 0,
+      `Missing required env: ${required.join(", ")}`,
+    );
+
+    // 1. Save credentials.
+    const saveTrace = createTraceId("e2e-zotero-pipeline-save");
+    const saveResponse = await request.post(`${env.apiUrl}/api/v1/zotero/save-credentials`, {
+      headers: authHeaders(env.authToken!, saveTrace),
+      data: {
+        zoteroUserId: process.env.E2E_ZOTERO_USER_ID,
+        apiKey: process.env.E2E_ZOTERO_API_KEY,
+        libraryType: process.env.E2E_ZOTERO_LIBRARY_TYPE || "user",
+      },
+    });
+    expect(saveResponse.ok()).toBeTruthy();
+    const saveBody = await parseEnvelope<Record<string, unknown>>(saveResponse);
+    expect(saveBody.ok).toBeTruthy();
+
+    // 2. Kick the sync.
+    const syncTrace = createTraceId("e2e-zotero-pipeline-sync");
+    const syncResponse = await request.post(`${env.apiUrl}/api/v1/zotero/sync-collection`, {
+      headers: authHeaders(env.authToken!, syncTrace),
+      data: {
+        projectId: env.projectId,
+        collectionKey: process.env.E2E_ZOTERO_COLLECTION_KEY,
+        maxItems: Number(process.env.E2E_ZOTERO_MAX_ITEMS || 5),
+        includeAttachments: false,
+        updateExisting: true,
+      },
+    });
+
+    if (syncResponse.status() === 503) {
+      test.skip(true, "Queue unavailable (Redis/Celery down) for sync-collection.");
+    }
+    expect([200, 202]).toContain(syncResponse.status());
+
+    const syncBody = await parseEnvelope<{ syncRunId: string }>(syncResponse);
+    expect(syncBody.ok).toBeTruthy();
+    expect(syncBody.trace_id).toBe(syncTrace);
+    const syncRunId = syncBody.data.syncRunId;
+    expect(syncRunId).toBeTruthy();
+
+    // 3. Poll status to terminal.
+    const final = await pollSyncToTerminal({
+      apiUrl: env.apiUrl,
+      token: env.authToken!,
+      syncRunId,
+      request,
+    });
+    test.skip(
+      final.status === "timeout",
+      "Sync did not reach terminal state — Celery worker likely not consuming.",
+    );
+
+    const terminal = final as SyncStatusBody;
+    expect(TERMINAL_STATUSES.has(terminal.status)).toBeTruthy();
+
+    // 4. Counts invariant: every received item must land in exactly one
+    // outcome bucket. A drifting service that double-counts or drops
+    // items silently breaks this identity.
+    const accounted =
+      terminal.counts.persisted +
+      terminal.counts.updated +
+      terminal.counts.skipped +
+      terminal.counts.failed +
+      terminal.counts.removedAtSource;
+    expect(accounted).toBe(terminal.counts.totalReceived);
+    expect(terminal.counts.reactivated).toBeGreaterThanOrEqual(0);
+
+    // 5. The sync-status surface must carry its own trace_id (separate
+    // from the envelope's), the syncRunId echoed back, and a
+    // completedAt timestamp for terminal states.
+    expect(terminal.syncRunId).toBe(syncRunId);
+    expect(terminal.traceId).toBeTruthy();
+    expect(terminal.completedAt).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds 4 missing test files (826 lines) surfaced during a branch-cleanup review. This branch never had a PR opened.

- `frontend/e2e/flows/zotero-full-pipeline.api.e2e.ts` (167) — full Zotero import E2E: credentials → sync-collection → poll sync-status to terminal → asserts the counts invariant (`persisted + updated + skipped + failed + removed_at_source == total_received`). Guards the swallowed-exception path where articles can be dropped silently while the run still ends "completed". The existing `zotero.e2e.ts` only covers cheap surfaces (validation 400, unknown-status 404).
- `backend/tests/integration/test_article_text_blocks_endpoint.py` (309)
- `backend/tests/integration/test_citations_endpoint.py` (151)
- `backend/tests/integration/test_project_template_active_service.py` (199)

## Why

Test coverage the `dev` branch is currently missing, aligned with the diff (80%) and critical-path (85%) coverage gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)