### PR TITLE
refactor(copy): drop duplicate exportButton key in extraction copy

### DIFF
--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -729,7 +729,6 @@ export const extraction = {
     fieldEditorTitle: 'Field editor',
     fieldEditorDesc: 'Fill in values for the selected instance',
     // ExtractionExportDialog (009-extraction-excel-export)
-    exportButton: 'Export',
     exportDialogTitle: 'Export extraction data',
     exportDialogSubtitle: 'Export extracted data from the active template as an Excel workbook (.xlsx).',
     exportSourceLabel: 'Source of values',


### PR DESCRIPTION
## Why
`exportButton: 'Export'` was declared **twice** in the `extraction` copy object — a dead, shadowed duplicate (TS1117). Flagged during the P2 PR review as pre-existing legacy.

## What changed
- Removed the redundant `exportButton` in the `// ExtractionExportDialog (009-extraction-excel-export)` block (`frontend/lib/copy/extraction.ts`). The canonical declaration stays in the general export cluster (line ~574) alongside its siblings (`exportTitle`, `exportSubtitle`, `exportTemplate`, `exportInstances`).
- The 009 dialog doesn't reference `exportButton`; its three real consumers — `NotificationCenter`, `ExtractionInterface`, `ExtractionExport` — read the kept definition. **Resolved value unchanged** (`'Export'`).

## Verification
- `npm run typecheck`: the sole **TS1117** duplicate-key error is gone (one off the #197 backlog); no new errors.
- `eslint frontend/lib/copy/extraction.ts`: clean.

Frontend-only, copy-only; no behaviour change.