### PR TITLE
ci(routines): reliable label-dispatch workflows (plan-quota /fire)

### DIFF
--- a/.github/workflows/_routine-label-dispatch.yml
+++ b/.github/workflows/_routine-label-dispatch.yml
@@ -1,0 +1,54 @@
+name: _Routine Label Dispatch (shared worker — not called directly)
+
+# Reusable workflow called by label-dispatch callers (bug-watch-write-dispatch.yml,
+# cleanup-on-demand-dispatch.yml, and any future routine callers). Callers own:
+#   - the `on:` trigger and `if:` label filter
+#   - the concurrency group (per-routine namespace)
+#   - the secret and trigger_id specific to their routine
+#
+# This worker owns the common fire logic: TOKEN guard, curl, response log.
+
+on:
+  workflow_call:
+    inputs:
+      routine_trigger_id:
+        # Routine trigger ID (trig_…).
+        # If the routine is deleted and recreated, this ID changes — update it
+        # in the `with:` block of the calling workflow (not here).
+        description: "Routine trigger ID (trig_…)"
+        required: true
+        type: string
+    secrets:
+      ROUTINE_TOKEN:
+        description: "Bearer token for this routine's API trigger"
+        required: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fire routine
+        env:
+          TOKEN: ${{ secrets.ROUTINE_TOKEN }}
+          TRIG: ${{ inputs.routine_trigger_id }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Missing ROUTINE_TOKEN secret — add the routine's API-trigger token (see the calling workflow's setup instructions)." >&2
+            echo "::notice::If the routine was recreated, also update routine_trigger_id in the calling workflow's 'with:' block." >&2
+            exit 1
+          fi
+          # anthropic-beta: this header is versioned. When the routine API graduates,
+          # check https://docs.anthropic.com/en/docs/claude-code/routines for the
+          # updated header value and bump it here.
+          curl -fsSL --max-time 30 -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/${TRIG}/fire" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg t "issue:${ISSUE} repo:${REPO}" '{text:$t}')" \
+            | tee /tmp/resp.json
+          echo "Fired. Session: $(jq -r '.claude_code_session_url // "(none)"' /tmp/resp.json)"

--- a/.github/workflows/bug-watch-write-dispatch.yml
+++ b/.github/workflows/bug-watch-write-dispatch.yml
@@ -1,0 +1,53 @@
+name: Bug Watch Write Dispatch
+
+# Reliable label-trigger for the `bug-watch-write` routine (native routine
+# issue-label triggers did not fire in testing). On `issues: labeled` with
+# `auto-fix-approved` AND the issue already carrying `auto-found`, this thin
+# workflow POSTs the routine's /fire endpoint. Runs on the routine's own bearer
+# token — Pro/Max plan quota, NOT ANTHROPIC_API_KEY (no API billing).
+#
+# One-time setup by repo owner:
+#   1. claude.ai/code/routines → edit `bug-watch-write` → Select a trigger →
+#      Add another trigger → API → Generate token → copy
+#   2. gh secret set CLAUDE_ROUTINE_BUGFIX_TOKEN -R raphaelfh/prumo   # paste token
+#
+# Routine: bug-watch-write  (trig_01T8PF56S19cJ5iKusnQwuZF)
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: none
+
+concurrency:
+  group: bugfix-dispatch-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: >-
+      github.event.label.name == 'auto-fix-approved'
+      && contains(github.event.issue.labels.*.name, 'auto-found')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fire bug-watch-write routine
+        env:
+          TOKEN: ${{ secrets.CLAUDE_ROUTINE_BUGFIX_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Missing secret CLAUDE_ROUTINE_BUGFIX_TOKEN — add the routine's API-trigger token (see workflow header)." >&2
+            exit 1
+          fi
+          curl -fsSL --max-time 30 -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/trig_01T8PF56S19cJ5iKusnQwuZF/fire" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg t "issue:${ISSUE} repo:${REPO}" '{text:$t}')" \
+            | tee /tmp/resp.json
+          echo "Fired. Session: $(jq -r '.claude_code_session_url // "(none)"' /tmp/resp.json)"

--- a/.github/workflows/bug-watch-write-dispatch.yml
+++ b/.github/workflows/bug-watch-write-dispatch.yml
@@ -3,15 +3,13 @@ name: Bug Watch Write Dispatch
 # Reliable label-trigger for the `bug-watch-write` routine (native routine
 # issue-label triggers did not fire in testing). On `issues: labeled` with
 # `auto-fix-approved` AND the issue already carrying `auto-found`, this thin
-# workflow POSTs the routine's /fire endpoint. Runs on the routine's own bearer
-# token — Pro/Max plan quota, NOT ANTHROPIC_API_KEY (no API billing).
+# caller fires the shared _routine-label-dispatch worker.
+# Runs on the routine's own bearer token — Pro/Max plan quota, NOT ANTHROPIC_API_KEY.
 #
 # One-time setup by repo owner:
-#   1. claude.ai/code/routines → edit `bug-watch-write` → Select a trigger →
-#      Add another trigger → API → Generate token → copy
+#   1. claude.ai/code/routines → edit `bug-watch-write` → API trigger → generate token → copy
 #   2. gh secret set CLAUDE_ROUTINE_BUGFIX_TOKEN -R raphaelfh/prumo   # paste token
-#
-# Routine: bug-watch-write  (trig_01T8PF56S19cJ5iKusnQwuZF)
+#   3. If routine is recreated: update routine_trigger_id in the `with:` block below.
 
 on:
   issues:
@@ -22,32 +20,15 @@ permissions:
 
 concurrency:
   group: bugfix-dispatch-${{ github.event.issue.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   dispatch:
     if: >-
       github.event.label.name == 'auto-fix-approved'
       && contains(github.event.issue.labels.*.name, 'auto-found')
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Fire bug-watch-write routine
-        env:
-          TOKEN: ${{ secrets.CLAUDE_ROUTINE_BUGFIX_TOKEN }}
-          ISSUE: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::Missing secret CLAUDE_ROUTINE_BUGFIX_TOKEN — add the routine's API-trigger token (see workflow header)." >&2
-            exit 1
-          fi
-          curl -fsSL --max-time 30 -X POST \
-            "https://api.anthropic.com/v1/claude_code/routines/trig_01T8PF56S19cJ5iKusnQwuZF/fire" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -nc --arg t "issue:${ISSUE} repo:${REPO}" '{text:$t}')" \
-            | tee /tmp/resp.json
-          echo "Fired. Session: $(jq -r '.claude_code_session_url // "(none)"' /tmp/resp.json)"
+    uses: ./.github/workflows/_routine-label-dispatch.yml
+    with:
+      routine_trigger_id: trig_01T8PF56S19cJ5iKusnQwuZF
+    secrets:
+      ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_BUGFIX_TOKEN }}

--- a/.github/workflows/cleanup-on-demand-dispatch.yml
+++ b/.github/workflows/cleanup-on-demand-dispatch.yml
@@ -1,0 +1,50 @@
+name: Cleanup On Demand Dispatch
+
+# Reliable label-trigger for the `cleanup` routine (native routine issue-label
+# triggers did not fire in testing). On `issues: labeled` with `tech-debt`, this
+# thin workflow POSTs the routine's /fire endpoint. It runs on the routine's own
+# bearer token — Pro/Max plan quota, NOT ANTHROPIC_API_KEY (no API billing).
+#
+# One-time setup by repo owner:
+#   1. claude.ai/code/routines → edit `cleanup` → Select a trigger →
+#      Add another trigger → API → Generate token → copy
+#   2. gh secret set CLAUDE_ROUTINE_CLEANUP_TOKEN -R raphaelfh/prumo   # paste token
+#
+# Routine: cleanup  (trig_01YBm1YjAd18JdZDe8thsPCd)
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: none
+
+concurrency:
+  group: cleanup-dispatch-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: github.event.label.name == 'tech-debt'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fire cleanup routine
+        env:
+          TOKEN: ${{ secrets.CLAUDE_ROUTINE_CLEANUP_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Missing secret CLAUDE_ROUTINE_CLEANUP_TOKEN — add the routine's API-trigger token (see workflow header)." >&2
+            exit 1
+          fi
+          curl -fsSL --max-time 30 -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/trig_01YBm1YjAd18JdZDe8thsPCd/fire" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg t "issue:${ISSUE} repo:${REPO}" '{text:$t}')" \
+            | tee /tmp/resp.json
+          echo "Fired. Session: $(jq -r '.claude_code_session_url // "(none)"' /tmp/resp.json)"

--- a/.github/workflows/cleanup-on-demand-dispatch.yml
+++ b/.github/workflows/cleanup-on-demand-dispatch.yml
@@ -2,15 +2,13 @@ name: Cleanup On Demand Dispatch
 
 # Reliable label-trigger for the `cleanup` routine (native routine issue-label
 # triggers did not fire in testing). On `issues: labeled` with `tech-debt`, this
-# thin workflow POSTs the routine's /fire endpoint. It runs on the routine's own
-# bearer token — Pro/Max plan quota, NOT ANTHROPIC_API_KEY (no API billing).
+# thin caller fires the shared _routine-label-dispatch worker.
+# Runs on the routine's own bearer token — Pro/Max plan quota, NOT ANTHROPIC_API_KEY.
 #
 # One-time setup by repo owner:
-#   1. claude.ai/code/routines → edit `cleanup` → Select a trigger →
-#      Add another trigger → API → Generate token → copy
+#   1. claude.ai/code/routines → edit `cleanup` → API trigger → generate token → copy
 #   2. gh secret set CLAUDE_ROUTINE_CLEANUP_TOKEN -R raphaelfh/prumo   # paste token
-#
-# Routine: cleanup  (trig_01YBm1YjAd18JdZDe8thsPCd)
+#   3. If routine is recreated: update routine_trigger_id in the `with:` block below.
 
 on:
   issues:
@@ -21,30 +19,13 @@ permissions:
 
 concurrency:
   group: cleanup-dispatch-${{ github.event.issue.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   dispatch:
     if: github.event.label.name == 'tech-debt'
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Fire cleanup routine
-        env:
-          TOKEN: ${{ secrets.CLAUDE_ROUTINE_CLEANUP_TOKEN }}
-          ISSUE: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::Missing secret CLAUDE_ROUTINE_CLEANUP_TOKEN — add the routine's API-trigger token (see workflow header)." >&2
-            exit 1
-          fi
-          curl -fsSL --max-time 30 -X POST \
-            "https://api.anthropic.com/v1/claude_code/routines/trig_01YBm1YjAd18JdZDe8thsPCd/fire" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -nc --arg t "issue:${ISSUE} repo:${REPO}" '{text:$t}')" \
-            | tee /tmp/resp.json
-          echo "Fired. Session: $(jq -r '.claude_code_session_url // "(none)"' /tmp/resp.json)"
+    uses: ./.github/workflows/_routine-label-dispatch.yml
+    with:
+      routine_trigger_id: trig_01YBm1YjAd18JdZDe8thsPCd
+    secrets:
+      ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_CLEANUP_TOKEN }}


### PR DESCRIPTION
## Why

Native routine **issue-label** triggers did not fire in testing:

| Routine | Label | Scenarios | Result |
|---|---|---|---|
| cleanup | `tech-debt` | #161 | ❌ no fire |
| bug-watch-write | `auto-fix-approved` | #181 (label-add) + #182 (label-at-create) | ❌ no fire |

3 scenarios, 2 routines, 0 fires → the native issue-label trigger isn't working for this setup (and the config isn't introspectable via API).

## What

Two thin GitHub Actions on `issues: labeled` that POST the routine's `/fire` endpoint:
- `cleanup-on-demand-dispatch.yml` → `tech-debt` → `cleanup` (`trig_01YBm1YjAd18JdZDe8thsPCd`)
- `bug-watch-write-dispatch.yml` → `auto-fix-approved` (+ issue already `auto-found`) → `bug-watch-write` (`trig_01T8PF56S19cJ5iKusnQwuZF`)

**Uses the routine's own bearer token (Pro/Max plan quota) — NOT `ANTHROPIC_API_KEY`.** No per-token API billing. The same `/fire` path was validated working earlier. Deterministic label filter + observable in Actions logs. Inert (clear error) until the secret is set.

## Required setup (one-time, repo owner)

Must merge to **dev** (default branch) for `issues` events to trigger it, then:

For **each** routine, in https://claude.ai/code/routines:
1. Edit the routine → **Select a trigger** → **Add another trigger** → **API** → **Generate token** → copy
2. Set the repo secret:
   ```bash
   gh secret set CLAUDE_ROUTINE_CLEANUP_TOKEN -R raphaelfh/prumo   # cleanup token
   gh secret set CLAUDE_ROUTINE_BUGFIX_TOKEN  -R raphaelfh/prumo   # bug-watch-write token
   ```

## Test plan

After merge + secrets:
- [ ] Apply `tech-debt` to an issue with body `module: backend/app/utils/<x>` → Actions tab shows `Cleanup On Demand Dispatch` fired; routine opens a draft PR or comments.
- [ ] Apply `auto-fix-approved` to an `auto-found` issue → `Bug Watch Write Dispatch` fires; routine acts per severity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)