### PR TITLE
fix(extraction): stop autosave writing past proposal/review stages

### DIFF
--- a/frontend/hooks/runs/useAutoSaveProposals.ts
+++ b/frontend/hooks/runs/useAutoSaveProposals.ts
@@ -81,6 +81,28 @@ export interface UseAutoSaveProposalsReturn {
   saveNow: () => Promise<void>;
 }
 
+/**
+ * Stages at which autosave is allowed to write.
+ *
+ *   - ``null`` / ``undefined`` — legacy QA single-user flow (writes
+ *     ``human`` proposals); callers that omit ``stage`` keep their
+ *     behaviour.
+ *   - ``'proposal'`` — extraction PROPOSAL stage; the proposer (or AI)
+ *     fills initial values as ``human`` proposals.
+ *   - ``'review'`` — per-reviewer ``ReviewerDecision`` writes (see
+ *     ``performSave``).
+ *
+ * Any other stage (``'consensus'``, ``'finalized'``, ``'pending'``, …) is
+ * read-only or terminal for autosave: the backend rejects a proposal
+ * write past PROPOSAL (HTTP 400 ``run stage is consensus, not in
+ * ['proposal']``), which used to surface as a spurious "Error saving
+ * data automatically" toast the moment a consolidated run was opened.
+ */
+const WRITABLE_STAGES = new Set(['proposal', 'review']);
+function isWritableStage(stage?: string | null): boolean {
+  return stage == null || WRITABLE_STAGES.has(stage);
+}
+
 export function useAutoSaveProposals(
   props: UseAutoSaveProposalsProps,
 ): UseAutoSaveProposalsReturn {
@@ -136,7 +158,16 @@ export function useAutoSaveProposals(
     }
 
     const currentRunId = runIdRef.current;
-    if (!currentRunId || !enabledRef.current) return;
+    // Skip when there's no run, autosave is disabled, or the run stage
+    // does not accept writes (consensus/finalized/pending). The stage
+    // guard here also protects the flush paths (unmount, pagehide,
+    // visibilitychange) so a consolidated run never fires a doomed POST.
+    if (
+      !currentRunId ||
+      !enabledRef.current ||
+      !isWritableStage(stageRef.current)
+    )
+      return;
 
     const dirty = computeDirtyEntries();
     if (dirty.length === 0) return;
@@ -242,7 +273,7 @@ export function useAutoSaveProposals(
   // countdown; the dedicated unmount-flush effect below handles the
   // route-change case.
   useEffect(() => {
-    if (!enabled || !runId) return;
+    if (!enabled || !runId || !isWritableStage(stage)) return;
 
     const dirty = computeDirtyEntries();
     if (dirty.length === 0) return;
@@ -257,7 +288,15 @@ export function useAutoSaveProposals(
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [values, enabled, runId, debounceMs, performSave, computeDirtyEntries]);
+  }, [
+    values,
+    enabled,
+    runId,
+    stage,
+    debounceMs,
+    performSave,
+    computeDirtyEntries,
+  ]);
 
   // (2) Flush pending edits on UNMOUNT. Separate effect with stable
   // deps so the cleanup only fires when the component truly unmounts —

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -325,7 +325,17 @@ export default function ExtractionFullScreen() {
     runId: activeRunId,
     stage,
     values,
-    enabled: !!activeRunId && !loading && valuesInitialized && !isFinalized,
+    // Only PROPOSAL and REVIEW accept autosave writes. Past that
+    // (consensus, finalized, pending) the backend rejects proposal
+    // writes, which surfaced as a spurious "Error saving data
+    // automatically" toast on opening a consolidated run. Mirrors the
+    // QA full-screen gate; ``!isFinalized`` alone let ``consensus``
+    // through.
+    enabled:
+      !!activeRunId &&
+      !loading &&
+      valuesInitialized &&
+      (stage === 'proposal' || stage === 'review'),
   });
 
   // "Submit for review" — flush pending edits and advance the run from

--- a/frontend/test/hooks/useAutoSaveProposals.test.tsx
+++ b/frontend/test/hooks/useAutoSaveProposals.test.tsx
@@ -310,6 +310,37 @@ describe('useAutoSaveProposals — stage-aware write target (Layer 2 fix)', () =
   });
 });
 
+describe('useAutoSaveProposals — non-writable stages are inert', () => {
+  // Regression: opening a run parked at ``consensus`` (or ``finalized``)
+  // fired a doomed POST /proposals on load, which the backend rejects
+  // (HTTP 400 "run stage is consensus, not in ['proposal']") and the UI
+  // surfaced as a spurious "Error saving data automatically" toast. Past
+  // the proposal/review stages, autosave must not write at all. ``review``
+  // routes to /decisions and ``proposal``/undefined to /proposals — those
+  // remain writable (covered by the stage-aware suite above).
+  it.each(['consensus', 'finalized', 'pending'])(
+    'does NOT POST and stays idle when stage=%s',
+    async (stage) => {
+      apiClientMock.mockResolvedValue(PROPOSAL_RESPONSE);
+
+      const { result } = renderHook(() =>
+        useAutoSaveProposals({
+          runId: 'run-1',
+          stage,
+          values: { 'inst-1_field-1': 'hello' },
+        }),
+      );
+
+      await act(async () => {
+        await result.current.saveNow();
+      });
+
+      expect(apiClientMock).not.toHaveBeenCalled();
+      expect(result.current.saveState).toBe('idle');
+    },
+  );
+});
+
 describe('useAutoSaveProposals — mutex + error handling', () => {
   it('concurrent saveNow invocations do not double-write unchanged values', async () => {
     let release!: () => void;


### PR DESCRIPTION
## Problem

Opening an extraction run that has advanced to **`consensus`** throws a **"Error saving data automatically"** toast on load, even though the extracted values render correctly. Console + network:

```
[POST] /api/v1/runs/{id}/proposals  =>  400
[ERROR] Auto-save error: Cannot record proposal: kind=extraction run stage is
        consensus, not in ['proposal']. For kind='extraction', writes at REVIEW
        must go through /decisions (ReviewerDecision), not /proposals.
```

The data isn't corrupted — the backend correctly rejects the write — but the user sees a scary error every time they open a consolidated run.

## Root cause

The `ExtractionFullScreen` autosave gate was:

```ts
enabled: !!activeRunId && !loading && valuesInitialized && !isFinalized,
```

`!isFinalized` lets **`consensus`** (and `pending`) through, so autosave fires a `human` proposal write at a stage the backend doesn't accept. The sibling **QA full-screen already gets this right**:

```ts
enabled: ... && (runDetail.run.stage === "proposal" || runDetail.run.stage === "review"),
```

Extraction now matches that proven pattern. Only `proposal` (human proposals) and `review` (per-reviewer decisions) accept autosave writes.

## Fix

1. **Caller (root cause)** — [`ExtractionFullScreen.tsx`](frontend/pages/ExtractionFullScreen.tsx): gate `enabled` on `stage === 'proposal' || 'review'`, mirroring QA.
2. **Defense in depth** — [`useAutoSaveProposals.ts`](frontend/hooks/runs/useAutoSaveProposals.ts): the hook itself now refuses to write at non-writable stages. `null`/`undefined`/`proposal`/`review` stay writable (preserves the QA single-user flow and every existing caller), so `consensus`/`finalized`/`pending` can't fire a doomed POST — including via the flush paths (unmount, `pagehide`, `visibilitychange`).

## How it surfaced

Found while browser-testing the prod **CORS fix (#176)**. Once the extraction page actually loaded (CORS was blocking it entirely before), this previously-invisible autosave write started 400ing on a real `consensus` run.

## Tests

3 new cases in [`useAutoSaveProposals.test.tsx`](frontend/test/hooks/useAutoSaveProposals.test.tsx) assert no POST + `saveState` stays `idle` for `consensus`/`finalized`/`pending`. Existing stage tests (`review` → `/decisions`, `proposal`/undefined → `/proposals`) still pass.

```
vitest run frontend/test/hooks/useAutoSaveProposals.test.tsx  ->  22 passed
tsc --noEmit  ->  0 errors   |   eslint  ->  clean
```

> Note: this is independent of #176 (CORS). That PR restores page loading; this one fixes a bug that loading then exposed. Both target `dev`, touch different files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)