### PR TITLE
fix(extraction): drop dead instance.status + indeterminate code (2 TS errors)

### DIFF
--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -445,12 +445,6 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
   const calculateExtractionProgress = (article: ArticleWithExtraction) => {
     if (article.instances.length === 0) return 0;
 
-      // Check if all instances have status 'completed'
-    const allCompleted = article.instances.every(instance => instance.status === 'completed');
-    if (allCompleted && article.instances.length > 0) {
-      return 100;
-    }
-
       // Count instances with at least one extracted value
     const instancesWithValues = article.instances.filter(instance =>
       article.extractedValues.some(value => value.instance_id === instance.id)
@@ -630,24 +624,8 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
     onCheckedChange: (checked: boolean) => void;
     'aria-label'?: string;
   }) => {
-    const checkboxRef = useRef<React.ElementRef<typeof Checkbox>>(null);
-
-    useEffect(() => {
-      if (checkboxRef.current) {
-          // Access underlying Radix UI DOM element
-        const element = checkboxRef.current as unknown as { 
-          querySelector?: (selector: string) => HTMLElement | null;
-        };
-        const buttonElement = element?.querySelector?.('button') as HTMLButtonElement | null;
-        if (buttonElement) {
-          buttonElement.indeterminate = indeterminate;
-        }
-      }
-    }, [indeterminate]);
-
     return (
       <Checkbox
-        ref={checkboxRef}
         checked={indeterminate ? false : checked}
         onCheckedChange={onCheckedChange}
         className={indeterminate ? 'data-[state=checked]:bg-primary/50' : ''}


### PR DESCRIPTION
## Summary
Removes two unreachable blocks in `ArticleExtractionTable.tsx` that each raised a `TS2339` type error and were runtime no-ops. Net **-22 lines, zero behaviour change**.

| Line | Dead code | Why it was dead |
|---|---|---|
| `calculateExtractionProgress` | `instance.status === 'completed'` fast-path | `ExtractionInstance` has no `status` field → `allCompleted` always `false` → `return 100` never ran. Progress already falls through to the value-count estimate. |
| `HeaderCheckbox` effect | `buttonElement.indeterminate = indeterminate` | `indeterminate` is an `HTMLInputElement` property; Radix `Checkbox` renders a `<button>`. The assignment was a no-op; the indeterminate visual is driven by the `checked`/`className` props. Removed the now-unused `ref`. |

## Verification
- `npm run typecheck`: **186 → 184** errors (exactly these two cleared, none introduced).
- `eslint` on the file: clean.

## Closes / relates
- Closes #100
- Supersedes #203 (same `status` fix, from an external fork — also clears the sibling `indeterminate` error in the same file)
- Chips 2 off the #197 typecheck-backlog

## Follow-up (out of scope, intentionally)
The `HeaderCheckbox` no longer attempts to render a true indeterminate state (it never did — the old effect was a no-op). Wiring Radix's native `checked="indeterminate"` for proper `aria-checked="mixed"` is a small a11y improvement left as a separate change.