### PR TITLE
fix(extraction): DB-level article coherence on HITL workflow rows (#79)

### DIFF
--- a/backend/alembic/versions/0023_workflow_article_coherence.py
+++ b/backend/alembic/versions/0023_workflow_article_coherence.py
@@ -1,0 +1,126 @@
+"""DB-level article coherence on HITL workflow rows (defense-in-depth for #79)
+
+Revision ID: 0023_workflow_article_coherence
+Revises: 0022_scope_model_progress_run
+Create Date: 2026-06-04
+
+Follow-up to GitHub issue #79 (fixed at the service layer in PR #189).
+
+``assert_coords_coherent`` (``app/services/coordinate_coherence.py``) rejects
+a ``(run_id, instance_id, field_id)`` triplet whose instance belongs to a
+different article than its run. That guard lives only in the application
+layer, so a direct SQL write, a backfill migration, or a future writer that
+forgets to call it could still create a workflow row whose instance's
+``article_id`` diverges from its run's ``article_id``.
+
+This migration moves the invariant into the database. For each of the five
+HITL workflow tables (``extraction_proposal_records``,
+``extraction_reviewer_decisions``, ``extraction_reviewer_states``,
+``extraction_consensus_decisions``, ``extraction_published_states``) a
+``CONSTRAINT TRIGGER`` calls a shared plpgsql function that asserts
+``instance.article_id IS NOT DISTINCT FROM run.article_id``.
+
+Why a trigger and not the composite-FK style of 0005 / 0012: those bound two
+columns that already lived on the row (``run_id`` + a decision id). Here the
+shared key (``article_id``) lives on the *parents* (runs, instances), not on
+the workflow row, so a composite FK would require denormalizing an
+``article_id`` column onto all five tables and forcing every writer to keep
+it populated. A constraint trigger keeps the invariant in one place and
+enforces it regardless of how the row is written. It mirrors the
+deferred-trigger house style of migration 0016
+(``check_model_section_parent_role``).
+
+The NULLABLE-``article_id`` wrinkle is handled for free:
+``extraction_runs.article_id`` is NOT NULL, so a template instance
+(``article_id IS NULL``) is ``DISTINCT FROM`` the run's article and is
+rejected — workflow rows can only ever reference concrete, article-bound
+instances.
+
+``DEFERRABLE INITIALLY DEFERRED`` so a transaction that legitimately
+re-points a run and its instances to a new article in one unit of work is
+judged on its end state, not mid-transaction.
+
+The function pins ``search_path`` to satisfy the Supabase linter
+``function_search_path_mutable`` (see migration 0008).
+"""
+
+from alembic import op
+
+revision = "0023_workflow_article_coherence"
+down_revision = "0022_scope_model_progress_run"
+branch_labels = None
+depends_on = None
+
+
+# The five HITL workflow tables. All share the (run_id, instance_id,
+# field_id) coordinate system; each carries only plain FKs to
+# extraction_runs.id and extraction_instances.id that say nothing about
+# article agreement between the two.
+_WORKFLOW_TABLES = (
+    "extraction_proposal_records",
+    "extraction_reviewer_decisions",
+    "extraction_reviewer_states",
+    "extraction_consensus_decisions",
+    "extraction_published_states",
+)
+
+
+def upgrade() -> None:
+    # Shared trigger function: reject a workflow row whose instance's article
+    # differs from its run's article. ``extraction_runs.article_id`` is NOT
+    # NULL, so a NULL (template) instance article is DISTINCT and therefore
+    # rejected — concrete article-bound instances only.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.assert_workflow_article_coherent()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SET search_path = public, pg_catalog
+        AS $$
+        DECLARE
+            run_article uuid;
+            instance_article uuid;
+        BEGIN
+            SELECT article_id INTO run_article
+              FROM public.extraction_runs
+             WHERE id = NEW.run_id;
+
+            SELECT article_id INTO instance_article
+              FROM public.extraction_instances
+             WHERE id = NEW.instance_id;
+
+            IF instance_article IS DISTINCT FROM run_article THEN
+                RAISE EXCEPTION
+                    'workflow row (run=%, instance=%) violates article '
+                    'coherence: run.article_id=% but instance.article_id=%',
+                    NEW.run_id, NEW.instance_id, run_article, instance_article
+                    USING ERRCODE = 'check_violation';
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$
+        """
+    )
+
+    # Attach the constraint trigger to every workflow table. Fires only when
+    # run_id or instance_id is written (INSERT, or the rare UPDATE that
+    # re-points them) — routine UPDATEs of value/version/current_decision_id
+    # carry no overhead. DEFERRED so the check runs at COMMIT.
+    for table in _WORKFLOW_TABLES:
+        op.execute(
+            f"""
+            CREATE CONSTRAINT TRIGGER trg_{table}_article_coherent
+            AFTER INSERT OR UPDATE OF run_id, instance_id
+            ON public.{table}
+            DEFERRABLE INITIALLY DEFERRED
+            FOR EACH ROW
+            EXECUTE FUNCTION public.assert_workflow_article_coherent()
+            """
+        )
+
+
+def downgrade() -> None:
+    for table in _WORKFLOW_TABLES:
+        op.execute(f"DROP TRIGGER IF EXISTS trg_{table}_article_coherent ON public.{table}")
+    op.execute("DROP FUNCTION IF EXISTS public.assert_workflow_article_coherent()")

--- a/backend/app/models/extraction_workflow.py
+++ b/backend/app/models/extraction_workflow.py
@@ -9,6 +9,15 @@ Five tables back the proposal -> review -> consensus -> published lifecycle:
 
 All five share the (run_id, instance_id, field_id) coordinate system that
 identifies a single field on a single instance under a single Run.
+
+DB-level invariant (no ORM representation): migration
+``0023_workflow_article_coherence`` attaches a deferred ``CONSTRAINT
+TRIGGER`` (``trg_<table>_article_coherent``) to each of the five tables
+that rejects any row whose ``instance.article_id`` differs from its
+``run.article_id``. This is the defense-in-depth backstop for the
+service-layer ``assert_coords_coherent`` guard (issue #79, PR #189) —
+a direct SQL write or future writer that skips that helper still cannot
+land a cross-article workflow row.
 """
 
 from datetime import datetime

--- a/backend/tests/integration/smoke_constraints/test_workflow_article_coherence.py
+++ b/backend/tests/integration/smoke_constraints/test_workflow_article_coherence.py
@@ -1,0 +1,244 @@
+"""DEFERRED trigger from migration 0023: ``trg_<table>_article_coherent``.
+
+Defense-in-depth backstop for GitHub issue #79 (service-layer fix in
+PR #189). Asserts the DB rejects any of the five HITL workflow rows whose
+``instance.article_id`` differs from its ``run.article_id`` — even on a
+direct SQL write that bypasses ``assert_coords_coherent``.
+
+The trigger is DEFERRABLE INITIALLY DEFERRED, so the violation surfaces at
+COMMIT. These tests use ``db_session_real`` because the SAVEPOINT-based
+default fixture never reaches commit; see
+``backend/tests/integration/smoke_constraints/``.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.asyncio
+
+WORKFLOW_TABLES = (
+    "extraction_proposal_records",
+    "extraction_reviewer_decisions",
+    "extraction_reviewer_states",
+    "extraction_consensus_decisions",
+    "extraction_published_states",
+)
+
+# Per-table INSERT for the cross-article (sad) path. Each satisfies its
+# table's *immediate* CHECKs (so the row inserts) and leaves only the
+# DEFERRED article-coherence trigger to fail at COMMIT. ``reviewer_states``
+# is intentionally absent: its (run_id, current_decision_id) composite FK
+# requires a coherent reviewer_decision in the same run, which can't exist
+# for a cross-article run without far more scaffolding — it is covered
+# structurally by ``test_article_coherence_trigger_present_on_all_tables``.
+_SAD_PATH_INSERTS: dict[str, str] = {
+    "extraction_proposal_records": (
+        "INSERT INTO public.extraction_proposal_records "
+        "(run_id, instance_id, field_id, source, proposed_value) "
+        "VALUES (:run, :inst, :field, 'ai', '{}'::jsonb)"
+    ),
+    "extraction_reviewer_decisions": (
+        "INSERT INTO public.extraction_reviewer_decisions "
+        "(run_id, instance_id, field_id, reviewer_id, decision) "
+        "VALUES (:run, :inst, :field, :prof, 'reject')"
+    ),
+    "extraction_consensus_decisions": (
+        "INSERT INTO public.extraction_consensus_decisions "
+        "(run_id, instance_id, field_id, consensus_user_id, mode, value, rationale) "
+        "VALUES (:run, :inst, :field, :prof, 'manual_override', '{}'::jsonb, 'guard')"
+    ),
+    "extraction_published_states": (
+        "INSERT INTO public.extraction_published_states "
+        "(run_id, instance_id, field_id, value, published_by) "
+        "VALUES (:run, :inst, :field, '{}'::jsonb, :prof)"
+    ),
+}
+
+
+class _Fixture(NamedTuple):
+    project_id: UUID
+    instance_id: UUID  # bound to ``instance_article``
+    instance_article: UUID
+    field_id: UUID
+    template_id: UUID
+    version_id: UUID
+    profile_id: UUID
+
+
+async def _discover(session: AsyncSession) -> _Fixture | None:
+    """Find a concrete (article-bound) instance plus everything needed to
+    spin up an extraction_run against a *different* article.
+
+    Discovery-based (``LIMIT 1``) rather than importing seed IDs, matching
+    the dominant integration-test idiom. The autouse seed guarantees at
+    least one such instance in CI.
+    """
+    inst = (
+        await session.execute(
+            text(
+                "SELECT id, article_id, template_id, project_id, entity_type_id "
+                "FROM public.extraction_instances "
+                "WHERE article_id IS NOT NULL "
+                "LIMIT 1"
+            )
+        )
+    ).first()
+    if inst is None:
+        return None
+    instance_id, instance_article, template_id, project_id, entity_type_id = inst
+
+    field_id = (
+        await session.execute(
+            text("SELECT id FROM public.extraction_fields WHERE entity_type_id = :etid LIMIT 1"),
+            {"etid": entity_type_id},
+        )
+    ).scalar()
+
+    version_id = (
+        await session.execute(
+            text(
+                "SELECT id FROM public.extraction_template_versions "
+                "WHERE project_template_id = :tid AND is_active LIMIT 1"
+            ),
+            {"tid": template_id},
+        )
+    ).scalar()
+
+    profile_id = (await session.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
+
+    if not all((field_id, version_id, profile_id)):
+        return None
+    return _Fixture(
+        project_id=project_id,
+        instance_id=instance_id,
+        instance_article=instance_article,
+        field_id=field_id,
+        template_id=template_id,
+        version_id=version_id,
+        profile_id=profile_id,
+    )
+
+
+async def _make_run(session: AsyncSession, fx: _Fixture, *, article_id: UUID) -> UUID:
+    """Insert an extraction_run for ``article_id`` under the fixture's
+    template/project. Returns the new run id. (``status`` has only a
+    Python-side ORM default, so a raw INSERT must set it explicitly.)
+    """
+    run_id = uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO public.extraction_runs "
+            "(id, project_id, article_id, template_id, version_id, kind, stage, "
+            " status, created_by) "
+            "VALUES (:rid, :pid, :aid, :tid, :vid, 'extraction', 'pending', "
+            " 'pending', :prof)"
+        ),
+        {
+            "rid": run_id,
+            "pid": fx.project_id,
+            "aid": article_id,
+            "tid": fx.template_id,
+            "vid": fx.version_id,
+            "prof": fx.profile_id,
+        },
+    )
+    return run_id
+
+
+async def _make_article(session: AsyncSession, fx: _Fixture) -> UUID:
+    article_id = uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:aid, :pid, 'cross-article coherence guard', 1)"
+        ),
+        {"aid": article_id, "pid": fx.project_id},
+    )
+    return article_id
+
+
+@pytest.mark.parametrize("table_name", list(_SAD_PATH_INSERTS))
+async def test_cross_article_workflow_row_rejected_at_commit(
+    db_session_real: AsyncSession,
+    table_name: str,
+) -> None:
+    """Sad path: a workflow row whose run and instance belong to different
+    articles is rejected. INSERT succeeds (trigger is DEFERRED); COMMIT
+    raises. The failed COMMIT rolls back the throwaway article + run, so no
+    explicit teardown is needed.
+    """
+    fx = await _discover(db_session_real)
+    if fx is None:
+        pytest.skip("Need a seeded article-bound instance with field/version/profile.")
+
+    other_article = await _make_article(db_session_real, fx)
+    run_id = await _make_run(db_session_real, fx, article_id=other_article)
+
+    # run -> other_article, instance -> fx.instance_article (different) => incoherent.
+    await db_session_real.execute(
+        text(_SAD_PATH_INSERTS[table_name]),
+        {"run": run_id, "inst": fx.instance_id, "field": fx.field_id, "prof": fx.profile_id},
+    )
+
+    with pytest.raises(IntegrityError) as exc_info:
+        await db_session_real.commit()
+    assert "article coherence" in str(exc_info.value).lower()
+    await db_session_real.rollback()
+
+
+async def test_same_article_workflow_row_commits(db_session_real: AsyncSession) -> None:
+    """Happy path: run and instance share an article → COMMIT succeeds."""
+    fx = await _discover(db_session_real)
+    if fx is None:
+        pytest.skip("Need a seeded article-bound instance with field/version/profile.")
+
+    # Run bound to the SAME article as the instance → coherent.
+    run_id = await _make_run(db_session_real, fx, article_id=fx.instance_article)
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.extraction_proposal_records "
+            "(run_id, instance_id, field_id, source, proposed_value) "
+            "VALUES (:run, :inst, :field, 'ai', '{}'::jsonb)"
+        ),
+        {"run": run_id, "inst": fx.instance_id, "field": fx.field_id},
+    )
+    try:
+        await db_session_real.commit()  # must not raise
+    finally:
+        # CASCADE from the run clears the proposal row. The instance and its
+        # article are seed-owned — leave them alone.
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :rid"),
+            {"rid": run_id},
+        )
+        await db_session_real.commit()
+
+
+@pytest.mark.parametrize("table_name", WORKFLOW_TABLES)
+async def test_article_coherence_trigger_present_on_all_tables(
+    db_session_real: AsyncSession,
+    table_name: str,
+) -> None:
+    """Structural guard: the coherence trigger is attached to every one of
+    the five workflow tables (so none is silently missed — incl.
+    ``reviewer_states``, which the behavioral test can't easily reach).
+    """
+    count = (
+        await db_session_real.execute(
+            text(
+                "SELECT count(*) FROM pg_trigger t "
+                "JOIN pg_class c ON c.oid = t.tgrelid "
+                "WHERE c.relname = :table "
+                "AND t.tgname = :tgname"
+            ),
+            {"table": table_name, "tgname": f"trg_{table_name}_article_coherent"},
+        )
+    ).scalar()
+    assert count == 1

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -104,8 +104,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0022_scope_model_progress_run" in out, (
-        f"Expected head revision '0022_scope_model_progress_run', got:\n{out}"
+    assert "0023_workflow_article_coherence" in out, (
+        f"Expected head revision '0023_workflow_article_coherence', got:\n{out}"
     )
 
 


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #79 (fixed at the service layer in PR #189, now on `dev`). Enforces the `instance.article_id == run.article_id` invariant at the **database level** on all five HITL workflow tables, so it can no longer be bypassed by a direct SQL write, a backfill migration, or a future writer that forgets to call `assert_coords_coherent`.

## Approach

Migration `0023_workflow_article_coherence` adds a shared `plpgsql` function `assert_workflow_article_coherent()` and attaches it as a `DEFERRABLE INITIALLY DEFERRED` `CONSTRAINT TRIGGER` (`trg_<table>_article_coherent`) to each of:
`extraction_proposal_records`, `extraction_reviewer_decisions`, `extraction_reviewer_states`, `extraction_consensus_decisions`, `extraction_published_states`.

The function rejects any row where `instance.article_id IS DISTINCT FROM run.article_id`.

**Why a trigger and not the composite-FK style of `0005`/`0012`:** those bound two columns already on the row (`run_id` + a decision id). Here the shared key (`article_id`) lives on the *parents* (runs, instances), not on the workflow row — a composite FK would require denormalizing an `article_id` column onto all five tables and forcing every writer to populate it. A constraint trigger keeps the invariant in one place and enforces it regardless of how the row is written. It mirrors the deferred-trigger house style of `0016` (`check_model_section_parent_role`). It's also pure standard-Postgres DDL (no Supabase-specific features), and `search_path` is pinned per the `0008` linter convention.

**NULLABLE-`article_id` wrinkle handled for free:** `extraction_runs.article_id` is `NOT NULL`, so a template instance (`article_id IS NULL`) is `DISTINCT FROM` the run's article and is rejected — workflow rows can only ever reference concrete, article-bound instances.

## Files

- `backend/alembic/versions/0023_workflow_article_coherence.py` — migration (function + 5 triggers; docstring cites #79 + PR #189).
- `backend/app/models/extraction_workflow.py` — module docstring documents the DB-level invariant (a trigger has no ORM representation).
- `backend/tests/integration/smoke_constraints/test_workflow_article_coherence.py` — regression test.
- `backend/tests/integration/test_migration_roundtrip.py` — head-revision pin bumped to `0023`.

## Verification

- **New tests: 10/10 pass** — cross-article insert rejected at COMMIT (parametrized over 4 tables) + structural trigger-presence on all 5 + happy path.
- **Negative control:** dropping the triggers makes all 4 cross-article tests fail (the DB then accepts the bad write) — proving the tests have teeth and the triggers are the fix.
- **Migration round-trip** proven via `alembic upgrade/downgrade --sql` (offline, both directions) for the `0022 → 0023` range; `alembic heads` shows a single head and `test_alembic_history_chain_is_continuous` confirms a clean linear `down_revision` chain.
- **Lint clean** (`ruff` + `eslint` + `vite build`; `squawk` approves the migration).
- **Prod data scan (read-only):** 331 existing workflow rows, **0 cross-article violations** — the invariant already holds, so this migration is purely preventive and applies cleanly (pure DDL, no apply-time data validation). Railway runs `alembic upgrade head` on boot.

## ⚠️ Note for the merger — migration-number race (still live)

This branch is rebased onto `dev` (currently `0022_scope_model_progress_run`, from #196) and mints `0023_workflow_article_coherence` off it. **Another unmerged branch already carries a different `0023_consensus_fk_restrict`** (observed migrating the shared local dev DB; not yet on `dev`). Whichever of the two lands in `dev` second must **renumber** (→ `0024…`), re-point `down_revision`, and bump the head pin in `test_migration_roundtrip.py`. Normal Alembic multi-branch hygiene — flagging so it isn't a surprise at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
