### PR TITLE
release(dev→main): drop dead extraction-table type errors (#209)

### DIFF
--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -445,12 +445,6 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
   const calculateExtractionProgress = (article: ArticleWithExtraction) => {
     if (article.instances.length === 0) return 0;
 
-      // Check if all instances have status 'completed'
-    const allCompleted = article.instances.every(instance => instance.status === 'completed');
-    if (allCompleted && article.instances.length > 0) {
-      return 100;
-    }
-
       // Count instances with at least one extracted value
     const instancesWithValues = article.instances.filter(instance =>
       article.extractedValues.some(value => value.instance_id === instance.id)
@@ -630,24 +624,8 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
     onCheckedChange: (checked: boolean) => void;
     'aria-label'?: string;
   }) => {
-    const checkboxRef = useRef<React.ElementRef<typeof Checkbox>>(null);
-
-    useEffect(() => {
-      if (checkboxRef.current) {
-          // Access underlying Radix UI DOM element
-        const element = checkboxRef.current as unknown as { 
-          querySelector?: (selector: string) => HTMLElement | null;
-        };
-        const buttonElement = element?.querySelector?.('button') as HTMLButtonElement | null;
-        if (buttonElement) {
-          buttonElement.indeterminate = indeterminate;
-        }
-      }
-    }, [indeterminate]);
-
     return (
       <Checkbox
-        ref={checkboxRef}
         checked={indeterminate ? false : checked}
         onCheckedChange={onCheckedChange}
         className={indeterminate ? 'data-[state=checked]:bg-primary/50' : ''}


### PR DESCRIPTION
Promote dev → main.

Single change since the last promotion (#208):
- **#209** `fix(extraction)`: removes two dead, type-erroring blocks in `ArticleExtractionTable.tsx` (the `instance.status` fast-path and the no-op `HeaderCheckbox` indeterminate effect). Net -22 lines, zero behaviour change. Closes #100, supersedes #203, clears 2 of the #197 typecheck backlog (186 → 184).

Frontend-only; no migrations, no backend changes.