### PR TITLE
test(integration): pin auth fixtures to seeded primary profile

### DIFF
--- a/backend/tests/integration/test_hitl_session.py
+++ b/backend/tests/integration/test_hitl_session.py
@@ -60,10 +60,8 @@ async def auth_as_profile(
     db_session: AsyncSession,
 ) -> AsyncGenerator[UUID, None]:
     """Override auth so the JWT sub points at a real profile."""
-    raw = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if raw is None:
-        pytest.skip("No profile rows available in test database")
-    profile_id = UUID(str(raw))
+    del db_session  # kept for fixture-dependency ordering; the seed runs first
+    profile_id = SEED.primary_profile
 
     async def override_get_current_user() -> TokenPayload:
         return TokenPayload(

--- a/backend/tests/integration/test_hitl_session_concurrency.py
+++ b/backend/tests/integration/test_hitl_session_concurrency.py
@@ -32,6 +32,7 @@ from app.services.run_lifecycle_service import (
     InvalidStageTransitionError,
     RunLifecycleService,
 )
+from tests.integration.conftest import SEED
 
 
 @pytest_asyncio.fixture
@@ -394,23 +395,13 @@ async def test_endpoint_translates_invalid_stage_transition_to_409(
     from app.core.security import TokenPayload, get_current_user
     from app.main import app
 
-    article = (
-        await db_session.execute(text("SELECT id, project_id FROM public.articles LIMIT 1"))
-    ).first()
-    template_id = (
-        await db_session.execute(
-            text(
-                "SELECT id FROM public.project_extraction_templates "
-                "WHERE kind = 'extraction' LIMIT 1"
-            )
-        )
-    ).scalar()
-    profile_id = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if article is None or template_id is None or profile_id is None:
-        pytest.skip("Missing fixtures")
-    article_id = UUID(str(article[0]))
-    project_id = UUID(str(article[1]))
-    profile_id = UUID(str(profile_id))
+    # Pin to the seeded sentinel graph so the endpoint's membership check
+    # passes deterministically (primary_profile manages primary_project).
+    # The service is mocked below, so only project membership matters here.
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
+    profile_id = SEED.primary_profile
 
     async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
         yield db_session

--- a/backend/tests/integration/test_hitl_telemetry.py
+++ b/backend/tests/integration/test_hitl_telemetry.py
@@ -23,16 +23,15 @@ from structlog.testing import LogCapture
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 
 @pytest_asyncio.fixture
 async def auth_as_profile(
     db_session: AsyncSession,
 ) -> AsyncGenerator[UUID, None]:
-    raw = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if raw is None:
-        pytest.skip("No profile rows available")
-    profile_id = UUID(str(raw))
+    del db_session  # kept for fixture-dependency ordering; the seed runs first
+    profile_id = SEED.primary_profile
 
     async def override_get_current_user() -> TokenPayload:
         return TokenPayload(

--- a/backend/tests/integration/test_qa_publish_flow.py
+++ b/backend/tests/integration/test_qa_publish_flow.py
@@ -31,16 +31,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 _SESSION_URL = "/api/v1/hitl/sessions"
 
 
 @pytest_asyncio.fixture
 async def auth_as_profile(db_session: AsyncSession) -> AsyncGenerator[UUID, None]:
-    raw = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if raw is None:
-        pytest.skip("No profile rows available")
-    profile_id = UUID(str(raw))
+    del db_session  # kept for fixture-dependency ordering; the seed runs first
+    profile_id = SEED.primary_profile
 
     async def override() -> TokenPayload:
         return TokenPayload(

--- a/backend/tests/integration/test_run_reopen.py
+++ b/backend/tests/integration/test_run_reopen.py
@@ -24,16 +24,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 
 @pytest_asyncio.fixture
 async def auth_as_profile(
     db_session: AsyncSession,
 ) -> AsyncGenerator[UUID, None]:
-    raw = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if raw is None:
-        pytest.skip("No profile rows available")
-    profile_id = UUID(str(raw))
+    del db_session  # kept for fixture-dependency ordering; the seed runs first
+    profile_id = SEED.primary_profile
 
     async def override_get_current_user() -> TokenPayload:
         return TokenPayload(

--- a/backend/tests/integration/test_run_reviewers_endpoint.py
+++ b/backend/tests/integration/test_run_reviewers_endpoint.py
@@ -21,16 +21,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 
 @pytest_asyncio.fixture
 async def auth_as_profile(
     db_session: AsyncSession,
 ) -> AsyncGenerator[UUID, None]:
-    raw = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if raw is None:
-        pytest.skip("No profile rows available")
-    profile_id = UUID(str(raw))
+    del db_session  # kept for fixture-dependency ordering; the seed runs first
+    profile_id = SEED.primary_profile
 
     async def override_get_current_user() -> TokenPayload:
         return TokenPayload(

--- a/backend/tests/integration/test_session_backfill_extensive.py
+++ b/backend/tests/integration/test_session_backfill_extensive.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
 from app.models.extraction import ExtractionEntityRole
+from tests.integration.conftest import SEED
 
 pytestmark = pytest.mark.asyncio
 
@@ -32,10 +33,8 @@ _SESSION_URL = "/api/v1/hitl/sessions"
 
 @pytest_asyncio.fixture
 async def auth_as_profile(db_session: AsyncSession) -> AsyncGenerator[UUID, None]:
-    raw = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if raw is None:
-        pytest.skip("No profile rows available in test database")
-    profile_id = UUID(str(raw))
+    del db_session  # kept for fixture-dependency ordering; the seed runs first
+    profile_id = SEED.primary_profile
 
     async def override_get_current_user() -> TokenPayload:
         return TokenPayload(

--- a/backend/tests/integration/test_template_clone_extraction.py
+++ b/backend/tests/integration/test_template_clone_extraction.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 CHARMS_GLOBAL_ID = UUID("000c0000-0000-0000-0000-000000000001")
 
@@ -24,10 +25,8 @@ async def auth_as_profile(
     db_session: AsyncSession,
 ) -> AsyncGenerator[UUID, None]:
     """JWT sub must be a real profile id (FK on project_extraction_templates)."""
-    raw = (await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
-    if raw is None:
-        pytest.skip("No profile rows available in test database")
-    profile_id = UUID(str(raw))
+    del db_session  # kept for fixture-dependency ordering; the seed runs first
+    profile_id = SEED.primary_profile
 
     async def override_get_current_user() -> TokenPayload:
         return TokenPayload(


### PR DESCRIPTION
## Why

80 backend integration tests fail on a developer DB but pass in CI. Root cause: the `auth_as_profile` fixture (and one inline endpoint picker) chose their JWT subject via `SELECT id FROM public.profiles LIMIT 1`, which is non-deterministic once the dev DB accumulates real profiles — the chosen profile isn't a member of the seeded project, so every membership-gated request 403s. This blocked trustworthy local verification before a release.

## What changed

- Pin `auth_as_profile` to `SEED.primary_profile` (conftest-seeded manager of `SEED.primary_project`) across 7 files: `test_hitl_session`, `test_qa_publish_flow`, `test_template_clone_extraction`, `test_session_backfill_extensive`, `test_run_reopen`, `test_run_reviewers_endpoint`, `test_hitl_telemetry`.
- Pin the inline endpoint picker in `test_hitl_session_concurrency` to the seeded sentinel graph.
- Matches the deterministic pattern already used by `test_extraction_runs_endpoints.py` / `test_runs_endpoint_lifecycle.py`.

## Risk

Test-only; no production code touched. The chosen profile is now a guaranteed project manager, so happy-path membership checks pass deterministically. No negative/BOLA test uses `auth_as_profile` (those use dedicated fixtures), so pinning to a member cannot mask an authz regression.

## Test plan

- [x] `make lint-backend` clean
- [x] `make test-backend` → 1034 passed, 6 skipped, 0 failed (randomized **and** fixed order) on a polluted dev DB
- [x] Frontend untouched (vitest 426, tsc, eslint already green)

## Out of scope

- ~40 inline `created_by = (SELECT … LIMIT 1)` attribution sites remain non-deterministic but harmless (not authz-gating).
- De-duplicating the per-file `auth_as_profile` copies into `conftest.py` is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)