### PR TITLE
fix(security): P1 batch — Gemini key leak, zotero membership gap, feedback RLS drift

### DIFF
--- a/backend/alembic/versions/0021_reconcile_feedback_rls.py
+++ b/backend/alembic/versions/0021_reconcile_feedback_rls.py
@@ -1,0 +1,66 @@
+"""Reconcile out-of-band RLS drift on feedback_reports (issue #185).
+
+Migration 0020 locked `feedback_reports` to service-role-only by dropping
+`feedback_reports_insert` and `feedback_reports_select_own`. The expected
+end-state after 0001 -> 0020 is therefore **zero permissive policies** — the
+API/worker reach the table as `service_role`, which bypasses RLS.
+
+The migration-drift detector (#185) found four policies on the table that no
+migration authored:
+
+  - feedback_reports_insert  (should have been dropped by 0020)
+  - feedback_reports_select  (never created by any migration)
+  - feedback_reports_update  (never created by any migration)
+  - feedback_reports_delete  (never created by any migration)
+
+They were added out-of-band (Supabase dashboard / MCP). A lingering permissive
+`insert` policy is the security-relevant one: it lets an authenticated user
+INSERT straight into the table, bypassing `POST /api/v1/feedback` (which
+validates, enriches, and queues the report for Linear) so the row is never
+forwarded.
+
+By the time this migration was written, prod had already self-reconciled
+(pg_policies showed 0 policies on both feedback tables, RLS still enabled).
+This migration therefore codifies the canonical state in version control and
+cleans any non-prod environment that still carries the stray policies — the
+`IF EXISTS` clauses make it a safe no-op where they are already gone.
+
+Per the project rule, this reconciliation runs through Alembic, never through
+the Supabase MCP/dashboard (which is what caused the drift in the first place).
+
+Revision ID: 0021_reconcile_feedback_rls
+Revises: 0020_feedback_outbox
+Create Date: 2026-06-04
+"""
+
+from alembic import op
+
+revision = "0021_reconcile_feedback_rls"
+down_revision = "0020_feedback_outbox"
+branch_labels = None
+depends_on = None
+
+
+# Every permissive policy that must NOT exist on feedback_reports.
+_STRAY_POLICIES = (
+    "feedback_reports_insert",
+    "feedback_reports_select",
+    "feedback_reports_update",
+    "feedback_reports_delete",
+    # also drop the legacy own-row read in case an older env still has it
+    "feedback_reports_select_own",
+)
+
+
+def upgrade() -> None:
+    # RLS must stay enabled; ENABLE is idempotent (no-op if already on).
+    op.execute("ALTER TABLE public.feedback_reports ENABLE ROW LEVEL SECURITY;")
+    for policy in _STRAY_POLICIES:
+        op.execute(f'DROP POLICY IF EXISTS "{policy}" ON public.feedback_reports;')
+
+
+def downgrade() -> None:
+    # Intentionally empty. This migration asserts the *absence* of policies that
+    # no migration ever created; recreating them on downgrade would re-introduce
+    # the exact drift (and security gap) it reconciles. RLS stays enabled.
+    pass

--- a/backend/app/api/v1/endpoints/zotero_import.py
+++ b/backend/app/api/v1/endpoints/zotero_import.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import CurrentUser, DbSession, SupabaseClient
 from app.core.error_handler import AppError, AuthorizationError, NotFoundError
@@ -63,6 +64,21 @@ class ZoteroAction(StrEnum):
     SYNC_STATUS = "sync-status"
     SYNC_RETRY_FAILED = "sync-retry-failed"
     SYNC_ITEM_RESULT = "sync-item-result"
+
+
+async def _assert_project_member(db: AsyncSession, project_id: UUID, user_sub: str) -> None:
+    """Authorize the caller against a project.
+
+    The API runs as service role and bypasses RLS, so every project-scoped action
+    must gate membership in code (mirrors the ``is_project_member`` RLS helper).
+
+    Raises:
+        AuthorizationError: if the user is not a member of the project.
+    """
+    async with UnitOfWork(db) as uow:
+        is_member = await uow.project_members.is_member(project_id, user_sub)
+    if not is_member:
+        raise AuthorizationError("User is not authorized for this project")
 
 
 @router.post(
@@ -139,10 +155,7 @@ async def zotero_action(
             case ZoteroAction.SYNC_COLLECTION:
                 sync_req = SyncCollectionRequest(**body)
                 project_id = UUID(sync_req.project_id)
-                async with UnitOfWork(db) as uow:
-                    is_member = await uow.project_members.is_member(project_id, user.sub)
-                    if not is_member:
-                        raise AuthorizationError("User is not authorized for this project")
+                await _assert_project_member(db, project_id, user.sub)
                 import_service = ZoteroImportService(
                     db=db,
                     user_id=user.sub,
@@ -187,6 +200,7 @@ async def zotero_action(
                 run = await import_service.get_sync_status(UUID(status_req.sync_run_id))
                 if not run:
                     raise NotFoundError(resource="sync_run", resource_id=status_req.sync_run_id)
+                await _assert_project_member(db, run.project_id, user.sub)
                 result = SyncStatusResponse(
                     syncRunId=str(run.id),
                     status=run.status,
@@ -215,6 +229,7 @@ async def zotero_action(
                 run = await import_service.get_sync_status(UUID(retry_req.sync_run_id))
                 if not run:
                     raise NotFoundError(resource="sync_run", resource_id=retry_req.sync_run_id)
+                await _assert_project_member(db, run.project_id, user.sub)
                 retry_run = await import_service.create_sync_run(
                     project_id=run.project_id,
                     collection_key=run.source_collection_key,
@@ -251,6 +266,7 @@ async def zotero_action(
                 run = await import_service.get_sync_status(UUID(result_req.sync_run_id))
                 if not run:
                     raise NotFoundError(resource="sync_run", resource_id=result_req.sync_run_id)
+                await _assert_project_member(db, run.project_id, user.sub)
                 events, total = await import_service.get_sync_item_results(
                     sync_run_id=UUID(result_req.sync_run_id),
                     status_filter=result_req.status_filter,

--- a/backend/app/services/api_key_service.py
+++ b/backend/app/services/api_key_service.py
@@ -397,7 +397,9 @@ class APIKeyService(LoggerMixin):
                 provider=provider,
                 error=str(e),
             )
-            return {"status": "pending", "message": f"Validation error: {str(e)}"}
+            # Defense-in-depth: never echo the raw exception to the client. Transport
+            # errors can embed request details; the full error is in the log above.
+            return {"status": "pending", "message": "Validation error: could not reach provider"}
 
     async def _validate_openai(self, api_key: str) -> dict[str, Any]:
         """Validate OpenAI API key by listing models."""
@@ -450,8 +452,12 @@ class APIKeyService(LoggerMixin):
     async def _validate_gemini(self, api_key: str) -> dict[str, Any]:
         """Validate Google Gemini API key."""
         async with httpx.AsyncClient() as client:
+            # Pass the key as a header, never in the URL query string: httpx embeds
+            # the full URL in transport-error messages, which would leak the secret
+            # into logs and the validation response. Mirrors the other providers.
             response = await client.get(
-                f"https://generativelanguage.googleapis.com/v1/models?key={api_key}",
+                "https://generativelanguage.googleapis.com/v1/models",
+                headers={"x-goog-api-key": api_key},
                 timeout=10.0,
             )
 

--- a/backend/tests/integration/test_membership_guards.py
+++ b/backend/tests/integration/test_membership_guards.py
@@ -576,3 +576,99 @@ async def test_cancel_export_rejects_non_owner(
     assert body["ok"] is False
     assert body["error"]["code"] == "FORBIDDEN"
     assert revoked == []
+
+
+# =================== #86: Zotero sync membership-revocation gap ===================
+#
+# SYNC_STATUS / SYNC_RETRY_FAILED / SYNC_ITEM_RESULT load the run via
+# ``get_owned_run`` (scoped to ``requested_by_user_id``), so they are not the
+# "any user with a sync_run_id" BOLA originally reported. The real gap: they did
+# NOT re-check *project membership* the way SYNC_COLLECTION does, so the user who
+# created a run could still read it / re-enqueue an import into that project AFTER
+# being removed from it. We model that by owning the run but not being a member.
+
+
+@pytest_asyncio.fixture
+async def outsider_sync_run(
+    db_session: AsyncSession,
+    outsider_user: UUID,
+) -> AsyncGenerator[str | None, None]:
+    """A run OWNED by the outsider, in a project they are NOT a member of."""
+    project_id = (
+        await db_session.execute(
+            text(
+                "SELECT id FROM public.projects "
+                "WHERE NOT public.is_project_member(id, :uid) LIMIT 1"
+            ),
+            {"uid": str(outsider_user)},
+        )
+    ).scalar()
+    if project_id is None:
+        yield None
+        return
+
+    sync_run_id = uuid.uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO public.article_sync_runs "
+            "(id, project_id, requested_by_user_id, started_at, status, source, failed) "
+            "VALUES (:id, :pid, :requester, now(), 'completed', 'zotero', 1)"
+        ),
+        # requested_by = the outsider so the run passes the get_owned_run ownership
+        # filter and execution reaches the new project-membership guard.
+        {"id": str(sync_run_id), "pid": str(project_id), "requester": str(outsider_user)},
+    )
+    await db_session.commit()
+    try:
+        yield str(sync_run_id)
+    finally:
+        await db_session.execute(
+            text("DELETE FROM public.article_sync_runs WHERE id = :id"),
+            {"id": str(sync_run_id)},
+        )
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_zotero_sync_status_403_for_non_member(
+    db_client: AsyncClient,
+    outsider_sync_run: str | None,
+) -> None:
+    if outsider_sync_run is None:
+        pytest.skip("Need a project the outsider does not belong to")
+    res = await db_client.post(
+        "/api/v1/zotero/sync-status",
+        json={"syncRunId": outsider_sync_run},
+    )
+    assert res.status_code == 403, res.text
+
+
+@pytest.mark.asyncio
+async def test_zotero_sync_retry_failed_403_for_non_member(
+    db_client: AsyncClient,
+    outsider_sync_run: str | None,
+) -> None:
+    """The most dangerous of the three: a non-member could enqueue a re-import
+    (a write + Celery task) into someone else's project. The guard must fire
+    before ``create_sync_run`` runs."""
+    if outsider_sync_run is None:
+        pytest.skip("Need a project the outsider does not belong to")
+    res = await db_client.post(
+        "/api/v1/zotero/sync-retry-failed",
+        json={"syncRunId": outsider_sync_run},
+    )
+    assert res.status_code == 403, res.text
+
+
+@pytest.mark.asyncio
+async def test_zotero_sync_item_result_403_for_non_member(
+    db_client: AsyncClient,
+    outsider_sync_run: str | None,
+) -> None:
+    if outsider_sync_run is None:
+        pytest.skip("Need a project the outsider does not belong to")
+    res = await db_client.post(
+        "/api/v1/zotero/sync-item-result",
+        json={"syncRunId": outsider_sync_run},
+    )
+    assert res.status_code == 403, res.text

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -104,8 +104,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0020_feedback_outbox" in out, (
-        f"Expected head revision '0020_feedback_outbox', got:\n{out}"
+    assert "0021_reconcile_feedback_rls" in out, (
+        f"Expected head revision '0021_reconcile_feedback_rls', got:\n{out}"
     )
 
 

--- a/backend/tests/integration/test_zotero_import_api.py
+++ b/backend/tests/integration/test_zotero_import_api.py
@@ -37,6 +37,7 @@ async def test_sync_status_returns_404_for_unknown_run(client: AsyncClient) -> N
 async def test_sync_item_result_returns_items(client: AsyncClient) -> None:
     run = MagicMock()
     run.id = uuid4()
+    run.project_id = uuid4()
     run.status = "completed"
     run.total_received = 1
     run.persisted = 1
@@ -57,11 +58,19 @@ async def test_sync_item_result_returns_items(client: AsyncClient) -> None:
     event.authority_rule_applied = "source_parity_wins"
     event.processed_at = "2026-03-28T00:00:00Z"
 
-    with patch("app.api.v1.endpoints.zotero_import.ZoteroImportService") as service_cls:
+    with (
+        patch("app.api.v1.endpoints.zotero_import.ZoteroImportService") as service_cls,
+        patch("app.api.v1.endpoints.zotero_import.UnitOfWork") as uow_cls,
+    ):
         service = MagicMock()
         service.get_sync_status = AsyncMock(return_value=run)
         service.get_sync_item_results = AsyncMock(return_value=([event], 1))
         service_cls.return_value = service
+
+        # The endpoint now re-checks project membership before returning results.
+        uow = AsyncMock()
+        uow.project_members.is_member = AsyncMock(return_value=True)
+        uow_cls.return_value.__aenter__.return_value = uow
 
         response = await client.post(
             "/api/v1/zotero/sync-item-result",

--- a/backend/tests/unit/test_api_key_service.py
+++ b/backend/tests/unit/test_api_key_service.py
@@ -603,6 +603,26 @@ class TestValidateGemini:
             result = await svc._validate_gemini("bad-key")
         assert result["status"] == "invalid"
 
+    @pytest.mark.asyncio
+    async def test_key_sent_as_header_never_in_url(self) -> None:
+        """Regression for #91: the Gemini key must travel in the x-goog-api-key
+        header, never in the URL query string. httpx embeds the request URL in
+        transport-error messages, so a key in the URL leaks into the logs and the
+        validation response on any timeout/network error."""
+        svc = make_service()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        get_mock = AsyncMock(return_value=mock_response)
+        with patch("httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__.return_value.get = get_mock
+            await svc._validate_gemini("SECRET-KEY")
+
+        args, kwargs = get_mock.call_args
+        url = args[0] if args else kwargs.get("url", "")
+        assert "SECRET-KEY" not in url
+        assert "key=" not in url
+        assert kwargs.get("headers") == {"x-goog-api-key": "SECRET-KEY"}
+
 
 class TestValidateGrok:
     @pytest.mark.asyncio


### PR DESCRIPTION
P1 security/authz batch from the open-issue triage. Each fix was verified against current code and covered by tests.

Closes #91, #86, #185.

## #91 — Gemini API key leaked via URL query string (was: P1)
`api_key_service._validate_gemini` passed the key as `?key=<secret>`. httpx embeds the request URL in transport-error messages, so any timeout/network error leaked the **plaintext key** into structlog **and** the validation-response body returned to the client. The other three providers already use headers.
- **Fix:** send the key via the `x-goog-api-key` header; stop echoing raw `str(e)` in `validation_message`.
- **Test:** `test_key_sent_as_header_never_in_url` asserts the secret never appears in the URL.

## #86 — Zotero sync branches skipped the membership check (corrected: membership-revocation gap, not open BOLA)
`SYNC_STATUS` / `SYNC_RETRY_FAILED` / `SYNC_ITEM_RESULT` didn't re-check project membership like `SYNC_COLLECTION` does. The runs are **already scoped to the caller** via `get_owned_run` (`requested_by_user_id`), so the original "any user with a sync_run_id" framing was an overstatement — but a user **removed from a project** could still read/re-enqueue an import for a run they created there (`SYNC_RETRY_FAILED` is a write + Celery enqueue).
- **Fix:** factor the guard into `_assert_project_member(db, project_id, user_sub)` and call it in all four branches (refactored `SYNC_COLLECTION` onto it too).
- **Tests:** three `*_403_for_non_member` tests in `test_membership_guards.py` (run owned by the caller, in a project they're not a member of → 403).

## #185 — feedback_reports out-of-band RLS drift
Migration 0020 locked the table to service-role-only (0 permissive policies). The drift detector found 4 dashboard-created policies; a lingering `insert` policy would let users bypass `POST /api/v1/feedback`.
- **Note:** prod had **already self-reconciled** (`pg_policies` = 0 on both feedback tables, RLS still enabled) by 2026-06-04. This migration codifies that canonical state, is idempotent (`DROP POLICY IF EXISTS` + `ENABLE RLS`), and cleans any lingering non-prod env. Done via Alembic, never the Supabase MCP/dashboard.
- **Verified:** `alembic upgrade head` → `downgrade -1` → `upgrade head` clean against local Supabase.

## Verification
- `ruff check` + `ruff format --check`: clean
- 74 tests pass across `test_api_key_service`, `test_membership_guards`, `test_zotero_import_api`, `test_zotero_endpoints`

🤖 Generated with [Claude Code](https://claude.com/claude-code)