### PR TITLE
fix(extraction): P1 data-integrity — reopen forks past finalized child, QA session stale-guard, model-progress run scoping

### DIFF
--- a/backend/alembic/versions/0022_scope_model_progress_run.py
+++ b/backend/alembic/versions/0022_scope_model_progress_run.py
@@ -1,0 +1,194 @@
+"""Scope calculate_model_progress reviewer decisions to the active run (#97).
+
+``calculate_model_progress`` (introduced in 0013) counts a field as "filled"
+when either a ``published_state`` carries a value (run-agnostic — the canonical
+finalized value, correct) OR a reviewer recorded a non-reject decision for it.
+The reviewer-states branch had **no run filter**, so for an article
+re-extracted across multiple runs (finalize -> reopen) the non-reject decisions
+from *prior* runs leaked into the current run's count and inflated the per-model
+progress badge (rendered via ``useModelManagement`` -> the RPC at
+``frontend/hooks/extraction/useModelManagement.ts``).
+
+The 0013 docstring already promised "on the active run"; this aligns the
+implementation with the spec. The active run is the most recent non-cancelled
+run for the ``(article, template)`` pair — instances are template-scoped (no
+``run_id`` column), so we derive the template from the model instance. When
+there is no active run the reviewer branch contributes nothing and only
+published values count.
+
+Only the reviewer-states ``EXISTS`` clause changes (it gains the
+``rs.run_id = active_run`` predicate). Signature, return shape,
+``SECURITY DEFINER``, ``search_path`` and grants are identical to 0013.
+
+Revision ID: 0022_scope_model_progress_run
+Revises: 0021_reconcile_feedback_rls
+Create Date: 2026-06-04
+"""
+
+from alembic import op
+
+revision = "0022_scope_model_progress_run"
+down_revision = "0021_reconcile_feedback_rls"
+branch_labels = None
+depends_on = None
+
+
+# Active-run-scoped body (the fix).
+_BODY_SCOPED = """
+CREATE OR REPLACE FUNCTION public.calculate_model_progress(
+    p_article_id uuid,
+    p_model_id uuid
+)
+RETURNS TABLE(
+    completed_fields integer,
+    total_fields integer,
+    percentage numeric
+)
+LANGUAGE plpgsql STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH model_instances AS (
+        SELECT id, entity_type_id
+        FROM public.extraction_instances
+        WHERE article_id = p_article_id
+          AND (id = p_model_id OR parent_instance_id = p_model_id)
+    ),
+    active_run AS (
+        SELECT r.id
+        FROM public.extraction_runs r
+        WHERE r.article_id = p_article_id
+          AND r.template_id = (
+              SELECT template_id
+              FROM public.extraction_instances
+              WHERE id = p_model_id
+          )
+          AND r.stage <> 'cancelled'
+        ORDER BY r.created_at DESC
+        LIMIT 1
+    ),
+    field_universe AS (
+        SELECT mi.id AS instance_id, ef.id AS field_id
+        FROM model_instances mi
+        JOIN public.extraction_fields ef ON ef.entity_type_id = mi.entity_type_id
+    ),
+    filled AS (
+        SELECT fu.instance_id, fu.field_id
+        FROM field_universe fu
+        WHERE EXISTS (
+            SELECT 1
+            FROM public.extraction_published_states ps
+            WHERE ps.instance_id = fu.instance_id
+              AND ps.field_id = fu.field_id
+              AND ps.value IS NOT NULL
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM public.extraction_reviewer_states rs
+            JOIN public.extraction_reviewer_decisions rd
+                ON rd.id = rs.current_decision_id
+            WHERE rs.instance_id = fu.instance_id
+              AND rd.field_id = fu.field_id
+              AND rd.decision <> 'reject'
+              AND rs.run_id = (SELECT id FROM active_run)
+        )
+    )
+    SELECT
+        (SELECT COUNT(*)::integer FROM filled)         AS completed_fields,
+        (SELECT COUNT(*)::integer FROM field_universe) AS total_fields,
+        CASE
+            WHEN (SELECT COUNT(*) FROM field_universe) = 0
+                THEN 0::numeric
+            ELSE ROUND(
+                (SELECT COUNT(*) FROM filled)::numeric * 100.0
+                    / (SELECT COUNT(*) FROM field_universe)::numeric,
+                2
+            )
+        END AS percentage;
+END;
+$$;
+"""
+
+# 0013 body, verbatim — reviewer-states branch NOT scoped to a run (for downgrade).
+_BODY_0013 = """
+CREATE OR REPLACE FUNCTION public.calculate_model_progress(
+    p_article_id uuid,
+    p_model_id uuid
+)
+RETURNS TABLE(
+    completed_fields integer,
+    total_fields integer,
+    percentage numeric
+)
+LANGUAGE plpgsql STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH model_instances AS (
+        SELECT id, entity_type_id
+        FROM public.extraction_instances
+        WHERE article_id = p_article_id
+          AND (id = p_model_id OR parent_instance_id = p_model_id)
+    ),
+    field_universe AS (
+        SELECT mi.id AS instance_id, ef.id AS field_id
+        FROM model_instances mi
+        JOIN public.extraction_fields ef ON ef.entity_type_id = mi.entity_type_id
+    ),
+    filled AS (
+        SELECT fu.instance_id, fu.field_id
+        FROM field_universe fu
+        WHERE EXISTS (
+            SELECT 1
+            FROM public.extraction_published_states ps
+            WHERE ps.instance_id = fu.instance_id
+              AND ps.field_id = fu.field_id
+              AND ps.value IS NOT NULL
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM public.extraction_reviewer_states rs
+            JOIN public.extraction_reviewer_decisions rd
+                ON rd.id = rs.current_decision_id
+            WHERE rs.instance_id = fu.instance_id
+              AND rd.field_id = fu.field_id
+              AND rd.decision <> 'reject'
+        )
+    )
+    SELECT
+        (SELECT COUNT(*)::integer FROM filled)         AS completed_fields,
+        (SELECT COUNT(*)::integer FROM field_universe) AS total_fields,
+        CASE
+            WHEN (SELECT COUNT(*) FROM field_universe) = 0
+                THEN 0::numeric
+            ELSE ROUND(
+                (SELECT COUNT(*) FROM filled)::numeric * 100.0
+                    / (SELECT COUNT(*) FROM field_universe)::numeric,
+                2
+            )
+        END AS percentage;
+END;
+$$;
+"""
+
+_GRANTS = [
+    "REVOKE ALL ON FUNCTION public.calculate_model_progress(uuid, uuid) FROM PUBLIC;",
+    "GRANT EXECUTE ON FUNCTION public.calculate_model_progress(uuid, uuid) "
+    "TO authenticated, service_role;",
+]
+
+
+def upgrade() -> None:
+    op.execute(_BODY_SCOPED)
+    for stmt in _GRANTS:
+        op.execute(stmt)
+
+
+def downgrade() -> None:
+    op.execute(_BODY_0013)
+    for stmt in _GRANTS:
+        op.execute(stmt)

--- a/backend/app/services/run_lifecycle_service.py
+++ b/backend/app/services/run_lifecycle_service.py
@@ -350,10 +350,15 @@ class RunLifecycleService:
                 f"Run {run_id} is in stage {old_run.stage}; only finalized runs can be reopened."
             )
 
-        # Idempotency: if a live (non-cancelled) child already exists for
-        # this parent, return it instead of forking a second revision. A
-        # cancelled child is NOT a blocker — the user abandoned that attempt
-        # and must be able to start a fresh revision from the original parent.
+        # Idempotency: if a live (non-cancelled, non-finalized) child already
+        # exists for this parent, return it instead of forking a second
+        # revision. Two stages do NOT count as a blocking live child:
+        #   - cancelled: the user abandoned that attempt and must be able to
+        #     start a fresh revision from the original parent.
+        #   - finalized: the previous reopen was completed and re-finalized, so
+        #     the caller is asking for a NEW editable revision. Returning the
+        #     finalized child here would hand back a read-only run (the reopen
+        #     button would appear to do nothing).
         existing_child = (
             await self.db.execute(
                 select(ExtractionRun)
@@ -361,7 +366,12 @@ class RunLifecycleService:
                     ExtractionRun.template_id == old_run.template_id,
                     ExtractionRun.article_id == old_run.article_id,
                     ExtractionRun.parameters["parent_run_id"].astext == str(old_run.id),
-                    ExtractionRun.stage != ExtractionRunStage.CANCELLED.value,
+                    ExtractionRun.stage.not_in(
+                        [
+                            ExtractionRunStage.CANCELLED.value,
+                            ExtractionRunStage.FINALIZED.value,
+                        ]
+                    ),
                 )
                 .order_by(ExtractionRun.created_at.desc())
                 .limit(1)

--- a/backend/tests/integration/test_calculate_model_progress.py
+++ b/backend/tests/integration/test_calculate_model_progress.py
@@ -562,3 +562,86 @@ async def test_progress_is_independent_of_caller_user(
         model_id=project_with_run["parent_inst"],
     )
     assert completed == 1
+
+
+async def test_prior_run_decisions_do_not_inflate_active_progress(
+    db_session: AsyncSession, project_with_run: dict
+) -> None:
+    """Regression for #97.
+
+    For an article re-extracted across runs (finalize -> reopen), a non-reject
+    decision recorded on a *prior* run must NOT count toward the current
+    (active) run's progress. The active run is the most recent non-cancelled
+    run for the ``(article, template)``; the fixture's review run is newer than
+    the finalized run we insert here, so it is the active one.
+    """
+    fx = project_with_run
+    version_id = (
+        await db_session.execute(
+            text(
+                "SELECT id FROM public.extraction_template_versions "
+                "WHERE project_template_id = :tid AND is_active = true"
+            ),
+            {"tid": str(fx["template_id"])},
+        )
+    ).scalar()
+
+    # An OLDER (finalized) run for the same article+template.
+    old_run_id = uuid4()
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO public.extraction_runs
+                (id, project_id, article_id, template_id, version_id, kind,
+                 stage, status, parameters, results, hitl_config_snapshot,
+                 created_by, created_at)
+            VALUES (:rid, :proj, :art, :tid, :vid, 'extraction',
+                    'finalized'::extraction_run_stage,
+                    'completed'::extraction_run_status,
+                    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, :uid,
+                    NOW() - INTERVAL '1 day')
+            """
+        ),
+        {
+            "rid": str(old_run_id),
+            "proj": str(fx["project_id"]),
+            "art": str(fx["article_id"]),
+            "tid": str(fx["template_id"]),
+            "vid": str(version_id),
+            "uid": str(fx["user_id"]),
+        },
+    )
+    # A non-reject decision recorded ONLY on the old run.
+    await _record_decision(
+        db_session,
+        run_id=old_run_id,
+        instance_id=fx["parent_inst"],
+        field_id=fx["parent_field"],
+        user_id=fx["user_id"],
+        decision="edit",
+        value="STALE-from-prior-run",
+    )
+    await db_session.commit()
+
+    # The prior-run decision must not leak into the active run's count.
+    completed, total, _ = await _call_progress(
+        db_session, article_id=fx["article_id"], model_id=fx["parent_inst"]
+    )
+    assert completed == 0, "prior-run decision leaked into active-run progress (#97)"
+    assert total == 3
+
+    # Sanity: the SAME field decided on the ACTIVE (fixture) run does count.
+    await _record_decision(
+        db_session,
+        run_id=fx["run_id"],
+        instance_id=fx["parent_inst"],
+        field_id=fx["parent_field"],
+        user_id=fx["user_id"],
+        decision="edit",
+        value="LIVE",
+    )
+    await db_session.commit()
+    completed_after, _, _ = await _call_progress(
+        db_session, article_id=fx["article_id"], model_id=fx["parent_inst"]
+    )
+    assert completed_after == 1

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -104,8 +104,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0021_reconcile_feedback_rls" in out, (
-        f"Expected head revision '0021_reconcile_feedback_rls', got:\n{out}"
+    assert "0022_scope_model_progress_run" in out, (
+        f"Expected head revision '0022_scope_model_progress_run', got:\n{out}"
     )
 
 

--- a/backend/tests/integration/test_run_reopen.py
+++ b/backend/tests/integration/test_run_reopen.py
@@ -241,3 +241,68 @@ async def test_reopen_creates_new_run_seeded_from_published_states(
         )
     ).scalar()
     assert old_published_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reopen_again_after_child_finalized_forks_fresh_run(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """Regression for #152.
+
+    Reopen → drive the child to finalized → reopen the SAME parent again. The
+    idempotency guard must NOT return the now-finalized child (a read-only run);
+    it must fork a fresh editable revision. Before the fix the guard only
+    excluded ``cancelled`` children, so the finalized child was handed back and
+    the reopen button appeared to do nothing.
+    """
+    fx = await _pick_fixtures(db_session)
+    if fx is None:
+        pytest.skip("Need projects + articles + template + instance/field fixture")
+    project_id, article_id, template_id, instance_id, field_id = fx
+
+    old_run_id = await _drive_run_to_finalized(
+        db_client, project_id, article_id, template_id, instance_id, field_id
+    )
+
+    # First reopen → child lands in REVIEW.
+    first = await db_client.post(f"/api/v1/runs/{old_run_id}/reopen")
+    assert first.status_code == 201, first.text
+    child_id = first.json()["data"]["id"]
+    assert child_id != old_run_id
+
+    # A second reopen *before* the child is finalized is idempotent — same child.
+    again = await db_client.post(f"/api/v1/runs/{old_run_id}/reopen")
+    assert again.status_code == 201, again.text
+    assert again.json()["data"]["id"] == child_id, "live child must be returned idempotently"
+
+    # Drive the child (REVIEW) all the way to finalized.
+    adv = await db_client.post(
+        f"/api/v1/runs/{child_id}/advance", json={"target_stage": "consensus"}
+    )
+    assert adv.status_code == 200, adv.text
+    cons = await db_client.post(
+        f"/api/v1/runs/{child_id}/consensus",
+        json={
+            "instance_id": instance_id,
+            "field_id": field_id,
+            "mode": "manual_override",
+            "value": {"text": "v2"},
+            "rationale": "second publish",
+        },
+    )
+    assert cons.status_code == 201, cons.text
+    fin = await db_client.post(
+        f"/api/v1/runs/{child_id}/advance", json={"target_stage": "finalized"}
+    )
+    assert fin.status_code == 200, fin.text
+
+    # Reopen the ORIGINAL parent again: the finalized child is no longer a live
+    # child, so a NEW editable revision must be forked.
+    second = await db_client.post(f"/api/v1/runs/{old_run_id}/reopen")
+    assert second.status_code == 201, second.text
+    grandchild = second.json()["data"]
+    assert grandchild["id"] != child_id, "must not return the finalized child"
+    assert grandchild["stage"] == "review", "the forked revision must be editable"
+    assert grandchild["parameters"]["parent_run_id"] == old_run_id

--- a/frontend/hooks/qa/useQAAssessmentSession.ts
+++ b/frontend/hooks/qa/useQAAssessmentSession.ts
@@ -56,11 +56,19 @@ export function useQAAssessmentSession({
   const [session, setSession] = useState<QAAssessmentSession | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const cancelledRef = useRef(false);
+  // Monotonically-increasing generation token. Each effect-driven open()
+  // reads the next value and only commits state when it still matches
+  // generationRef.current. A shared cancelledRef toggle can't solve this:
+  // React runs cleanup *then* the new effect body synchronously, so a
+  // cancelled=true flag is reset to false before any in-flight Promise
+  // observes it — a stale response would route proposals to the wrong run
+  // (#109). Mirrors useExtractionSession.
+  const generationRef = useRef(0);
 
   const open = useCallback(async () => {
     if (!enabled || !projectId || !articleId) return;
     if (!globalTemplateId && !projectTemplateId) return;
+    const myGeneration = ++generationRef.current;
     setLoading(true);
     setError(null);
     try {
@@ -75,29 +83,33 @@ export function useQAAssessmentSession({
             : { global_template_id: globalTemplateId }),
         },
       });
-      if (!cancelledRef.current) {
-        setSession({
-          runId: data.run_id,
-          projectTemplateId: data.project_template_id,
-          instancesByEntityType: data.instances_by_entity_type,
-        });
-      }
+      // Only the most-recent open() may commit. If a new effect fired while
+      // we were in flight (article navigation, prop change), this generation
+      // is stale and the response belongs to a previous article — discarding
+      // it prevents autosave from routing proposals to the wrong run (#109).
+      if (myGeneration !== generationRef.current) return;
+      setSession({
+        runId: data.run_id,
+        projectTemplateId: data.project_template_id,
+        instancesByEntityType: data.instances_by_entity_type,
+      });
     } catch (err) {
-      if (!cancelledRef.current) {
-        setError(
-          err instanceof Error ? err.message : "Failed to open QA session",
-        );
-      }
+      if (myGeneration !== generationRef.current) return;
+      console.error("[useQAAssessmentSession] open() failed:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to open QA session",
+      );
     } finally {
-      if (!cancelledRef.current) setLoading(false);
+      if (myGeneration === generationRef.current) setLoading(false);
     }
   }, [enabled, projectId, articleId, globalTemplateId, projectTemplateId]);
 
   useEffect(() => {
-    cancelledRef.current = false;
     void open();
     return () => {
-      cancelledRef.current = true;
+      // Bump the generation so any in-flight open() resolves into a no-op
+      // when this effect tears down (unmount or dependency change).
+      generationRef.current += 1;
     };
   }, [open]);
 

--- a/frontend/test/hooks/useQAAssessmentSessionStaleGuard.test.tsx
+++ b/frontend/test/hooks/useQAAssessmentSessionStaleGuard.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Regression test for issue #109 — stale-response overwrite in
+ * useQAAssessmentSession.
+ *
+ * When the user navigates between articles while an open() POST is still in
+ * flight, the slow response for the *previous* article must not overwrite the
+ * session for the current one — otherwise useAutoSaveProposals routes the new
+ * article's QA values to the wrong run. The fix is the generation-counter
+ * guard (mirroring useExtractionSession); the old cancelledRef toggle could not
+ * solve it because React resets it to false before the in-flight Promise reads it.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/integrations/api', () => ({
+  apiClient: vi.fn(),
+}));
+
+import { apiClient } from '@/integrations/api';
+import { useQAAssessmentSession } from '@/hooks/qa/useQAAssessmentSession';
+
+const apiClientMock = apiClient as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useQAAssessmentSession — stale-response guard (#109)', () => {
+  it('discards an open() response that resolves after articleId changed', async () => {
+    // art-1's open() is slow; art-2's is fast.
+    let resolveFirst!: (v: unknown) => void;
+    const firstOpen = new Promise((res) => {
+      resolveFirst = res;
+    });
+
+    apiClientMock.mockReturnValueOnce(firstOpen).mockResolvedValue({
+      run_id: 'run-art2',
+      project_template_id: 'tpl-1',
+      instances_by_entity_type: {},
+    });
+
+    const { result, rerender } = renderHook(
+      ({ articleId }) =>
+        useQAAssessmentSession({
+          projectId: 'proj-1',
+          articleId,
+          projectTemplateId: 'tpl-1',
+        }),
+      { initialProps: { articleId: 'art-1' } },
+    );
+
+    // Navigate to art-2 while art-1's open() is still pending.
+    rerender({ articleId: 'art-2' });
+
+    // art-2 resolves fast → session points at run-art2.
+    await waitFor(() => expect(result.current.session?.runId).toBe('run-art2'));
+
+    // Now let the stale art-1 response arrive. With the generation guard it is
+    // discarded; with the old cancelledRef toggle it would overwrite run-art2.
+    await act(async () => {
+      resolveFirst({
+        run_id: 'run-art1-STALE',
+        project_template_id: 'tpl-1',
+        instances_by_entity_type: {},
+      });
+    });
+
+    expect(result.current.session?.runId).toBe('run-art2');
+    expect(result.current.session?.runId).not.toBe('run-art1-STALE');
+  });
+});


### PR DESCRIPTION
P1/P2 data-integrity batch from the open-issue triage. Each fix is verified by a red-green test.

Closes #152, #109, #97.

> **Stacked on #193.** The model-progress migration (`0022`) chains off the RLS migration (`0021`) in #193 to keep a single alembic head — so **merge #193 first**, then rebase/merge this. Until #193 merges, this PR's diff also shows the #193 commit.

## #152 — reopen_run hands back a finalized (read-only) child
The idempotency guard returned a child run even when its stage was `FINALIZED`, so a second reopen (after the first revision was itself finalized) handed the caller a read-only run — the reopen button appeared to do nothing.
- **Fix:** exclude `FINALIZED` as well as `CANCELLED` from the "live child" filter in `run_lifecycle_service.reopen_run`, so a re-finalized lineage forks a fresh editable revision.
- **Test (red-green verified):** `test_reopen_again_after_child_finalized_forks_fresh_run` — drives reopen → finalize child → reopen again, asserts a new editable run. Without the fix it returns the finalized child.

## #109 — useQAAssessmentSession routes proposals to the wrong run
The `cancelledRef` toggle can't guard against stale responses: React runs the effect cleanup **then** the new effect body synchronously, resetting `cancelled` to `false` before the in-flight Promise reads it. A slow `open()` for the previous article could overwrite the current article's session → `useAutoSaveProposals` writes QA values to the wrong run.
- **Fix:** adopt the `generationRef` pattern from `useExtractionSession` (the cleanup bumps the counter; stale responses become no-ops).
- **Test (red-green verified):** `useQAAssessmentSessionStaleGuard.test.tsx` — a stale art-1 response must not overwrite art-2's session.

## #97 — per-model progress badge inflated across runs
`calculate_model_progress` counted non-reject reviewer decisions from **all** runs, so an article re-extracted across runs (finalize → reopen) had its badge inflated by prior-run decisions.
- **Fix:** migration `0022` scopes the reviewer-states branch to the active run (most recent non-cancelled run for the article+template); published-states stay run-agnostic. Signature/returns/grants unchanged from 0013; faithful downgrade to the 0013 body.
- **Test (red-green verified):** `test_prior_run_decisions_do_not_inflate_active_progress` — a decision on a prior run must not count. Fails on the 0013 body, passes on 0022.

## Verification
- `ruff check` + `ruff format --check`: clean
- Backend: 16 tests pass (`test_run_reopen`, `test_calculate_model_progress`)
- Frontend: `useQAAssessmentSessionStaleGuard` passes
- Migration `0022`: `upgrade head` → `downgrade -1` → `upgrade head` clean against local Supabase

Note: #79 (coordinate-coherence cross-article) from the same triage batch was already fixed independently by #189 and is excluded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)