### PR TITLE
fix(frontend): extraction toast/refresh/race UX — #102 #159 #160 #110

### DIFF
--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -199,9 +199,10 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
     // Hook for batch AI extraction
   const { extractFullAI, loading: isExtracting } = useFullAIExtraction({
     onSuccess: async () => {
-        // Reload articles after extraction
+        // Refresh only — useFullAIExtraction owns every user-facing toast
+        // (success / no-models warning / partial-failure), so firing one here
+        // produced a false-success toast on the failure and no-models paths.
       await loadArticles();
-        toast.success(t('extraction', 'tableExtractionSuccess'));
     },
   });
 

--- a/frontend/hooks/extraction/ai/useAISuggestions.ts
+++ b/frontend/hooks/extraction/ai/useAISuggestions.ts
@@ -122,10 +122,10 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
     loadSuggestions();
   }, [articleId, enabled, loadSuggestions]);
 
-  const acceptSuggestion = useCallback(async (instanceId: string, fieldId: string) => {
+  const acceptSuggestionCore = useCallback(async (instanceId: string, fieldId: string, silent: boolean): Promise<boolean> => {
     const key = getSuggestionKey(instanceId, fieldId);
     const suggestion = suggestions[key];
-    if (!suggestion) return;
+    if (!suggestion) return false;
 
     // Feedback visual imediato
     setActionLoading(prev => ({ ...prev, [key]: 'accept' }));
@@ -181,12 +181,14 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
         });
       }
 
-        toast.success(t('extraction', 'toastSuggestionAcceptedSuccess'));
+        if (!silent) toast.success(t('extraction', 'toastSuggestionAcceptedSuccess'));
+        return true;
 
     } catch (err: any) {
         console.error('Error accepting suggestion:', err);
       const message = getErrorMessage(err);
-        toast.error(`${t('extraction', 'errors_acceptSuggestion')}: ${message}`);
+        if (!silent) toast.error(`${t('extraction', 'errors_acceptSuggestion')}: ${message}`);
+        return false;
     } finally {
         // Clear loading after operation
       setActionLoading(prev => {
@@ -196,6 +198,15 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
       });
     }
   }, [suggestions, projectId, articleId, runId, acceptStrategy, onSuggestionAccepted]);
+
+  // Public accept: surfaces its own toasts (silent=false) and keeps the
+  // Promise<void> contract — only the batch path needs the success flag.
+  const acceptSuggestion = useCallback(
+    async (instanceId: string, fieldId: string): Promise<void> => {
+      await acceptSuggestionCore(instanceId, fieldId, false);
+    },
+    [acceptSuggestionCore],
+  );
 
   const rejectSuggestion = useCallback(async (instanceId: string, fieldId: string) => {
     const key = getSuggestionKey(instanceId, fieldId);
@@ -278,23 +289,31 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
         return;
       }
 
-      await Promise.all(
+      // Accept each in silent mode so we fire ONE batch toast instead of N+1,
+      // and count real successes so the batch toast can't claim success when
+      // every accept actually failed (#160).
+      const results = await Promise.all(
         filtered.map(([key]) => {
           // key format: `${instanceId}_${fieldId}`
           const [instanceId, ...fieldIdParts] = key.split('_');
           const fieldId = fieldIdParts.join('_'); // Caso field_id tenha underscores
-          return acceptSuggestion(instanceId, fieldId);
+          return acceptSuggestionCore(instanceId, fieldId, /* silent */ true);
         })
       );
 
-        toast.success(t('extraction', 'batchAcceptCountToast').replace('{{n}}', String(filtered.length)));
+      const accepted = results.filter(Boolean).length;
+      if (accepted === 0) {
+          toast.error(t('extraction', 'errors_batchAcceptSuggestions'));
+        return;
+      }
+        toast.success(t('extraction', 'batchAcceptCountToast').replace('{{n}}', String(accepted)));
 
     } catch (err: any) {
       console.error('❌ Erro no batch accept:', err);
       const message = getErrorMessage(err);
         toast.error(`${t('extraction', 'errors_batchAcceptSuggestions')}: ${message}`);
     }
-  }, [suggestions, acceptSuggestion]);
+  }, [suggestions, acceptSuggestionCore]);
 
   /**
    * Fetches full suggestion history for a specific field

--- a/frontend/hooks/extraction/useFullAIExtraction.ts
+++ b/frontend/hooks/extraction/useFullAIExtraction.ts
@@ -239,18 +239,28 @@ export function useFullAIExtraction(options?: {
 
           console.warn('[useFullAIExtraction] Full AI extraction completed successfully');
 
-          // Final success toast
+          // Final toast. If the study-level (top-level) branch rejected, the
+          // models still succeeded but study-level sections were not saved —
+          // the sub-hook already toasted the specific error, so surface a
+          // partial-success WARNING here, never an unqualified success (#159).
         const topLevelSectionsCount = topLevelSectionsResult?.totalSections || 0;
         const topLevelSectionsSuccess = topLevelSectionsResult?.successfulSections || 0;
 
-          let description = t('extraction', 'fullAISuccessDescription').replace('{{n}}', String(models.length));
-        if (topLevelSectionsCount > 0) {
-            description += ' ' + t('extraction', 'fullAITopLevelSections').replace('{{n}}', String(topLevelSectionsSuccess));
-        }
-          toast.success(t('extraction', 'fullAICompleteSuccessTitle'), {
-              description,
-              duration: 8000,
+        if (topLevelSettled.status === 'rejected') {
+          toast.warning(t('extraction', 'fullAIPartialTitle'), {
+            description: t('extraction', 'fullAIPartialTopLevelFailed'),
+            duration: 8000,
           });
+        } else {
+          let description = t('extraction', 'fullAISuccessDescription').replace('{{n}}', String(models.length));
+          if (topLevelSectionsCount > 0) {
+            description += ' ' + t('extraction', 'fullAITopLevelSections').replace('{{n}}', String(topLevelSectionsSuccess));
+          }
+          toast.success(t('extraction', 'fullAICompleteSuccessTitle'), {
+            description,
+            duration: 8000,
+          });
+        }
 
           // Call success callback if provided
         if (options?.onSuccess) {

--- a/frontend/hooks/extraction/useFullAIExtraction.ts
+++ b/frontend/hooks/extraction/useFullAIExtraction.ts
@@ -178,34 +178,45 @@ export function useFullAIExtraction(options?: {
           stage: 'extracting_models',
         });
 
-          // Run both extractions in parallel
-          const [_modelsResult, topLevelSectionsResult] = await Promise.all([
-          extractModelsHook({
-            projectId,
-            articleId,
-            templateId,
-          }),
-          extractTopLevelSections({
-            projectId,
-            articleId,
-            templateId,
-          }),
+        // Run both extractions in parallel. allSettled (not all) so a
+        // rejection in one branch does not orphan the other still-running
+        // request. Each sub-hook surfaces its OWN error toast, so a Phase-1
+        // failure is handled here and never reaches the catch below — that is
+        // what removes the double error toast (#102).
+        const [modelsSettled, topLevelSettled] = await Promise.allSettled([
+          extractModelsHook({ projectId, articleId, templateId }),
+          extractTopLevelSections({ projectId, articleId, templateId }),
         ]);
 
-          console.warn('[useFullAIExtraction] Models and top-level sections extracted successfully', {
-          modelsExtracted: true,
-          topLevelSectionsExtracted: topLevelSectionsResult.totalSections > 0,
-        });
+        const topLevelSectionsResult =
+          topLevelSettled.status === 'fulfilled' ? topLevelSettled.value : null;
 
-          // PHASE 2: Fetch extracted models
-          console.warn('[useFullAIExtraction] Phase 2: Fetching extracted models...');
+        if (modelsSettled.status === 'rejected') {
+          // Model extraction gates phases 2-3 and already toasted its own
+          // error. Refresh whatever the top-level phase produced, then stop —
+          // no second toast.
+          setError(
+            modelsSettled.reason instanceof Error
+              ? modelsSettled.reason.message
+              : String(modelsSettled.reason),
+          );
+          if (options?.onSuccess) await options.onSuccess();
+          setProgress(null);
+          return;
+        }
+
+        // PHASE 2: Fetch extracted models
         const modelParentEntityTypeId = await fetchModelParentEntityTypeId(templateId);
         const models = await fetchExtractedModels(articleId, modelParentEntityTypeId);
 
         if (models.length === 0) {
-            toast.warning(t('extraction', 'noModelsFoundTitle'), {
-                description: t('extraction', 'noModelsExtractionComplete'),
+          toast.warning(t('extraction', 'noModelsFoundTitle'), {
+            description: t('extraction', 'noModelsExtractionComplete'),
           });
+          // Top-level (study-level) proposals were still created in Phase 1 —
+          // refresh so they appear instead of leaving the UI stale (#159).
+          if (options?.onSuccess) await options.onSuccess();
+          setProgress(null);
           return;
         }
 

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -199,6 +199,8 @@ export const extraction = {
     fullAICompleteSuccessTitle: 'Full AI extraction complete!',
     fullAISuccessDescription: '{{n}} model(s) processed with all sections extracted.',
     fullAITopLevelSections: '{{n}} top-level section(s) extracted.',
+    fullAIPartialTitle: 'Extraction partially complete',
+    fullAIPartialTopLevelFailed: 'Prediction models were extracted, but study-level sections failed and were not saved. Re-run extraction to retry them.',
     fullAIErrorPrefix: 'Error in full AI extraction',
     modelExtractionCompleteNoModels: 'Model extraction completed but no prediction models were found.',
     modelExtractionSuccessTitle: 'Extraction complete! {{n}} model(s) found and created.',
@@ -313,7 +315,6 @@ export const extraction = {
     aiSuggestionsPending: 'AI suggestions pending',
     aiClickToView: ' — Click to view',
     // ArticleExtractionTable (toast)
-    tableExtractionSuccess: 'Extraction completed successfully!',
     tableErrorLoadArticles: 'Error loading articles',
     tableSelectAtLeastOne: 'Select at least one article',
     tableErrorProcessAI: 'Error processing AI extraction',

--- a/frontend/pages/ProjectView.tsx
+++ b/frontend/pages/ProjectView.tsx
@@ -122,6 +122,10 @@ export default function ProjectView() {
 
     const [articles, setArticles] = useState<ProjectArticle[]>([]);
   const [loading, setLoading] = useState(true);
+  // Generation counter: a project navigation bumps it so an in-flight load for
+  // the previous projectId resolves into a no-op instead of overwriting the
+  // current project's data (#110).
+  const projectLoadRef = useRef(0);
     const [zoteroDialogOpen, setZoteroDialogOpen] = useState(false);
     const [risDialogOpen, setRisDialogOpen] = useState(false);
     const articlesListRef = useRef<ArticlesListHandle>(null);
@@ -206,15 +210,26 @@ export default function ProjectView() {
     }, [activeTab, searchParams, setSearchParams]);
 
   useEffect(() => {
-    if (projectId) {
-      loadProject();
-      loadArticles();
-    }
+    if (!projectId) return;
+    // New project selected: bump the generation so any in-flight load for the
+    // previous project resolves into a no-op, and show the spinner again
+    // instead of leaving the old project's data on screen (#110).
+    projectLoadRef.current += 1;
+    setLoading(true);
+    void loadProject();
+    void loadArticles();
+    return () => {
+      // Invalidate in-flight loads on projectId change / unmount.
+      projectLoadRef.current += 1;
+    };
   }, [projectId]);
 
   const loadProject = async () => {
     if (!projectId) return;
-    
+    // Captured synchronously before the first await; both loaders read the same
+    // post-bump value because the effect bumps once before calling them.
+    const generation = projectLoadRef.current;
+
     try {
       const { data, error } = await supabase
         .from("projects")
@@ -228,18 +243,21 @@ export default function ProjectView() {
         .single();
 
       if (error) throw error;
+      if (generation !== projectLoadRef.current) return;
       setContextProject(data);
     } catch (error: any) {
+      if (generation !== projectLoadRef.current) return;
         toast.error("Error loading project");
       console.error(error);
     } finally {
-      setLoading(false);
+      if (generation === projectLoadRef.current) setLoading(false);
     }
   };
 
   const loadArticles = async () => {
     if (!projectId) return;
-    
+    const generation = projectLoadRef.current;
+
     try {
       const { data, error } = await supabase
         .from("articles")
@@ -248,6 +266,7 @@ export default function ProjectView() {
         .order("created_at", { ascending: false });
 
       if (error) throw error;
+      if (generation !== projectLoadRef.current) return;
       setArticles(data || []);
     } catch (error: any) {
       console.error(error);

--- a/frontend/test/hooks/useAISuggestions.test.tsx
+++ b/frontend/test/hooks/useAISuggestions.test.tsx
@@ -43,6 +43,8 @@ vi.mock('@/lib/copy', () => ({
   t: (_ns: string, key: string) => key,
 }));
 
+import { toast } from 'sonner';
+
 import { AISuggestionService } from '@/services/aiSuggestionService';
 import { useAISuggestions } from '@/hooks/extraction/ai/useAISuggestions';
 import type { AISuggestion } from '@/types/ai-extraction';
@@ -324,6 +326,64 @@ describe('useAISuggestions — reviewer-decision strategy (Data Extraction)', ()
     expect(
       (AISuggestionService.acceptSuggestion as any).mock.calls[0][0].fieldId,
     ).toBe('f-1');
+  });
+
+  it('batchAccept fires ONE success toast, not one per item (#160)', async () => {
+    (AISuggestionService.loadSuggestions as any).mockResolvedValue({
+      suggestions: {
+        [getSuggestionKey('inst-1', 'f-1')]: makeSuggestion('inst-1', 'f-1', { confidence: 0.95 }),
+        [getSuggestionKey('inst-1', 'f-2')]: makeSuggestion('inst-1', 'f-2', { confidence: 0.92 }),
+        [getSuggestionKey('inst-1', 'f-3')]: makeSuggestion('inst-1', 'f-3', { confidence: 0.9 }),
+      },
+      count: 3,
+    });
+    const { result } = renderHook(() =>
+      useAISuggestions({
+        articleId: 'art-1',
+        projectId: 'proj-1',
+        instanceIds: ['inst-1'],
+        runId: 'run-active',
+      }),
+    );
+    await waitFor(() => expect(Object.keys(result.current.suggestions)).toHaveLength(3));
+
+    await act(async () => {
+      await result.current.batchAccept(0.8);
+    });
+
+    expect(AISuggestionService.acceptSuggestion).toHaveBeenCalledTimes(3);
+    // The per-item accepts run silently; only the batch summary toasts.
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('batchAccept reports an error (no false success) when every accept fails (#160)', async () => {
+    (AISuggestionService.loadSuggestions as any).mockResolvedValue({
+      suggestions: {
+        [getSuggestionKey('inst-1', 'f-1')]: makeSuggestion('inst-1', 'f-1', { confidence: 0.95 }),
+        [getSuggestionKey('inst-1', 'f-2')]: makeSuggestion('inst-1', 'f-2', { confidence: 0.92 }),
+      },
+      count: 2,
+    });
+    (AISuggestionService.acceptSuggestion as any)
+      .mockRejectedValueOnce(new Error('backend down'))
+      .mockRejectedValueOnce(new Error('backend down'));
+
+    const { result } = renderHook(() =>
+      useAISuggestions({
+        articleId: 'art-1',
+        projectId: 'proj-1',
+        instanceIds: ['inst-1'],
+        runId: 'run-active',
+      }),
+    );
+    await waitFor(() => expect(Object.keys(result.current.suggestions)).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.batchAccept(0.8);
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
   });
 });
 

--- a/frontend/test/hooks/useFullAIExtraction.test.tsx
+++ b/frontend/test/hooks/useFullAIExtraction.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for ``useFullAIExtraction`` toast behaviour (#102 / #159).
+ *
+ * The bug class these lock down: the hook owns every user-facing toast, and a
+ * caller (ArticleExtractionTable) used to ALSO fire a success toast from
+ * ``onSuccess``. Combined with the failure / no-models / partial paths calling
+ * ``onSuccess`` for refresh, that produced contradictory "error + success" or
+ * "warning + success" toast pairs. These tests assert the hook itself never
+ * emits an unqualified success toast on a non-success outcome, and that
+ * ``onSuccess`` (refresh) still fires on every terminal path.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  extractModels: vi.fn(),
+  extractTopLevelSections: vi.fn(),
+  extractAllSectionsForAllModels: vi.fn(),
+  // Result of supabase fetchExtractedModels (.order(...) resolves to this).
+  modelsResult: { data: [] as Array<{ id: string; label: string }>, error: null as unknown },
+}));
+
+vi.mock('@/hooks/extraction/useModelExtraction', () => ({
+  useModelExtraction: () => ({ extractModels: h.extractModels }),
+}));
+vi.mock('@/hooks/extraction/useTopLevelSectionsExtraction', () => ({
+  useTopLevelSectionsExtraction: () => ({ extractTopLevelSections: h.extractTopLevelSections }),
+}));
+vi.mock('@/hooks/extraction/useBatchAllModelsSectionsExtraction', () => ({
+  useBatchAllModelsSectionsExtraction: () => ({
+    extractAllSectionsForAllModels: h.extractAllSectionsForAllModels,
+  }),
+}));
+vi.mock('@/hooks/extraction/helpers/queryEntityTypes', () => ({
+  queryEntityTypesWithFallback: vi.fn(async () => [{ id: 'model-container-1' }]),
+}));
+vi.mock('@/lib/extraction/entityTypeRoles', () => ({
+  ENTITY_ROLE: { MODEL_CONTAINER: 'model_container' },
+}));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            order: () => Promise.resolve(h.modelsResult),
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+import { toast } from 'sonner';
+import { useFullAIExtraction } from '@/hooks/extraction/useFullAIExtraction';
+
+const PARAMS = { projectId: 'p1', articleId: 'a1', templateId: 't1' };
+
+function setup() {
+  const onSuccess = vi.fn(async () => undefined);
+  const { result } = renderHook(() => useFullAIExtraction({ onSuccess }));
+  return { onSuccess, result };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.extractModels.mockResolvedValue(undefined);
+  h.extractTopLevelSections.mockResolvedValue({ totalSections: 2, successfulSections: 2 });
+  h.extractAllSectionsForAllModels.mockResolvedValue(undefined);
+  h.modelsResult = { data: [{ id: 'inst-1', label: 'Model 1' }], error: null };
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('useFullAIExtraction toast contract', () => {
+  it('full success: one success toast, no warning/error, refreshes', async () => {
+    const { onSuccess, result } = setup();
+    await act(async () => {
+      await result.current.extractFullAI(PARAMS);
+    });
+    expect(toast.success).toHaveBeenCalledWith('fullAICompleteSuccessTitle', expect.anything());
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('models rejected: NO success toast, still refreshes (#102 false-success guard)', async () => {
+    h.extractModels.mockRejectedValue(new Error('boom'));
+    const { onSuccess, result } = setup();
+    await act(async () => {
+      await result.current.extractFullAI(PARAMS);
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('no models found: warning only, NO success toast, refreshes (#159)', async () => {
+    h.modelsResult = { data: [], error: null };
+    const { onSuccess, result } = setup();
+    await act(async () => {
+      await result.current.extractFullAI(PARAMS);
+    });
+    expect(toast.warning).toHaveBeenCalledWith('noModelsFoundTitle', expect.anything());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('top-level sections rejected but models succeed: partial WARNING, not success', async () => {
+    h.extractTopLevelSections.mockRejectedValue(new Error('study-level failed'));
+    const { onSuccess, result } = setup();
+    await act(async () => {
+      await result.current.extractFullAI(PARAMS);
+    });
+    expect(toast.warning).toHaveBeenCalledWith('fullAIPartialTitle', expect.anything());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
P2/P3 frontend behavior batch from the open-issue triage.

Closes #102, #159, #160, #110.

## #102 — double error toast + orphaned request
`useFullAIExtraction` Phase 1 used `Promise.all`, so one branch rejecting orphaned the other still-running request, and the outer `catch` fired a **second** error toast on top of the sub-hook's own.
- **Fix:** `Promise.allSettled`; a Phase-1 model-extraction rejection is handled inline (already toasted by the sub-hook) and never reaches the catch → single toast, no orphan.

## #159 — UI not refreshed when no models are found
The `models.length === 0` early-return skipped `onSuccess`, so the study-level proposals created in Phase 1 stayed invisible until a manual reload.
- **Fix:** call `onSuccess` (and clear progress) on that path too.

## #160 — batchAccept toast spam + false success
It fired N per-item success toasts **plus** a batch toast, and reported batch-success even when every accept failed.
- **Fix:** internal `acceptSuggestionCore(silent)` returns a success flag; `batchAccept` accepts silently, counts real successes, shows **one** summary toast, and an error toast when nothing succeeded. Public `acceptSuggestion` keeps its `Promise<void>` contract (no consumer ripple).
- **Tests:** one summary toast (not N+1); error-not-success when all fail.

## #110 — stale project data across navigations
`ProjectView`'s `loadProject`/`loadArticles` had no cancellation guard and the effect never reset `loading` on `projectId` change — a slow load for the previous project could overwrite the current one, and the spinner didn't reappear.
- **Fix:** `generationRef` guard (both loaders capture the generation synchronously, so external callers like `onImportComplete={loadArticles}` keep working) + `setLoading(true)` on navigation.

## Verification
- `tsc -p tsconfig.app.json`: no new errors from these changes (the one remaining `ProjectView` error is pre-existing — tracked in #197)
- `eslint`: clean
- **Full frontend suite: 435 passed**
- #102/#159/#110 are verified via tsc + reuse of the `generationRef` pattern already covered by the colaboracao / QA stale-guard tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)