### PR TITLE
Promote dev → main: coordinate_coherence cross-article fix (#79)

### DIFF
--- a/backend/app/services/coordinate_coherence.py
+++ b/backend/app/services/coordinate_coherence.py
@@ -22,6 +22,10 @@ async def assert_coords_coherent(
     Coherent means:
     - The run exists.
     - instance_id belongs to the run's template.
+    - instance_id belongs to the run's article. Runs are per-article and so
+      are instances, so a template-coherent instance from a *different*
+      article must still be rejected; otherwise a proposal/decision/consensus
+      row could be written against the wrong article's run (#79).
     - field_id belongs to instance_id's entity_type.
     """
     result = await db.execute(
@@ -30,7 +34,9 @@ async def assert_coords_coherent(
             SELECT 1
             FROM public.extraction_runs r
             JOIN public.extraction_instances i
-              ON i.id = :instance_id AND i.template_id = r.template_id
+              ON i.id = :instance_id
+             AND i.template_id = r.template_id
+             AND i.article_id = r.article_id
             JOIN public.extraction_entity_types et
               ON et.id = i.entity_type_id
             JOIN public.extraction_fields f

--- a/backend/tests/integration/test_coordinate_coherence.py
+++ b/backend/tests/integration/test_coordinate_coherence.py
@@ -11,6 +11,7 @@ from app.services.coordinate_coherence import (
     assert_coords_coherent,
 )
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _coherent_triplet(db: AsyncSession):
@@ -121,5 +122,41 @@ async def test_field_from_different_entity_type_raises(db_session: AsyncSession)
     with pytest.raises(CoordinateMismatchError):
         await assert_coords_coherent(
             db_session, run_id=run_id, instance_id=instance_id, field_id=other_field_id
+        )
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_cross_article_instance_raises(db_session: AsyncSession) -> None:
+    """Regression for #79: an instance from article A must not validate against
+    a run for article B that shares the same template (only article_id differs)."""
+    # Article B: same project + same template as the seeded instance, so the
+    # article_id mismatch is the only variable under test.
+    article_b_id = uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {
+            "id": article_b_id,
+            "pid": SEED.primary_project,
+            "title": "Integration Test Article B (#79 cross-article repro)",
+        },
+    )
+
+    run_b = await RunLifecycleService(db_session).create_run(
+        project_id=SEED.primary_project,
+        article_id=article_b_id,
+        project_template_id=SEED.primary_template,
+        user_id=SEED.primary_profile,
+    )
+
+    with pytest.raises(CoordinateMismatchError):
+        await assert_coords_coherent(
+            db_session,
+            run_id=run_b.id,
+            instance_id=SEED.primary_instance,
+            field_id=SEED.primary_field,
         )
     await db_session.rollback()


### PR DESCRIPTION
Promotion of `dev` → `main` (production / Railway deploy).

Sole change vs `main`: the #79 fix — `assert_coords_coherent` now rejects a cross-article `instance_id` (adds `AND i.article_id = r.article_id` to the join) + integration regression test. Merged to `dev` via #189 (squash `0553e5a`).

Verified `git log origin/main..origin/dev` = 1 commit, 2 files (`backend/app/services/coordinate_coherence.py`, `backend/tests/integration/test_coordinate_coherence.py`). Full CI green on #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
