### PR TITLE
fix(cors): pin prod frontend origin so extraction preflights pass

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -33,19 +33,24 @@ class Settings(BaseSettings):
     API_V1_PREFIX: str = "/api/v1"
 
     # =================== CORS ===================
-    CORS_ORIGINS: str = "http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000,http://localhost:8080,http://127.0.0.1:8080,https://prumo.vercel.app"
+    CORS_ORIGINS: str = "http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000,http://localhost:8080,http://127.0.0.1:8080,https://prumoai.vercel.app,https://prumo.vercel.app"
 
     @property
     def cors_origins_list(self) -> list[str]:
-        """Return lista de origens CORS with fallback seguro for desenvolvimento."""
+        """Return the CORS allow-list with a safe development fallback."""
         configured = [origin.strip() for origin in self.CORS_ORIGINS.split(",") if origin.strip()]
-        # Mantem origens essenciais for desenvolvimento mesmo quando CORS_ORIGINS in the .env estiver desatualizado.
+        # Always-allowed origins so a stale CORS_ORIGINS env can never lock
+        # out local dev or the canonical production frontend. The prod
+        # origin (prumoai.vercel.app) is pinned here because env drift
+        # between the Vercel domain and this list caused the 2026-05-31
+        # extraction outage (preflights rejected as "Disallowed CORS origin").
         defaults = [
             "http://localhost:5173",
             "http://127.0.0.1:5173",
             "http://localhost:3000",
             "http://localhost:8080",
             "http://127.0.0.1:8080",
+            "https://prumoai.vercel.app",
             "https://prumo.vercel.app",
         ]
         merged: list[str] = []

--- a/backend/tests/unit/test_cors_config.py
+++ b/backend/tests/unit/test_cors_config.py
@@ -1,0 +1,36 @@
+"""CORS allow-list regression tests.
+
+Guards the 2026-05-31 production outage: the live frontend origin
+``https://prumoai.vercel.app`` was missing from the backend CORS
+allow-list, so every browser -> backend preflight (e.g.
+``POST /api/v1/hitl/sessions``) was rejected with "Disallowed CORS
+origin". Reads that went straight to Supabase (global templates) kept
+working, which made the failure look selective. The production frontend
+origin must always be allowed, even when ``CORS_ORIGINS`` env is stale.
+"""
+
+from app.core.config import Settings, settings
+
+PROD_FRONTEND_ORIGIN = "https://prumoai.vercel.app"
+
+
+def test_prod_frontend_origin_always_allowed_even_when_env_omits_it() -> None:
+    """The canonical prod origin lives in the hardcoded defaults, so a
+    stale ``CORS_ORIGINS`` env value can never lock the frontend out."""
+    stale = Settings.model_construct(CORS_ORIGINS="https://unrelated.example")
+    origins = stale.cors_origins_list
+    assert PROD_FRONTEND_ORIGIN in origins
+    # configured values are still honoured (merge, not replace)
+    assert "https://unrelated.example" in origins
+
+
+def test_cors_origins_list_dedupes() -> None:
+    """A configured origin that also appears in the defaults is not
+    duplicated."""
+    dup = Settings.model_construct(CORS_ORIGINS=PROD_FRONTEND_ORIGIN)
+    origins = dup.cors_origins_list
+    assert origins.count(PROD_FRONTEND_ORIGIN) == 1
+
+
+def test_singleton_includes_prod_origin() -> None:
+    assert PROD_FRONTEND_ORIGIN in settings.cors_origins_list


### PR DESCRIPTION
## Problem

The production extraction view (e.g. `/projects/.../extraction/...`) could not load already-extracted values. The browser console showed:

```
Access to fetch at '.../api/v1/hitl/sessions' from origin 'https://prumoai.vercel.app'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present
[useExtractionSession] open() failed: ApiError: Connection error.
```

## Root cause

The live frontend origin `https://prumoai.vercel.app` was **not in the backend CORS allow-list**. Three different domains were drifting:

| Source | Value |
|---|---|
| Railway `CORS_ORIGINS` env | `https://prumo-alpha.vercel.app` |
| Code default (`config.py`) | `https://prumo.vercel.app` |
| **Actual live frontend** | **`https://prumoai.vercel.app`** |

So every browser→backend preflight was rejected by Starlette's CORSMiddleware as `Disallowed CORS origin` (HTTP 400, no `Access-Control-Allow-Origin`). The extraction view never opened its HITL session, so no extracted data loaded.

The failure *looked* selective because global templates are read **directly from Supabase** ([`useGlobalTemplates.ts`](frontend/hooks/extraction/useGlobalTemplates.ts) — permissive CORS), while session open goes through the **Railway FastAPI backend** ([`useExtractionSession.ts`](frontend/hooks/extraction/useExtractionSession.ts) — enforced allow-list).

## Fix

- Pin `https://prumoai.vercel.app` in the always-allowed `defaults` in [`config.py`](backend/app/core/config.py) so a stale `CORS_ORIGINS` env can never lock the frontend out again.
- Regression test in [`test_cors_config.py`](backend/tests/unit/test_cors_config.py).

## Prod hotfix (already applied)

Railway `CORS_ORIGINS` updated to include `https://prumoai.vercel.app` (web service redeployed). Verified live:

```
OPTIONS /api/v1/hitl/sessions  ->  HTTP 200, Access-Control-Allow-Origin: https://prumoai.vercel.app
POST    /api/v1/hitl/sessions  ->  HTTP 401 (auth) + Access-Control-Allow-Origin present
```

This PR makes the code source-of-truth match reality so the fix survives future fresh deploys.

## Test

```
uv run pytest tests/unit/test_cors_config.py  ->  3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)