### PR TITLE
cleanup(article_source_normalization): dedupe author creator-row builder

### DIFF
--- a/backend/app/services/article_source_normalization.py
+++ b/backend/app/services/article_source_normalization.py
@@ -49,6 +49,14 @@ def normalize_author_display_name(creator: dict[str, Any]) -> str:
     return first or last or "Unknown"
 
 
+def _author_creator_rows(names: Any) -> list[dict[str, Any]]:
+    return [
+        {"creator_type": "author", "display_name": str(name).strip(), "raw": {"name": name}}
+        for name in (names or [])
+        if str(name).strip()
+    ]
+
+
 @dataclass(slots=True)
 class CanonicalArticlePayload:
     canonical_identity: dict[str, str | None]
@@ -115,16 +123,7 @@ def normalize_zotero_item(
 def normalize_ris_entry(entry: dict[str, Any]) -> CanonicalArticlePayload:
     doi = normalize_doi(entry.get("doi"))
     url_landing = normalize_url(entry.get("url"))
-    creators = entry.get("authors") or []
-    creator_rows = [
-        {
-            "creator_type": "author",
-            "display_name": str(name).strip(),
-            "raw": {"name": name},
-        }
-        for name in creators
-        if str(name).strip()
-    ]
+    creator_rows = _author_creator_rows(entry.get("authors"))
     article_fields: dict[str, Any] = {
         "title": entry.get("title") or "Untitled",
         "abstract": entry.get("abstract"),
@@ -150,12 +149,7 @@ def normalize_ris_entry(entry: dict[str, Any]) -> CanonicalArticlePayload:
 def normalize_manual_entry(entry: dict[str, Any]) -> CanonicalArticlePayload:
     doi = normalize_doi(entry.get("doi"))
     url_landing = normalize_url(entry.get("url_landing"))
-    authors = entry.get("authors") or []
-    creator_rows = [
-        {"creator_type": "author", "display_name": str(name).strip(), "raw": {"name": name}}
-        for name in authors
-        if str(name).strip()
-    ]
+    creator_rows = _author_creator_rows(entry.get("authors"))
     article_fields: dict[str, Any] = {
         "title": entry.get("title") or "Untitled",
         "abstract": entry.get("abstract"),


### PR DESCRIPTION
Proactive weekly cleanup. Module untouched 60+ days (last real change `2026-03-30`, nothing in the 30-day window).

## Module
`backend/app/services/article_source_normalization.py`

## What
- `normalize_ris_entry` and `normalize_manual_entry` each built a **verbatim-identical** `creator_rows` list comprehension from a list of author-name strings.
- Extracted the shared logic into a private `_author_creator_rows(names)` helper and called it from both.
- Behavior-preserving refactor. Category: *consolidate near-identical helpers* (Layer C fallback — the `code-simplifier` skill was not loaded in this session).

## Anti-conflict gate
0 open PRs touch this module. The only open PR (#183, `autofix/issue-161`) touches frontend colaboracao hooks — disjoint.

## Evidence
**Duplication removed** (identical comprehension in two functions):
```
normalize_ris_entry:    creator_rows = [ {creator_type:"author", display_name:str(name).strip(), raw:{name}} for name in (authors) if str(name).strip() ]
normalize_manual_entry: creator_rows = [ {creator_type:"author", display_name:str(name).strip(), raw:{name}} for name in (authors) if str(name).strip() ]
```

**Diff size:** `1 file changed, 10 insertions(+), 16 deletions(-)` → net **−6 LOC**, 1 file (well within ≤200 LOC / ≤15 files).

**Lint:** `uv run ruff check .` → `All checks passed!`; `ruff format --diff` → already formatted.

**Tests:** `tests/unit/test_article_source_normalization.py` → `2 passed` (the cross-source test exercises both changed functions with `authors=["Jane Doe"]`, so the new helper is covered). Integration tests require a live Postgres/Supabase not available in the cleanup sandbox — CI validates the full suite.

## Constraints respected
No API/contract changes, no public symbol renames, no new abstractions beyond the single private dedupe helper. Forbidden paths untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbstZX31meM8kAvB14Foak)_