### PR TITLE
fix(backend): reliability batch — retry resilience, fail-run rollback, streamed download, atomic upsert

### DIFF
--- a/backend/app/repositories/hitl_config_repository.py
+++ b/backend/app/repositories/hitl_config_repository.py
@@ -3,6 +3,7 @@
 from uuid import UUID
 
 from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.extraction_versioning import (
@@ -41,24 +42,34 @@ class HitlConfigRepository:
         consensus_rule: str,
         arbitrator_id: UUID | None,
     ) -> ExtractionHitlConfig:
-        existing = await self.get_by_scope(scope_kind, scope_id)
-        if existing is None:
-            config = ExtractionHitlConfig(
+        # Atomic upsert: a plain SELECT-then-INSERT races two concurrent
+        # first-time creates into a unique-violation IntegrityError (HTTP 500).
+        # ON CONFLICT collapses both paths into one statement (#83).
+        mutable = {
+            "reviewer_count": reviewer_count,
+            "consensus_rule": consensus_rule,
+            "arbitrator_id": arbitrator_id,
+        }
+        stmt = (
+            pg_insert(ExtractionHitlConfig)
+            .values(
                 scope_kind=_scope_value(scope_kind),
                 scope_id=scope_id,
-                reviewer_count=reviewer_count,
-                consensus_rule=consensus_rule,
-                arbitrator_id=arbitrator_id,
+                **mutable,
             )
-            self.db.add(config)
-            await self.db.flush()
-            return config
-
-        existing.reviewer_count = reviewer_count
-        existing.consensus_rule = consensus_rule
-        existing.arbitrator_id = arbitrator_id
+            .on_conflict_do_update(
+                constraint="uq_extraction_hitl_configs_scope",
+                set_=mutable,
+            )
+            .returning(ExtractionHitlConfig.id)
+        )
+        config_id = (await self.db.execute(stmt)).scalar_one()
         await self.db.flush()
-        return existing
+        # populate_existing refreshes any stale identity-map copy, since the
+        # Core upsert bypassed the ORM.
+        config = await self.db.get(ExtractionHitlConfig, config_id, populate_existing=True)
+        assert config is not None  # just upserted
+        return config
 
     async def delete_by_scope(
         self,

--- a/backend/app/repositories/hitl_config_repository.py
+++ b/backend/app/repositories/hitl_config_repository.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -50,6 +50,11 @@ class HitlConfigRepository:
             "consensus_rule": consensus_rule,
             "arbitrator_id": arbitrator_id,
         }
+        # On the conflict (update) path, bump updated_at explicitly: the
+        # Python-side onupdate=func.now() does not fire for a Core
+        # ON CONFLICT DO UPDATE. On first insert, server_default covers it,
+        # so updated_at is only added to the update set.
+        update_set = {**mutable, "updated_at": func.now()}
         stmt = (
             pg_insert(ExtractionHitlConfig)
             .values(
@@ -59,7 +64,7 @@ class HitlConfigRepository:
             )
             .on_conflict_do_update(
                 constraint="uq_extraction_hitl_configs_scope",
-                set_=mutable,
+                set_=update_set,
             )
             .returning(ExtractionHitlConfig.id)
         )

--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -121,11 +121,6 @@ class OpenAIService(LoggerMixin):
             await self._client.aclose()
             self._client = None
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10),
-        retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
-    )
     async def chat_completion(
         self,
         messages: list[dict[str, Any]],
@@ -156,6 +151,11 @@ class OpenAIService(LoggerMixin):
         )
         return response.content
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        retry=retry_if_exception_type((httpx.TimeoutException, httpx.NetworkError)),
+    )
     async def chat_completion_full(
         self,
         messages: list[dict[str, Any]],
@@ -168,6 +168,11 @@ class OpenAIService(LoggerMixin):
         Execute chat completion with full metadata.
 
         Returns object with content, usage, and metadata.
+
+        The transient-error retry lives here (not on ``chat_completion``) so that
+        callers hitting this method directly — the extraction services — get the
+        same resilience. ``chat_completion`` / ``chat_completion_structured``
+        delegate here, so the retry applies once across every path (#89).
         """
         start_time = time.time()
 

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -295,7 +295,7 @@ class SectionExtractionService(LoggerMixin):
             # session, not by a single AI call — failing it here would
             # break subsequent section extractions on the same run.
             if manage_lifecycle:
-                await self._runs.fail_run(run.id, str(e))
+                await self._rollback_then_fail_run(run.id, str(e))
             self.logger.error(
                 "section_extraction_failed",
                 trace_id=self.trace_id,
@@ -446,7 +446,7 @@ class SectionExtractionService(LoggerMixin):
                 sections=section_results,
             )
         except Exception as e:
-            await self._runs.fail_run(run.id, str(e))
+            await self._rollback_then_fail_run(run.id, str(e))
             self.logger.error(
                 "qa_extraction_failed",
                 trace_id=self.trace_id,
@@ -778,8 +778,35 @@ class SectionExtractionService(LoggerMixin):
             )
 
         except Exception as e:
-            await self._runs.fail_run(run.id, str(e))
+            await self._rollback_then_fail_run(run.id, str(e))
             raise
+
+    async def _rollback_then_fail_run(self, run_id: UUID, error: str) -> None:
+        """Mark a run failed after an error, rolling back the session first.
+
+        A DB-level error leaves the asyncpg session in a failed-transaction
+        state, so every subsequent statement raises ``InFailedSQLTransactionError``
+        — including ``fail_run`` itself, which would then leave the run stuck at
+        ``status='running'``. Roll back first so ``fail_run`` runs on a clean
+        session. Both calls are defensively guarded so neither masks the original
+        error. Mirrors ``ModelExtractionService`` (#88).
+        """
+        try:
+            await self.db.rollback()
+        except Exception:
+            self.logger.warning(
+                "section_extraction_rollback_failed",
+                trace_id=self.trace_id,
+                run_id=str(run_id),
+            )
+        try:
+            await self._runs.fail_run(run_id, error)
+        except Exception:
+            self.logger.error(
+                "section_extraction_mark_failed_error",
+                trace_id=self.trace_id,
+                run_id=str(run_id),
+            )
 
     async def _extract_section_with_memory(
         self,
@@ -893,7 +920,7 @@ class SectionExtractionService(LoggerMixin):
             }
 
         except Exception as e:
-            await self._runs.fail_run(run.id, str(e))
+            await self._rollback_then_fail_run(run.id, str(e))
             raise
 
     def _generate_extraction_summary(

--- a/backend/app/services/zotero_service.py
+++ b/backend/app/services/zotero_service.py
@@ -325,8 +325,12 @@ class ZoteroService(LoggerMixin):
 
         url = f"{ZOTERO_API_BASE}{library_prefix}/items/{attachment_key}/file"
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
+        max_bytes = 50 * 1024 * 1024  # 50 MB
+
+        async with (
+            httpx.AsyncClient() as client,
+            client.stream(
+                "GET",
                 url,
                 headers={
                     "Zotero-API-Key": credentials["api_key"],
@@ -334,16 +338,30 @@ class ZoteroService(LoggerMixin):
                 },
                 timeout=60.0,
                 follow_redirects=True,
-            )
-
+            ) as response,
+        ):
             if not response.is_success:
                 raise ValueError(f"Download failed: {response.status_code}")
 
-            content = response.content
-            size_mb = len(content) / (1024 * 1024)
+            # Reject early when the server advertises an oversize body, before
+            # streaming a single byte.
+            declared = response.headers.get("Content-Length")
+            if declared and declared.isdigit() and int(declared) > max_bytes:
+                raise ValueError(
+                    f"Arquivo muito grande: {int(declared) / (1024 * 1024):.1f}MB. Maximo: 50MB"
+                )
 
-            if size_mb > 50:
-                raise ValueError(f"Arquivo muito grande: {size_mb:.1f}MB. Maximo: 50MB")
+            # Stream with a running-total cap so a missing/dishonest
+            # Content-Length can't OOM the worker — abort the moment we cross
+            # the limit instead of buffering the whole body first (#90).
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError("Arquivo muito grande: maior que 50MB. Maximo: 50MB")
+                chunks.append(chunk)
+            content = b"".join(chunks)
 
             # Extrair filename do header
             content_disposition = response.headers.get("Content-Disposition", "")

--- a/backend/tests/integration/test_hitl_config_repository.py
+++ b/backend/tests/integration/test_hitl_config_repository.py
@@ -1,0 +1,60 @@
+"""Integration tests for HitlConfigRepository.upsert (#83).
+
+The old SELECT-then-INSERT raced two concurrent first-time creates into a
+unique-violation IntegrityError (HTTP 500). The repository now upserts via
+``ON CONFLICT DO UPDATE`` on ``uq_extraction_hitl_configs_scope``. We can't
+easily reproduce the concurrent race in a single transactional test, but we pin
+the upsert semantics the ON CONFLICT path guarantees: idempotent on scope, and a
+second call updates the existing row instead of inserting a duplicate.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.extraction_versioning import ExtractionHitlConfig, HitlConfigScopeKind
+from app.repositories.hitl_config_repository import HitlConfigRepository
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_upsert_inserts_then_updates_same_row(db_session: AsyncSession) -> None:
+    repo = HitlConfigRepository(db_session)
+    scope_id = uuid4()  # scope_id carries no FK
+
+    created = await repo.upsert(
+        HitlConfigScopeKind.PROJECT,
+        scope_id,
+        reviewer_count=2,
+        consensus_rule="majority",
+        arbitrator_id=None,
+    )
+    assert created.reviewer_count == 2
+    assert created.consensus_rule == "majority"
+
+    # Second call on the same scope must hit ON CONFLICT → update, not insert.
+    updated = await repo.upsert(
+        HitlConfigScopeKind.PROJECT,
+        scope_id,
+        reviewer_count=3,
+        consensus_rule="unanimous",
+        arbitrator_id=None,
+    )
+    assert updated.id == created.id
+    assert updated.reviewer_count == 3
+    assert updated.consensus_rule == "unanimous"
+
+    # Exactly one row exists for the scope (no duplicate from the second call).
+    count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(ExtractionHitlConfig)
+            .where(
+                ExtractionHitlConfig.scope_kind == HitlConfigScopeKind.PROJECT.value,
+                ExtractionHitlConfig.scope_id == scope_id,
+            )
+        )
+    ).scalar_one()
+    assert count == 1

--- a/backend/tests/unit/test_openai_service.py
+++ b/backend/tests/unit/test_openai_service.py
@@ -103,6 +103,16 @@ class TestOpenAIService:
             assert result.usage.prompt_tokens == 100
             assert result.usage.completion_tokens == 50
 
+    def test_retry_decorator_lives_on_chat_completion_full(self) -> None:
+        """#89: the transient-error retry must sit on chat_completion_full so the
+        extraction services (which call it directly) get resilience — and NOT
+        also on chat_completion, which would double-retry (3x3=9 attempts).
+
+        tenacity attaches a ``retry`` attribute to the function it decorates.
+        """
+        assert hasattr(OpenAIService.chat_completion_full, "retry")
+        assert not hasattr(OpenAIService.chat_completion, "retry")
+
     @pytest.mark.asyncio
     async def test_chat_completion_handles_error(
         self,

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -1805,3 +1805,33 @@ class TestExtractForRunErrorPath:
         assert result.failed_sections == 1
         assert result.sections[0]["success"] is False
         assert "type fetch error" in result.sections[0]["error"]
+
+
+class TestRollbackThenFailRun:
+    """#88: a DB error during suggestion creation leaves the asyncpg session in a
+    failed-transaction state, so an unguarded ``fail_run`` raises and the run is
+    left stuck at ``status='running'``. The helper rolls back first."""
+
+    @pytest.mark.asyncio
+    async def test_rolls_back_before_marking_failed(self, service) -> None:
+        order: list[str] = []
+        service.db.rollback = AsyncMock(side_effect=lambda: order.append("rollback"))
+        service._runs.fail_run = AsyncMock(
+            side_effect=lambda *_a, **_k: order.append("fail_run")
+        )
+
+        await service._rollback_then_fail_run(uuid4(), "boom")
+
+        assert order == ["rollback", "fail_run"]
+
+    @pytest.mark.asyncio
+    async def test_swallows_fail_run_error(self, service) -> None:
+        # Even if marking the run failed itself errors, the helper must not raise
+        # (the original error has already been surfaced by the caller).
+        service.db.rollback = AsyncMock()
+        service._runs.fail_run = AsyncMock(side_effect=RuntimeError("still broken"))
+
+        await service._rollback_then_fail_run(uuid4(), "boom")
+
+        service.db.rollback.assert_awaited_once()
+        service._runs.fail_run.assert_awaited_once()

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -1816,9 +1816,7 @@ class TestRollbackThenFailRun:
     async def test_rolls_back_before_marking_failed(self, service) -> None:
         order: list[str] = []
         service.db.rollback = AsyncMock(side_effect=lambda: order.append("rollback"))
-        service._runs.fail_run = AsyncMock(
-            side_effect=lambda *_a, **_k: order.append("fail_run")
-        )
+        service._runs.fail_run = AsyncMock(side_effect=lambda *_a, **_k: order.append("fail_run"))
 
         await service._rollback_then_fail_run(uuid4(), "boom")
 

--- a/backend/tests/unit/test_zotero_service.py
+++ b/backend/tests/unit/test_zotero_service.py
@@ -16,6 +16,34 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.services.zotero_service import ZoteroService
 
 
+def _streaming_response(chunks, headers, counter=None):
+    """Build a mock httpx streaming response whose ``aiter_bytes`` yields ``chunks``.
+
+    ``counter['count']`` (when provided) is bumped per chunk consumed, so a test
+    can assert the body was aborted early instead of fully buffered.
+    """
+    resp = MagicMock()
+    resp.is_success = True
+    resp.headers = headers
+
+    async def _aiter():
+        for chunk in chunks:
+            if counter is not None:
+                counter["count"] += 1
+            yield chunk
+
+    resp.aiter_bytes = _aiter
+    return resp
+
+
+def _wire_stream(mock_client, mock_response):
+    """Wire ``patch('httpx.AsyncClient')`` so ``client.stream(...)`` yields the response."""
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_client.return_value.__aenter__.return_value.stream = MagicMock(return_value=stream_cm)
+
+
 @pytest.fixture
 def mock_db():
     """Mock da sessão de banco."""
@@ -281,17 +309,14 @@ class TestZoteroServiceDownload:
         pdf_content = b"%PDF-1.4 fake pdf content"
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_response = MagicMock()
-            mock_response.is_success = True
-            mock_response.content = pdf_content
-            mock_response.headers = {
-                "Content-Type": "application/pdf",
-                "Content-Disposition": 'attachment; filename="paper.pdf"',
-            }
-
-            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
-                return_value=mock_response
+            mock_response = _streaming_response(
+                chunks=[pdf_content],
+                headers={
+                    "Content-Type": "application/pdf",
+                    "Content-Disposition": 'attachment; filename="paper.pdf"',
+                },
             )
+            _wire_stream(mock_client, mock_response)
 
             result = await zotero_service.download_attachment("ATT123")
 
@@ -304,8 +329,9 @@ class TestZoteroServiceDownload:
         assert decoded == pdf_content
 
     @pytest.mark.asyncio
-    async def test_download_attachment_too_large(self, zotero_service, mock_repo):
-        """Testa erro com arquivo muito grande."""
+    async def test_download_attachment_too_large_aborts_early(self, zotero_service, mock_repo):
+        """#90: a body without a trustworthy Content-Length must abort the moment
+        the running total crosses 50MB — not after buffering the whole thing."""
         encrypted_key = zotero_service._encrypt("api-key")
 
         mock_integration = MagicMock()
@@ -314,18 +340,55 @@ class TestZoteroServiceDownload:
         mock_integration.library_type = "user"
         mock_repo.get_by_user = AsyncMock(return_value=mock_integration)
 
-        # Criar conteúdo maior que 50MB
-        large_content = b"x" * (51 * 1024 * 1024)
+        # A lazy generator of 10MB chunks; if fully drained it would be 1GB.
+        def chunk_stream():
+            for _ in range(100):
+                yield b"x" * (10 * 1024 * 1024)
+
+        counter = {"count": 0}
 
         with patch("httpx.AsyncClient") as mock_client:
-            mock_response = MagicMock()
-            mock_response.is_success = True
-            mock_response.content = large_content
-            mock_response.headers = {"Content-Type": "application/pdf"}
-
-            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
-                return_value=mock_response
+            mock_response = _streaming_response(
+                chunks=chunk_stream(),
+                headers={"Content-Type": "application/pdf"},  # no Content-Length
+                counter=counter,
             )
+            _wire_stream(mock_client, mock_response)
 
             with pytest.raises(ValueError, match="muito grande"):
                 await zotero_service.download_attachment("ATT123")
+
+        # Crossed 50MB after the 6th 10MB chunk; must not have drained all 100.
+        assert counter["count"] <= 7
+
+    @pytest.mark.asyncio
+    async def test_download_attachment_rejects_oversize_content_length(
+        self, zotero_service, mock_repo
+    ):
+        """#90: an advertised oversize Content-Length is rejected before a single
+        byte of the body is streamed."""
+        encrypted_key = zotero_service._encrypt("api-key")
+
+        mock_integration = MagicMock()
+        mock_integration.zotero_user_id = "12345"
+        mock_integration.encrypted_api_key = encrypted_key
+        mock_integration.library_type = "user"
+        mock_repo.get_by_user = AsyncMock(return_value=mock_integration)
+
+        counter = {"count": 0}
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = _streaming_response(
+                chunks=[b"x"],
+                headers={
+                    "Content-Type": "application/pdf",
+                    "Content-Length": str(60 * 1024 * 1024),
+                },
+                counter=counter,
+            )
+            _wire_stream(mock_client, mock_response)
+
+            with pytest.raises(ValueError, match="muito grande"):
+                await zotero_service.download_attachment("ATT123")
+
+        assert counter["count"] == 0  # rejected before streaming the body


### PR DESCRIPTION
P2/P3 backend reliability batch from the open-issue triage. Each fix is covered by tests.

Closes #89, #88, #90, #83.

## #89 — extraction services had no retry resilience
`chat_completion_full` is called directly by the extraction services, but `@retry` sat on `chat_completion`, so those callers failed on the first transient OpenAI timeout/network blip.
- **Fix:** move `@retry` onto `chat_completion_full`; `chat_completion` / `chat_completion_structured` delegate to it → one retry layer across every path (no double-retry).
- **Test:** asserts the decorator lives on `_full`, not on `chat_completion`.

## #88 — run stuck `running` on a DB error
The 4 `fail_run` exception sites in `section_extraction_service` had no `db.rollback()` first. A DB error during suggestion creation leaves the asyncpg session in a failed-transaction state, so `fail_run` itself raised and the run stayed `status='running'`.
- **Fix:** `_rollback_then_fail_run` helper (mirrors `ModelExtractionService`), routing all 4 sites; the `manage_lifecycle` guard is preserved.
- **Tests:** rollback-before-fail ordering; fail_run error is swallowed (doesn't mask the original).

## #90 — Zotero download could OOM the worker
`download_attachment` buffered the entire body before the 50MB check.
- **Fix:** `client.stream()` + `Content-Length` pre-check + running-total cap that aborts the moment it crosses 50MB.
- **Tests:** abort-early on a no-`Content-Length` oversize stream (asserts it didn't drain all chunks); reject on advertised oversize `Content-Length` (asserts zero body bytes streamed). The 3 existing download tests were rewritten for the streaming API.

## #83 — concurrent first-time config create → HTTP 500
`hitl_config_repository.upsert` used SELECT-then-INSERT, racing two concurrent creates into a unique-violation `IntegrityError`.
- **Fix:** `pg_insert(...).on_conflict_do_update` on `uq_extraction_hitl_configs_scope`.
- **Test:** upsert is idempotent on scope (second call updates the same row, no duplicate).

## Verification
- `ruff check` + `ruff format`: clean
- 96 backend tests green across `test_openai_service`, `test_zotero_service`, `test_section_extraction_service`, `test_hitl_config_repository`, `test_hitl_configs_endpoints`

🤖 Generated with [Claude Code](https://claude.com/claude-code)