### PR TITLE
fix(extraction): generation-counter guard against stale articleId data in colaboracao hooks

### DIFF
--- a/frontend/hooks/extraction/colaboracao/useAllUserInstances.ts
+++ b/frontend/hooks/extraction/colaboracao/useAllUserInstances.ts
@@ -5,7 +5,7 @@
  * Used to group correctly by label in comparison.
  */
 
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {supabase} from '@/integrations/supabase/client';
 import {t} from '@/lib/copy';
 import type {ExtractionInstance} from '@/types/extraction';
@@ -32,6 +32,7 @@ export function useAllUserInstances(props: UseAllUserInstancesProps): UseAllUser
   const [instances, setInstances] = useState<InstanceWithCreator[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const generationRef = useRef(0);
 
   useEffect(() => {
     if (!enabled || !articleId) {
@@ -40,9 +41,13 @@ export function useAllUserInstances(props: UseAllUserInstancesProps): UseAllUser
     }
 
     loadInstances();
+    return () => {
+      generationRef.current += 1;
+    };
   }, [articleId, enabled]);
 
   const loadInstances = async () => {
+    const myGeneration = ++generationRef.current;
     setLoading(true);
     setError(null);
 
@@ -55,16 +60,18 @@ export function useAllUserInstances(props: UseAllUserInstancesProps): UseAllUser
         .eq('article_id', articleId)
         .order('created_at', { ascending: true });
 
+      if (myGeneration !== generationRef.current) return;
       if (queryError) throw queryError;
 
       setInstances((data || []) as InstanceWithCreator[]);
         console.warn(`✅ Loaded ${(data || []).length} instances from all users`);
 
     } catch (err: any) {
+      if (myGeneration !== generationRef.current) return;
         console.error('❌ Error loading instances:', err);
         setError(err.message || t('extraction', 'errors_loadInstances'));
     } finally {
-      setLoading(false);
+      if (myGeneration === generationRef.current) setLoading(false);
     }
   };
 

--- a/frontend/hooks/extraction/colaboracao/useOtherExtractions.ts
+++ b/frontend/hooks/extraction/colaboracao/useOtherExtractions.ts
@@ -7,7 +7,7 @@
  * `profiles` (display name + avatar). Used by the comparison UI.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ExtractionValueService } from '@/services/extractionValueService';
 import { t } from '@/lib/copy';
@@ -49,6 +49,7 @@ export function useOtherExtractions(
   const [otherExtractions, setOtherExtractions] = useState<OtherExtraction[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const generationRef = useRef(0);
 
   useEffect(() => {
     if (!enabled || !articleId || !currentUserId) {
@@ -56,21 +57,26 @@ export function useOtherExtractions(
       return;
     }
     void loadOtherExtractions();
+    return () => {
+      generationRef.current += 1;
+    };
   }, [articleId, currentUserId, enabled, templateId]);
 
   const loadOtherExtractions = async () => {
+    const myGeneration = ++generationRef.current;
     setLoading(true);
     setError(null);
 
     try {
       if (!templateId) {
-        setOtherExtractions([]);
+        if (myGeneration === generationRef.current) setOtherExtractions([]);
         return;
       }
       const run = await ExtractionValueService.findActiveRun(
         articleId,
         templateId,
       );
+      if (myGeneration !== generationRef.current) return;
       if (!run) {
         setOtherExtractions([]);
         return;
@@ -81,6 +87,7 @@ export function useOtherExtractions(
         currentUserId,
       );
 
+      if (myGeneration !== generationRef.current) return;
       setOtherExtractions(
         others.map((o) => ({
           userId: o.reviewerId,
@@ -91,10 +98,11 @@ export function useOtherExtractions(
         })),
       );
     } catch (err: any) {
+      if (myGeneration !== generationRef.current) return;
       console.error('Error loading other extractions:', err);
       setError(err.message || t('extraction', 'errors_loadOtherExtractions'));
     } finally {
-      setLoading(false);
+      if (myGeneration === generationRef.current) setLoading(false);
     }
   };
 

--- a/frontend/test/hooks/useColaboracaoStaleGuard.test.tsx
+++ b/frontend/test/hooks/useColaboracaoStaleGuard.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for issue #161 — stale-data overwrite in colaboracao hooks.
+ *
+ * Both `useOtherExtractions` and `useAllUserInstances` must discard responses
+ * that arrive after `articleId` has changed (generation-counter guard).
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+// ── useOtherExtractions ────────────────────────────────────────────────────
+
+vi.mock('@/services/extractionValueService', () => ({
+  ExtractionValueService: {
+    findActiveRun: vi.fn(),
+    loadValuesForOthers: vi.fn(),
+  },
+}));
+
+import { ExtractionValueService } from '@/services/extractionValueService';
+import { useOtherExtractions } from '@/hooks/extraction/colaboracao/useOtherExtractions';
+
+const findActiveRunMock = ExtractionValueService.findActiveRun as ReturnType<typeof vi.fn>;
+const loadValuesForOthersMock = ExtractionValueService.loadValuesForOthers as ReturnType<typeof vi.fn>;
+
+// ── useAllUserInstances ────────────────────────────────────────────────────
+
+vi.mock('@/integrations/supabase/client', () => {
+  const orderMock = vi.fn();
+  const eqMock = vi.fn(() => ({ order: orderMock }));
+  const selectMock = vi.fn(() => ({ eq: eqMock }));
+  const fromMock = vi.fn(() => ({ select: selectMock }));
+  return { supabase: { from: fromMock, __orderMock: orderMock } };
+});
+
+import { supabase } from '@/integrations/supabase/client';
+import { useAllUserInstances } from '@/hooks/extraction/colaboracao/useAllUserInstances';
+
+const supabaseOrderMock = (supabase as any).__orderMock as ReturnType<typeof vi.fn>;
+
+// ──────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useOtherExtractions — stale-data guard', () => {
+  it('discards a response that arrives after articleId has changed', async () => {
+    // Deferred promise simulates a slow first fetch.
+    let resolveFirst!: (v: unknown) => void;
+    const firstFetch = new Promise((res) => { resolveFirst = res; });
+
+    findActiveRunMock
+      .mockReturnValueOnce(firstFetch)          // art-1: slow
+      .mockResolvedValue(null);                 // art-2: fast, no run
+
+    const { result, rerender } = renderHook(
+      ({ articleId }) =>
+        useOtherExtractions({
+          articleId,
+          projectId: 'proj-1',
+          templateId: 'tpl-1',
+          currentUserId: 'user-1',
+        }),
+      { initialProps: { articleId: 'art-1' } },
+    );
+
+    // Switch article while art-1 fetch is still in flight.
+    rerender({ articleId: 'art-2' });
+
+    // Now let the stale art-1 response arrive.
+    resolveFirst({ id: 'run-stale' });
+    loadValuesForOthersMock.mockResolvedValue([
+      {
+        reviewerId: 'r-1',
+        reviewerName: 'Alice',
+        reviewerAvatar: null,
+        values: { field1: 'STALE' },
+        latestDecidedAt: null,
+      },
+    ]);
+
+    // art-2 has no run → resolves to empty immediately.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Stale data from art-1 must NOT appear.
+    expect(result.current.otherExtractions).toHaveLength(0);
+  });
+});
+
+describe('useAllUserInstances — stale-data guard', () => {
+  it('discards a response that arrives after articleId has changed', async () => {
+    let resolveFirst!: (v: unknown) => void;
+    const firstFetch = new Promise((res) => { resolveFirst = res; });
+
+    supabaseOrderMock
+      .mockReturnValueOnce(firstFetch)          // art-1: slow
+      .mockResolvedValue({ data: [], error: null }); // art-2: fast, empty
+
+    const staleInstances = [
+      { id: 'inst-stale', article_id: 'art-1', created_by: 'user-1' },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ articleId }) => useAllUserInstances({ articleId }),
+      { initialProps: { articleId: 'art-1' } },
+    );
+
+    // Switch article before art-1 resolves.
+    rerender({ articleId: 'art-2' });
+
+    // Let the stale art-1 response arrive.
+    resolveFirst({ data: staleInstances, error: null });
+
+    // art-2 resolves to empty immediately.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Stale data from art-1 must NOT appear.
+    expect(result.current.instances).toHaveLength(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1136,6 +1136,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1155,6 +1158,9 @@
       "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1176,6 +1182,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1196,6 +1205,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1215,6 +1227,9 @@
       "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3162,6 +3177,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3179,6 +3197,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3196,6 +3217,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3213,6 +3237,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3230,6 +3257,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3247,6 +3277,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3538,6 +3571,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3555,6 +3591,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3572,6 +3611,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3589,6 +3631,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3606,6 +3651,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3623,6 +3671,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7489,6 +7540,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7510,6 +7564,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7531,6 +7588,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7552,6 +7612,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1136,9 +1136,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,9 +1155,6 @@
       "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1182,9 +1176,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1205,9 +1196,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,9 +1215,6 @@
       "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3177,9 +3162,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3197,9 +3179,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3217,9 +3196,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3237,9 +3213,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3257,9 +3230,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3277,9 +3247,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3571,9 +3538,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3591,9 +3555,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3611,9 +3572,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3631,9 +3589,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3651,9 +3606,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3671,9 +3623,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7540,9 +7489,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7564,9 +7510,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7588,9 +7531,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7612,9 +7552,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
Closes #161.

## Root cause

Both `useOtherExtractions` and `useAllUserInstances` called their fetch functions as plain async functions with no cancellation mechanism. When `articleId` changed while the component was still mounted, the response from the **previous** article's request could arrive after the new request started and call `setOtherExtractions` / `setInstances` with stale data — overwriting the current article's reviewer comparison data.

## Fix

- Added `generationRef = useRef(0)` to both hooks (matching the existing pattern in `useExtractionSession`, lines 62–116).
- Each call to the load function captures `const myGeneration = ++generationRef.current` at entry and guards every `setState` call with `if (myGeneration !== generationRef.current) return`.
- The `useEffect` cleanup bumps `generationRef.current` so any in-flight request from the previous `articleId` becomes stale immediately on re-render.

## Regression test added

`frontend/test/hooks/useColaboracaoStaleGuard.test.tsx`

- `useOtherExtractions — stale-data guard` — defers the art-1 `findActiveRun` response, switches to art-2, then resolves the stale promise; asserts `otherExtractions` remains empty.
- `useAllUserInstances — stale-data guard` — same pattern via mocked Supabase order chain; asserts `instances` remains empty.

## Verification

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  03:01:11
   Duration  1.29s
```

Lint: clean (no ESLint warnings or errors).


---
_Generated by [Claude Code](https://claude.ai/code/session_016iLkAGNBwabVQX75YEQaGe)_