### PR TITLE
release(dev→main): consensus finalize copy fix (#188) + colaboracao stale-guard + cleanup (#187) + CI routines (#184)

### DIFF
--- a/.github/workflows/_routine-label-dispatch.yml
+++ b/.github/workflows/_routine-label-dispatch.yml
@@ -1,0 +1,54 @@
+name: _Routine Label Dispatch (shared worker — not called directly)
+
+# Reusable workflow called by label-dispatch callers (bug-watch-write-dispatch.yml,
+# cleanup-on-demand-dispatch.yml, and any future routine callers). Callers own:
+#   - the `on:` trigger and `if:` label filter
+#   - the concurrency group (per-routine namespace)
+#   - the secret and trigger_id specific to their routine
+#
+# This worker owns the common fire logic: TOKEN guard, curl, response log.
+
+on:
+  workflow_call:
+    inputs:
+      routine_trigger_id:
+        # Routine trigger ID (trig_…).
+        # If the routine is deleted and recreated, this ID changes — update it
+        # in the `with:` block of the calling workflow (not here).
+        description: "Routine trigger ID (trig_…)"
+        required: true
+        type: string
+    secrets:
+      ROUTINE_TOKEN:
+        description: "Bearer token for this routine's API trigger"
+        required: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Fire routine
+        env:
+          TOKEN: ${{ secrets.ROUTINE_TOKEN }}
+          TRIG: ${{ inputs.routine_trigger_id }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Missing ROUTINE_TOKEN secret — add the routine's API-trigger token (see the calling workflow's setup instructions)." >&2
+            echo "::notice::If the routine was recreated, also update routine_trigger_id in the calling workflow's 'with:' block." >&2
+            exit 1
+          fi
+          # anthropic-beta: this header is versioned. When the routine API graduates,
+          # check https://docs.anthropic.com/en/docs/claude-code/routines for the
+          # updated header value and bump it here.
+          curl -fsSL --max-time 30 -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/${TRIG}/fire" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg t "issue:${ISSUE} repo:${REPO}" '{text:$t}')" \
+            | tee /tmp/resp.json
+          echo "Fired. Session: $(jq -r '.claude_code_session_url // "(none)"' /tmp/resp.json)"

--- a/.github/workflows/bug-watch-write-dispatch.yml
+++ b/.github/workflows/bug-watch-write-dispatch.yml
@@ -1,0 +1,34 @@
+name: Bug Watch Write Dispatch
+
+# Reliable label-trigger for the `bug-watch-write` routine (native routine
+# issue-label triggers did not fire in testing). On `issues: labeled` with
+# `auto-fix-approved` AND the issue already carrying `auto-found`, this thin
+# caller fires the shared _routine-label-dispatch worker.
+# Runs on the routine's own bearer token — Pro/Max plan quota, NOT ANTHROPIC_API_KEY.
+#
+# One-time setup by repo owner:
+#   1. claude.ai/code/routines → edit `bug-watch-write` → API trigger → generate token → copy
+#   2. gh secret set CLAUDE_ROUTINE_BUGFIX_TOKEN -R raphaelfh/prumo   # paste token
+#   3. If routine is recreated: update routine_trigger_id in the `with:` block below.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: none
+
+concurrency:
+  group: bugfix-dispatch-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    if: >-
+      github.event.label.name == 'auto-fix-approved'
+      && contains(github.event.issue.labels.*.name, 'auto-found')
+    uses: ./.github/workflows/_routine-label-dispatch.yml
+    with:
+      routine_trigger_id: trig_01T8PF56S19cJ5iKusnQwuZF
+    secrets:
+      ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_BUGFIX_TOKEN }}

--- a/.github/workflows/cleanup-on-demand-dispatch.yml
+++ b/.github/workflows/cleanup-on-demand-dispatch.yml
@@ -1,0 +1,31 @@
+name: Cleanup On Demand Dispatch
+
+# Reliable label-trigger for the `cleanup` routine (native routine issue-label
+# triggers did not fire in testing). On `issues: labeled` with `tech-debt`, this
+# thin caller fires the shared _routine-label-dispatch worker.
+# Runs on the routine's own bearer token — Pro/Max plan quota, NOT ANTHROPIC_API_KEY.
+#
+# One-time setup by repo owner:
+#   1. claude.ai/code/routines → edit `cleanup` → API trigger → generate token → copy
+#   2. gh secret set CLAUDE_ROUTINE_CLEANUP_TOKEN -R raphaelfh/prumo   # paste token
+#   3. If routine is recreated: update routine_trigger_id in the `with:` block below.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: none
+
+concurrency:
+  group: cleanup-dispatch-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    if: github.event.label.name == 'tech-debt'
+    uses: ./.github/workflows/_routine-label-dispatch.yml
+    with:
+      routine_trigger_id: trig_01YBm1YjAd18JdZDe8thsPCd
+    secrets:
+      ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_CLEANUP_TOKEN }}

--- a/backend/app/services/article_source_normalization.py
+++ b/backend/app/services/article_source_normalization.py
@@ -49,6 +49,14 @@ def normalize_author_display_name(creator: dict[str, Any]) -> str:
     return first or last or "Unknown"
 
 
+def _author_creator_rows(names: Any) -> list[dict[str, Any]]:
+    return [
+        {"creator_type": "author", "display_name": str(name).strip(), "raw": {"name": name}}
+        for name in (names or [])
+        if str(name).strip()
+    ]
+
+
 @dataclass(slots=True)
 class CanonicalArticlePayload:
     canonical_identity: dict[str, str | None]
@@ -115,16 +123,7 @@ def normalize_zotero_item(
 def normalize_ris_entry(entry: dict[str, Any]) -> CanonicalArticlePayload:
     doi = normalize_doi(entry.get("doi"))
     url_landing = normalize_url(entry.get("url"))
-    creators = entry.get("authors") or []
-    creator_rows = [
-        {
-            "creator_type": "author",
-            "display_name": str(name).strip(),
-            "raw": {"name": name},
-        }
-        for name in creators
-        if str(name).strip()
-    ]
+    creator_rows = _author_creator_rows(entry.get("authors"))
     article_fields: dict[str, Any] = {
         "title": entry.get("title") or "Untitled",
         "abstract": entry.get("abstract"),
@@ -150,12 +149,7 @@ def normalize_ris_entry(entry: dict[str, Any]) -> CanonicalArticlePayload:
 def normalize_manual_entry(entry: dict[str, Any]) -> CanonicalArticlePayload:
     doi = normalize_doi(entry.get("doi"))
     url_landing = normalize_url(entry.get("url_landing"))
-    authors = entry.get("authors") or []
-    creator_rows = [
-        {"creator_type": "author", "display_name": str(name).strip(), "raw": {"name": name}}
-        for name in authors
-        if str(name).strip()
-    ]
+    creator_rows = _author_creator_rows(entry.get("authors"))
     article_fields: dict[str, Any] = {
         "title": entry.get("title") or "Untitled",
         "abstract": entry.get("abstract"),

--- a/frontend/components/runs/ConsensusPanel.tsx
+++ b/frontend/components/runs/ConsensusPanel.tsx
@@ -9,7 +9,7 @@
  *      the arbitrator to publish something nobody picked).
  *
  * Once every divergent coord has a corresponding ConsensusDecision in
- * the run aggregate, "Finalize run" advances stage → finalized which
+ * the run aggregate, finalizing advances stage → finalized which
  * also flips status → completed and materializes the final published
  * state per coord.
  *
@@ -336,7 +336,7 @@ export function ConsensusPanel({
       >
         <p className="font-medium">No conflicts to resolve.</p>
         <p className="mt-1">
-          Every reviewer agreed on every field. You can finalize the run.
+          Every reviewer agreed on every field. You can finalize now.
         </p>
         <Button
           size="sm"
@@ -345,7 +345,7 @@ export function ConsensusPanel({
           disabled={isFinalizing}
           data-testid="consensus-finalize-empty"
         >
-          {isFinalizing ? "Finalizing…" : "Finalize run"}
+          {isFinalizing ? "Finalizing…" : "Finalize"}
         </Button>
       </div>
     );
@@ -371,7 +371,7 @@ export function ConsensusPanel({
             {isFinalizing
               ? "Finalizing…"
               : allResolved
-                ? "Finalize run"
+                ? "Finalize"
                 : `${totalCount - resolvedCount} left`}
           </Button>
         </div>

--- a/frontend/hooks/extraction/colaboracao/useAllUserInstances.ts
+++ b/frontend/hooks/extraction/colaboracao/useAllUserInstances.ts
@@ -5,7 +5,7 @@
  * Used to group correctly by label in comparison.
  */
 
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {supabase} from '@/integrations/supabase/client';
 import {t} from '@/lib/copy';
 import type {ExtractionInstance} from '@/types/extraction';
@@ -32,6 +32,7 @@ export function useAllUserInstances(props: UseAllUserInstancesProps): UseAllUser
   const [instances, setInstances] = useState<InstanceWithCreator[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const generationRef = useRef(0);
 
   useEffect(() => {
     if (!enabled || !articleId) {
@@ -40,9 +41,13 @@ export function useAllUserInstances(props: UseAllUserInstancesProps): UseAllUser
     }
 
     loadInstances();
+    return () => {
+      generationRef.current += 1;
+    };
   }, [articleId, enabled]);
 
   const loadInstances = async () => {
+    const myGeneration = ++generationRef.current;
     setLoading(true);
     setError(null);
 
@@ -55,16 +60,18 @@ export function useAllUserInstances(props: UseAllUserInstancesProps): UseAllUser
         .eq('article_id', articleId)
         .order('created_at', { ascending: true });
 
+      if (myGeneration !== generationRef.current) return;
       if (queryError) throw queryError;
 
       setInstances((data || []) as InstanceWithCreator[]);
         console.warn(`✅ Loaded ${(data || []).length} instances from all users`);
 
     } catch (err: any) {
+      if (myGeneration !== generationRef.current) return;
         console.error('❌ Error loading instances:', err);
         setError(err.message || t('extraction', 'errors_loadInstances'));
     } finally {
-      setLoading(false);
+      if (myGeneration === generationRef.current) setLoading(false);
     }
   };
 

--- a/frontend/hooks/extraction/colaboracao/useOtherExtractions.ts
+++ b/frontend/hooks/extraction/colaboracao/useOtherExtractions.ts
@@ -7,7 +7,7 @@
  * `profiles` (display name + avatar). Used by the comparison UI.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ExtractionValueService } from '@/services/extractionValueService';
 import { t } from '@/lib/copy';
@@ -49,6 +49,7 @@ export function useOtherExtractions(
   const [otherExtractions, setOtherExtractions] = useState<OtherExtraction[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const generationRef = useRef(0);
 
   useEffect(() => {
     if (!enabled || !articleId || !currentUserId) {
@@ -56,21 +57,26 @@ export function useOtherExtractions(
       return;
     }
     void loadOtherExtractions();
+    return () => {
+      generationRef.current += 1;
+    };
   }, [articleId, currentUserId, enabled, templateId]);
 
   const loadOtherExtractions = async () => {
+    const myGeneration = ++generationRef.current;
     setLoading(true);
     setError(null);
 
     try {
       if (!templateId) {
-        setOtherExtractions([]);
+        if (myGeneration === generationRef.current) setOtherExtractions([]);
         return;
       }
       const run = await ExtractionValueService.findActiveRun(
         articleId,
         templateId,
       );
+      if (myGeneration !== generationRef.current) return;
       if (!run) {
         setOtherExtractions([]);
         return;
@@ -81,6 +87,7 @@ export function useOtherExtractions(
         currentUserId,
       );
 
+      if (myGeneration !== generationRef.current) return;
       setOtherExtractions(
         others.map((o) => ({
           userId: o.reviewerId,
@@ -91,10 +98,11 @@ export function useOtherExtractions(
         })),
       );
     } catch (err: any) {
+      if (myGeneration !== generationRef.current) return;
       console.error('Error loading other extractions:', err);
       setError(err.message || t('extraction', 'errors_loadOtherExtractions'));
     } finally {
-      setLoading(false);
+      if (myGeneration === generationRef.current) setLoading(false);
     }
   };
 

--- a/frontend/test/copy-run-vocabulary.test.ts
+++ b/frontend/test/copy-run-vocabulary.test.ts
@@ -58,4 +58,15 @@ describe('user-facing copy does not leak the internal "Run" entity', () => {
     expect(src).not.toContain('Run finalized');
     expect(src).toContain('Assessment finalized.');
   });
+
+  it('no longer ships the "Finalize run" labels in the shared consensus panel', () => {
+    const src = readFileSync(
+      resolve(here, '../components/runs/ConsensusPanel.tsx'),
+      'utf8',
+    );
+    // The panel is shared by extraction + QA, so the finalize affordance is
+    // phrased neutrally ("Finalize") rather than leaking the internal "run".
+    expect(src).not.toMatch(/Finalize run/);
+    expect(src).not.toMatch(/finalize the run/);
+  });
 });

--- a/frontend/test/hooks/useColaboracaoStaleGuard.test.tsx
+++ b/frontend/test/hooks/useColaboracaoStaleGuard.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for issue #161 — stale-data overwrite in colaboracao hooks.
+ *
+ * Both `useOtherExtractions` and `useAllUserInstances` must discard responses
+ * that arrive after `articleId` has changed (generation-counter guard).
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+// ── useOtherExtractions ────────────────────────────────────────────────────
+
+vi.mock('@/services/extractionValueService', () => ({
+  ExtractionValueService: {
+    findActiveRun: vi.fn(),
+    loadValuesForOthers: vi.fn(),
+  },
+}));
+
+import { ExtractionValueService } from '@/services/extractionValueService';
+import { useOtherExtractions } from '@/hooks/extraction/colaboracao/useOtherExtractions';
+
+const findActiveRunMock = ExtractionValueService.findActiveRun as ReturnType<typeof vi.fn>;
+const loadValuesForOthersMock = ExtractionValueService.loadValuesForOthers as ReturnType<typeof vi.fn>;
+
+// ── useAllUserInstances ────────────────────────────────────────────────────
+
+vi.mock('@/integrations/supabase/client', () => {
+  const orderMock = vi.fn();
+  const eqMock = vi.fn(() => ({ order: orderMock }));
+  const selectMock = vi.fn(() => ({ eq: eqMock }));
+  const fromMock = vi.fn(() => ({ select: selectMock }));
+  return { supabase: { from: fromMock, __orderMock: orderMock } };
+});
+
+import { supabase } from '@/integrations/supabase/client';
+import { useAllUserInstances } from '@/hooks/extraction/colaboracao/useAllUserInstances';
+
+const supabaseOrderMock = (supabase as any).__orderMock as ReturnType<typeof vi.fn>;
+
+// ──────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useOtherExtractions — stale-data guard', () => {
+  it('discards a response that arrives after articleId has changed', async () => {
+    // Deferred promise simulates a slow first fetch.
+    let resolveFirst!: (v: unknown) => void;
+    const firstFetch = new Promise((res) => { resolveFirst = res; });
+
+    findActiveRunMock
+      .mockReturnValueOnce(firstFetch)          // art-1: slow
+      .mockResolvedValue(null);                 // art-2: fast, no run
+
+    const { result, rerender } = renderHook(
+      ({ articleId }) =>
+        useOtherExtractions({
+          articleId,
+          projectId: 'proj-1',
+          templateId: 'tpl-1',
+          currentUserId: 'user-1',
+        }),
+      { initialProps: { articleId: 'art-1' } },
+    );
+
+    // Switch article while art-1 fetch is still in flight.
+    rerender({ articleId: 'art-2' });
+
+    // Now let the stale art-1 response arrive.
+    resolveFirst({ id: 'run-stale' });
+    loadValuesForOthersMock.mockResolvedValue([
+      {
+        reviewerId: 'r-1',
+        reviewerName: 'Alice',
+        reviewerAvatar: null,
+        values: { field1: 'STALE' },
+        latestDecidedAt: null,
+      },
+    ]);
+
+    // art-2 has no run → resolves to empty immediately.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Stale data from art-1 must NOT appear.
+    expect(result.current.otherExtractions).toHaveLength(0);
+  });
+});
+
+describe('useAllUserInstances — stale-data guard', () => {
+  it('discards a response that arrives after articleId has changed', async () => {
+    let resolveFirst!: (v: unknown) => void;
+    const firstFetch = new Promise((res) => { resolveFirst = res; });
+
+    supabaseOrderMock
+      .mockReturnValueOnce(firstFetch)          // art-1: slow
+      .mockResolvedValue({ data: [], error: null }); // art-2: fast, empty
+
+    const staleInstances = [
+      { id: 'inst-stale', article_id: 'art-1', created_by: 'user-1' },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ articleId }) => useAllUserInstances({ articleId }),
+      { initialProps: { articleId: 'art-1' } },
+    );
+
+    // Switch article before art-1 resolves.
+    rerender({ articleId: 'art-2' });
+
+    // Let the stale art-1 response arrive.
+    resolveFirst({ data: staleInstances, error: null });
+
+    // art-2 resolves to empty immediately.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Stale data from art-1 must NOT appear.
+    expect(result.current.instances).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Promote `dev` → `main` to ship the consensus-panel copy fix to production (triggers the Railway deploy from `main`).

## Included (already merged + green on `dev`)

| Commit | Summary |
| --- | --- |
| `8e1ab09` (#188) | **fix(copy):** drop internal "Run" term from the shared consensus finalize panel — button → "Finalize", sentence → "You can finalize now". Extends the copy-run-vocabulary guard test. |
| `16a378a` | **fix(extraction):** generation-counter guard against stale `articleId` data in colaboracao hooks (+ `useColaboracaoStaleGuard` test). |
| `f84e368` (#187) | **cleanup:** dedupe author creator-row builder in `article_source_normalization`. |
| `8cf51e1` (#184) | **ci(routines):** reliable label-dispatch workflows (plan-quota `/fire`). |

## Why now

The "Run" user-facing vocabulary change was already in `main`, but `ConsensusPanel.tsx` (a hardcoded literal, never in that change's scope) still leaked "Finalize run". This promotes the gap-closing fix to prod alongside the other `dev`-integrated work.

All checks were green on the feature PR (#188) and on `dev`. Backend tests, frontend build/lint, E2E config gate, and Architectural Fitness all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
