### PR TITLE
fix(feedback): avoid MissingGreenlet on attachment-less submit

### DIFF
--- a/backend/app/services/feedback_service.py
+++ b/backend/app/services/feedback_service.py
@@ -77,6 +77,10 @@ class FeedbackService:
             "feedback_report_created",
             report_id=str(report.id),
             type=report.type,
-            attachments=len(report.attachments),
+            # Count the input payload, not report.attachments: the latter is a
+            # lazy relationship and reading it post-flush triggers a sync IO
+            # load that raises MissingGreenlet under the async session when the
+            # collection wasn't initialized (i.e. no attachments).
+            attachments=len(payload.attachments),
         )
         return report

--- a/backend/tests/integration/test_feedback_service.py
+++ b/backend/tests/integration/test_feedback_service.py
@@ -47,6 +47,25 @@ async def test_create_report_persists(db_session) -> None:
     assert len(fetched.attachments) == 1
 
 
+async def test_create_report_persists_without_attachments(db_session) -> None:
+    """Regression: a report with no attachments must not trigger a post-flush
+    lazy-load of the ``attachments`` relationship (raises MissingGreenlet under
+    the async session). Reproduces the prod 500 caught by the post-deploy smoke
+    test — the common case (text-only feedback) had no test coverage because
+    ``_payload`` always carried one attachment.
+    """
+    service = FeedbackService(db=db_session, user_id="not-a-uuid")
+    report = await service.create_report(_payload(attachments=[]))
+    await db_session.flush()
+
+    fetched = (
+        await db_session.execute(select(FeedbackReport).where(FeedbackReport.id == report.id))
+    ).scalar_one()
+    assert fetched.type == "bug"
+    assert fetched.forward_status == "pending"
+    assert len(fetched.attachments) == 0
+
+
 async def test_rejects_foreign_storage_key(db_session) -> None:
     uid = "11111111-1111-1111-1111-111111111111"
     service = FeedbackService(db=db_session, user_id=uid)


### PR DESCRIPTION
## Why

`POST /api/v1/feedback` returns **HTTP 500** in production for any submission **without attachments** (the common text-only case) — caught by the post-deploy smoke test. Root cause: `FeedbackService.create_report` logs `len(report.attachments)` immediately after `flush()`; reading that lazy relationship on a freshly-flushed ORM object emits a synchronous lazy-load → `sqlalchemy.exc.MissingGreenlet` under the async session.

It was masked because (a) with attachments, the append loop initializes the collection before flush, and (b) the only integration test reaching that log line (`test_create_report_persists`) always carried one attachment — so CI was green while prod broke.

## What changed

- `feedback_service.py`: count `payload.attachments` (in-memory input) instead of the `report.attachments` relationship — identical value, no ORM IO.
- `test_feedback_service.py`: add `test_create_report_persists_without_attachments` (real async session, empty attachments) — fails with `MissingGreenlet` before the fix, passes after.

## Risk

One-line behavioral fix in a log statement; no schema/API change. Regression test now guards the path.

## Test plan

- [x] New test reproduces `MissingGreenlet` before fix, passes after
- [x] `make test-backend` → 1035 passed / 0 failed
- [x] `make lint-backend` clean
- [ ] Post-merge: re-run prod smoke test → expect 202 + Linear issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)