### PR TITLE
fix: remove dead instance.status check in extraction progress

### DIFF
--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -445,12 +445,6 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
   const calculateExtractionProgress = (article: ArticleWithExtraction) => {
     if (article.instances.length === 0) return 0;
 
-      // Check if all instances have status 'completed'
-    const allCompleted = article.instances.every(instance => instance.status === 'completed');
-    if (allCompleted && article.instances.length > 0) {
-      return 100;
-    }
-
       // Count instances with at least one extracted value
     const instancesWithValues = article.instances.filter(instance =>
       article.extractedValues.some(value => value.instance_id === instance.id)


### PR DESCRIPTION
## Summary

The `calculateExtractionProgress` function in `ArticleExtractionTable.tsx` checks `instance.status === 'completed'` to short-circuit the progress calculation at 100%. The `ExtractionInstance` interface (defined at line 81) does **not** have a `status` property — the check is always `false` and the early-return is dead code.

This causes a TypeScript error (`TS2339: Property 'status' does not exist on type 'ExtractionInstance'`).

## Fix

Remove the broken `allCompleted` check and keep the working fallback logic that correctly computes progress based on extracted values.

## Changes
- `frontend/components/extraction/ArticleExtractionTable.tsx`: Remove 6 lines of dead code (the `allCompleted` check and early return)

Fixes #100