### PR TITLE
fix(copy): drop internal "Run" term from the shared consensus finalize panel

### DIFF
--- a/frontend/components/runs/ConsensusPanel.tsx
+++ b/frontend/components/runs/ConsensusPanel.tsx
@@ -9,7 +9,7 @@
  *      the arbitrator to publish something nobody picked).
  *
  * Once every divergent coord has a corresponding ConsensusDecision in
- * the run aggregate, "Finalize run" advances stage → finalized which
+ * the run aggregate, finalizing advances stage → finalized which
  * also flips status → completed and materializes the final published
  * state per coord.
  *
@@ -336,7 +336,7 @@ export function ConsensusPanel({
       >
         <p className="font-medium">No conflicts to resolve.</p>
         <p className="mt-1">
-          Every reviewer agreed on every field. You can finalize the run.
+          Every reviewer agreed on every field. You can finalize now.
         </p>
         <Button
           size="sm"
@@ -345,7 +345,7 @@ export function ConsensusPanel({
           disabled={isFinalizing}
           data-testid="consensus-finalize-empty"
         >
-          {isFinalizing ? "Finalizing…" : "Finalize run"}
+          {isFinalizing ? "Finalizing…" : "Finalize"}
         </Button>
       </div>
     );
@@ -371,7 +371,7 @@ export function ConsensusPanel({
             {isFinalizing
               ? "Finalizing…"
               : allResolved
-                ? "Finalize run"
+                ? "Finalize"
                 : `${totalCount - resolvedCount} left`}
           </Button>
         </div>

--- a/frontend/test/copy-run-vocabulary.test.ts
+++ b/frontend/test/copy-run-vocabulary.test.ts
@@ -58,4 +58,15 @@ describe('user-facing copy does not leak the internal "Run" entity', () => {
     expect(src).not.toContain('Run finalized');
     expect(src).toContain('Assessment finalized.');
   });
+
+  it('no longer ships the "Finalize run" labels in the shared consensus panel', () => {
+    const src = readFileSync(
+      resolve(here, '../components/runs/ConsensusPanel.tsx'),
+      'utf8',
+    );
+    // The panel is shared by extraction + QA, so the finalize affordance is
+    // phrased neutrally ("Finalize") rather than leaking the internal "run".
+    expect(src).not.toMatch(/Finalize run/);
+    expect(src).not.toMatch(/finalize the run/);
+  });
 });


### PR DESCRIPTION
## What

Closes the one remaining surface where the internal HITL **"Run"** term still leaked into user-facing copy: the shared **consensus finalize panel**.

The [2026-05-30 user-facing vocabulary change](docs/superpowers/specs/2026-05-30-run-user-facing-vocabulary-design.md) scoped `Run` → domain terms for the consensus-settings banner, the AI panel, and the QA finalize toast — but `ConsensusPanel.tsx` (a hardcoded component literal) was never in that change set, so it still showed **"Finalize run"** / **"You can finalize the run"**.

## Why neutral wording

`ConsensusPanel` is rendered for **both** kinds — `ExtractionFullScreen` and `QualityAssessmentFullScreen` — so per the spec's own rule for shared surfaces it gets a neutral phrasing instead of a kind-specific noun, and avoids stage names (`review`/`consensus`):

| Location | Before | After |
| --- | --- | --- |
| `ConsensusPanel.tsx:339` | "You can finalize **the run**." | "You can finalize **now**." |
| `ConsensusPanel.tsx:348` | "Finalize **run**" | "Finalize" |
| `ConsensusPanel.tsx:374` | "Finalize **run**" | "Finalize" |
| `ConsensusPanel.tsx:12` (internal comment) | …`"Finalize run"` advances stage… | …finalizing advances stage… |

Internal identifiers (`onFinalize`, `isFinalizing`, "run aggregate") are untouched — the spec keeps "Run" as internal ubiquitous language.

## Tests

- Extends `copy-run-vocabulary.test.ts` to assert the panel source no longer ships the `Finalize run` / `finalize the run` labels (same readFileSync pattern as the existing QA-toast guard).
- Existing testid-based `ConsensusPanel.test.tsx` stays green and exercises the changed lines (`consensus-finalize-empty`, `consensus-finalize-button`).
- `vitest` for both files: 11/11 pass. `tsc -p tsconfig.app.json`: no new errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
