### PR TITLE
fix(coordinate_coherence): reject cross-article instance_id in coherence check

### DIFF
--- a/backend/app/services/coordinate_coherence.py
+++ b/backend/app/services/coordinate_coherence.py
@@ -22,6 +22,10 @@ async def assert_coords_coherent(
     Coherent means:
     - The run exists.
     - instance_id belongs to the run's template.
+    - instance_id belongs to the run's article. Runs are per-article and so
+      are instances, so a template-coherent instance from a *different*
+      article must still be rejected; otherwise a proposal/decision/consensus
+      row could be written against the wrong article's run (#79).
     - field_id belongs to instance_id's entity_type.
     """
     result = await db.execute(
@@ -30,7 +34,9 @@ async def assert_coords_coherent(
             SELECT 1
             FROM public.extraction_runs r
             JOIN public.extraction_instances i
-              ON i.id = :instance_id AND i.template_id = r.template_id
+              ON i.id = :instance_id
+             AND i.template_id = r.template_id
+             AND i.article_id = r.article_id
             JOIN public.extraction_entity_types et
               ON et.id = i.entity_type_id
             JOIN public.extraction_fields f

--- a/backend/tests/integration/test_coordinate_coherence.py
+++ b/backend/tests/integration/test_coordinate_coherence.py
@@ -11,6 +11,7 @@ from app.services.coordinate_coherence import (
     assert_coords_coherent,
 )
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _coherent_triplet(db: AsyncSession):
@@ -121,5 +122,41 @@ async def test_field_from_different_entity_type_raises(db_session: AsyncSession)
     with pytest.raises(CoordinateMismatchError):
         await assert_coords_coherent(
             db_session, run_id=run_id, instance_id=instance_id, field_id=other_field_id
+        )
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_cross_article_instance_raises(db_session: AsyncSession) -> None:
+    """Regression for #79: an instance from article A must not validate against
+    a run for article B that shares the same template (only article_id differs)."""
+    # Article B: same project + same template as the seeded instance, so the
+    # article_id mismatch is the only variable under test.
+    article_b_id = uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {
+            "id": article_b_id,
+            "pid": SEED.primary_project,
+            "title": "Integration Test Article B (#79 cross-article repro)",
+        },
+    )
+
+    run_b = await RunLifecycleService(db_session).create_run(
+        project_id=SEED.primary_project,
+        article_id=article_b_id,
+        project_template_id=SEED.primary_template,
+        user_id=SEED.primary_profile,
+    )
+
+    with pytest.raises(CoordinateMismatchError):
+        await assert_coords_coherent(
+            db_session,
+            run_id=run_b.id,
+            instance_id=SEED.primary_instance,
+            field_id=SEED.primary_field,
         )
     await db_session.rollback()


### PR DESCRIPTION
## Summary

Fixes #79. `assert_coords_coherent` validated a `(run_id, instance_id, field_id)` triplet by joining `extraction_instances` on `i.template_id = r.template_id` only — never `i.article_id = r.article_id`. Because a project reuses one template across all its articles, an `instance_id` from article A passed the check when paired with a run for article B, so a proposal / reviewer-decision / consensus row could be written with a cross-article `instance_id`, silently corrupting extraction data with no error surfaced. Same-project only (not cross-tenant — project membership and article-in-project are enforced elsewhere), so severity is data integrity, Medium.

## Fix

One predicate added to the join in `backend/app/services/coordinate_coherence.py`:

```sql
JOIN public.extraction_instances i
  ON i.id = :instance_id
 AND i.template_id = r.template_id
 AND i.article_id = r.article_id   -- NEW
```

`extraction_runs.article_id` is `NOT NULL`, so `NULL = value` is UNKNOWN in SQL → NULL-article (template) instances are rejected too, which is correct: a run always targets a concrete article and proposals target concrete per-article instances. `assert_coords_coherent` is the single choke point for all three write paths (proposal / review / consensus), so the fix closes every path at once.

## Test plan

- New integration regression test `test_cross_article_instance_raises`: builds a second article B in the same project + a run for it against the seeded template, then asserts `assert_coords_coherent(run_B, instance_A, field)` raises `CoordinateMismatchError`. Confirmed **RED** before the fix (`DID NOT RAISE`), **GREEN** after.
- `coordinate_coherence` module: 5 passed (incl. the coherent control that must keep passing).
- Caller/flow + endpoint suites (proposal, review, consensus, hitl, manual, qa-publish, runs endpoints, multi-run scoping, workflow tables): all green.
- Full non-e2e backend suite: **1051 passed, 5 skipped, 0 failures**.
- `ruff check .` + `ruff format --check .`: clean.

## Follow-up (out of scope for this PR)

This invariant is currently enforced only at the service layer. The codebase already enforces analogous "child row must not reference a sibling in another run" invariants declaratively at the DB layer (composite FKs in migrations `0005` and `0012`). A defense-in-depth follow-up could add a composite-FK / deferred-trigger migration so a direct SQL write or a future writer that forgets the helper can't reintroduce the gap — left out here because it is a separate schema change with a nullable-`article_id` wrinkle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
