### PR TITLE
hotfix: feedback 500 on attachment-less submit (MissingGreenlet)

### DIFF
--- a/backend/app/services/feedback_service.py
+++ b/backend/app/services/feedback_service.py
@@ -77,6 +77,10 @@ class FeedbackService:
             "feedback_report_created",
             report_id=str(report.id),
             type=report.type,
-            attachments=len(report.attachments),
+            # Count the input payload, not report.attachments: the latter is a
+            # lazy relationship and reading it post-flush triggers a sync IO
+            # load that raises MissingGreenlet under the async session when the
+            # collection wasn't initialized (i.e. no attachments).
+            attachments=len(payload.attachments),
         )
         return report

--- a/backend/tests/integration/test_feedback_service.py
+++ b/backend/tests/integration/test_feedback_service.py
@@ -47,6 +47,25 @@ async def test_create_report_persists(db_session) -> None:
     assert len(fetched.attachments) == 1
 
 
+async def test_create_report_persists_without_attachments(db_session) -> None:
+    """Regression: a report with no attachments must not trigger a post-flush
+    lazy-load of the ``attachments`` relationship (raises MissingGreenlet under
+    the async session). Reproduces the prod 500 caught by the post-deploy smoke
+    test — the common case (text-only feedback) had no test coverage because
+    ``_payload`` always carried one attachment.
+    """
+    service = FeedbackService(db=db_session, user_id="not-a-uuid")
+    report = await service.create_report(_payload(attachments=[]))
+    await db_session.flush()
+
+    fetched = (
+        await db_session.execute(select(FeedbackReport).where(FeedbackReport.id == report.id))
+    ).scalar_one()
+    assert fetched.type == "bug"
+    assert fetched.forward_status == "pending"
+    assert len(fetched.attachments) == 0
+
+
 async def test_rejects_foreign_storage_key(db_session) -> None:
     uid = "11111111-1111-1111-1111-111111111111"
     service = FeedbackService(db=db_session, user_id=uid)


### PR DESCRIPTION
## Why

The post-deploy smoke test caught a production **HTTP 500** on `POST /api/v1/feedback` for any **text-only** submission (no attachments) — the common case. Hotfix.

## What changed (1 commit since the last release)

- **fix(feedback)** [#174] — `FeedbackService.create_report` read `len(report.attachments)` right after `flush()`, lazy-loading the relationship → `sqlalchemy.exc.MissingGreenlet` under the async session when no attachments were present. Now counts `payload.attachments` (in-memory). Adds a regression test (real async session, empty attachments) that reproduced the 500.

## Risk

One-line fix in a log statement; no schema/API change. Regression test guards it. Verified: `make test-backend` 1035 passed / 0 failed, lint clean, CI green on #174.

## Operational

No new migrations. Railway will redeploy `web` (+`worker`) on merge; no Alembic/Supabase changes.

## Test plan

- [x] Reproduced `MissingGreenlet` with a new test; fixed; green
- [x] `make test-backend` 1035 / 0; `make lint-backend` clean; CI green on #174
- [ ] Re-run prod smoke test after deploy → expect 202 + Linear issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)