### PR TITLE
ci(frontend): run a real typecheck — the gate was a silent no-op

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,8 +430,15 @@ jobs:
       - name: Run ESLint
         run: npm run lint || true
 
-      - name: Type check
-        run: npm run typecheck || npx tsc --noEmit
+      # Runs the REAL frontend typecheck. The previous
+      # `npm run typecheck || npx tsc --noEmit` was a silent no-op: there was no
+      # `typecheck` script, and plain `tsc --noEmit` against the references-mode
+      # root tsconfig (files: []) checks nothing. The frontend carries ~186
+      # pre-existing type errors (tracked in #197), so this is non-blocking for
+      # now — flip `continue-on-error` to false once `npm run typecheck` is clean.
+      - name: Type check (frontend)
+        run: npm run typecheck
+        continue-on-error: true
 
   # =================== FRONTEND BUILD ===================
   frontend-build:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit",
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",


### PR DESCRIPTION
## Problem

The `Frontend Lint` job's type-check step (`ci.yml`) was:

```yaml
- name: Type check
  run: npm run typecheck || npx tsc --noEmit
```

It **never caught a type error**:
- No `typecheck` script existed → `npm run typecheck` errors → `||` fallback runs.
- `tsc --noEmit` runs against the root `tsconfig.json`, which is references-mode (`"files": []`). Plain `tsc --noEmit` (no `--build`) checks no referenced project → exits 0.
- `npm run build` is `vite build` (esbuild) — strips types, no check.

So the frontend has had **zero** enforced type checking in CI. That's how the type bugs in #99 / #100 / #101 / #103 slipped in.

## Change

- Add a real `typecheck` script: `tsc -p tsconfig.app.json --noEmit`.
- Run it in CI as a **reporting** step (`continue-on-error: true`) — it surfaces the errors as annotations without breaking every open PR.

## Why non-blocking (for now)

`npm run typecheck` currently reports **186** pre-existing errors, dominated by the unfixed frontend issues:

| Code | Count | Notable |
|---|---|---|
| TS2345 | 80 | #99 (≈71 missing copy keys) |
| TS2339 | 23 | #100, #103 |
| TS6133 | 22 | unused (mechanical) |
| TS2322 | 22 | #101, #103 |
| other | 39 | TS18047/7006/2769/… |

Making it blocking now would red-wall every PR until that backlog is cleared. The burndown plan and full categorization live in **#197**; once `npm run typecheck` is clean, flip `continue-on-error` to `false`.

## Also noticed (not changed here)

The same job swallows ESLint: `npm run lint || true` never fails either. Flagged in #197 for the same effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)