### PR TITLE
fix(backend): schema/ORM hygiene + reopen status — #93 #94 #95 #81 #153

### DIFF
--- a/backend/alembic/versions/0023_consensus_fk_restrict.py
+++ b/backend/alembic/versions/0023_consensus_fk_restrict.py
@@ -1,0 +1,51 @@
+"""Fix composite FK fk_extraction_consensus_decisions_selected_run_match (#81).
+
+The ``(run_id, selected_decision_id)`` FK on ``extraction_consensus_decisions``
+(added in 0012) used ``ON DELETE SET NULL``. But ``run_id`` is ``NOT NULL``, so a
+composite SET NULL would try to null ``run_id`` as well and abort with a
+not-null violation whenever a referenced reviewer decision is directly deleted —
+the cascade fails instead of cleaning up. SET NULL was also incoherent with the
+``select_existing_has_decision`` CHECK (which forbids a null
+``selected_decision_id`` for select_existing rows).
+
+Re-create the constraint with ``ON DELETE RESTRICT`` (matching the sibling
+reviewer-states composite FK). Normal run/project deletion still CASCADE-drops
+both sides in one statement; RESTRICT only blocks a *direct* delete of a
+referenced reviewer decision, which is the correct, fail-loud behaviour.
+
+Revision ID: 0023_consensus_fk_restrict
+Revises: 0022_scope_model_progress_run
+Create Date: 2026-06-04
+"""
+
+from alembic import op
+
+revision = "0023_consensus_fk_restrict"
+down_revision = "0022_scope_model_progress_run"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT = "fk_extraction_consensus_decisions_selected_run_match"
+_TABLE = "public.extraction_consensus_decisions"
+_REF = "public.extraction_reviewer_decisions (run_id, id)"
+
+
+def _recreate(on_delete: str) -> None:
+    op.execute(f"ALTER TABLE {_TABLE} DROP CONSTRAINT IF EXISTS {_CONSTRAINT}")
+    op.execute(
+        f"""
+        ALTER TABLE {_TABLE}
+        ADD CONSTRAINT {_CONSTRAINT}
+        FOREIGN KEY (run_id, selected_decision_id)
+        REFERENCES {_REF}
+        ON DELETE {on_delete}
+        """
+    )
+
+
+def upgrade() -> None:
+    _recreate("RESTRICT")
+
+
+def downgrade() -> None:
+    _recreate("SET NULL")

--- a/backend/app/api/v1/endpoints/extraction_runs.py
+++ b/backend/app/api/v1/endpoints/extraction_runs.py
@@ -9,7 +9,7 @@ the ones that drive consensus + publish later.
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps.security import ensure_project_member, get_current_user_sub
@@ -407,6 +407,7 @@ async def list_run_reviewers(
 async def reopen_run(
     run_id: UUID,
     request: Request,
+    response: Response,
     db: DbSession,
     current_user_sub: UUID = Depends(get_current_user_sub),
 ) -> ApiResponse[RunSummaryResponse]:
@@ -421,7 +422,7 @@ async def reopen_run(
     service = RunLifecycleService(db)
     trace_id = _trace(request)
     try:
-        new_run = await service.reopen_run(run_id=run_id, user_id=current_user_sub)
+        new_run, created = await service.reopen_run(run_id=run_id, user_id=current_user_sub)
     except CannotReopenRunError as e:
         logger.warning(
             "hitl_reopen_rejected",
@@ -439,12 +440,17 @@ async def reopen_run(
         )
         raise HTTPException(status_code=404, detail=str(e)) from e
     await db.commit()
+    # 201 when a fresh revision was forked; 200 when an existing live child was
+    # resumed idempotently (mirrors POST /hitl/sessions). (#153)
+    if not created:
+        response.status_code = status.HTTP_200_OK
     logger.info(
         "hitl_run_reopened",
         trace_id=trace_id,
         old_run_id=str(run_id),
         new_run_id=str(new_run.id),
         new_stage=new_run.stage,
+        created=created,
     )
     return ApiResponse.success(
         RunSummaryResponse.model_validate(new_run),

--- a/backend/app/models/article.py
+++ b/backend/app/models/article.py
@@ -105,7 +105,7 @@ class Article(BaseModel):
     # Metadata adicionais
     study_design: Mapped[str | None] = mapped_column(String, nullable=True)
     registration: Mapped[dict[str, Any]] = mapped_column(JSONB, default={}, nullable=True)
-    funding: Mapped[dict[str, Any]] = mapped_column(JSONB, default=[], nullable=True)
+    funding: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, default=list, nullable=True)
     conflicts_of_interest: Mapped[str | None] = mapped_column(Text, nullable=True)
     data_availability: Mapped[str | None] = mapped_column(Text, nullable=True)
 

--- a/backend/app/models/extraction.py
+++ b/backend/app/models/extraction.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
@@ -278,7 +279,9 @@ class ExtractionEntityType(BaseModel):
     role: Mapped[str] = mapped_column(
         PostgreSQLEnumType("extraction_entity_role"),
         default=ExtractionEntityRole.STUDY_SECTION.value,
-        server_default=ExtractionEntityRole.STUDY_SECTION.value,
+        # No server_default: migration 0016 step 4 removed it so an INSERT that
+        # omits `role` fails loudly rather than silently defaulting to
+        # study_section. Keep the Python-side `default` for ORM inserts.
         nullable=False,
     )
 
@@ -305,6 +308,37 @@ class ExtractionEntityType(BaseModel):
         "ExtractionEntityType",
         remote_side="ExtractionEntityType.id",
         foreign_keys=[parent_entity_type_id],
+    )
+
+    # These four DB invariants exist in the schema (baseline + 0016) but were
+    # absent from the ORM, so `alembic revision --autogenerate` would emit DROPs
+    # for them (silently un-guarding the role model). Declaring them here keeps
+    # the model the source of truth. The deferred `model_section`-under-
+    # `model_container` trigger (0016 step 7) can't live in __table_args__ and
+    # stays migration-only. (#93)
+    __table_args__ = (
+        CheckConstraint(
+            "(template_id IS NULL) <> (project_template_id IS NULL)",
+            name="ck_extraction_entity_types_template_xor",
+        ),
+        CheckConstraint(
+            "(role IN ('study_section', 'model_container') AND parent_entity_type_id IS NULL)"
+            " OR (role = 'model_section' AND parent_entity_type_id IS NOT NULL)",
+            name="ck_extraction_entity_types_role_parent",
+        ),
+        Index(
+            "uq_extraction_entity_types_one_container_per_global",
+            "template_id",
+            unique=True,
+            postgresql_where=text("role = 'model_container' AND template_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_extraction_entity_types_one_container_per_project",
+            "project_template_id",
+            unique=True,
+            postgresql_where=text("role = 'model_container' AND project_template_id IS NOT NULL"),
+        ),
+        {"schema": "public"},
     )
 
     def __repr__(self) -> str:
@@ -334,7 +368,9 @@ class ExtractionField(BaseModel):
     )
 
     is_required: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    validation_schema: Mapped[dict[str, Any]] = mapped_column(JSONB, default={}, nullable=True)
+    validation_schema: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, default={}, nullable=True
+    )
     allowed_values: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     unit: Mapped[str | None] = mapped_column(String, nullable=True)
     allowed_units: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
@@ -419,7 +455,7 @@ class ExtractionInstance(BaseModel):
         default=ExtractionInstanceStatus.PENDING.value,
         nullable=False,
     )
-    is_template: Mapped[bool] = mapped_column(Boolean, default=False, nullable=True)
+    is_template: Mapped[bool | None] = mapped_column(Boolean, default=False, nullable=True)
 
     # Relationships
     template: Mapped["ProjectExtractionTemplate"] = relationship(
@@ -498,7 +534,7 @@ class ExtractionEvidence(BaseModel):
     )
 
     page_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    position: Mapped[dict[str, Any]] = mapped_column(JSONB, default={}, nullable=True)
+    position: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default={}, nullable=True)
     text_content: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_by: Mapped[UUID] = mapped_column(

--- a/backend/app/models/extraction_workflow.py
+++ b/backend/app/models/extraction_workflow.py
@@ -289,7 +289,10 @@ class ExtractionConsensusDecision(BaseModel):
                 "public.extraction_reviewer_decisions.id",
             ],
             name="fk_extraction_consensus_decisions_selected_run_match",
-            ondelete="SET NULL",
+            # RESTRICT, not SET NULL: run_id is NOT NULL, so a composite SET NULL
+            # would try to null run_id too and abort with a not-null violation.
+            # (SET NULL was also incoherent with the select_existing CHECK.) (#81)
+            ondelete="RESTRICT",
         ),
         CheckConstraint(
             "mode <> 'select_existing' OR selected_decision_id IS NOT NULL",

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -78,7 +78,7 @@ class Project(BaseModel):
     review_title: Mapped[str | None] = mapped_column(Text, nullable=True)
     condition_studied: Mapped[str | None] = mapped_column(String, nullable=True)
     review_rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
-    review_keywords: Mapped[dict[str, Any]] = mapped_column(JSONB, default=[], nullable=False)
+    review_keywords: Mapped[list[str]] = mapped_column(JSONB, default=list, nullable=False)
     eligibility_criteria: Mapped[dict[str, Any]] = mapped_column(JSONB, default={}, nullable=False)
     study_design: Mapped[dict[str, Any]] = mapped_column(JSONB, default={}, nullable=False)
     review_context: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -98,7 +98,7 @@ class Project(BaseModel):
         },
     )
 
-    review_type: Mapped[str] = mapped_column(
+    review_type: Mapped[str | None] = mapped_column(
         PostgreSQLEnumType("review_type"),
         default="interventional",
         nullable=True,

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -147,7 +147,7 @@ class ProjectResponse(BaseModel):
     eligibility_criteria: dict[str, Any] = Field(default={}, alias="eligibilityCriteria")
     study_design: dict[str, Any] = Field(default={}, alias="studyDesign")
 
-    review_type: str = Field(default="interventional", alias="reviewType")
+    review_type: str | None = Field(default="interventional", alias="reviewType")
     picots_config_ai_review: PICOTSConfig | None = Field(
         default=None,
         alias="picotsConfigAiReview",
@@ -225,7 +225,7 @@ class ProjectListItem(BaseModel):
     name: str
     description: str | None = None
     is_active: bool = Field(..., alias="isActive")
-    review_type: str = Field(default="interventional", alias="reviewType")
+    review_type: str | None = Field(default="interventional", alias="reviewType")
 
     articles_count: int = Field(default=0, alias="articlesCount")
     members_count: int = Field(default=0, alias="membersCount")

--- a/backend/app/services/run_lifecycle_service.py
+++ b/backend/app/services/run_lifecycle_service.py
@@ -315,9 +315,13 @@ class RunLifecycleService:
         *,
         run_id: UUID,
         user_id: UUID,
-    ) -> ExtractionRun:
+    ) -> tuple[ExtractionRun, bool]:
         """Create a new Run derived from a finalized one, pre-populated with
         the previous published values as ``source='system'`` proposals.
+
+        Returns ``(run, created)``: ``created`` is False when an existing live
+        child is resumed idempotently (the endpoint maps that to HTTP 200) and
+        True when a fresh revision is forked (HTTP 201).
 
         Implements the "Option C" reopen UX: each revision is its own
         immutable Run, linked to the parent via
@@ -378,7 +382,7 @@ class RunLifecycleService:
             )
         ).scalar_one_or_none()
         if existing_child is not None:
-            return existing_child
+            return existing_child, False
 
         # 1. Resolve the active version (lazy-create if the template was
         #    born outside the backfill path).
@@ -456,7 +460,7 @@ class RunLifecycleService:
         new_run.stage = ExtractionRunStage.REVIEW.value
         await self.db.flush()
         await self.db.refresh(new_run)
-        return new_run
+        return new_run, True
 
     async def _snapshot_initial_version(
         self,

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -104,8 +104,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0022_scope_model_progress_run" in out, (
-        f"Expected head revision '0022_scope_model_progress_run', got:\n{out}"
+    assert "0023_consensus_fk_restrict" in out, (
+        f"Expected head revision '0023_consensus_fk_restrict', got:\n{out}"
     )
 
 

--- a/backend/tests/integration/test_run_lifecycle_concurrency.py
+++ b/backend/tests/integration/test_run_lifecycle_concurrency.py
@@ -372,7 +372,9 @@ async def test_concurrent_reopen_does_not_fork_multiple_children(
         parent_id = run.id
 
     async def _reopen(session: AsyncSession) -> UUID:
-        child = await RunLifecycleService(session).reopen_run(run_id=parent_id, user_id=profile_id)
+        child, _ = await RunLifecycleService(session).reopen_run(
+            run_id=parent_id, user_id=profile_id
+        )
         await session.commit()
         return child.id
 

--- a/backend/tests/integration/test_run_lifecycle_service.py
+++ b/backend/tests/integration/test_run_lifecycle_service.py
@@ -306,7 +306,8 @@ async def test_reopen_after_cancelled_child_creates_fresh_run(
     await db_session.refresh(parent)
 
     # Step 2: Reopen → child B in REVIEW.
-    child_b = await service.reopen_run(run_id=parent.id, user_id=profile_id)
+    child_b, created_b = await service.reopen_run(run_id=parent.id, user_id=profile_id)
+    assert created_b is True  # fresh fork
     assert child_b.stage == ExtractionRunStage.REVIEW.value
     child_b_id = child_b.id
 
@@ -318,7 +319,8 @@ async def test_reopen_after_cancelled_child_creates_fresh_run(
     )
 
     # Step 4: Reopen A again — must produce a NEW child C, not return B.
-    child_c = await service.reopen_run(run_id=parent.id, user_id=profile_id)
+    child_c, created_c = await service.reopen_run(run_id=parent.id, user_id=profile_id)
+    assert created_c is True  # the cancelled child is not reused → a new fork
     assert child_c.id != child_b_id, "reopen_run returned the cancelled child instead of a new run"
     assert child_c.stage == ExtractionRunStage.REVIEW.value
 

--- a/backend/tests/integration/test_run_reopen.py
+++ b/backend/tests/integration/test_run_reopen.py
@@ -272,9 +272,10 @@ async def test_reopen_again_after_child_finalized_forks_fresh_run(
     child_id = first.json()["data"]["id"]
     assert child_id != old_run_id
 
-    # A second reopen *before* the child is finalized is idempotent — same child.
+    # A second reopen *before* the child is finalized resumes the same live
+    # child idempotently — HTTP 200, not a fresh 201 (#153).
     again = await db_client.post(f"/api/v1/runs/{old_run_id}/reopen")
-    assert again.status_code == 201, again.text
+    assert again.status_code == 200, again.text
     assert again.json()["data"]["id"] == child_id, "live child must be returned idempotently"
 
     # Drive the child (REVIEW) all the way to finalized.


### PR DESCRIPTION
P2/P3 schema/ORM-hygiene batch from the open-issue triage. Verified against the full backend suite.

Closes #93, #94, #95, #81, #153.

## #93 — ORM omitted the entity-type DB invariants
`ExtractionEntityType` didn't declare the template-XOR check, the role↔parent check, or the two partial-unique "one `model_container` per template" indexes, and it kept a `role` `server_default` that migration 0016 removed. So `alembic revision --autogenerate` would emit **DROPs** for the role invariants and re-add the server_default.
- **Fix:** declare the four constraints in `__table_args__`; drop the `server_default` (keep the Python-side `default`).
- **Verified:** `alembic check` no longer reports the entity-type constraints (in sync).

## #94 — array columns typed as `dict`
`Project.review_keywords` / `Article.funding` store JSON arrays but were `Mapped[dict]`.
- **Fix:** `Mapped[list[str]]` / `Mapped[list[dict[str, Any]]]`; `default=[]` → `default=list`.

## #95 — nullable columns typed non-Optional
`validation_schema`, `is_template`, `position`, `review_type` are nullable in the DB but annotated non-Optional.
- **Fix:** add `| None` so the type stops lying about legacy/unset rows.

## #81 — composite FK `SET NULL` with a `NOT NULL` column
`fk_extraction_consensus_decisions_selected_run_match` used `ON DELETE SET NULL`, but `run_id` is `NOT NULL`, so a composite SET NULL would null `run_id` too and abort. (Also incoherent with the `select_existing` CHECK.)
- **Fix:** migration **0023** re-creates it with `ON DELETE RESTRICT` (matching the sibling reviewer-states FK); model `ondelete` flipped. Validated `upgrade → downgrade → upgrade`.

## #153 — reopen always returned 201
- **Fix:** `reopen_run` now returns `(run, created)`; the endpoint sets **200** on an idempotent resume of an existing live child and **201** on a fresh fork (mirrors `POST /hitl/sessions`). Endpoint + service-level tests updated to the tuple contract; the idempotent-resume assertion now expects 200.

## Verification
- `ruff check` + `ruff format`: clean
- Migration 0023: `upgrade head → downgrade -1 → upgrade head` clean; `alembic check` shows the touched objects in sync
- **Full backend suite: 1057 passed, 6 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)