### PR TITLE
Promote dev → main: Phase 2 RunView server-side collapse (#228)

### DIFF
--- a/backend/alembic/versions/0026_widen_template_snapshot.py
+++ b/backend/alembic/versions/0026_widen_template_snapshot.py
@@ -1,0 +1,98 @@
+"""Widen legacy template-version snapshots to the full entity_types/fields shape.
+
+The frozen snapshot in ``extraction_template_versions.schema_`` historically
+omitted ``role`` + ``description`` on entity_types and 8 field columns
+(``validation_schema``, ``unit``, ``allowed_units``, ``llm_description``,
+``allow_other``, ``other_label``, ``other_placeholder``, ``description``). The
+run-open view (Phase 2) reads the snapshot structurally for the first time, so
+narrow snapshots would render wrong.
+
+Nothing read ``schema_`` structurally before this change — every consumer read
+the live ``extraction_entity_types``/``extraction_fields`` tables — so
+re-deriving a narrow snapshot from the current live template for that
+``project_template_id`` loses no frozen behavior that was ever honored.
+
+Idempotent: only snapshots whose first entity_type lacks the ``role`` key
+(narrow) are rewritten; re-running is a no-op. Forward-only: the downgrade
+cannot reliably reconstruct the prior narrow shape and is a documented no-op.
+
+Revision ID: 0026_widen_template_snapshot
+Revises: 0025_reviewer_scoped_select_rls
+Create Date: 2026-06-08
+"""
+
+from alembic import op
+
+revision = "0026_widen_template_snapshot"
+down_revision = "0025_reviewer_scoped_select_rls"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Re-derive the entity_types tree from the live template, but only for
+    # snapshots detected as narrow (first entity_type missing the 'role' key).
+    # Empty-tree snapshots (entity_types = []) are excluded: `'[]'::jsonb -> 0`
+    # is NULL and `NOT (NULL ? 'role')` is NULL, which is not-true in WHERE, so
+    # the row is skipped unchanged — the correct outcome (nothing to widen).
+    # Keep this jsonb_build_object key list IN SYNC with
+    # app/services/extraction_snapshot.SNAPSHOT_SQL.
+    op.execute(
+        """
+        UPDATE public.extraction_template_versions v
+        SET schema = jsonb_build_object(
+            'entity_types', COALESCE(
+                (
+                    SELECT jsonb_agg(
+                        jsonb_build_object(
+                            'id', et.id,
+                            'name', et.name,
+                            'label', et.label,
+                            'description', et.description,
+                            'parent_entity_type_id', et.parent_entity_type_id,
+                            'cardinality', et.cardinality,
+                            'role', et.role,
+                            'sort_order', et.sort_order,
+                            'is_required', et.is_required,
+                            'fields', COALESCE(
+                                (
+                                    SELECT jsonb_agg(jsonb_build_object(
+                                        'id', f.id,
+                                        'name', f.name,
+                                        'label', f.label,
+                                        'description', f.description,
+                                        'field_type', f.field_type,
+                                        'is_required', f.is_required,
+                                        'validation_schema', f.validation_schema,
+                                        'allowed_values', f.allowed_values,
+                                        'unit', f.unit,
+                                        'allowed_units', f.allowed_units,
+                                        'sort_order', f.sort_order,
+                                        'llm_description', f.llm_description,
+                                        'allow_other', f.allow_other,
+                                        'other_label', f.other_label,
+                                        'other_placeholder', f.other_placeholder
+                                    ) ORDER BY f.sort_order)
+                                    FROM public.extraction_fields f
+                                    WHERE f.entity_type_id = et.id
+                                ),
+                                '[]'::jsonb
+                            )
+                        ) ORDER BY et.sort_order
+                    )
+                    FROM public.extraction_entity_types et
+                    WHERE et.project_template_id = v.project_template_id
+                ),
+                '[]'::jsonb
+            )
+        )
+        WHERE NOT ((v.schema -> 'entity_types' -> 0) ? 'role');
+        """
+    )
+
+
+def downgrade() -> None:
+    # Forward-only data widening. The prior narrow shape cannot be reconstructed
+    # without re-dropping columns the read path now depends on, and no consumer
+    # relies on the snapshot being narrow. Intentional no-op.
+    pass

--- a/backend/app/api/v1/endpoints/extraction_runs.py
+++ b/backend/app/api/v1/endpoints/extraction_runs.py
@@ -30,6 +30,7 @@ from app.schemas.extraction_run import (
     RunDetailResponse,
     RunReviewersResponse,
     RunSummaryResponse,
+    RunViewResponse,
 )
 from app.services.coordinate_coherence import CoordinateMismatchError
 from app.services.extraction_consensus_service import (
@@ -47,6 +48,7 @@ from app.services.extraction_review_service import (
 )
 from app.services.extraction_run_read_service import (
     RunNotFoundError,
+    build_run_view,
     get_run_or_raise,
     get_run_with_workflow_history,
     is_run_arbitrator,
@@ -156,6 +158,21 @@ async def get_run(
         detail,
         trace_id=getattr(request.state, "trace_id", None),
     )
+
+
+@router.get("/{run_id}/view")
+async def get_run_view(
+    run_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse[RunViewResponse]:
+    """One-round-trip run-open view: blind-filtered run detail + the frozen
+    entity_types tree + the caller's current_values."""
+    run = await _load_run_and_check_member(db, run_id, current_user_sub)
+    is_arbitrator = await is_run_arbitrator(db, run.project_id, current_user_sub)
+    view = await build_run_view(db, run_id, caller_id=current_user_sub, is_arbitrator=is_arbitrator)
+    return ApiResponse.success(view, trace_id=_trace(request))
 
 
 @router.post("/{run_id}/proposals", status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/v1/endpoints/hitl_sessions.py
+++ b/backend/app/api/v1/endpoints/hitl_sessions.py
@@ -11,11 +11,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from app.api.deps.security import ensure_project_member, get_current_user_sub
 from app.core.deps import DbSession
 from app.schemas.common import ApiResponse
+from app.schemas.extraction_run import RunViewResponse
 from app.schemas.hitl_session import (
     OpenHITLSessionRequest,
     OpenHITLSessionResponse,
     TemplateKind,
 )
+from app.services.extraction_run_read_service import build_run_view, is_run_arbitrator
 from app.services.hitl_session_service import (
     HITLSessionInputError,
     HITLSessionService,
@@ -77,6 +79,14 @@ async def open_hitl_session(
         # internal advance to PROPOSAL. The caller should retry — return
         # 409 Conflict instead of bubbling up an unhandled 500.
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+
+    run_view: RunViewResponse | None = None
+    if session.kind == TemplateKind.EXTRACTION:
+        is_arbitrator = await is_run_arbitrator(db, body.project_id, current_user_sub)
+        run_view = await build_run_view(
+            db, session.run_id, caller_id=current_user_sub, is_arbitrator=is_arbitrator
+        )
+
     await db.commit()
     # Issue #32: a resumed Run is not a created resource; emit 200.
     if not session.created:
@@ -87,6 +97,7 @@ async def open_hitl_session(
             kind=session.kind.value,
             project_template_id=session.project_template_id,
             instances_by_entity_type=session.instances_by_entity_type,
+            run_view=run_view,
         ),
         trace_id=getattr(request.state, "trace_id", None),
     )

--- a/backend/app/schemas/extraction_run.py
+++ b/backend/app/schemas/extraction_run.py
@@ -142,6 +142,70 @@ class RunDetailResponse(BaseModel):
     published_states: list[PublishedStateResponse]
 
 
+class RunViewField(BaseModel):
+    """A field in the frozen template snapshot, widened to every column the
+    run-open form renders from. Sourced from the version snapshot (or the live
+    table when the snapshot is a pre-0026 narrow one)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    label: str
+    description: str | None = None
+    field_type: str
+    is_required: bool
+    validation_schema: Any | None = None
+    allowed_values: Any | None = None
+    unit: str | None = None
+    allowed_units: Any | None = None
+    sort_order: int
+    llm_description: str | None = None
+    allow_other: bool = False
+    other_label: str | None = None
+    other_placeholder: str | None = None
+
+
+class RunViewEntityType(BaseModel):
+    """An entity type in the frozen template snapshot, with its fields embedded.
+    ``role`` drives the study/model partition; the tree hierarchy is conveyed by
+    ``parent_entity_type_id`` (flat array, ordered by ``sort_order``)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    label: str
+    description: str | None = None
+    parent_entity_type_id: UUID | None = None
+    cardinality: str
+    role: str
+    sort_order: int
+    is_required: bool
+    fields: list[RunViewField]
+
+
+class RunViewCurrentValue(BaseModel):
+    """The caller's current value for one (instance, field) coordinate, resolved
+    server-side for review/consensus/finalized. ``value`` is the raw jsonb
+    envelope (``{value, unit}`` or scalar) — the client unwraps it exactly as it
+    did for ``loadValuesForUser``. Empty list for proposal/pending/cancelled."""
+
+    instance_id: UUID
+    field_id: UUID
+    value: dict[str, Any] | None
+    decision: str
+
+
+class RunViewResponse(RunDetailResponse):
+    """``RunDetailResponse`` (run + blind-filtered workflow rows) plus the two
+    pieces the run-open form needs server-side: the frozen entity_types tree and
+    the caller's current_values. (``instances`` is added in Task 12.)"""
+
+    entity_types: list[RunViewEntityType]
+    current_values: list[RunViewCurrentValue]
+
+
 class RunReviewerProfile(BaseModel):
     """Display profile for a reviewer who participated in a run."""
 

--- a/backend/app/schemas/hitl_session.py
+++ b/backend/app/schemas/hitl_session.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, model_validator
 # canonical enum value without importing directly from app.models.* —
 # enforced by scripts/fitness/check_layered_arch.py.
 from app.models.extraction_versioning import TemplateKind  # noqa: E402,F401
+from app.schemas.extraction_run import RunViewResponse
 
 
 class OpenHITLSessionRequest(BaseModel):
@@ -30,6 +31,10 @@ class OpenHITLSessionResponse(BaseModel):
     kind: Literal["extraction", "quality_assessment"]
     project_template_id: UUID
     instances_by_entity_type: dict[str, str]
+    # Embedded run-open view (extraction only). Lets the client render from a
+    # single round-trip instead of session -> GET /runs/{id} -> values. Null for
+    # quality_assessment (its surface does not consume this).
+    run_view: RunViewResponse | None = None
 
 
 class CloneTemplateRequest(BaseModel):

--- a/backend/app/services/extraction_run_read_service.py
+++ b/backend/app/services/extraction_run_read_service.py
@@ -13,16 +13,19 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
-from app.models.extraction import ExtractionRun, ExtractionRunStage
+from app.models.extraction import ExtractionEntityType, ExtractionRun, ExtractionRunStage
+from app.models.extraction_versioning import ExtractionTemplateVersion
 from app.models.extraction_workflow import (
     ExtractionConsensusDecision,
     ExtractionProposalRecord,
     ExtractionProposalSource,
     ExtractionPublishedState,
     ExtractionReviewerDecision,
+    ExtractionReviewerState,
 )
 from app.models.project import ProjectMemberRole
 from app.models.user import Profile
@@ -44,6 +47,9 @@ from app.schemas.extraction_run import (
     RunDetailResponse,
     RunReviewerProfile,
     RunSummaryResponse,
+    RunViewCurrentValue,
+    RunViewEntityType,
+    RunViewResponse,
 )
 
 
@@ -119,6 +125,183 @@ async def get_run_with_workflow_history(
         decisions=[ReviewerDecisionResponse.model_validate(d) for d in visible_decisions],
         consensus_decisions=[ConsensusDecisionResponse.model_validate(c) for c in consensus],
         published_states=[PublishedStateResponse.model_validate(ps) for ps in published_rows],
+    )
+
+
+def _snapshot_is_narrow(entity_types: list[dict]) -> bool:
+    """A pre-0026 snapshot is detected by its first entity_type lacking 'role'.
+    Empty trees are treated as narrow so the live fallback repopulates them —
+    a legitimately empty template just round-trips to an empty live read, which
+    is the correct (if marginally wasteful) recovery, not a structural read to
+    'optimize away'."""
+    return not entity_types or "role" not in entity_types[0]
+
+
+async def _entity_types_for_run(
+    db: AsyncSession, run: RunSummaryResponse
+) -> list[RunViewEntityType]:
+    """Frozen entity_types tree from the run's version snapshot, with a live
+    read fallback for pre-0026 narrow snapshots (belt-and-suspenders: migration
+    0026 backfills these, but the fallback turns a 'silent broken study/model
+    partition' into a correct live render if any narrow snapshot slips through).
+    Both paths produce the same shape via ``model_validate``."""
+    version = await db.get(ExtractionTemplateVersion, run.version_id)
+    snapshot_types: list[dict] = (version.schema_ or {}).get("entity_types", []) if version else []
+    if not _snapshot_is_narrow(snapshot_types):
+        return [RunViewEntityType.model_validate(et) for et in snapshot_types]
+
+    # Live fallback — one statement, fields eager-loaded (selectinload), then
+    # model_validate straight off the ORM (RunViewEntityType/RunViewField carry
+    # from_attributes=True). The relationship is not guaranteed field-ordered,
+    # so sort the validated fields by sort_order to match the snapshot path.
+    et_rows = (
+        (
+            await db.execute(
+                select(ExtractionEntityType)
+                .where(ExtractionEntityType.project_template_id == run.template_id)
+                .options(selectinload(ExtractionEntityType.fields))
+                .order_by(ExtractionEntityType.sort_order)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    result: list[RunViewEntityType] = []
+    for et in et_rows:
+        view_et = RunViewEntityType.model_validate(et)
+        view_et.fields.sort(key=lambda f: f.sort_order)
+        result.append(view_et)
+    return result
+
+
+async def resolve_caller_current_values(
+    db: AsyncSession, run_id: UUID, *, caller_id: UUID
+) -> list[RunViewCurrentValue]:
+    """The caller's current value per (instance, field) coordinate.
+
+    Mirrors the frontend ``loadValuesForUser`` it replaces, value-for-value:
+      Layer 1 (base): the caller's own human proposals, newest-per-coord;
+      Layer 2 (override): the caller's current reviewer decision per coord,
+        resolved through the materialized ``extraction_reviewer_states`` pointer
+        (``current_decision_id`` -> the live ``extraction_reviewer_decisions`` row).
+    ``reject`` decisions are kept (the client clears the coord but the audit row
+    stays). Caller-scoped: only ``reviewer_id == caller_id`` /
+    ``source_user_id == caller_id`` rows — this is the 4th lockstep copy of the
+    blind predicate and MUST stay identical to migration 0025 + the service
+    filter in get_run_with_workflow_history.
+
+    NOTE: ``ExtractionExportService._build_single_user_value_map`` looks similar
+    but encodes a DIFFERENT contract (it sources ``accept_proposal`` from the
+    accepted proposal and drops ``reject``, with no human-proposal base layer).
+    This resolver mirrors the FRONTEND ``loadValuesForUser`` it replaces, not the
+    export contract — do NOT DRY them together, or run-open values diverge from
+    the form's current behavior (Invariant 6). The two reads below are
+    independent but run sequentially on the shared AsyncSession (a single
+    asyncpg connection cannot multiplex, so ``asyncio.gather`` here is unsafe);
+    this matches the sequential read pattern of the composed
+    get_run_with_workflow_history. Merging them into one CTE is a possible future
+    optimization, deliberately not taken here to keep this security-sensitive
+    resolver simple.
+    """
+    merged: dict[tuple[UUID, UUID], RunViewCurrentValue] = {}
+
+    # Layer 1 — caller's own human proposals, newest-first; first-per-coord wins
+    # (ties on created_at are skipped by the `key in merged` guard below).
+    proposal_rows = (
+        (
+            await db.execute(
+                select(ExtractionProposalRecord)
+                .where(
+                    ExtractionProposalRecord.run_id == run_id,
+                    ExtractionProposalRecord.source == ExtractionProposalSource.HUMAN.value,
+                    ExtractionProposalRecord.source_user_id == caller_id,
+                )
+                .order_by(ExtractionProposalRecord.created_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for p in proposal_rows:
+        key = (p.instance_id, p.field_id)
+        if key in merged:
+            continue
+        merged[key] = RunViewCurrentValue(
+            instance_id=p.instance_id,
+            field_id=p.field_id,
+            value=p.proposed_value,
+            decision="human_proposal",
+        )
+
+    # Layer 2 — caller's current reviewer decision per coord (overrides Layer 1).
+    state_rows = (
+        await db.execute(
+            select(ExtractionReviewerState, ExtractionReviewerDecision)
+            .join(
+                ExtractionReviewerDecision,
+                and_(
+                    ExtractionReviewerDecision.run_id == ExtractionReviewerState.run_id,
+                    ExtractionReviewerDecision.id == ExtractionReviewerState.current_decision_id,
+                ),
+            )
+            .where(
+                ExtractionReviewerState.run_id == run_id,
+                ExtractionReviewerState.reviewer_id == caller_id,
+            )
+        )
+    ).all()
+    for state, decision in state_rows:
+        merged[(state.instance_id, state.field_id)] = RunViewCurrentValue(
+            instance_id=state.instance_id,
+            field_id=state.field_id,
+            value=decision.value,
+            decision=decision.decision,
+        )
+
+    return list(merged.values())
+
+
+# Stages whose form hydrates from the materialized reviewer_states + decisions
+# (current_values). In 'proposal' the client uses proposals[]; pending/cancelled
+# show nothing.
+_CURRENT_VALUE_STAGES = frozenset(
+    {
+        ExtractionRunStage.REVIEW.value,
+        ExtractionRunStage.CONSENSUS.value,
+        ExtractionRunStage.FINALIZED.value,
+    }
+)
+
+
+async def build_run_view(
+    db: AsyncSession, run_id: UUID, *, caller_id: UUID, is_arbitrator: bool
+) -> RunViewResponse:
+    """The one-round-trip run-open view: the blind-filtered run detail plus the
+    frozen entity_types tree and the caller's current_values. COMPOSES
+    get_run_with_workflow_history (the single blind filter) — it never re-queries
+    the workflow tables, so the blind boundary cannot drift. The composed
+    ``detail.run`` (a RunSummaryResponse) already carries ``version_id`` /
+    ``template_id`` / ``stage`` / ``article_id``, so there is no second ORM
+    fetch of the run here."""
+    detail = await get_run_with_workflow_history(
+        db, run_id, caller_id=caller_id, is_arbitrator=is_arbitrator
+    )
+
+    entity_types = await _entity_types_for_run(db, detail.run)
+    current_values = (
+        await resolve_caller_current_values(db, run_id, caller_id=caller_id)
+        if detail.run.stage in _CURRENT_VALUE_STAGES
+        else []
+    )
+
+    return RunViewResponse(
+        run=detail.run,
+        proposals=detail.proposals,
+        decisions=detail.decisions,
+        consensus_decisions=detail.consensus_decisions,
+        published_states=detail.published_states,
+        entity_types=entity_types,
+        current_values=current_values,
     )
 
 

--- a/backend/app/services/extraction_snapshot.py
+++ b/backend/app/services/extraction_snapshot.py
@@ -1,0 +1,85 @@
+"""Single source of truth for the template-version snapshot shape.
+
+``RunLifecycleService._snapshot_initial_version`` and
+``TemplateCloneService._snapshot`` both freeze the entity_types + fields tree
+into ``extraction_template_versions.schema_``. They used to embed two copies of
+the ``jsonb_build_object`` SQL that drifted — ``role`` was added to the clone
+builder but not the lifecycle one (forcing migration 0017 to retro-patch).
+This module owns the single, widened query so the two builders cannot diverge
+again, and so migration 0026 can backfill old snapshots to the same shape.
+
+The key set mirrors the data columns of ``ExtractionEntityType`` and
+``ExtractionField`` that the run-open form renders from (FK/audit columns are
+intentionally excluded — the form does not read them).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# WARNING: migration 0026_widen_template_snapshot embeds a copy of this
+# key set for its one-time backfill. If you add a key here, update that
+# migration's SQL too (migrations must stay self-contained; they cannot import
+# app code that may change after they are committed).
+SNAPSHOT_SQL = text(
+    """
+    SELECT jsonb_build_object(
+        'entity_types', COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'id', et.id,
+                        'name', et.name,
+                        'label', et.label,
+                        'description', et.description,
+                        'parent_entity_type_id', et.parent_entity_type_id,
+                        'cardinality', et.cardinality,
+                        'role', et.role,
+                        'sort_order', et.sort_order,
+                        'is_required', et.is_required,
+                        'fields', COALESCE(
+                            (
+                                SELECT jsonb_agg(jsonb_build_object(
+                                    'id', f.id,
+                                    'name', f.name,
+                                    'label', f.label,
+                                    'description', f.description,
+                                    'field_type', f.field_type,
+                                    'is_required', f.is_required,
+                                    'validation_schema', f.validation_schema,
+                                    'allowed_values', f.allowed_values,
+                                    'unit', f.unit,
+                                    'allowed_units', f.allowed_units,
+                                    'sort_order', f.sort_order,
+                                    'llm_description', f.llm_description,
+                                    'allow_other', f.allow_other,
+                                    'other_label', f.other_label,
+                                    'other_placeholder', f.other_placeholder
+                                ) ORDER BY f.sort_order)
+                                FROM public.extraction_fields f
+                                WHERE f.entity_type_id = et.id
+                            ),
+                            '[]'::jsonb
+                        )
+                    ) ORDER BY et.sort_order
+                )
+                FROM public.extraction_entity_types et
+                WHERE et.project_template_id = :tid
+            ),
+            '[]'::jsonb
+        )
+    )
+    """
+)
+
+
+async def build_template_version_snapshot(
+    db: AsyncSession, project_template_id: UUID
+) -> dict[str, Any]:
+    """Build the frozen ``{entity_types: [...]}`` snapshot for a project template."""
+    row = await db.execute(SNAPSHOT_SQL, {"tid": str(project_template_id)})
+    return row.scalar_one()

--- a/backend/app/services/run_lifecycle_service.py
+++ b/backend/app/services/run_lifecycle_service.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,6 +25,7 @@ from app.models.extraction_workflow import (
     ExtractionReviewerDecisionType,
     ExtractionReviewerState,
 )
+from app.services.extraction_snapshot import build_template_version_snapshot
 from app.services.hitl_config_service import HitlConfigService
 
 
@@ -473,50 +474,7 @@ class RunLifecycleService:
         Captures the current entity_types + fields tree as the v=1 snapshot.
         Marked active so subsequent runs reuse it via the ``is_active`` index.
         """
-        snapshot_row = await self.db.execute(
-            text(
-                """
-                SELECT jsonb_build_object(
-                    'entity_types', COALESCE(
-                        (
-                            SELECT jsonb_agg(
-                                jsonb_build_object(
-                                    'id', et.id,
-                                    'name', et.name,
-                                    'label', et.label,
-                                    'parent_entity_type_id', et.parent_entity_type_id,
-                                    'cardinality', et.cardinality,
-                                    'sort_order', et.sort_order,
-                                    'is_required', et.is_required,
-                                    'fields', COALESCE(
-                                        (
-                                            SELECT jsonb_agg(jsonb_build_object(
-                                                'id', f.id,
-                                                'name', f.name,
-                                                'label', f.label,
-                                                'field_type', f.field_type,
-                                                'is_required', f.is_required,
-                                                'allowed_values', f.allowed_values,
-                                                'sort_order', f.sort_order
-                                            ) ORDER BY f.sort_order)
-                                            FROM public.extraction_fields f
-                                            WHERE f.entity_type_id = et.id
-                                        ),
-                                        '[]'::jsonb
-                                    )
-                                ) ORDER BY et.sort_order
-                            )
-                            FROM public.extraction_entity_types et
-                            WHERE et.project_template_id = :tid
-                        ),
-                        '[]'::jsonb
-                    )
-                )
-                """
-            ),
-            {"tid": str(project_template_id)},
-        )
-        snapshot = snapshot_row.scalar_one()
+        snapshot = await build_template_version_snapshot(self.db, project_template_id)
 
         # Upsert v=1 idempotently. Three races to handle:
         #

--- a/backend/app/services/template_clone_service.py
+++ b/backend/app/services/template_clone_service.py
@@ -16,6 +16,7 @@ from app.models.extraction import (
     TemplateKind,
 )
 from app.models.extraction_versioning import ExtractionTemplateVersion
+from app.services.extraction_snapshot import build_template_version_snapshot
 
 
 class TemplateNotFoundError(Exception):
@@ -475,50 +476,4 @@ class TemplateCloneService:
         return (await self.db.execute(stmt)).scalar_one_or_none()
 
     async def _snapshot(self, project_template_id: UUID) -> dict[str, Any]:
-        from sqlalchemy import text
-
-        result = await self.db.execute(
-            text(
-                """
-                SELECT jsonb_build_object(
-                    'entity_types', COALESCE(
-                        (
-                            SELECT jsonb_agg(
-                                jsonb_build_object(
-                                    'id', et.id,
-                                    'name', et.name,
-                                    'label', et.label,
-                                    'parent_entity_type_id', et.parent_entity_type_id,
-                                    'cardinality', et.cardinality,
-                                    'role', et.role,
-                                    'sort_order', et.sort_order,
-                                    'is_required', et.is_required,
-                                    'fields', COALESCE(
-                                        (
-                                            SELECT jsonb_agg(jsonb_build_object(
-                                                'id', f.id,
-                                                'name', f.name,
-                                                'label', f.label,
-                                                'field_type', f.field_type,
-                                                'is_required', f.is_required,
-                                                'allowed_values', f.allowed_values,
-                                                'sort_order', f.sort_order
-                                            ) ORDER BY f.sort_order)
-                                            FROM public.extraction_fields f
-                                            WHERE f.entity_type_id = et.id
-                                        ),
-                                        '[]'::jsonb
-                                    )
-                                ) ORDER BY et.sort_order
-                            )
-                            FROM public.extraction_entity_types et
-                            WHERE et.project_template_id = :tid
-                        ),
-                        '[]'::jsonb
-                    )
-                )
-                """
-            ),
-            {"tid": str(project_template_id)},
-        )
-        return result.scalar_one()
+        return await build_template_version_snapshot(self.db, project_template_id)

--- a/backend/tests/integration/test_build_run_view.py
+++ b/backend/tests/integration/test_build_run_view.py
@@ -1,0 +1,45 @@
+"""build_run_view composes get_run_with_workflow_history (the single blind
+filter) and adds entity_types + current_values. It must NOT re-introduce a
+blind leak, and current_values must be empty in proposal stage."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.extraction_run_read_service import build_run_view
+from tests.integration.test_blind_review_isolation import (
+    _build_two_reviewer_review_run,
+)
+from tests.integration.test_run_proposals_latest_wins import _proposal_stage_coord
+
+
+@pytest.mark.asyncio
+async def test_build_run_view_blinds_peer_in_review(db_session: AsyncSession) -> None:
+    built = await _build_two_reviewer_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, reviewer_b = built
+
+    view = await build_run_view(db_session, run_id, caller_id=reviewer_b, is_arbitrator=False)
+    reviewer_ids = {d.reviewer_id for d in view.decisions}
+    assert reviewer_b in reviewer_ids
+    assert reviewer_a not in reviewer_ids, "build_run_view leaked a peer decision"
+    assert view.entity_types, "entity_types tree must be populated"
+    assert isinstance(view.current_values, list)
+
+
+@pytest.mark.asyncio
+async def test_build_run_view_current_values_empty_in_proposal(
+    db_session: AsyncSession,
+) -> None:
+    fx = await _proposal_stage_coord(db_session)
+    if fx is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, _instance_id, _field_id, user_id = fx
+
+    view = await build_run_view(db_session, run_id, caller_id=user_id, is_arbitrator=False)
+    assert view.run.stage == "proposal"
+    assert view.current_values == [], (
+        "proposal stage must use proposals[] on the client, not server current_values"
+    )

--- a/backend/tests/integration/test_hitl_session_embeds_run_view.py
+++ b/backend/tests/integration/test_hitl_session_embeds_run_view.py
@@ -1,0 +1,156 @@
+"""Integration tests for the embedded RunViewResponse in POST /api/v1/hitl/sessions.
+
+Pins that the extraction session-open response embeds a populated ``run_view``
+(the same data the client would previously fetch with a follow-up
+GET /api/v1/runs/{id}/view), allowing the run-open form to render in one
+round-trip.
+
+Test 2 (reviewer-scoped embed / blind isolation for a review-stage run) is
+omitted here. The endpoint's ``is_arbitrator`` wiring (computed via
+``is_run_arbitrator(db, body.project_id, current_user_sub)``) relies on
+``test_build_run_view_blinds_peer_in_review`` (Task 5) for blind coverage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from tests.integration.conftest import SEED
+
+_SESSION_URL = "/api/v1/hitl/sessions"
+
+
+# =================== FIXTURES ===================
+
+
+@pytest_asyncio.fixture
+async def auth_as_profile(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Override ``get_current_user`` so its JWT subject is ``SEED.primary_profile``.
+
+    Identical to the pattern used in ``test_run_view_endpoint.py`` and
+    ``test_hitl_session.py``.
+    """
+    del db_session  # kept for fixture-dependency ordering (seed runs first)
+    profile_id = SEED.primary_profile
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="primary@integration-test.prumo.local",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield profile_id
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+# =================== TESTS ===================
+
+
+@pytest.mark.asyncio
+async def test_extraction_session_open_embeds_run_view(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001 — fixture order: seed runs first
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """Core embed: POST /api/v1/hitl/sessions (extraction) returns run_view != null.
+
+    Asserts:
+    - ``data["run_view"]`` is not None (embed is present).
+    - ``run_view["run"]["id"]`` matches ``data["run_id"]`` (same run).
+    - ``run_view`` has ``entity_types`` and ``current_values`` keys
+      (the RunViewResponse contract beyond RunDetailResponse).
+    - Stage is 'proposal' (session open advances pending → proposal).
+    - ``current_values`` is empty (proposal stage → no value resolution yet).
+    """
+    res = await db_client.post(
+        _SESSION_URL,
+        json={
+            "kind": "extraction",
+            "project_id": str(SEED.primary_project),
+            "article_id": str(SEED.primary_article),
+            "project_template_id": str(SEED.primary_template),
+        },
+    )
+    assert res.status_code in (200, 201), res.text
+
+    payload = res.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+
+    run_id = data["run_id"]
+    view = data["run_view"]
+
+    assert view is not None, "run_view must be embedded for extraction kind"
+    assert view["run"]["id"] == run_id, "Embedded run id must match run_id in response"
+    assert "entity_types" in view, "run_view must contain entity_types"
+    assert "current_values" in view, "run_view must contain current_values"
+    assert view["run"]["stage"] == "proposal", "Session open must advance the run to proposal stage"
+    assert view["current_values"] == [], (
+        "current_values must be empty for a freshly-opened proposal-stage run"
+    )
+    # RunDetailResponse keys inherited by RunViewResponse
+    assert "proposals" in view
+    assert "decisions" in view
+    assert "consensus_decisions" in view
+    assert "published_states" in view
+
+
+@pytest.mark.asyncio
+async def test_qa_session_open_has_null_run_view(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """Quality-assessment sessions must return ``run_view: null`` — the QA
+    surface does not consume this field and we must not break the QA path.
+    """
+    global_tpl_id: UUID | None = None
+
+    raw = (
+        await db_session.execute(
+            text(
+                "SELECT id FROM public.extraction_templates_global "
+                "WHERE kind='quality_assessment' AND name='PROBAST' LIMIT 1"
+            )
+        )
+    ).scalar()
+    if raw is not None:
+        global_tpl_id = UUID(str(raw))
+
+    if global_tpl_id is None:
+        pytest.skip("No global QA template (PROBAST) seeded — run `python -m backend.app.seed`")
+
+    res = await db_client.post(
+        _SESSION_URL,
+        json={
+            "kind": "quality_assessment",
+            "project_id": str(SEED.primary_project),
+            "article_id": str(SEED.primary_article),
+            "global_template_id": str(global_tpl_id),
+        },
+    )
+    assert res.status_code in (200, 201), res.text
+
+    payload = res.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+
+    assert data["run_view"] is None, "run_view must be null for quality_assessment sessions"
+    assert data["kind"] == "quality_assessment"
+    assert UUID(data["run_id"])

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -104,8 +104,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0025_reviewer_scoped_select_rls" in out, (
-        f"Expected head revision '0025_reviewer_scoped_select_rls', got:\n{out}"
+    assert "0026_widen_template_snapshot" in out, (
+        f"Expected head revision '0026_widen_template_snapshot', got:\n{out}"
     )
 
 

--- a/backend/tests/integration/test_run_view_current_values.py
+++ b/backend/tests/integration/test_run_view_current_values.py
@@ -1,0 +1,83 @@
+"""resolve_caller_current_values must mirror the frontend loadValuesForUser it
+replaces: human proposals are the base layer, the caller's current reviewer
+decision (via the materialized reviewer_states pointer) overrides, and another
+reviewer's rows are never returned (caller-scoped blind boundary)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.extraction_run_read_service import resolve_caller_current_values
+from tests.integration.test_blind_review_isolation import (
+    _build_two_reviewer_review_run,
+)
+
+
+@pytest.mark.asyncio
+async def test_current_values_are_caller_scoped(db_session: AsyncSession) -> None:
+    built = await _build_two_reviewer_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, reviewer_b = built
+
+    a_values = await resolve_caller_current_values(db_session, run_id, caller_id=reviewer_a)
+    b_values = await resolve_caller_current_values(db_session, run_id, caller_id=reviewer_b)
+    assert a_values, "reviewer A should resolve at least one current value"
+    a_blob = " ".join(str(v.value) for v in a_values)
+    assert "REVIEWER-B-SECRET" not in a_blob
+    b_blob = " ".join(str(v.value) for v in b_values)
+    assert "REVIEWER-A-SECRET" not in b_blob
+
+
+@pytest.mark.asyncio
+async def test_current_values_empty_when_no_caller_rows(
+    db_session: AsyncSession,
+) -> None:
+    # No reviewer_states and no human proposals for this (run, caller) — the
+    # resolver returns an EMPTY list, not an error (the proposal stage path never
+    # calls this). Use non-existent ids so emptiness is deterministic (a LIMIT 1
+    # real run/user could already share rows and make `== []` flaky).
+    from uuid import uuid4
+
+    values = await resolve_caller_current_values(db_session, uuid4(), caller_id=uuid4())
+    assert values == [], "no matching rows must resolve to an empty list"
+
+
+@pytest.mark.asyncio
+async def test_current_values_match_loadvaluesforuser_contract(
+    db_session: AsyncSession,
+) -> None:
+    built = await _build_two_reviewer_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, _reviewer_b = built
+
+    values = await resolve_caller_current_values(db_session, run_id, caller_id=reviewer_a)
+    assert values, "reviewer A must resolve at least their own current value"
+    by_decision = {v.decision for v in values}
+    assert by_decision <= {"human_proposal", "edit", "accept_proposal", "reject"}
+
+    # TIGHTEN — pin against _build_two_reviewer_review_run's REAL output for
+    # reviewer A. The builder records ONE reviewer decision for A: an ``edit``
+    # with value ``{"value": "REVIEWER-A-SECRET"}``, and (via record_decision ->
+    # _states.upsert) the materialized extraction_reviewer_states pointer that
+    # Layer 2 joins on. The only proposal it records is an AI proposal
+    # (source='ai'), so reviewer A has NO human-proposal base layer and NO
+    # reject — the single resolved coord must come through Layer 2.
+    edits = [v for v in values if v.decision == "edit"]
+    assert len(edits) == 1, (
+        "reviewer A's single edit decision must resolve to exactly one coord "
+        "via the reviewer_states pointer (Layer 2 override)"
+    )
+    edit = edits[0]
+    # loadValuesForUser semantics: the decision's OWN value is sourced (the raw
+    # jsonb envelope), NOT an accepted proposal's value, NOT the AI candidate.
+    assert edit.value == {"value": "REVIEWER-A-SECRET"}
+    # The builder produces no human proposal and no reject for reviewer A, so
+    # those decision kinds must be absent (a stray 'human_proposal' would mean
+    # Layer 1 leaked the AI candidate; a 'reject' would be fabricated).
+    assert "human_proposal" not in by_decision
+    assert "reject" not in by_decision
+    # No accept_proposal either — the lone decision is an edit.
+    assert by_decision == {"edit"}

--- a/backend/tests/integration/test_run_view_endpoint.py
+++ b/backend/tests/integration/test_run_view_endpoint.py
@@ -1,0 +1,295 @@
+"""API contract tests for GET /api/v1/runs/{run_id}/view.
+
+Pins three behaviours:
+1. A project member gets 200 with envelope ``{"ok": true, "data": {...}}``
+   where ``data`` has keys ``run``, ``proposals``, ``entity_types``,
+   ``current_values`` (plus the RunDetailResponse keys inherited by
+   RunViewResponse: ``decisions``, ``consensus_decisions``,
+   ``published_states``).
+2. A non-member (different project) gets 403 (BOLA gate).
+3. QA parity: ``/view`` also works (200, same keys) for a
+   ``kind=quality_assessment`` run opened via ``POST /api/v1/hitl/sessions``.
+
+Pattern copied from ``test_extraction_runs_endpoints.py``:
+- ``db_client`` (real-DB AsyncClient from ``backend/tests/conftest.py``)
+- ``auth_as_profile`` fixture pins JWT sub to ``SEED.primary_profile``
+- ``outsider_user`` fixture from ``test_membership_guards.py`` for BOLA case
+- ``_create_run_via_api`` helper for extraction run setup
+- ``_pick_qa_global_template`` / ``_open_qa_session`` from
+  ``test_qa_publish_flow.py`` for QA run setup
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from tests.integration.conftest import SEED
+
+API_PREFIX = "/api/v1/runs"
+_SESSION_URL = "/api/v1/hitl/sessions"
+
+
+# =================== FIXTURES ===================
+
+
+@pytest_asyncio.fixture
+async def auth_as_profile(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Override ``get_current_user`` so its JWT subject is ``SEED.primary_profile``.
+
+    Identical to the pattern used in ``test_extraction_runs_endpoints.py`` and
+    ``test_hitl_session.py``.
+    """
+    del db_session  # kept for fixture-dependency ordering (seed runs first)
+    profile_id = SEED.primary_profile
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="primary@integration-test.prumo.local",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield profile_id
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest_asyncio.fixture
+async def outsider_user(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Create a fresh auth.users row + profile that has no project membership.
+
+    Copied from ``test_membership_guards.py``.
+    """
+    import uuid as _uuid_mod
+
+    outsider_id = _uuid_mod.uuid4()
+    email = f"outsider-view-{outsider_id}@run-view-test.local"
+
+    await db_session.execute(
+        text(
+            "INSERT INTO auth.users (id, email, instance_id, aud, role) "
+            "VALUES (:id, :email, '00000000-0000-0000-0000-000000000000', "
+            "'authenticated', 'authenticated')"
+        ),
+        {"id": str(outsider_id), "email": email},
+    )
+    await db_session.commit()
+
+    # Ensure the profile exists (trigger may be absent on CI).
+    profile_id = (
+        await db_session.execute(
+            text("SELECT id FROM public.profiles WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+    ).scalar()
+    if profile_id is None:
+        await db_session.execute(
+            text("INSERT INTO public.profiles (id, full_name) VALUES (:id, 'Outsider View')"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.commit()
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(outsider_id),
+            email=email,
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield outsider_id
+    finally:
+        await db_session.execute(
+            text("DELETE FROM public.profiles WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.execute(
+            text("DELETE FROM auth.users WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.commit()
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+# =================== HELPERS ===================
+
+
+async def _create_extraction_run(
+    client: AsyncClient,
+) -> dict[str, Any]:
+    """Create a new extraction run against the seed sentinel fixtures."""
+    body = {
+        "project_id": str(SEED.primary_project),
+        "article_id": str(SEED.primary_article),
+        "project_template_id": str(SEED.primary_template),
+    }
+    resp = await client.post(API_PREFIX, json=body)
+    assert resp.status_code == 201, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    return payload["data"]
+
+
+async def _pick_qa_global_template(db: AsyncSession, name: str = "PROBAST") -> UUID | None:
+    """Return the id of a seeded global QA template (PROBAST or QUADAS-2)."""
+    raw = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.extraction_templates_global "
+                "WHERE kind='quality_assessment' AND name=:n LIMIT 1"
+            ),
+            {"n": name},
+        )
+    ).scalar()
+    return UUID(str(raw)) if raw is not None else None
+
+
+async def _open_qa_session(
+    client: AsyncClient,
+    *,
+    project_id: UUID,
+    article_id: UUID,
+    global_template_id: UUID,
+) -> dict[str, Any]:
+    """Open a quality_assessment HITL session and return its run data."""
+    res = await client.post(
+        _SESSION_URL,
+        json={
+            "kind": "quality_assessment",
+            "project_id": str(project_id),
+            "article_id": str(article_id),
+            "global_template_id": str(global_template_id),
+        },
+    )
+    assert res.status_code in (200, 201), res.text
+    return res.json()["data"]
+
+
+async def _pick_run_for_outsider(db: AsyncSession, outsider_id: UUID) -> UUID | None:
+    """Return any run_id belonging to a project the outsider is NOT a member of."""
+    row = (
+        await db.execute(
+            text(
+                """
+                SELECT r.id
+                FROM public.extraction_runs r
+                WHERE NOT public.is_project_member(r.project_id, :uid)
+                LIMIT 1
+                """
+            ),
+            {"uid": str(outsider_id)},
+        )
+    ).first()
+    if row is None:
+        return None
+    return UUID(str(row[0]))
+
+
+# =================== TESTS ===================
+
+
+@pytest.mark.asyncio
+async def test_get_run_view_returns_200_with_required_keys(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001 — fixture order: seed runs first
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """Happy path: member gets 200 envelope with the four required data keys."""
+    created = await _create_extraction_run(db_client)
+    run_id = created["id"]
+
+    resp = await db_client.get(f"{API_PREFIX}/{run_id}/view")
+    assert resp.status_code == 200, resp.text
+
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+
+    # RunDetailResponse fields (inherited)
+    assert data["run"]["id"] == run_id
+    assert "proposals" in data
+    assert "decisions" in data
+    assert "consensus_decisions" in data
+    assert "published_states" in data
+
+    # RunViewResponse additional fields
+    assert "entity_types" in data
+    assert "current_values" in data
+
+    # Freshly-created run in pending stage: no workflow rows yet; no
+    # current_values (pending stage bypasses value resolution).
+    assert data["proposals"] == []
+    assert data["current_values"] == []
+    # entity_types may be empty when the seed template has no entity types
+    # stored in the version snapshot, which is valid.
+    assert isinstance(data["entity_types"], list)
+
+
+@pytest.mark.asyncio
+async def test_get_run_view_returns_403_for_non_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    outsider_user: UUID,
+) -> None:
+    """BOLA gate: a caller who is not a member of the run's project gets 403."""
+    run_id = await _pick_run_for_outsider(db_session, outsider_user)
+    if run_id is None:
+        pytest.skip("Need a run in a project the outsider does not belong to")
+
+    resp = await db_client.get(f"{API_PREFIX}/{run_id}/view")
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_run_view_works_for_qa_run(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """QA parity: /view returns 200 with the same four keys for kind=quality_assessment."""
+    global_tpl_id = await _pick_qa_global_template(db_session)
+    if global_tpl_id is None:
+        pytest.skip("No global QA template (PROBAST) seeded — run `python -m backend.app.seed`")
+
+    session_data = await _open_qa_session(
+        db_client,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        global_template_id=global_tpl_id,
+    )
+    # OpenHITLSessionResponse has ``run_id`` at top level (not ``run.id``).
+    run_id = session_data["run_id"]
+
+    resp = await db_client.get(f"{API_PREFIX}/{run_id}/view")
+    assert resp.status_code == 200, resp.text
+
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+
+    assert data["run"]["id"] == run_id
+    assert data["run"]["kind"] == "quality_assessment"
+    assert "proposals" in data
+    assert "entity_types" in data
+    assert "current_values" in data
+    assert isinstance(data["entity_types"], list)
+    assert isinstance(data["current_values"], list)

--- a/backend/tests/integration/test_run_view_entity_types.py
+++ b/backend/tests/integration/test_run_view_entity_types.py
@@ -1,0 +1,99 @@
+"""The run view's entity_types tree must come from the run's frozen version
+snapshot, and fall back to a live read when the snapshot is a pre-0026 narrow
+one (first entity_type missing 'role')."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.extraction_run import RunSummaryResponse
+from app.services.extraction_run_read_service import _entity_types_for_run
+from app.services.run_lifecycle_service import RunLifecycleService
+
+
+async def _new_run(db: AsyncSession):
+    project_id = (await db.execute(text("SELECT id FROM public.projects LIMIT 1"))).scalar()
+    if project_id is None:
+        return None
+    article_id = (
+        await db.execute(
+            text("SELECT id FROM public.articles WHERE project_id = :pid LIMIT 1"),
+            {"pid": str(project_id)},
+        )
+    ).scalar()
+    template_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.project_extraction_templates "
+                "WHERE project_id = :pid AND kind = 'extraction' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
+        )
+    ).scalar()
+    user_id = (await db.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
+    if not all((article_id, template_id, user_id)):
+        return None
+    run = await RunLifecycleService(db).create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=user_id,
+    )
+    return run
+
+
+@pytest.mark.asyncio
+async def test_entity_types_from_widened_snapshot(db_session: AsyncSession) -> None:
+    run = await _new_run(db_session)
+    if run is None:
+        pytest.skip("Seed graph incomplete")
+
+    entity_types = await _entity_types_for_run(db_session, RunSummaryResponse.model_validate(run))
+    assert entity_types, "expected a non-empty entity_types tree"
+    roles = {et.role for et in entity_types}
+    assert roles, "every entity type must carry a role from the widened snapshot"
+    assert roles <= {"study_section", "model_container", "model_section"}
+
+
+@pytest.mark.asyncio
+async def test_entity_types_live_fallback_for_narrow_snapshot(
+    db_session: AsyncSession,
+) -> None:
+    run = await _new_run(db_session)
+    if run is None:
+        pytest.skip("Seed graph incomplete")
+
+    # Capture identity before expiry so attribute access doesn't fire a sync load.
+    run_id = run.id
+    version_id = run.version_id
+    run_type = type(run)
+
+    # Force the snapshot back to a pre-0026 narrow shape (strip 'role').
+    await db_session.execute(
+        text(
+            """
+            UPDATE public.extraction_template_versions
+            SET schema = jsonb_set(
+                schema, '{entity_types}',
+                (
+                    SELECT COALESCE(jsonb_agg(elem - 'role'), '[]'::jsonb)
+                    FROM jsonb_array_elements(schema -> 'entity_types') elem
+                )
+            )
+            WHERE id = :vid
+            """
+        ),
+        {"vid": str(version_id)},
+    )
+    db_session.expire_all()
+
+    refetched = await db_session.get(run_type, run_id)
+    entity_types = await _entity_types_for_run(
+        db_session, RunSummaryResponse.model_validate(refetched)
+    )
+    assert entity_types, "live fallback must yield the entity_types tree"
+    assert all(
+        et.role in ("study_section", "model_container", "model_section") for et in entity_types
+    ), "fallback reads role from the live table"

--- a/backend/tests/integration/test_template_version_snapshot_shape.py
+++ b/backend/tests/integration/test_template_version_snapshot_shape.py
@@ -1,0 +1,73 @@
+"""The frozen template-version snapshot must carry every column the run-open
+form renders from — role (study/model partition), plus the field columns that
+drive units, validation, and the 'other' option. Both builders share one SQL
+fragment so they can never drift again (role was once added to clone but not
+lifecycle)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.extraction_snapshot import build_template_version_snapshot
+
+_ENTITY_KEYS = {
+    "id",
+    "name",
+    "label",
+    "description",
+    "parent_entity_type_id",
+    "cardinality",
+    "role",
+    "sort_order",
+    "is_required",
+    "fields",
+}
+_FIELD_KEYS = {
+    "id",
+    "name",
+    "label",
+    "description",
+    "field_type",
+    "is_required",
+    "validation_schema",
+    "allowed_values",
+    "unit",
+    "allowed_units",
+    "sort_order",
+    "llm_description",
+    "allow_other",
+    "other_label",
+    "other_placeholder",
+}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_carries_role_and_all_field_columns(
+    db_session: AsyncSession,
+) -> None:
+    template_id = (
+        await db_session.execute(
+            text(
+                "SELECT id FROM public.project_extraction_templates "
+                "WHERE kind = 'extraction' LIMIT 1"
+            )
+        )
+    ).scalar()
+    if template_id is None:
+        pytest.skip("Seed graph incomplete")
+
+    snapshot = await build_template_version_snapshot(db_session, template_id)
+    entity_types = snapshot["entity_types"]
+    assert entity_types, "expected a non-empty entity_types tree for a seeded template"
+
+    for et in entity_types:
+        assert set(et.keys()) >= _ENTITY_KEYS, (
+            f"entity_type missing keys: {_ENTITY_KEYS - set(et.keys())}"
+        )
+        assert et["role"] in ("study_section", "model_container", "model_section")
+        for f in et["fields"]:
+            assert set(f.keys()) >= _FIELD_KEYS, (
+                f"field missing keys: {_FIELD_KEYS - set(f.keys())}"
+            )

--- a/docs/superpowers/plans/2026-06-08-runopen-slowload-phase2-runview.md
+++ b/docs/superpowers/plans/2026-06-08-runopen-slowload-phase2-runview.md
@@ -1,0 +1,1783 @@
+---
+status: in_progress
+last_reviewed: 2026-06-08
+owner: '@raphaelfh'
+---
+
+# Run-open slow-load — Phase 2 (RunView server-side collapse) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the serial waves that fire when `ExtractionFullScreen` opens a saved run (session → `useRun` → values) into a single server-composed `RunViewResponse`, embedded in the `POST /hitl/sessions` open response and served by a new read-only `GET /api/v1/runs/{id}/view`, so the run + values render from one round-trip. (The view also serves the frozen entity_types tree; folding the still-parallel entity_types/instances Supabase reads into it is the deferred Task 12.)
+
+**Architecture:** Add a server read-side composer `build_run_view()` that **composes** (never re-queries) `get_run_with_workflow_history` (the item-3 blind filter stays the single source) plus two new pieces: the frozen template **entity_types tree** (read from the run's version snapshot, with a live-read fallback for legacy "narrow" snapshots) and the caller-scoped **current_values** (review/consensus/finalized only). (Seeded **instances** are part of the same read-model but are deferred to Task 12 — see the Task 3 scope note — because their only consumer needs a wider shape than Phase 2 would ship.) Two prerequisites guard correctness: the template-version snapshot is **lossy** today (omits `role`, `description`, and 8 field columns), so we first unify both snapshot builders behind one widened SQL fragment and backfill old snapshots; and the new `current_values` resolver becomes a 4th lockstep copy of the blind predicate, so it must reuse the exact `reviewer_id == caller` / `source_user_id == caller` scope. `POST /hitl/sessions` stays the **only** mutating entry point — no GET ever seeds.
+
+**Tech Stack:** Backend: FastAPI, SQLAlchemy 2.0 async, Alembic (raw-SQL migrations), Pydantic v2, pytest integration tests against local Supabase. Frontend: React 18 + TS strict, TanStack Query, vitest. Branch `feat/runopen-slowload-phase2-runview` (based on `fix/extraction-stale-blind-progress`, which carries RLS `0025` + the item-3 blind filter). Verify with `cd backend && uv run pytest`, `make lint-backend`, `npm run typecheck`, `npx vitest run`, `npx eslint`.
+
+---
+
+## Background: invariants this plan must preserve
+
+These are non-negotiable. Violating any one re-opens a documented incident class.
+
+1. **Single mutating entry point.** `POST /hitl/sessions` (`HITLSessionService.open_or_resume`) is the only path that seeds instances + advances the run. **No GET ever seeds.** `build_run_view` and `GET /runs/{id}/view` are pure reads (`db.flush()`/no writes; no `db.commit()`).
+2. **Blind filter in lockstep.** The predicate "a human row is visible iff the caller authored it, unless the run is `finalized` or the caller is an arbitrator (manager/consensus)" lives in 3 places today and **gains a 4th** with this plan:
+   - `extraction_run_read_service.get_run_with_workflow_history` (service path) — `build_run_view` **composes** this, never re-queries the workflow tables.
+   - `0025_reviewer_scoped_select_rls` RLS policies (PostgREST path) — unchanged.
+   - `frontend/services/extractionValueService.loadValuesForUser` (current_values, review+) — this plan **replaces** it with…
+   - …the new `resolve_caller_current_values` (server). It MUST use the same caller scope (`reviewer_id == caller_id`, `source_user_id == caller_id`).
+3. **current_values only for `{review, consensus, finalized}`.** In `proposal`, values come from `proposals[]` via `pickLatestProposalPerCoord` (client). The server returns `current_values = []` for `proposal`/`pending`/`cancelled` — do **not** duplicate proposal resolution on the server.
+4. **`computeRowProgress` stays pure/client.** No progress field on the server (`frontend/lib/extraction/progress.ts` is pure; a server field would fork the metric).
+5. **Reviewer scoping on the embed.** The embedded `RunViewResponse` MUST be built with the **same** `current_user_sub` that opened the session, and `is_arbitrator` MUST be computed via `is_run_arbitrator(db, project_id, caller)` — never hardcoded `True`, or the embed leaks peers' human proposals.
+6. **Behavior parity, not behavior change.** `resolve_caller_current_values` must be value-for-value identical to the `loadValuesForUser` it replaces (human-proposal base layer, reviewer-decision override, `reject` sentinel preserved). If a discrepancy surfaces (e.g. `accept_proposal` value sourcing), match the **current production** behavior; do not "fix" it here.
+
+---
+
+## File Structure
+
+**Backend — new files**
+
+- `backend/app/services/extraction_snapshot.py` — single source of truth for the template-version snapshot SQL (`build_template_version_snapshot`). Both snapshot builders import it so they can never drift again.
+- `backend/alembic/versions/0026_widen_template_version_snapshot.py` — backfills legacy "narrow" snapshots to the widened shape.
+
+**Backend — modified files**
+
+- `backend/app/services/run_lifecycle_service.py` — `_snapshot_initial_version` (lines 465–557) delegates to `build_template_version_snapshot`.
+- `backend/app/services/template_clone_service.py` — `_snapshot` (lines 477–524) delegates to `build_template_version_snapshot`.
+- `backend/app/schemas/extraction_run.py` — add `RunViewField`, `RunViewEntityType`, `RunViewCurrentValue`, `RunViewResponse` (after `RunDetailResponse`, ~line 142). (`RunViewInstance` lands in Task 12.)
+- `backend/app/services/extraction_run_read_service.py` — add `resolve_caller_current_values`, `_entity_types_for_run` (snapshot + live fallback), and `build_run_view` (composes `get_run_with_workflow_history`). (`_instances_for_run` lands in Task 12.)
+- `backend/app/api/v1/endpoints/extraction_runs.py` — add `GET /{run_id}/view`.
+- `backend/app/schemas/hitl_session.py` — add `run_view: RunViewResponse | None` to `OpenHITLSessionResponse`.
+- `backend/app/api/v1/endpoints/hitl_sessions.py` — build + embed the run view (extraction only) between `open_or_resume` and `commit`.
+- `backend/tests/integration/test_migration_roundtrip.py` — bump the head-pin assertion `0025_…` → `0026_…`.
+
+**Frontend — modified files**
+
+- `frontend/hooks/runs/types.ts` — add `RunViewFieldResponse`, `RunViewEntityType`, `RunViewCurrentValue`, `RunViewResponse` (extends `RunDetailResponse`). (`RunViewInstance` lands in Task 12.)
+- `frontend/hooks/runs/useRun.ts` — re-point GET to `/api/v1/runs/${runId}/view`; return `RunViewResponse`.
+- `frontend/hooks/extraction/useExtractionSession.ts` — add `run_detail` to `OpenResponse`; inject `useQueryClient`; seed `runsKeys.detail(run_id)` inside the generation guard.
+- `frontend/hooks/qa/useQAAssessmentSession.ts` — mirror the optional `run_detail` field (QA ignores it).
+- `frontend/services/extractionValueService.ts` — export `unwrapValue` (now consumed by the hook).
+- `frontend/hooks/extraction/useExtractedValues.ts` — review/consensus/finalized branch consumes a `currentValues` prop (from the view) instead of calling `loadValuesForUser`; drop the now-unused `ExtractionValueService` import.
+- `frontend/pages/ExtractionFullScreen.tsx` — pass `currentValues={runDetail?.current_values}` into `useExtractedValues` (Task 11). (Sourcing `entityTypes`/`instances` from the view is the deferred sub-phase — Task 12.)
+
+**Frontend — deferred sub-phase (Task 12, not executed in Phase 2)**
+
+- `frontend/hooks/extraction/useExtractionData.ts` — remove the direct Supabase reads of `extraction_entity_types` + `extraction_instances`. **Deferred** (off the critical serial path; carries a read-after-write hazard — see Task 12).
+- `frontend/lib/extraction/runViewAdapters.ts` (new) — map the view's `entity_types`/`instances` onto the form's types. **Deferred** (Task 12).
+
+---
+
+## Phase A — Backend: widen the lossy snapshot (prerequisite)
+
+Without this, reopening a run against an edited template renders wrong: the snapshot the view reads omits `role` (so `partitionEntityTypes` can't split study/model regions), `validation_schema`, `unit`, `allowed_units`, `allow_other`/`other_label`/`other_placeholder`, `llm_description`, and `description`.
+
+### Task 1: One widened snapshot builder, shared by both services
+
+There are **two** snapshot builders with drifted key sets (the clone builder already emits `role`; the lifecycle builder does not). Unify them behind one SQL fragment and widen it to the full column set.
+
+**Files:**
+- Create: `backend/app/services/extraction_snapshot.py`
+- Modify: `backend/app/services/run_lifecycle_service.py` (`_snapshot_initial_version`, lines 465–557)
+- Modify: `backend/app/services/template_clone_service.py` (`_snapshot`, lines 477–524)
+- Test: `backend/tests/integration/test_template_version_snapshot_shape.py` (new)
+
+- [ ] **Step 1: Write the failing test.** Create `backend/tests/integration/test_template_version_snapshot_shape.py`:
+
+```python
+"""The frozen template-version snapshot must carry every column the run-open
+form renders from — role (study/model partition), plus the field columns that
+drive units, validation, and the 'other' option. Both builders share one SQL
+fragment so they can never drift again (role was once added to clone but not
+lifecycle)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.extraction_snapshot import build_template_version_snapshot
+
+_ENTITY_KEYS = {
+    "id", "name", "label", "description", "parent_entity_type_id",
+    "cardinality", "role", "sort_order", "is_required", "fields",
+}
+_FIELD_KEYS = {
+    "id", "name", "label", "description", "field_type", "is_required",
+    "validation_schema", "allowed_values", "unit", "allowed_units",
+    "sort_order", "llm_description", "allow_other", "other_label",
+    "other_placeholder",
+}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_carries_role_and_all_field_columns(
+    db_session: AsyncSession,
+) -> None:
+    template_id = (
+        await db_session.execute(
+            text(
+                "SELECT id FROM public.project_extraction_templates "
+                "WHERE kind = 'extraction' LIMIT 1"
+            )
+        )
+    ).scalar()
+    if template_id is None:
+        pytest.skip("Seed graph incomplete")
+
+    snapshot = await build_template_version_snapshot(db_session, template_id)
+    entity_types = snapshot["entity_types"]
+    assert entity_types, "expected a non-empty entity_types tree for a seeded template"
+
+    for et in entity_types:
+        assert _ENTITY_KEYS <= set(et.keys()), (
+            f"entity_type missing keys: {_ENTITY_KEYS - set(et.keys())}"
+        )
+        assert et["role"] in ("study_section", "model_container", "model_section")
+        for f in et["fields"]:
+            assert _FIELD_KEYS <= set(f.keys()), (
+                f"field missing keys: {_FIELD_KEYS - set(f.keys())}"
+            )
+```
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `cd backend && uv run pytest tests/integration/test_template_version_snapshot_shape.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.extraction_snapshot'`.
+
+- [ ] **Step 3: Create the shared snapshot module.** Write `backend/app/services/extraction_snapshot.py`:
+
+```python
+"""Single source of truth for the template-version snapshot shape.
+
+``RunLifecycleService._snapshot_initial_version`` and
+``TemplateCloneService._snapshot`` both freeze the entity_types + fields tree
+into ``extraction_template_versions.schema_``. They used to embed two copies of
+the ``jsonb_build_object`` SQL that drifted — ``role`` was added to the clone
+builder but not the lifecycle one (forcing migration 0017 to retro-patch).
+This module owns the single, widened query so the two builders cannot diverge
+again, and so migration 0026 can backfill old snapshots to the same shape.
+
+The key set mirrors the data columns of ``ExtractionEntityType`` and
+``ExtractionField`` that the run-open form renders from (FK/audit columns are
+intentionally excluded — the form does not read them).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# WARNING: migration 0026_widen_template_version_snapshot embeds a copy of this
+# key set for its one-time backfill. If you add a key here, update that
+# migration's SQL too (migrations must stay self-contained; they cannot import
+# app code that may change after they are committed).
+SNAPSHOT_SQL = text(
+    """
+    SELECT jsonb_build_object(
+        'entity_types', COALESCE(
+            (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'id', et.id,
+                        'name', et.name,
+                        'label', et.label,
+                        'description', et.description,
+                        'parent_entity_type_id', et.parent_entity_type_id,
+                        'cardinality', et.cardinality,
+                        'role', et.role,
+                        'sort_order', et.sort_order,
+                        'is_required', et.is_required,
+                        'fields', COALESCE(
+                            (
+                                SELECT jsonb_agg(jsonb_build_object(
+                                    'id', f.id,
+                                    'name', f.name,
+                                    'label', f.label,
+                                    'description', f.description,
+                                    'field_type', f.field_type,
+                                    'is_required', f.is_required,
+                                    'validation_schema', f.validation_schema,
+                                    'allowed_values', f.allowed_values,
+                                    'unit', f.unit,
+                                    'allowed_units', f.allowed_units,
+                                    'sort_order', f.sort_order,
+                                    'llm_description', f.llm_description,
+                                    'allow_other', f.allow_other,
+                                    'other_label', f.other_label,
+                                    'other_placeholder', f.other_placeholder
+                                ) ORDER BY f.sort_order)
+                                FROM public.extraction_fields f
+                                WHERE f.entity_type_id = et.id
+                            ),
+                            '[]'::jsonb
+                        )
+                    ) ORDER BY et.sort_order
+                )
+                FROM public.extraction_entity_types et
+                WHERE et.project_template_id = :tid
+            ),
+            '[]'::jsonb
+        )
+    )
+    """
+)
+
+
+async def build_template_version_snapshot(
+    db: AsyncSession, project_template_id: UUID
+) -> dict[str, Any]:
+    """Build the frozen ``{entity_types: [...]}`` snapshot for a project template."""
+    row = await db.execute(SNAPSHOT_SQL, {"tid": str(project_template_id)})
+    return row.scalar_one()
+```
+
+- [ ] **Step 4: Run the test to verify it passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_template_version_snapshot_shape.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Delegate the lifecycle builder to the shared module.** In `backend/app/services/run_lifecycle_service.py`, replace the inline `text(""" SELECT jsonb_build_object( ... )""")` + `snapshot_row = await self.db.execute(...)` + `snapshot = snapshot_row.scalar_one()` block inside `_snapshot_initial_version` (lines ~474–501) with:
+
+```python
+        snapshot = await build_template_version_snapshot(
+            self.db, project_template_id
+        )
+```
+
+Add the import near the other service imports at the top of the file:
+
+```python
+from app.services.extraction_snapshot import build_template_version_snapshot
+```
+
+`text` was used **only** by the deleted snapshot block. Drop it from the lifecycle import line (`from sqlalchemy import func, select, text` → `from sqlalchemy import func, select`) or ruff F401 fails at Step 8.
+
+- [ ] **Step 6: Delegate the clone builder to the shared module.** In `backend/app/services/template_clone_service.py`, replace the body of `_snapshot` (lines 477–524) with:
+
+```python
+    async def _snapshot(self, project_template_id: UUID) -> dict[str, Any]:
+        return await build_template_version_snapshot(self.db, project_template_id)
+```
+
+Add the import near the top of the file (remove the now-unused local `from sqlalchemy import text` import inside `_snapshot` if it is no longer referenced elsewhere in the method):
+
+```python
+from app.services.extraction_snapshot import build_template_version_snapshot
+```
+
+- [ ] **Step 7: Verify the existing snapshot/lifecycle tests still pass.**
+
+Run: `cd backend && uv run pytest tests/integration/test_template_versions_lifecycle.py tests/integration/test_run_lifecycle_concurrency.py tests/integration/test_template_version_snapshot_shape.py -v`
+Expected: PASS (the upsert/race semantics in `_snapshot_initial_version` are untouched — only the snapshot-building SQL moved).
+
+- [ ] **Step 8: Lint.**
+
+Run: `cd backend && uv run ruff check app/services/extraction_snapshot.py app/services/run_lifecycle_service.py app/services/template_clone_service.py && uv run ruff format --check app/services/extraction_snapshot.py app/services/run_lifecycle_service.py app/services/template_clone_service.py`
+Expected: clean (run `uv run ruff format` to fix formatting if needed).
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add backend/app/services/extraction_snapshot.py \
+        backend/app/services/run_lifecycle_service.py \
+        backend/app/services/template_clone_service.py \
+        backend/tests/integration/test_template_version_snapshot_shape.py
+git commit -m "refactor(extraction): unify + widen template-version snapshot builder"
+```
+
+---
+
+### Task 2: Migration 0026 — backfill legacy narrow snapshots
+
+New snapshots are now wide (Task 1). Existing snapshots created before this change are still "narrow". Nothing reads `schema_` structurally **today** (every consumer reads live tables), so re-deriving a narrow snapshot from the current live template loses no previously-honored frozen data — it only makes old runs render against the (widened) frozen tree once the view starts reading it.
+
+**Files:**
+- Create: `backend/alembic/versions/0026_widen_template_version_snapshot.py`
+- Modify: `backend/tests/integration/test_migration_roundtrip.py` (head-pin assertion, lines ~107–108)
+- Test: reuse `test_migration_roundtrip.py` (head + continuous-chain assertions)
+
+- [ ] **Step 1: Write the migration.** Create `backend/alembic/versions/0026_widen_template_version_snapshot.py`:
+
+```python
+"""Widen legacy template-version snapshots to the full entity_types/fields shape.
+
+The frozen snapshot in ``extraction_template_versions.schema_`` historically
+omitted ``role`` + ``description`` on entity_types and 8 field columns
+(``validation_schema``, ``unit``, ``allowed_units``, ``llm_description``,
+``allow_other``, ``other_label``, ``other_placeholder``, ``description``). The
+run-open view (Phase 2) reads the snapshot structurally for the first time, so
+narrow snapshots would render wrong.
+
+Nothing read ``schema_`` structurally before this change — every consumer read
+the live ``extraction_entity_types``/``extraction_fields`` tables — so
+re-deriving a narrow snapshot from the current live template for that
+``project_template_id`` loses no frozen behavior that was ever honored.
+
+Idempotent: only snapshots whose first entity_type lacks the ``role`` key
+(narrow) are rewritten; re-running is a no-op. Forward-only: the downgrade
+cannot reliably reconstruct the prior narrow shape and is a documented no-op.
+
+Revision ID: 0026_widen_template_version_snapshot
+Revises: 0025_reviewer_scoped_select_rls
+Create Date: 2026-06-08
+"""
+
+from alembic import op
+
+revision = "0026_widen_template_version_snapshot"
+down_revision = "0025_reviewer_scoped_select_rls"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Re-derive the entity_types tree from the live template, but only for
+    # snapshots detected as narrow (first entity_type missing the 'role' key).
+    # Empty-tree snapshots fall under the same predicate and rebuild to an
+    # empty tree (harmless). Keep this jsonb_build_object key list IN SYNC with
+    # app/services/extraction_snapshot.SNAPSHOT_SQL.
+    op.execute(
+        """
+        UPDATE public.extraction_template_versions v
+        SET schema = jsonb_build_object(
+            'entity_types', COALESCE(
+                (
+                    SELECT jsonb_agg(
+                        jsonb_build_object(
+                            'id', et.id,
+                            'name', et.name,
+                            'label', et.label,
+                            'description', et.description,
+                            'parent_entity_type_id', et.parent_entity_type_id,
+                            'cardinality', et.cardinality,
+                            'role', et.role,
+                            'sort_order', et.sort_order,
+                            'is_required', et.is_required,
+                            'fields', COALESCE(
+                                (
+                                    SELECT jsonb_agg(jsonb_build_object(
+                                        'id', f.id,
+                                        'name', f.name,
+                                        'label', f.label,
+                                        'description', f.description,
+                                        'field_type', f.field_type,
+                                        'is_required', f.is_required,
+                                        'validation_schema', f.validation_schema,
+                                        'allowed_values', f.allowed_values,
+                                        'unit', f.unit,
+                                        'allowed_units', f.allowed_units,
+                                        'sort_order', f.sort_order,
+                                        'llm_description', f.llm_description,
+                                        'allow_other', f.allow_other,
+                                        'other_label', f.other_label,
+                                        'other_placeholder', f.other_placeholder
+                                    ) ORDER BY f.sort_order)
+                                    FROM public.extraction_fields f
+                                    WHERE f.entity_type_id = et.id
+                                ),
+                                '[]'::jsonb
+                            )
+                        ) ORDER BY et.sort_order
+                    )
+                    FROM public.extraction_entity_types et
+                    WHERE et.project_template_id = v.project_template_id
+                ),
+                '[]'::jsonb
+            )
+        )
+        WHERE NOT ((v.schema -> 'entity_types' -> 0) ? 'role');
+        """
+    )
+
+
+def downgrade() -> None:
+    # Forward-only data widening. The prior narrow shape cannot be reconstructed
+    # without re-dropping columns the read path now depends on, and no consumer
+    # relies on the snapshot being narrow. Intentional no-op.
+    pass
+```
+
+- [ ] **Step 2: Bump the head-pin assertion.** In `backend/tests/integration/test_migration_roundtrip.py`, update `test_alembic_head_is_expected_revision` (lines ~107–108):
+
+```python
+    assert "0026_widen_template_version_snapshot" in out, (
+        f"Expected head revision '0026_widen_template_version_snapshot', got:\n{out}"
+    )
+```
+
+- [ ] **Step 3: Apply the migration locally and verify the chain.**
+
+Run: `cd backend && uv run alembic upgrade head && uv run pytest tests/integration/test_migration_roundtrip.py -v`
+Expected: `alembic upgrade head` applies `0026_widen_template_version_snapshot`; both `test_alembic_head_is_expected_revision` and `test_alembic_history_chain_is_continuous` PASS.
+(If the local DB is shared across worktrees and `alembic current` reports an unexpected head, verify offline with `uv run alembic upgrade head --sql` instead of resetting the DB — see the project memory on local integration tests.)
+
+- [ ] **Step 4: Verify the backfill is idempotent (re-run is a no-op).**
+
+Run: `cd backend && uv run alembic downgrade -1 && uv run alembic upgrade head && uv run pytest tests/integration/test_template_version_snapshot_shape.py -v`
+Expected: downgrade is a no-op (snapshots stay wide), upgrade re-applies cleanly, snapshot-shape test PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/alembic/versions/0026_widen_template_version_snapshot.py \
+        backend/tests/integration/test_migration_roundtrip.py
+git commit -m "feat(migrations): 0026 backfill widened template-version snapshots"
+```
+
+---
+
+## Phase B — Backend: the RunView composer + endpoint + embed
+
+### Task 3: `RunViewResponse` schema + entity_types reader
+
+`build_run_view` returns a superset of `RunDetailResponse`: the run + workflow rows (blind-filtered, composed from `get_run_with_workflow_history`) plus `entity_types` and `current_values`. This task adds the schema and the entity_types reader; current_values is Task 4; the composer is Task 5.
+
+> **Scope note (from the `/simplify` pass):** Phase 2's frontend consumes only `current_values` (Task 11) and keeps reading `entity_types`/`instances` from `useExtractionData` (the deferred Task 12). `entity_types` is still built + returned server-side here because it is the *reason Phase A exists* — the snapshot-widening is only provably correct if the view serves the frozen tree, and the tests below exercise it. **`instances` is intentionally NOT included in Phase 2:** it has no Phase-2 consumer, and its only future consumer (Task 12) needs a wider shape (`project_id`/`created_by`/`created_at`/`updated_at`, which `RunViewInstance` would omit) — so it is added in the Task 12 PR where its required-field set is known, rather than shipped now in a shape that would be rewritten.
+
+**Files:**
+- Modify: `backend/app/schemas/extraction_run.py` (add after `RunDetailResponse`, ~line 142)
+- Modify: `backend/app/services/extraction_run_read_service.py` (imports + `_entity_types_for_run`)
+- Test: `backend/tests/integration/test_run_view_entity_types.py` (new)
+
+- [ ] **Step 1: Add the response schemas.** In `backend/app/schemas/extraction_run.py`, after `RunDetailResponse` (line ~142), add. `RunViewField`/`RunViewEntityType` carry `from_attributes=True` so the live fallback can `model_validate` straight off ORM rows (matching the four sibling response models in this file):
+
+```python
+class RunViewField(BaseModel):
+    """A field in the frozen template snapshot, widened to every column the
+    run-open form renders from. Sourced from the version snapshot (or the live
+    table when the snapshot is a pre-0026 narrow one)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    label: str
+    description: str | None = None
+    field_type: str
+    is_required: bool
+    validation_schema: Any | None = None
+    allowed_values: Any | None = None
+    unit: str | None = None
+    allowed_units: Any | None = None
+    sort_order: int
+    llm_description: str | None = None
+    allow_other: bool = False
+    other_label: str | None = None
+    other_placeholder: str | None = None
+
+
+class RunViewEntityType(BaseModel):
+    """An entity type in the frozen template snapshot, with its fields embedded.
+    ``role`` drives the study/model partition; the tree hierarchy is conveyed by
+    ``parent_entity_type_id`` (flat array, ordered by ``sort_order``)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    label: str
+    description: str | None = None
+    parent_entity_type_id: UUID | None = None
+    cardinality: str
+    role: str
+    sort_order: int
+    is_required: bool
+    fields: list[RunViewField]
+
+
+class RunViewCurrentValue(BaseModel):
+    """The caller's current value for one (instance, field) coordinate, resolved
+    server-side for review/consensus/finalized. ``value`` is the raw jsonb
+    envelope (``{value, unit}`` or scalar) — the client unwraps it exactly as it
+    did for ``loadValuesForUser``. Empty list for proposal/pending/cancelled."""
+
+    instance_id: UUID
+    field_id: UUID
+    value: dict[str, Any] | None
+    decision: str
+
+
+class RunViewResponse(RunDetailResponse):
+    """``RunDetailResponse`` (run + blind-filtered workflow rows) plus the two
+    pieces the run-open form needs server-side: the frozen entity_types tree and
+    the caller's current_values. (``instances`` is added in Task 12 — see the
+    scope note above.)"""
+
+    entity_types: list[RunViewEntityType]
+    current_values: list[RunViewCurrentValue]
+```
+
+- [ ] **Step 2: Write the failing entity_types reader test.** Create `backend/tests/integration/test_run_view_entity_types.py`:
+
+```python
+"""The run view's entity_types tree must come from the run's frozen version
+snapshot, and fall back to a live read when the snapshot is a pre-0026 narrow
+one (first entity_type missing 'role')."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.extraction_run import RunSummaryResponse
+from app.services.extraction_run_read_service import _entity_types_for_run
+from app.services.run_lifecycle_service import RunLifecycleService
+
+
+async def _new_run(db: AsyncSession):
+    project_id = (await db.execute(text("SELECT id FROM public.projects LIMIT 1"))).scalar()
+    if project_id is None:
+        return None
+    article_id = (
+        await db.execute(
+            text("SELECT id FROM public.articles WHERE project_id = :pid LIMIT 1"),
+            {"pid": str(project_id)},
+        )
+    ).scalar()
+    template_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.project_extraction_templates "
+                "WHERE project_id = :pid AND kind = 'extraction' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
+        )
+    ).scalar()
+    user_id = (await db.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
+    if not all((article_id, template_id, user_id)):
+        return None
+    run = await RunLifecycleService(db).create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=user_id,
+    )
+    return run
+
+
+@pytest.mark.asyncio
+async def test_entity_types_from_widened_snapshot(db_session: AsyncSession) -> None:
+    run = await _new_run(db_session)
+    if run is None:
+        pytest.skip("Seed graph incomplete")
+
+    entity_types = await _entity_types_for_run(
+        db_session, RunSummaryResponse.model_validate(run)
+    )
+    assert entity_types, "expected a non-empty entity_types tree"
+    roles = {et.role for et in entity_types}
+    assert roles, "every entity type must carry a role from the widened snapshot"
+    # role must be a real value (not a placeholder) so the study/model partition works
+    assert roles <= {"study_section", "model_container", "model_section"}
+
+
+@pytest.mark.asyncio
+async def test_entity_types_live_fallback_for_narrow_snapshot(
+    db_session: AsyncSession,
+) -> None:
+    run = await _new_run(db_session)
+    if run is None:
+        pytest.skip("Seed graph incomplete")
+
+    # Force the snapshot back to a pre-0026 narrow shape (strip 'role').
+    await db_session.execute(
+        text(
+            """
+            UPDATE public.extraction_template_versions
+            SET schema = jsonb_set(
+                schema, '{entity_types}',
+                (
+                    SELECT COALESCE(jsonb_agg(elem - 'role'), '[]'::jsonb)
+                    FROM jsonb_array_elements(schema -> 'entity_types') elem
+                )
+            )
+            WHERE id = :vid
+            """
+        ),
+        {"vid": str(run.version_id)},
+    )
+    db_session.expire_all()
+
+    refetched = await db_session.get(type(run), run.id)
+    entity_types = await _entity_types_for_run(
+        db_session, RunSummaryResponse.model_validate(refetched)
+    )
+    assert entity_types, "live fallback must yield the entity_types tree"
+    assert all(
+        et.role in ("study_section", "model_container", "model_section")
+        for et in entity_types
+    ), "fallback reads role from the live table"
+```
+
+- [ ] **Step 3: Run it to verify it fails.**
+
+Run: `cd backend && uv run pytest tests/integration/test_run_view_entity_types.py -v`
+Expected: FAIL — `ImportError: cannot import name '_entity_types_for_run'`.
+
+- [ ] **Step 4: Implement the entity_types reader.** In `backend/app/services/extraction_run_read_service.py`, extend the imports. The file already imports `from sqlalchemy import select` and `from app.models.extraction import ExtractionRun, ExtractionRunStage` — **merge** into those (do not add a second `select`/`ExtractionRun` import, or ruff/F811 fails). It already imports `RunSummaryResponse` in the schema block (reused below). Add only the new names:
+
+```python
+# extend `from sqlalchemy import select`  ->
+from sqlalchemy import and_, select   # and_ is used by Task 4's resolver
+
+# new import line (selectinload eager-loads the fields relationship in one go):
+from sqlalchemy.orm import selectinload
+
+# extend `from app.models.extraction import ExtractionRun, ExtractionRunStage`  ->
+from app.models.extraction import (
+    ExtractionEntityType,
+    ExtractionRun,
+    ExtractionRunStage,
+)
+
+# new import lines:
+from app.models.extraction_versioning import ExtractionTemplateVersion
+from app.models.extraction_workflow import ExtractionReviewerState  # add to the existing extraction_workflow import block
+
+# extend the existing `from app.schemas.extraction_run import (...)` block with:
+from app.schemas.extraction_run import (
+    RunViewCurrentValue,
+    RunViewEntityType,
+    RunViewResponse,
+)
+```
+
+Then add, after `get_run_with_workflow_history`. Note `_entity_types_for_run` takes the already-loaded `RunSummaryResponse` (`detail.run`) — it needs only `version_id`/`template_id`, both on that schema — so `build_run_view` does **not** re-fetch the ORM run:
+
+```python
+def _snapshot_is_narrow(entity_types: list[dict]) -> bool:
+    """A pre-0026 snapshot is detected by its first entity_type lacking 'role'.
+    Empty trees are treated as narrow so the live fallback repopulates them —
+    a legitimately empty template just round-trips to an empty live read, which
+    is the correct (if marginally wasteful) recovery, not a structural read to
+    'optimize away'."""
+    return not entity_types or "role" not in entity_types[0]
+
+
+async def _entity_types_for_run(
+    db: AsyncSession, run: RunSummaryResponse
+) -> list[RunViewEntityType]:
+    """Frozen entity_types tree from the run's version snapshot, with a live
+    read fallback for pre-0026 narrow snapshots (belt-and-suspenders: migration
+    0026 backfills these, but the fallback turns a 'silent broken study/model
+    partition' into a correct live render if any narrow snapshot slips through).
+    Both paths produce the same shape via ``model_validate``."""
+    version = await db.get(ExtractionTemplateVersion, run.version_id)
+    snapshot_types: list[dict] = (
+        (version.schema_ or {}).get("entity_types", []) if version else []
+    )
+    if not _snapshot_is_narrow(snapshot_types):
+        return [RunViewEntityType.model_validate(et) for et in snapshot_types]
+
+    # Live fallback — one statement, fields eager-loaded (selectinload), then
+    # model_validate straight off the ORM (RunViewEntityType/RunViewField carry
+    # from_attributes=True). The relationship is not guaranteed field-ordered,
+    # so sort the validated fields by sort_order to match the snapshot path.
+    et_rows = (
+        (
+            await db.execute(
+                select(ExtractionEntityType)
+                .where(ExtractionEntityType.project_template_id == run.template_id)
+                .options(selectinload(ExtractionEntityType.fields))
+                .order_by(ExtractionEntityType.sort_order)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    result: list[RunViewEntityType] = []
+    for et in et_rows:
+        view_et = RunViewEntityType.model_validate(et)
+        view_et.fields.sort(key=lambda f: f.sort_order)
+        result.append(view_et)
+    return result
+```
+
+> `instances` is deliberately not read here — see the Task 3 scope note. It lands in Task 12 (with the widened `RunViewInstance` shape its consumer needs).
+
+- [ ] **Step 5: Run the test to verify it passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_run_view_entity_types.py -v`
+Expected: PASS (both the snapshot and live-fallback tests).
+
+- [ ] **Step 6: Lint + commit.**
+
+```bash
+cd backend && uv run ruff check app/schemas/extraction_run.py app/services/extraction_run_read_service.py && uv run ruff format app/schemas/extraction_run.py app/services/extraction_run_read_service.py
+cd /Users/raphael/PycharmProjects/prumo
+git add backend/app/schemas/extraction_run.py \
+        backend/app/services/extraction_run_read_service.py \
+        backend/tests/integration/test_run_view_entity_types.py
+git commit -m "feat(extraction): RunView schema + frozen-snapshot entity_types reader"
+```
+
+---
+
+### Task 4: Caller-scoped `current_values` resolver (4th blind copy)
+
+Server-side equivalent of `loadValuesForUser`: human proposals as the base layer, the caller's current reviewer decision (via the materialized `reviewer_states` pointer) overriding. Caller-scoped — this is a 4th lockstep copy of the blind predicate.
+
+**Files:**
+- Modify: `backend/app/services/extraction_run_read_service.py` (`resolve_caller_current_values`)
+- Test: `backend/tests/integration/test_run_view_current_values.py` (new)
+
+- [ ] **Step 1: Write the failing test.** Create `backend/tests/integration/test_run_view_current_values.py`:
+
+```python
+"""resolve_caller_current_values must mirror the frontend loadValuesForUser it
+replaces: human proposals are the base layer, the caller's current reviewer
+decision (via the materialized reviewer_states pointer) overrides, and another
+reviewer's rows are never returned (caller-scoped blind boundary)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.extraction_run_read_service import resolve_caller_current_values
+from tests.integration.test_blind_review_isolation import (
+    _build_two_reviewer_review_run,
+)
+
+
+@pytest.mark.asyncio
+async def test_current_values_are_caller_scoped(db_session: AsyncSession) -> None:
+    built = await _build_two_reviewer_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, reviewer_b = built
+
+    a_values = await resolve_caller_current_values(
+        db_session, run_id, caller_id=reviewer_a
+    )
+    b_values = await resolve_caller_current_values(
+        db_session, run_id, caller_id=reviewer_b
+    )
+    # Each reviewer resolves only their own coordinates — no cross-leak.
+    a_coords = {(v.instance_id, v.field_id) for v in a_values}
+    b_coords = {(v.instance_id, v.field_id) for v in b_values}
+    assert a_values, "reviewer A should resolve at least one current value"
+    # A's resolved values must not surface B's secret edits and vice-versa.
+    a_blob = " ".join(str(v.value) for v in a_values)
+    assert "REVIEWER-B-SECRET" not in a_blob
+    b_blob = " ".join(str(v.value) for v in b_values)
+    assert "REVIEWER-A-SECRET" not in b_blob
+
+
+@pytest.mark.asyncio
+async def test_current_values_empty_for_non_review_stage(
+    db_session: AsyncSession,
+) -> None:
+    # A run with no reviewer_states / human proposals resolves to an empty list,
+    # not an error (the proposal stage path never calls this).
+    from sqlalchemy import text
+
+    project_id = (
+        await db_session.execute(text("SELECT id FROM public.projects LIMIT 1"))
+    ).scalar()
+    if project_id is None:
+        pytest.skip("Seed graph incomplete")
+    fake_run = (
+        await db_session.execute(
+            text("SELECT id FROM public.extraction_runs LIMIT 1")
+        )
+    ).scalar()
+    fake_user = (
+        await db_session.execute(text("SELECT id FROM public.profiles LIMIT 1"))
+    ).scalar()
+    if not all((fake_run, fake_user)):
+        pytest.skip("Seed graph incomplete")
+    values = await resolve_caller_current_values(
+        db_session, fake_run, caller_id=fake_user
+    )
+    assert isinstance(values, list)
+```
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `cd backend && uv run pytest tests/integration/test_run_view_current_values.py -v`
+Expected: FAIL — `ImportError: cannot import name 'resolve_caller_current_values'`.
+
+- [ ] **Step 3: Implement the resolver.** In `backend/app/services/extraction_run_read_service.py`, add:
+
+```python
+async def resolve_caller_current_values(
+    db: AsyncSession, run_id: UUID, *, caller_id: UUID
+) -> list[RunViewCurrentValue]:
+    """The caller's current value per (instance, field) coordinate.
+
+    Mirrors the frontend ``loadValuesForUser`` it replaces, value-for-value:
+      Layer 1 (base): the caller's own human proposals, newest-per-coord;
+      Layer 2 (override): the caller's current reviewer decision per coord,
+        resolved through the materialized ``extraction_reviewer_states`` pointer
+        (``current_decision_id`` -> the live ``extraction_reviewer_decisions`` row).
+    ``reject`` decisions are kept (the client clears the coord but the audit row
+    stays). Caller-scoped: only ``reviewer_id == caller_id`` /
+    ``source_user_id == caller_id`` rows — this is the 4th lockstep copy of the
+    blind predicate and MUST stay identical to migration 0025 + the service
+    filter in get_run_with_workflow_history.
+
+    NOTE: ``ExtractionExportService._build_single_user_value_map`` looks similar
+    but encodes a DIFFERENT contract (it sources ``accept_proposal`` from the
+    accepted proposal and drops ``reject``, with no human-proposal base layer).
+    This resolver mirrors the FRONTEND ``loadValuesForUser`` it replaces, not the
+    export contract — do NOT DRY them together, or run-open values diverge from
+    the form's current behavior (Invariant 6). The two reads below are
+    independent but run sequentially on the shared AsyncSession (a single
+    asyncpg connection cannot multiplex, so ``asyncio.gather`` here is unsafe);
+    this matches the sequential read pattern of the composed
+    get_run_with_workflow_history. Merging them into one CTE is a possible future
+    optimization, deliberately not taken here to keep this security-sensitive
+    resolver simple.
+    """
+    merged: dict[tuple[UUID, UUID], RunViewCurrentValue] = {}
+
+    # Layer 1 — caller's own human proposals, newest-first so first-per-coord wins.
+    proposal_rows = (
+        (
+            await db.execute(
+                select(ExtractionProposalRecord)
+                .where(
+                    ExtractionProposalRecord.run_id == run_id,
+                    ExtractionProposalRecord.source
+                    == ExtractionProposalSource.HUMAN.value,
+                    ExtractionProposalRecord.source_user_id == caller_id,
+                )
+                .order_by(ExtractionProposalRecord.created_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for p in proposal_rows:
+        key = (p.instance_id, p.field_id)
+        if key in merged:
+            continue
+        merged[key] = RunViewCurrentValue(
+            instance_id=p.instance_id,
+            field_id=p.field_id,
+            value=p.proposed_value,
+            decision="human_proposal",
+        )
+
+    # Layer 2 — caller's current reviewer decision per coord (overrides Layer 1).
+    state_rows = (
+        await db.execute(
+            select(ExtractionReviewerState, ExtractionReviewerDecision)
+            .join(
+                ExtractionReviewerDecision,
+                and_(
+                    ExtractionReviewerDecision.run_id
+                    == ExtractionReviewerState.run_id,
+                    ExtractionReviewerDecision.id
+                    == ExtractionReviewerState.current_decision_id,
+                ),
+            )
+            .where(
+                ExtractionReviewerState.run_id == run_id,
+                ExtractionReviewerState.reviewer_id == caller_id,
+            )
+        )
+    ).all()
+    for state, decision in state_rows:
+        merged[(state.instance_id, state.field_id)] = RunViewCurrentValue(
+            instance_id=state.instance_id,
+            field_id=state.field_id,
+            value=decision.value,
+            decision=decision.decision,
+        )
+
+    return list(merged.values())
+```
+
+Add `ExtractionReviewerDecision` to the existing `from app.models.extraction_workflow import (...)` block if it is not already imported (it is imported today for `get_run_with_workflow_history`'s repository; verify the name is in scope).
+
+- [ ] **Step 4: Add an automated parity test** (this resolver is the 4th copy of a security-critical predicate — a one-time by-hand check is the weak link). Append to `test_run_view_current_values.py` a test that pins the contract `resolve_caller_current_values` shares with the production `loadValuesForUser`:
+
+```python
+@pytest.mark.asyncio
+async def test_current_values_match_loadvaluesforuser_contract(
+    db_session: AsyncSession,
+) -> None:
+    """Layer precedence + value sourcing must match the frontend loadValuesForUser:
+      - a coord with ONLY a human proposal -> decision='human_proposal', proposal value
+      - a coord with an 'edit' reviewer decision -> decision='edit', the decision's
+        own `value` column (reviewer decision overrides the human-proposal layer)
+      - a 'reject' decision is RETAINED in the output (decision='reject'); the client
+        drops it, the server does not.
+    Build the decisions with the SAME reviewer-decision service the rest of the
+    suite uses (see _build_two_reviewer_review_run in test_blind_review_isolation
+    for the exact record-decision + reviewer_state upsert helper)."""
+    built = await _build_two_reviewer_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, _reviewer_b = built
+
+    values = await resolve_caller_current_values(
+        db_session, run_id, caller_id=reviewer_a
+    )
+    by_decision = {v.decision for v in values}
+    # The builder records reviewer A's REVIEW-stage decision(s); reviewer A must
+    # see them resolved as their current value, sourced from the decision's own
+    # `value` column (parity with loadValuesForUser, NOT the export contract).
+    assert values, "reviewer A must resolve at least their own current value"
+    assert by_decision <= {"human_proposal", "edit", "accept_proposal", "reject"}
+    # If the builder records a 'reject', it must survive (server keeps it; client drops).
+    # (Assert the specific decision/value pairs your builder produces — pin them
+    # against the documented loadValuesForUser output, not the export helper's.)
+```
+
+> The frontend reads `reviewer_decision.value` (the decision row's own column), so this resolver does too. If `accept_proposal` surfaces a `null` value in production today, preserve that — do not source the value from the accepted proposal here (that would be a behavior change, out of scope). Tighten the final assertion to the exact `(decision, value)` pairs your chosen builder records.
+
+- [ ] **Step 5: Run the tests to verify they pass.**
+
+Run: `cd backend && uv run pytest tests/integration/test_run_view_current_values.py -v`
+Expected: PASS (caller-scope + parity).
+
+- [ ] **Step 6: Lint + commit.**
+
+```bash
+cd backend && uv run ruff check app/services/extraction_run_read_service.py && uv run ruff format app/services/extraction_run_read_service.py
+cd /Users/raphael/PycharmProjects/prumo
+git add backend/app/services/extraction_run_read_service.py \
+        backend/tests/integration/test_run_view_current_values.py
+git commit -m "feat(extraction): server-side caller-scoped current_values resolver"
+```
+
+---
+
+### Task 5: `build_run_view` — compose, don't duplicate
+
+**Files:**
+- Modify: `backend/app/services/extraction_run_read_service.py` (`build_run_view`)
+- Test: `backend/tests/integration/test_build_run_view.py` (new)
+
+- [ ] **Step 1: Write the failing test.** Create `backend/tests/integration/test_build_run_view.py`:
+
+```python
+"""build_run_view composes get_run_with_workflow_history (the single blind
+filter) and adds entity_types + current_values. It must NOT re-introduce a
+blind leak, and current_values must be empty in proposal stage."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.extraction_run_read_service import build_run_view
+from tests.integration.test_blind_review_isolation import (
+    _build_two_reviewer_review_run,
+)
+from tests.integration.test_run_proposals_latest_wins import _proposal_stage_coord
+
+
+@pytest.mark.asyncio
+async def test_build_run_view_blinds_peer_in_review(db_session: AsyncSession) -> None:
+    built = await _build_two_reviewer_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, reviewer_b = built
+
+    view = await build_run_view(
+        db_session, run_id, caller_id=reviewer_b, is_arbitrator=False
+    )
+    reviewer_ids = {d.reviewer_id for d in view.decisions}
+    assert reviewer_b in reviewer_ids
+    assert reviewer_a not in reviewer_ids, "build_run_view leaked a peer decision"
+    # The aggregate pieces are present.
+    assert view.entity_types, "entity_types tree must be populated"
+    # In review stage, current_values resolve for the caller.
+    assert isinstance(view.current_values, list)
+
+
+@pytest.mark.asyncio
+async def test_build_run_view_current_values_empty_in_proposal(
+    db_session: AsyncSession,
+) -> None:
+    fx = await _proposal_stage_coord(db_session)
+    if fx is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, _instance_id, _field_id, user_id = fx
+
+    view = await build_run_view(
+        db_session, run_id, caller_id=user_id, is_arbitrator=False
+    )
+    assert view.run.stage == "proposal"
+    assert view.current_values == [], (
+        "proposal stage must use proposals[] on the client, not server current_values"
+    )
+```
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `cd backend && uv run pytest tests/integration/test_build_run_view.py -v`
+Expected: FAIL — `ImportError: cannot import name 'build_run_view'`.
+
+- [ ] **Step 3: Implement `build_run_view`.** In `backend/app/services/extraction_run_read_service.py`, add:
+
+```python
+# Stages whose form hydrates from the materialized reviewer_states + decisions
+# (current_values). In 'proposal' the client uses proposals[]; pending/cancelled
+# show nothing.
+_CURRENT_VALUE_STAGES = frozenset(
+    {
+        ExtractionRunStage.REVIEW.value,
+        ExtractionRunStage.CONSENSUS.value,
+        ExtractionRunStage.FINALIZED.value,
+    }
+)
+
+
+async def build_run_view(
+    db: AsyncSession, run_id: UUID, *, caller_id: UUID, is_arbitrator: bool
+) -> RunViewResponse:
+    """The one-round-trip run-open view: the blind-filtered run detail plus the
+    frozen entity_types tree and the caller's current_values. COMPOSES
+    get_run_with_workflow_history (the single blind filter) — it never re-queries
+    the workflow tables, so the blind boundary cannot drift. The composed
+    ``detail.run`` (a RunSummaryResponse) already carries ``version_id`` /
+    ``template_id`` / ``stage`` / ``article_id``, so there is no second ORM
+    fetch of the run here."""
+    detail = await get_run_with_workflow_history(
+        db, run_id, caller_id=caller_id, is_arbitrator=is_arbitrator
+    )
+
+    entity_types = await _entity_types_for_run(db, detail.run)
+    current_values = (
+        await resolve_caller_current_values(db, run_id, caller_id=caller_id)
+        if detail.run.stage in _CURRENT_VALUE_STAGES
+        else []
+    )
+
+    return RunViewResponse(
+        run=detail.run,
+        proposals=detail.proposals,
+        decisions=detail.decisions,
+        consensus_decisions=detail.consensus_decisions,
+        published_states=detail.published_states,
+        entity_types=entity_types,
+        current_values=current_values,
+    )
+```
+
+- [ ] **Step 4: Run the test to verify it passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_build_run_view.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full read-service regression to confirm nothing drifted.**
+
+Run: `cd backend && uv run pytest tests/integration/test_run_read_blind_filter.py tests/integration/test_run_proposals_latest_wins.py tests/integration/test_blind_review_isolation.py -v`
+Expected: PASS (composition did not change `get_run_with_workflow_history`).
+
+- [ ] **Step 6: Lint + commit.**
+
+```bash
+cd backend && uv run ruff check app/services/extraction_run_read_service.py && uv run ruff format app/services/extraction_run_read_service.py
+cd /Users/raphael/PycharmProjects/prumo
+git add backend/app/services/extraction_run_read_service.py \
+        backend/tests/integration/test_build_run_view.py
+git commit -m "feat(extraction): build_run_view composes detail + entity_types + current_values"
+```
+
+---
+
+### Task 6: `GET /api/v1/runs/{run_id}/view`
+
+Mirror `get_run` exactly: `_load_run_and_check_member` (BOLA gate) → `is_run_arbitrator` → `build_run_view` → `ApiResponse.success`. Read-only (no commit).
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/extraction_runs.py` (add handler + import)
+- Test: `backend/tests/integration/test_run_view_endpoint.py` (new)
+
+- [ ] **Step 1: Write the failing endpoint test.** Create `backend/tests/integration/test_run_view_endpoint.py`:
+
+```python
+"""GET /api/v1/runs/{id}/view returns the composed RunViewResponse, gated by
+project membership (BOLA)."""
+
+from __future__ import annotations
+
+import pytest
+
+# Reuse the integration client fixture + a seeded run helper from the existing
+# run-endpoint test module. Match its fixture names (e.g. `client`, auth headers,
+# and the seeded extraction run) — see tests/integration/test_extraction_runs_*.py
+# for the exact pattern used in this repo.
+from tests.integration.conftest import (  # type: ignore  # adjust to real fixture module
+    seeded_extraction_run,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_run_view_returns_aggregate(client, seeded_extraction_run) -> None:
+    run_id = seeded_extraction_run.run_id
+    resp = await client.get(f"/api/v1/runs/{run_id}/view")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    data = body["data"]
+    assert "run" in data and "proposals" in data
+    assert "entity_types" in data and "current_values" in data
+
+
+@pytest.mark.asyncio
+async def test_get_run_view_rejects_non_member(
+    client_other_project, seeded_extraction_run
+) -> None:
+    run_id = seeded_extraction_run.run_id
+    resp = await client_other_project.get(f"/api/v1/runs/{run_id}/view")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_run_view_works_for_qa_run(client, seeded_qa_run) -> None:
+    # /view is kind-agnostic: QA runs also have a version snapshot and (in
+    # review+) current_values. useRun routes BOTH surfaces here, so
+    # build_run_view must not assume kind=extraction.
+    resp = await client.get(f"/api/v1/runs/{seeded_qa_run.run_id}/view")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert "entity_types" in data and "current_values" in data
+```
+
+> The exact fixture names (`client`, `client_other_project`, `seeded_extraction_run`, `seeded_qa_run`) differ by repo convention — open `backend/tests/integration/` for the existing run-endpoint test that calls `GET /api/v1/runs/{id}` and the QA-session tests, and copy their fixtures verbatim. The assertions above (envelope `ok`/`data`, the two new keys `entity_types`/`current_values`, the 403 BOLA gate, and **QA parity** — `/view` works for `kind=quality_assessment` runs) are what this task pins.
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `cd backend && uv run pytest tests/integration/test_run_view_endpoint.py -v`
+Expected: FAIL — 404 (route does not exist yet).
+
+- [ ] **Step 3: Add the handler.** In `backend/app/api/v1/endpoints/extraction_runs.py`, add `build_run_view` + `RunViewResponse` to the imports:
+
+```python
+from app.schemas.extraction_run import (
+    # ... existing imports ...
+    RunViewResponse,
+)
+from app.services.extraction_run_read_service import (
+    # ... existing imports ...
+    build_run_view,
+)
+```
+
+Add the handler immediately after `get_run` (line ~158):
+
+```python
+@router.get("/{run_id}/view")
+async def get_run_view(
+    run_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse[RunViewResponse]:
+    """One-round-trip run-open view: blind-filtered run detail + the frozen
+    entity_types tree + the caller's current_values."""
+    run = await _load_run_and_check_member(db, run_id, current_user_sub)
+    is_arbitrator = await is_run_arbitrator(db, run.project_id, current_user_sub)
+    view = await build_run_view(
+        db, run_id, caller_id=current_user_sub, is_arbitrator=is_arbitrator
+    )
+    return ApiResponse.success(view, trace_id=_trace(request))
+```
+
+- [ ] **Step 4: Run the test to verify it passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_run_view_endpoint.py -v`
+Expected: PASS (aggregate shape + 403 BOLA gate).
+
+- [ ] **Step 5: Confirm the layered-architecture fitness check still passes** (the endpoint must import only from `app.services`/`app.schemas`/`app.core`/`app.api.deps`).
+
+Run: `cd backend && uv run pytest tests/ -k layered_arch -v`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit.**
+
+```bash
+cd backend && uv run ruff check app/api/v1/endpoints/extraction_runs.py && uv run ruff format app/api/v1/endpoints/extraction_runs.py
+cd /Users/raphael/PycharmProjects/prumo
+git add backend/app/api/v1/endpoints/extraction_runs.py \
+        backend/tests/integration/test_run_view_endpoint.py
+git commit -m "feat(api): GET /runs/{id}/view returns the composed RunViewResponse"
+```
+
+---
+
+### Task 7: Embed `RunViewResponse` in `POST /hitl/sessions` (extraction only)
+
+The open response carries the run view so the first paint needs no extra GET. Built **after** `open_or_resume` (seeding + advance already flushed) and **before** `commit`, with the same caller + computed `is_arbitrator`. Extraction only (QA gets `null`).
+
+**Files:**
+- Modify: `backend/app/schemas/hitl_session.py` (`OpenHITLSessionResponse`, lines 28–33)
+- Modify: `backend/app/api/v1/endpoints/hitl_sessions.py` (lines 59–92)
+- Test: `backend/tests/integration/test_hitl_session_embeds_run_view.py` (new)
+
+- [ ] **Step 1: Write the failing test.** Create `backend/tests/integration/test_hitl_session_embeds_run_view.py`:
+
+```python
+"""POST /hitl/sessions (kind=extraction) embeds the run view so the client
+renders from one round-trip. The embed is reviewer-scoped to the opener."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_open_extraction_session_embeds_run_view(
+    client, seeded_project_article_template
+) -> None:
+    fx = seeded_project_article_template
+    resp = await client.post(
+        "/api/v1/hitl/sessions",
+        json={
+            "kind": "extraction",
+            "project_id": str(fx.project_id),
+            "article_id": str(fx.article_id),
+            "project_template_id": str(fx.template_id),
+        },
+    )
+    assert resp.status_code in (200, 201)
+    data = resp.json()["data"]
+    assert data["run_id"]
+    assert data["run_view"] is not None, "extraction open must embed the run view"
+    view = data["run_view"]
+    assert view["run"]["id"] == data["run_id"]
+    assert "entity_types" in view and "current_values" in view
+    # Freshly opened run is in proposal stage -> current_values empty.
+    assert view["run"]["stage"] == "proposal"
+    assert view["current_values"] == []
+
+
+@pytest.mark.asyncio
+async def test_embedded_run_view_is_reviewer_scoped(
+    client_as_reviewer_b, two_reviewer_review_run
+) -> None:
+    """The embed must be blind-scoped to the OPENER. The endpoint computes
+    is_arbitrator from body.project_id (not run.project_id) — this pins that the
+    embedded run_view never leaks a peer's decisions when a plain reviewer opens
+    a review-stage run. (build_run_view's blind filter is unit-tested in
+    test_build_run_view; this covers the endpoint's own caller_id/is_arbitrator
+    wiring on the mutating path.)"""
+    fx = two_reviewer_review_run  # (project_id, article_id, template_id, reviewer_a)
+    resp = await client_as_reviewer_b.post(
+        "/api/v1/hitl/sessions",
+        json={
+            "kind": "extraction",
+            "project_id": str(fx.project_id),
+            "article_id": str(fx.article_id),
+            "project_template_id": str(fx.template_id),
+        },
+    )
+    assert resp.status_code in (200, 201)
+    view = resp.json()["data"]["run_view"]
+    reviewer_ids = {d["reviewer_id"] for d in view["decisions"]}
+    assert str(fx.reviewer_a) not in reviewer_ids, (
+        "embed leaked reviewer A's decision to reviewer B"
+    )
+```
+
+> Match `client` / `seeded_project_article_template` to the existing `hitl_sessions` integration test fixtures (`backend/tests/integration/test_hitl_session*.py`). For the second test, `two_reviewer_review_run` builds a review-stage run on a shared (article × template) with reviewer A having recorded a decision — base it on `_build_two_reviewer_review_run` (from `test_blind_review_isolation.py`) but expose the project/article/template ids so the endpoint can resume it; `client_as_reviewer_b` is the integration client authenticated as reviewer B. If wiring a reviewer-B-authenticated client is impractical, keep the first test and rely on `test_build_run_view_blinds_peer_in_review` (Task 5) — but note the endpoint's `body.project_id`-sourced `is_arbitrator` then stays unpinned.
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `cd backend && uv run pytest tests/integration/test_hitl_session_embeds_run_view.py -v`
+Expected: FAIL — `KeyError: 'run_view'` (field not on the response yet).
+
+- [ ] **Step 3: Extend the response schema.** In `backend/app/schemas/hitl_session.py`, import `RunViewResponse` and add the field:
+
+```python
+from app.schemas.extraction_run import RunViewResponse
+
+
+class OpenHITLSessionResponse(BaseModel):
+    run_id: UUID
+    kind: Literal["extraction", "quality_assessment"]
+    project_template_id: UUID
+    instances_by_entity_type: dict[str, str]
+    # Embedded run-open view (extraction only). Lets the client render from a
+    # single round-trip instead of session -> GET /runs/{id} -> values. Null for
+    # quality_assessment (its surface does not consume this).
+    run_view: RunViewResponse | None = None
+```
+
+- [ ] **Step 4: Build + embed the view in the endpoint.** In `backend/app/api/v1/endpoints/hitl_sessions.py`, add imports:
+
+```python
+from app.schemas.extraction_run import RunViewResponse  # noqa: F401 (used in response model)
+from app.services.extraction_run_read_service import build_run_view, is_run_arbitrator
+from app.services.hitl_session_service import TemplateKind  # if not already imported
+```
+
+Between the `try/except` (after `session = await service.open_or_resume(...)`) and `await db.commit()`, add:
+
+```python
+    run_view: RunViewResponse | None = None
+    if session.kind == TemplateKind.EXTRACTION:
+        is_arbitrator = await is_run_arbitrator(db, body.project_id, current_user_sub)
+        run_view = await build_run_view(
+            db, session.run_id, caller_id=current_user_sub, is_arbitrator=is_arbitrator
+        )
+
+    await db.commit()
+```
+
+Then pass it into the response:
+
+```python
+    return ApiResponse.success(
+        OpenHITLSessionResponse(
+            run_id=session.run_id,
+            kind=session.kind.value,
+            project_template_id=session.project_template_id,
+            instances_by_entity_type=session.instances_by_entity_type,
+            run_view=run_view,
+        ),
+        trace_id=getattr(request.state, "trace_id", None),
+    )
+```
+
+> `build_run_view` is a pure read (no writes); building it before `commit` reads the just-seeded/advanced state under the same advisory lock. If `session.kind` is `quality_assessment`, `run_view` stays `None`. Verify `TemplateKind.EXTRACTION` is the correct enum member name (it backs `kind.value == "extraction"`).
+
+- [ ] **Step 5: Run the test to verify it passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_hitl_session_embeds_run_view.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Confirm the existing session tests still pass** (resume → 200, create → 201, QA path unaffected).
+
+Run: `cd backend && uv run pytest tests/integration/test_hitl_session_service.py -v`
+Expected: PASS (adjust the module name to the repo's actual hitl-session integration test file).
+
+- [ ] **Step 7: Lint + commit.**
+
+```bash
+cd backend && uv run ruff check app/schemas/hitl_session.py app/api/v1/endpoints/hitl_sessions.py && uv run ruff format app/schemas/hitl_session.py app/api/v1/endpoints/hitl_sessions.py
+cd /Users/raphael/PycharmProjects/prumo
+git add backend/app/schemas/hitl_session.py \
+        backend/app/api/v1/endpoints/hitl_sessions.py \
+        backend/tests/integration/test_hitl_session_embeds_run_view.py
+git commit -m "feat(api): embed RunViewResponse in extraction session-open response"
+```
+
+---
+
+## Phase C — Frontend: consume the view, drop the direct reads
+
+### Task 8: TS types for the view
+
+**Files:**
+- Modify: `frontend/hooks/runs/types.ts`
+- Modify: `frontend/hooks/runs/index.ts` (re-export the new types if the barrel enumerates them)
+
+- [ ] **Step 1: Add the response types.** In `frontend/hooks/runs/types.ts`, after `RunDetailResponse`, add (snake_case to match the backend JSON):
+
+```typescript
+export interface RunViewFieldResponse {
+  id: string;
+  name: string;
+  label: string;
+  description: string | null;
+  field_type: string;
+  is_required: boolean;
+  validation_schema: unknown | null;
+  allowed_values: unknown | null;
+  unit: string | null;
+  allowed_units: unknown | null;
+  sort_order: number;
+  llm_description: string | null;
+  allow_other: boolean;
+  other_label: string | null;
+  other_placeholder: string | null;
+}
+
+export interface RunViewEntityType {
+  id: string;
+  name: string;
+  label: string;
+  description: string | null;
+  parent_entity_type_id: string | null;
+  cardinality: string;
+  role: string;
+  sort_order: number;
+  is_required: boolean;
+  fields: RunViewFieldResponse[];
+}
+
+export interface RunViewCurrentValue {
+  instance_id: string;
+  field_id: string;
+  value: Record<string, unknown> | null;
+  decision: string;
+}
+
+// `instances` is added here in Task 12 (deferred), alongside its backend field
+// and the frontend adapter that consumes it.
+export interface RunViewResponse extends RunDetailResponse {
+  entity_types: RunViewEntityType[];
+  current_values: RunViewCurrentValue[];
+}
+```
+
+- [ ] **Step 2: Typecheck.**
+
+Run (from repo root): `npm run typecheck`
+Expected: clean (types only; no consumer references yet).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add frontend/hooks/runs/types.ts frontend/hooks/runs/index.ts
+git commit -m "feat(runs): RunViewResponse TS types (superset of RunDetailResponse)"
+```
+
+---
+
+### Task 9: `useRun` reads `/view`
+
+`RunViewResponse extends RunDetailResponse`, so every existing `useRun` consumer (reading `.run`/`.proposals`/`.decisions`) keeps compiling; the two new fields (`entity_types`, `current_values`) become available. The query key stays `runsKeys.detail(runId)`, so all mutation invalidation is unchanged.
+
+> **QA surface note:** `useRun` is consumed by **both** `ExtractionFullScreen.tsx` and `QualityAssessmentFullScreen.tsx`. Re-pointing it to `/view` routes QA runs through `build_run_view` too. This is safe — `/view` is kind-agnostic (Task 6 pins QA parity), QA templates are cloned and carry version snapshots, and the QA page reads only `.run`/`.proposals`/`.decisions`/`.consensus_decisions` (verified: `useReviewerSummary` reads `.decisions`, `ConsensusPanel` reads `.consensus_decisions`) — it ignores the two new fields. QA's session hook (`useQAAssessmentSession`) gets `run_view: null` and does not seed, so QA still does one real `GET /view`; that is acceptable (QA is not the slow-load target). Do not gate `useRun` by kind.
+
+**Files:**
+- Modify: `frontend/hooks/runs/useRun.ts`
+- Modify: `frontend/test/hooks-runs.test.tsx` (re-point expectation `/api/v1/runs/{id}` → `/view`)
+
+- [ ] **Step 1: Update the failing test first.** In `frontend/test/hooks-runs.test.tsx`, find the assertion that `useRun` fetches `/api/v1/runs/${runId}` and change the expected path to `/api/v1/runs/${runId}/view`. (If the test mocks `apiClient`, assert it was called with the `/view` suffix.)
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run (from repo root): `npx vitest run frontend/test/hooks-runs.test.tsx`
+Expected: FAIL (still calls the old path).
+
+- [ ] **Step 3: Re-point the hook.** In `frontend/hooks/runs/useRun.ts`, change the import + return type + queryFn:
+
+```typescript
+import { runsKeys, type RunViewResponse } from "./types";
+
+export interface UseRunOptions {
+  enabled?: boolean;
+}
+
+export function useRun(runId: string | null | undefined, options: UseRunOptions = {}) {
+  const { enabled = true } = options;
+
+  return useQuery<RunViewResponse>({
+    queryKey: runId ? runsKeys.detail(runId) : ["runs", "disabled"],
+    queryFn: async () => {
+      if (!runId) {
+        throw new Error("Missing run ID");
+      }
+      return apiClient<RunViewResponse>(`/api/v1/runs/${runId}/view`);
+    },
+    enabled: enabled && Boolean(runId),
+    staleTime: 30_000,
+    retry: 1,
+  });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes.**
+
+Run (from repo root): `npx vitest run frontend/test/hooks-runs.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck.**
+
+Run (from repo root): `npm run typecheck`
+Expected: clean (`RunViewResponse` is a superset; no consumer breaks).
+
+- [ ] **Step 6: Lint + commit.**
+
+```bash
+npx eslint frontend/hooks/runs/useRun.ts
+git add frontend/hooks/runs/useRun.ts frontend/test/hooks-runs.test.tsx
+git commit -m "feat(runs): useRun reads GET /runs/{id}/view (RunViewResponse)"
+```
+
+---
+
+### Task 10: `useExtractionSession` consumes the embed + seeds the cache
+
+The session response now carries `run_view`; seed `runsKeys.detail(run_id)` so `useRun` reads from cache on first paint (no extra GET). Must happen inside the stale-generation guard.
+
+**Files:**
+- Modify: `frontend/hooks/extraction/useExtractionSession.ts`
+- Modify: `frontend/hooks/qa/useQAAssessmentSession.ts` (mirror the optional field, ignore it)
+- Test: `frontend/test/hooks/useExtractionSession.test.tsx` (extend)
+
+- [ ] **Step 1: Write the failing test.** In `frontend/test/hooks/useExtractionSession.test.tsx`, add a case: mock `apiClient` to resolve `{ run_id, kind, project_template_id, instances_by_entity_type, run_view: <RunViewResponse fixture> }`, render `useExtractionSession` inside a `QueryClientProvider`, and assert after settle that `queryClient.getQueryData(["runs", run_id])` deep-equals the embedded `run_view`. Add a second case where `run_view` is `null` (QA-style) and assert no cache write happens and the hook still resolves `session`.
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run (from repo root): `npx vitest run frontend/test/hooks/useExtractionSession.test.tsx`
+Expected: FAIL (no cache write yet).
+
+- [ ] **Step 3: Consume + seed.** In `frontend/hooks/extraction/useExtractionSession.ts`:
+
+Add imports and the `run_view` field:
+
+```typescript
+import { useQueryClient } from "@tanstack/react-query";
+
+import { runsKeys, type RunViewResponse } from "@/hooks/runs/types";
+
+interface OpenResponse {
+  run_id: string;
+  kind: "extraction" | "quality_assessment";
+  project_template_id: string;
+  instances_by_entity_type: Record<string, string>;
+  run_view: RunViewResponse | null;
+}
+```
+
+Inside the hook, get the query client:
+
+```typescript
+  const queryClient = useQueryClient();
+```
+
+In `open()`, right after the generation guard `if (myGeneration !== generationRef.current) return;` and before `setSession(...)`, seed the cache:
+
+```typescript
+      if (myGeneration !== generationRef.current) return;
+      // Pre-seed the run-detail cache from the embedded view so useRun reads
+      // from cache on first paint — collapsing the session -> GET /runs/{id} ->
+      // values serial waterfall. Inside the generation guard so a stale
+      // article's view can never poison the new article's run cache.
+      if (data.run_view) {
+        queryClient.setQueryData(runsKeys.detail(data.run_id), data.run_view);
+      }
+      setSession({
+        runId: data.run_id,
+        projectTemplateId: data.project_template_id,
+        instancesByEntityType: data.instances_by_entity_type,
+      });
+```
+
+Add `queryClient` to the `open` `useCallback` dependency array.
+
+- [ ] **Step 4: Mirror the QA twin.** In `frontend/hooks/qa/useQAAssessmentSession.ts`, add `run_view: RunViewResponse | null` to its local `OpenResponse` interface (import the type) so the shared backend response type-checks. QA does **not** seed the cache (its `run_view` is always `null`); leave its body otherwise unchanged.
+
+- [ ] **Step 5: Run the test to verify it passes.**
+
+Run (from repo root): `npx vitest run frontend/test/hooks/useExtractionSession.test.tsx`
+Expected: PASS (cache seeded when `run_view` present; no write when `null`).
+
+- [ ] **Step 6: Typecheck + lint + commit.**
+
+```bash
+npm run typecheck
+npx eslint frontend/hooks/extraction/useExtractionSession.ts frontend/hooks/qa/useQAAssessmentSession.ts
+git add frontend/hooks/extraction/useExtractionSession.ts \
+        frontend/hooks/qa/useQAAssessmentSession.ts \
+        frontend/test/hooks/useExtractionSession.test.tsx
+git commit -m "feat(extraction): seed run-detail cache from embedded session run_view"
+```
+
+---
+
+### Task 11: `useExtractedValues` consumes `current_values` from the view
+
+Replace the only network read left in the hook (`loadValuesForUser`) with the `currentValues` already present in `runDetail`. The hook becomes pure given its props.
+
+**Files:**
+- Modify: `frontend/services/extractionValueService.ts` (export `unwrapValue`)
+- Modify: `frontend/hooks/extraction/useExtractedValues.ts`
+- Modify: `frontend/pages/ExtractionFullScreen.tsx` (pass `currentValues={runDetail?.current_values}`)
+- Test: `frontend/test/hooks/useExtractedValues.test.tsx` (extend)
+
+- [ ] **Step 1: Export `unwrapValue`.** In `frontend/services/extractionValueService.ts`, change `function unwrapValue(...)` (line 65) to `export function unwrapValue(...)` so the hook reuses the identical envelope-stripping logic.
+
+- [ ] **Step 2: Write the failing test.** In `frontend/test/hooks/useExtractedValues.test.tsx`, add a review-stage case: render the hook with `stage="review"`, `currentValues=[{ instance_id, field_id, value: { value: "X", unit: null }, decision: "edit" }, { instance_id, field_id: f2, value: {...}, decision: "reject" }]`, and assert the produced `values` map contains the `edit` coord and **omits** the `reject` coord — and that `ExtractionValueService.loadValuesForUser` is NOT called.
+
+- [ ] **Step 3: Run it to verify it fails.**
+
+Run (from repo root): `npx vitest run frontend/test/hooks/useExtractedValues.test.tsx`
+Expected: FAIL (hook still calls `loadValuesForUser`).
+
+- [ ] **Step 4: Consume `currentValues`.** In `frontend/hooks/extraction/useExtractedValues.ts`:
+
+Add to `UseExtractedValuesProps` and the destructure:
+
+```typescript
+import { unwrapValue } from "@/services/extractionValueService";
+import type { RunViewCurrentValue } from "@/hooks/runs/types";
+
+// in UseExtractedValuesProps:
+  currentValues?: RunViewCurrentValue[];
+
+// in the destructure:
+  const { runId, stage, proposals, currentValues, currentUserId, enabled = true } = props;
+```
+
+Replace the `REVIEWER_STATE_STAGES` branch body (the `await ExtractionValueService.loadValuesForUser(...)` block) with a pure read of `currentValues` — identical value-shaping to the old path (`unwrapValue` then unit extraction then `extractValueFromDb`, skipping `reject`):
+
+```typescript
+        if (REVIEWER_STATE_STAGES.has(stage)) {
+          if (!currentUserId) {
+            hydratedRunIdRef.current = runId;
+            resetValuesIfNeeded(setValues);
+            return;
+          }
+
+          const valuesMap: Record<string, any> = {};
+          for (const cv of currentValues ?? []) {
+            if (cv.decision === 'reject') continue;
+            const key = `${cv.instance_id}_${cv.field_id}`;
+            const unwrapped = unwrapValue(cv.value);
+            const unit =
+              typeof unwrapped === 'object' &&
+              unwrapped !== null &&
+              'unit' in (unwrapped as Record<string, unknown>)
+                ? ((unwrapped as { unit: string | null }).unit ?? null)
+                : null;
+            valuesMap[key] = extractValueFromDb({ value: unwrapped, unit });
+          }
+          applyLoadedValues(valuesMap);
+          setInitialized(true);
+          return;
+        }
+```
+
+Add `currentValues` to the `loadValues` `useCallback` dependency array (replacing the data dependency that `loadValuesForUser` implied). The branch is now synchronous, but keep `loadValues` async (the proposal branch and the function signature are unchanged).
+
+`loadValuesForUser` was the only `ExtractionValueService.*` call in this hook — remove the now-unused `ExtractionValueService` import. (The hook still imports the named `unwrapValue` from the same `extractionValueService` module — keep that one.) Otherwise eslint `no-unused-vars` fails at Step 7.
+
+> This preserves parity exactly: the old service did `value: unwrapValue(proposed_value | reviewer_decision.value)` then the hook read `unit` off that and called `extractValueFromDb`. Here the server sends the **raw** envelope and the hook applies the same `unwrapValue` + unit + `extractValueFromDb`, so `unwrapped` equals the old `row.value`. The `reject`-skip and `currentUserId`-null reset are unchanged.
+
+- [ ] **Step 5: Wire the prop in the page.** In `frontend/pages/ExtractionFullScreen.tsx`, in the `useExtractedValues({ ... })` call, add `currentValues: runDetail?.current_values`:
+
+```typescript
+  const {
+    values, loadedValues, updateValue,
+    loading: valuesLoading, initialized: valuesInitialized, refresh: refreshValues,
+  } = useExtractedValues({
+    runId: activeRunId,
+    stage,
+    proposals,
+    currentValues: runDetail?.current_values,
+    currentUserId,
+    enabled: !!activeRunId,
+  });
+```
+
+- [ ] **Step 6: Run the tests to verify they pass.**
+
+Run (from repo root): `npx vitest run frontend/test/hooks/useExtractedValues.test.tsx`
+Expected: PASS (review branch reads `currentValues`; `reject` omitted; `loadValuesForUser` not called).
+
+- [ ] **Step 7: Typecheck + lint + commit.**
+
+```bash
+npm run typecheck
+npx eslint frontend/hooks/extraction/useExtractedValues.ts frontend/pages/ExtractionFullScreen.tsx frontend/services/extractionValueService.ts
+git add frontend/services/extractionValueService.ts \
+        frontend/hooks/extraction/useExtractedValues.ts \
+        frontend/pages/ExtractionFullScreen.tsx \
+        frontend/test/hooks/useExtractedValues.test.tsx
+git commit -m "feat(extraction): review-stage values come from the view's current_values"
+```
+
+---
+
+### Task 12 (deferred sub-phase): source entity_types + instances from the view in `useExtractionData`
+
+> **Status: deferred — design + hazards only, not a bite-sized TDD task.** This is the "remove the direct Supabase reads of `extraction_entity_types` + `extraction_instances`" step from the brief. It is **intentionally sequenced after** Tasks 1–11 and **not** broken into executable steps here, because an adversarial review found two hazards that need a dedicated investigation pass with the page open. The structural slow-load win does **not** depend on this task — see "Why deferral costs nothing structural" below — so Phase 2 ships correct without it, and this sub-phase lands as its own PR (it overlaps the brief's item C "single API read path").
+
+**Why deferral costs nothing structural.** The serial waterfall the brief targets is `session → useRun → values`. Tasks 7/9/10/11 collapse exactly that (embed seeds the cache; `useRun` reads `/view`; values come from `current_values`). The `extraction_entity_types` + `extraction_instances` reads in `useExtractionData.loadData` already run in a **parallel** `Promise.all` gated only on `template.id` (`useExtractionData.ts:262-273`) — they are off the critical serial path. Moving them server-side removes 2 parallel requests (a request-count win, not a depth win), so it is pure cleanup, not the structural fix.
+
+**Hazard 1 — read-after-write on instances (the blocker).** `refreshInstances()` is called from ~11 sites in `ExtractionFullScreen.tsx` (model create/delete, finalize, reopen, extraction-complete), and several `await refreshInstances()` then **immediately read the refreshed `instances` array** (e.g. `handleFinalize` does `instances.map(i => i.id)` right after a direct `extraction_instances` write + refresh). Today `refreshInstances` does a direct Supabase read and `setInstances`, so the next render sees fresh data. If `instances` instead derives from `runDetail` (the cached view), `await queryClient.invalidateQueries(...)` does **not** return the fresh data and the derived `instances` memo only updates after the refetch resolves and the component re-renders — so the code reading `instances` right after reads **stale** data. This is a real correctness regression in the finalize/model flows.
+
+**Hazard 2 — the view's shapes do not satisfy the frontend types.** Verified against `frontend/types/extraction.ts`:
+- `ExtractionEntityTypeWithFields.template_id` is required `string` (inherited from `ExtractionEntityType`, `types/extraction.ts:89`) — the snapshot tree carries no `template_id`, so an adapter cannot set `null`. (A child interface cannot relax an inherited required field to `string | null` in TS.)
+- `ExtractionInstance` requires `project_id`, `template_id`, `created_by`, `created_at`, `updated_at` (`types/extraction.ts:137-151`) — none are in `RunViewInstance`. An `instancesFromRunView` adapter would have to `as unknown as` past 5 missing required fields (a type lie that strands future consumers).
+
+**Design for when this is picked up** (resolve both hazards explicitly):
+
+0. **Add `instances` to the view server-side** (net-new here, since Phase 2 deliberately omitted it): a `RunViewInstance` schema carrying the **full** field set the frontend `ExtractionInstance` needs — `id`, `entity_type_id`, `parent_instance_id`, `label`, `sort_order`, `status`, `metadata` (via the `metadata_`→`metadata` `serialization_alias`), **plus** `project_id`, `created_by`, `created_at`, `updated_at` (all on the ORM row) — so the adapter is lossless rather than casting past missing fields; a `_instances_for_run(db, run)` reader (keyed by `article_id`+`template_id`, not run-scoped — cross-reference `ExtractionExportService._load_instances_for_runs` as the canonical scoping rule, do not import it); `instances: list[RunViewInstance]` on `RunViewResponse` (backend + the frontend `RunViewInstance` interface). Extend the Task 5 `build_run_view` + the Task 6 endpoint test to cover it (incl. the `metadata` wire-key assertion).
+1. **Adapters** in a new `frontend/lib/extraction/runViewAdapters.ts`:
+   - `entityTypesFromRunView(view)`: map `view.entity_types` → `ExtractionEntityTypeWithFields[]`, setting `template_id: view.run.template_id` (a real string — the project template the run belongs to; the form never reads it, and `partitionEntityTypes` reads only `role`). Keep `allowed_values`/`allowed_units` as arrays and `validation_schema` as-is.
+   - `instancesFromRunView(view, run)`: with the widened `RunViewInstance` from step 0, this is a straight map (set `article_id: run.article_id` if `RunViewInstance` omits it). No `as unknown as` casts past missing fields.
+2. **Source from the view in `ExtractionFullScreen.tsx`** via `useMemo(() => entityTypesFromRunView(runDetail), [runDetail])` and the instances analog.
+3. **Resolve Hazard 1** by converting every `await refreshInstances()`-then-read site to **refetch-and-derive**: `const { data } = await refetchRun(); const fresh = instancesFromRunView(data, run);` and use `fresh` for the immediate read — never read the memo-derived `instances` in the same tick as the refetch. Audit all sites first: `grep -n "refreshInstances" frontend/pages/ExtractionFullScreen.tsx`. Sites that do **not** read instances immediately may use `queryClient.invalidateQueries({ queryKey: runsKeys.detail(activeRunId) })`.
+4. **Strip the direct reads** from `useExtractionData` (remove `entityTypes`/`instances`/`refreshInstances`/`loadInstances`/`mergeInstancesById` + the `extraction_entity_types`/`extraction_instances` queries; keep article/project/template/articles). Re-point any other `useExtractionData.entityTypes`/`.instances` consumer (`grep -rn "useExtractionData" frontend/`).
+5. **Behavior to preserve:** the frozen-snapshot entity_types now drive rendering (was live) — confirm a run opened against a since-edited template renders its frozen structure (the whole point of the Phase-A widening). Keep `mergeInstancesById`'s structural-sharing intent (avoid form remount/scroll-reset) — derive `instances` with a stable-identity memo, or keep a small by-id merge in the adapter.
+
+When this sub-phase lands, the backend `instances` field added in step 0 becomes the single source for the form's instances, closing the last direct Supabase read on the open path.
+
+---
+
+## Phase D — Docs/CI + end-to-end verification
+
+### Task 13: Register the plan doc + full verification sweep
+
+**Files:**
+- Modify: `.markdownlintignore` (add this plan doc if the `2026-06-08-*` glob is not already covered)
+- Verify: `.github/workflows/docs-ci.yml` (the `docs/superpowers/plans/2026-06-08-*.md` ignore glob already covers this doc — confirm, don't duplicate)
+
+- [ ] **Step 1: Confirm docs-ci already ignores this doc.** `.github/workflows/docs-ci.yml`'s markdownlint step already lists `"!docs/superpowers/plans/2026-06-08-*.md"`, which matches this file. No change needed there. If `.markdownlintignore` is used by a local `make lint-docs` target and lacks a `2026-06-08` entry, add:
+
+```text
+docs/superpowers/plans/2026-06-08-runopen-slowload-phase2-runview.md
+```
+
+- [ ] **Step 2: Backend full suite (touched areas).**
+
+Run: `cd backend && uv run pytest tests/integration/test_template_version_snapshot_shape.py tests/integration/test_run_view_entity_types.py tests/integration/test_run_view_current_values.py tests/integration/test_build_run_view.py tests/integration/test_run_view_endpoint.py tests/integration/test_hitl_session_embeds_run_view.py tests/integration/test_run_read_blind_filter.py tests/integration/test_migration_roundtrip.py -v`
+Expected: all PASS.
+
+- [ ] **Step 3: Backend lint.**
+
+Run: `make lint-backend`
+Expected: clean.
+
+- [ ] **Step 4: Frontend full verification.**
+
+Run (from repo root): `npm run typecheck && npx vitest run frontend/ && npx eslint frontend/hooks frontend/pages frontend/lib/extraction frontend/services`
+Expected: typecheck clean, vitest green for the touched suites, eslint clean.
+
+- [ ] **Step 5 (manual, on the PR preview): re-measure the fan-out.** Open a saved run for `teste@prumo.local`, and via Resource Timing confirm: exactly one `POST /api/v1/hitl/sessions`, **zero** follow-up `GET /api/v1/runs/{id}/view` on first paint (served from the seeded cache), and **zero** direct PostgREST reads of `extraction_reviewer_states` on the open path (the review-stage `loadValuesForUser` read is gone — values come from the embedded `current_values`). The `extraction_entity_types` + `extraction_instances` parallel reads **still fire** in Phase 2 (their removal is the deferred Task 12) — that is expected. Confirm the form renders study + per-model sections, progress, and blinding correctly across `proposal` and `review` stages.
+
+- [ ] **Step 6: Multi-reviewer blind E2E.** With two reviewers on the same (article × template) in `review` stage, confirm reviewer B's form never shows reviewer A's in-flight human values — now enforced server-side by `resolve_caller_current_values` (caller scope) + the composed `get_run_with_workflow_history` blind filter in the embed.
+
+- [ ] **Step 7: Commit the doc registration (if `.markdownlintignore` changed).**
+
+```bash
+git add .markdownlintignore docs/superpowers/plans/2026-06-08-runopen-slowload-phase2-runview.md
+git commit -m "docs(plans): Phase 2 RunView server-collapse implementation plan"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (against the blueprint §Phase 2 + the task brief item A):**
+
+- Snapshot widening migration (lossy `_snapshot_initial_version`): Tasks 1 (unify + widen both builders) + 2 (0026 backfill + head-pin bump). Covers `role`, `description`, `validation_schema`, `unit`, `allowed_units`, `allow_other`/`other_label`/`other_placeholder`, `llm_description` — verified against the actual ORM columns. Live-read fallback for narrow legacy snapshots: Task 3 (`_snapshot_is_narrow` + `_entity_types_for_run`). ✓
+- `build_run_view` composes (not duplicates) `get_run_with_workflow_history` + entity_types (snapshot/live) + current_values: Task 5. (Instances deferred to Task 12 — see scope note.) ✓
+- Read-only `GET /runs/{id}/view` + embed in `POST /hitl/sessions`: Tasks 6 + 7. ✓
+- Frontend: `useExtractionSession` consumes the embed (Task 10); `useRun` reads `/view` (Task 9); `useExtractedValues` reads current_values (Task 11). Removing the direct entity_types+instances Supabase reads from `useExtractionData` is **deferred to Task 12** (a documented sub-phase, not executed in Phase 2) — those reads are parallel/off the critical serial path and carry a read-after-write hazard. The structural slow-load collapse (the brief's intent) is fully delivered by Tasks 7/9/10/11. ⚠️ partial-by-design
+
+**Invariants preserved:**
+
+- Single mutating entry point — embed built between `open_or_resume` and `commit`; `/view` is read-only (no `commit`). No GET seeds. ✓ (Invariant 1)
+- Blind filter in lockstep — `build_run_view` composes `get_run_with_workflow_history`; `resolve_caller_current_values` uses `reviewer_id == caller` / `source_user_id == caller` (4th copy, predicate-identical to 0025). Test `test_build_run_view_blinds_peer_in_review` + `test_current_values_are_caller_scoped` pin it. ✓ (Invariant 2, 5)
+- current_values only for `{review, consensus, finalized}` — `_CURRENT_VALUE_STAGES` gate; proposal returns `[]` (test `test_build_run_view_current_values_empty_in_proposal`); the proposal-stage client path (`pickLatestProposalPerCoord`) is untouched. ✓ (Invariant 3)
+- `computeRowProgress` stays pure/client — no server progress field; it keeps receiving `instances`/`values`/`entityTypes` on the client (from `useExtractionData` in Phase 2, from the view after Task 12). ✓ (Invariant 4)
+- Behavior parity for current_values — Task 4 mirrors `loadValuesForUser` (human base layer + reviewer-decision override via the materialized pointer, `reject` preserved); the client applies the identical `unwrapValue` + `extractValueFromDb`. ✓ (Invariant 6)
+
+**Type consistency:** `RunViewResponse` (backend `extends RunDetailResponse` via subclass; frontend `extends RunDetailResponse` via interface) carries the same two Phase-2 fields `entity_types`/`current_values` (`instances` added in Task 12). `RunViewField`/`RunViewEntityType`/`RunViewCurrentValue` names match across `backend/app/schemas/extraction_run.py` and `frontend/hooks/runs/types.ts`. `RunViewCurrentValue` (the only view field consumed in Phase 2) flows server → `useRun` → `runDetail.current_values` → `useExtractedValues` prop with matching `instance_id`/`field_id`/`value`/`decision`. `build_run_view(db, run_id, *, caller_id, is_arbitrator)` signature is identical in the endpoint (Task 6) and the embed (Task 7). `runsKeys.detail(runId)` is the single cache key seeded (Task 10) and read (Task 9) — all five mutation hooks already invalidate it, so no invalidation change is needed.
+
+**Known reconciliation points flagged for the implementer (not placeholders — explicit verify-then-adjust):**
+
+- Integration-test fixture names (`client`, `seeded_extraction_run`, `seeded_project_article_template`) differ by repo convention — copy them from the existing `tests/integration/test_extraction_runs*.py` / `test_hitl_session*.py` modules (Tasks 6, 7).
+- `resolve_caller_current_values` `accept_proposal` value sourcing — match current production `loadValuesForUser` behavior exactly; do not "fix" (Task 4 automated parity test).
+- Frontend type reconciliation for the view's `entity_types`/`instances` (`template_id` non-null; `ExtractionInstance` missing 5 required fields) — owned by the deferred Task 12, which proposes widening `RunViewInstance` rather than casting past missing fields.

--- a/frontend/hooks/extraction/useExtractedValues.ts
+++ b/frontend/hooks/extraction/useExtractedValues.ts
@@ -39,8 +39,8 @@ import { extractValueFromDb } from '@/lib/validations/selectOther';
 import { dispatchValueUpdates } from '@/lib/extraction/valueUpdates';
 import { pickLatestProposalPerCoord } from '@/lib/extraction/proposalValues';
 import { t } from '@/lib/copy';
-import { ExtractionValueService } from '@/services/extractionValueService';
-import type { ProposalRecordResponse } from '@/hooks/runs/types';
+import { unwrapValue } from '@/services/extractionValueService';
+import type { ProposalRecordResponse, RunViewCurrentValue } from '@/hooks/runs/types';
 
 export interface ExtractedValueData {
   id?: string;
@@ -55,6 +55,13 @@ interface UseExtractedValuesProps {
   runId: string | null | undefined;
   stage: string | null | undefined;
   proposals?: ProposalRecordResponse[];
+  /**
+   * Pre-computed reviewer values embedded in the run view (review /
+   * consensus / finalized stages) — the current decision per coord,
+   * resolved and reviewer-scoped server-side. The review branch hydrates
+   * directly from this array, with no separate client-side query.
+   */
+  currentValues?: RunViewCurrentValue[];
   /**
    * Current reviewer id, supplied by the caller (from AuthContext via
    * ``useCurrentUser``) so this hook never fires its own ``auth.getUser``
@@ -86,14 +93,6 @@ function resetValuesIfNeeded(
   setValues: Dispatch<SetStateAction<Record<string, any>>>,
 ) {
   setValues((prev) => (Object.keys(prev).length > 0 ? {} : prev));
-}
-
-function unwrapProposalValue(raw: unknown): unknown {
-  if (raw === null || raw === undefined) return null;
-  if (typeof raw === 'object' && raw !== null && 'value' in raw) {
-    return (raw as { value: unknown }).value ?? null;
-  }
-  return raw;
 }
 
 function mergeValuesById(
@@ -128,7 +127,7 @@ function mergeValuesById(
 export function useExtractedValues(
   props: UseExtractedValuesProps,
 ): UseExtractedValuesReturn {
-  const { runId, stage, proposals, currentUserId, enabled = true } = props;
+  const { runId, stage, proposals, currentValues, currentUserId, enabled = true } = props;
 
   const [values, setValues] = useState<Record<string, any>>({});
   // Raw server map the hook hydrated from — the autosave baseline.
@@ -204,7 +203,7 @@ export function useExtractedValues(
             currentUserId,
           });
           for (const [key, p] of latestByCoord) {
-            const unwrapped = unwrapProposalValue(p.proposed_value);
+            const unwrapped = unwrapValue(p.proposed_value);
             const unit =
               typeof p.proposed_value === 'object' &&
               p.proposed_value !== null &&
@@ -228,21 +227,18 @@ export function useExtractedValues(
             return;
           }
 
-          const rows = await ExtractionValueService.loadValuesForUser(
-            runId,
-            currentUserId,
-          );
           const valuesMap: Record<string, any> = {};
-          for (const row of rows) {
-            if (row.decision === 'reject') continue;
-            const key = `${row.instanceId}_${row.fieldId}`;
+          for (const cv of currentValues ?? []) {
+            if (cv.decision === 'reject') continue;
+            const key = `${cv.instance_id}_${cv.field_id}`;
+            const unwrapped = unwrapValue(cv.value);
             const unit =
-              typeof row.value === 'object' &&
-              row.value !== null &&
-              'unit' in (row.value as Record<string, unknown>)
-                ? ((row.value as { unit: string | null }).unit ?? null)
+              typeof unwrapped === 'object' &&
+              unwrapped !== null &&
+              'unit' in (unwrapped as Record<string, unknown>)
+                ? ((unwrapped as { unit: string | null }).unit ?? null)
                 : null;
-            valuesMap[key] = extractValueFromDb({ value: row.value, unit });
+            valuesMap[key] = extractValueFromDb({ value: unwrapped, unit });
           }
           applyLoadedValues(valuesMap);
           setInitialized(true);
@@ -261,7 +257,7 @@ export function useExtractedValues(
         if (!silent) setLoading(false);
       }
     },
-    [runId, stage, proposals, currentUserId, applyLoadedValues],
+    [runId, stage, proposals, currentValues, currentUserId, applyLoadedValues],
   );
 
   useEffect(() => {

--- a/frontend/hooks/extraction/useExtractionSession.ts
+++ b/frontend/hooks/extraction/useExtractionSession.ts
@@ -14,7 +14,10 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+
 import { apiClient } from "@/integrations/api";
+import { runsKeys, type RunViewResponse } from "@/hooks/runs/types";
 
 // Monotonically-increasing generation token. Each effect-driven call to
 // `open()` reads the next value and only commits state when it still
@@ -48,6 +51,7 @@ interface OpenResponse {
   kind: "extraction" | "quality_assessment";
   project_template_id: string;
   instances_by_entity_type: Record<string, string>;
+  run_view: RunViewResponse | null;
 }
 
 export function useExtractionSession({
@@ -60,6 +64,7 @@ export function useExtractionSession({
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const generationRef = useRef(0);
+  const queryClient = useQueryClient();
 
   const open = useCallback(async () => {
     if (!enabled || !projectId || !articleId || !projectTemplateId) return;
@@ -82,6 +87,13 @@ export function useExtractionSession({
       // article — discarding it prevents autosave from routing
       // proposals to the wrong run (#23).
       if (myGeneration !== generationRef.current) return;
+      // Pre-seed the run-detail cache from the embedded view so useRun reads
+      // from cache on first paint — collapsing the session -> GET /runs/{id} ->
+      // values serial waterfall. Inside the generation guard so a stale
+      // article's view can never poison the new article's run cache.
+      if (data.run_view) {
+        queryClient.setQueryData(runsKeys.detail(data.run_id), data.run_view);
+      }
       setSession({
         runId: data.run_id,
         projectTemplateId: data.project_template_id,
@@ -103,7 +115,7 @@ export function useExtractionSession({
     } finally {
       if (myGeneration === generationRef.current) setLoading(false);
     }
-  }, [enabled, projectId, articleId, projectTemplateId]);
+  }, [enabled, projectId, articleId, projectTemplateId, queryClient]);
 
   useEffect(() => {
     void open();

--- a/frontend/hooks/qa/useQAAssessmentSession.ts
+++ b/frontend/hooks/qa/useQAAssessmentSession.ts
@@ -18,6 +18,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { apiClient } from "@/integrations/api";
+import { type RunViewResponse } from "@/hooks/runs/types";
 
 export interface QAAssessmentSession {
   runId: string;
@@ -44,6 +45,7 @@ interface OpenResponse {
   run_id: string;
   project_template_id: string;
   instances_by_entity_type: Record<string, string>;
+  run_view: RunViewResponse | null;
 }
 
 export function useQAAssessmentSession({

--- a/frontend/hooks/runs/index.ts
+++ b/frontend/hooks/runs/index.ts
@@ -39,4 +39,8 @@ export {
   type ReviewerDecisionResponse,
   type RunDetailResponse,
   type RunSummaryResponse,
+  type RunViewCurrentValue,
+  type RunViewEntityType,
+  type RunViewFieldResponse,
+  type RunViewResponse,
 } from "./types";

--- a/frontend/hooks/runs/types.ts
+++ b/frontend/hooks/runs/types.ts
@@ -128,6 +128,51 @@ export interface RunDetailResponse {
   published_states: PublishedStateResponse[];
 }
 
+export interface RunViewFieldResponse {
+  id: string;
+  name: string;
+  label: string;
+  description: string | null;
+  field_type: string;
+  is_required: boolean;
+  validation_schema: unknown | null;
+  allowed_values: unknown | null;
+  unit: string | null;
+  allowed_units: unknown | null;
+  sort_order: number;
+  llm_description: string | null;
+  allow_other: boolean;
+  other_label: string | null;
+  other_placeholder: string | null;
+}
+
+export interface RunViewEntityType {
+  id: string;
+  name: string;
+  label: string;
+  description: string | null;
+  parent_entity_type_id: string | null;
+  cardinality: string;
+  role: string;
+  sort_order: number;
+  is_required: boolean;
+  fields: RunViewFieldResponse[];
+}
+
+export interface RunViewCurrentValue {
+  instance_id: string;
+  field_id: string;
+  value: Record<string, unknown> | null;
+  decision: string;
+}
+
+// `instances` is added here in Task 12 (deferred), alongside its backend field
+// and the frontend adapter that consumes it.
+export interface RunViewResponse extends RunDetailResponse {
+  entity_types: RunViewEntityType[];
+  current_values: RunViewCurrentValue[];
+}
+
 /**
  * TanStack Query key factory for run-scoped data.
  */

--- a/frontend/hooks/runs/useAutoSaveProposals.ts
+++ b/frontend/hooks/runs/useAutoSaveProposals.ts
@@ -59,8 +59,8 @@ export interface UseAutoSaveProposalsProps {
    * Active run stage. Drives the write target:
    *   - ``'review'`` → POST ``/decisions`` with decision='edit' so each
    *     reviewer's typing lands as a per-user ReviewerDecision (the
-   *     blind-review contract). The read path (``loadValuesForUser``)
-   *     reads these back, scoped to the active reviewer.
+   *     blind-review contract). The run view reads these back resolved
+   *     and scoped to the active reviewer (``currentValues``).
    *   - any other value (``'proposal'``, ``undefined``, …) → POST
    *     ``/proposals`` with source='human'. Preserves the existing QA
    *     single-user publish flow and the extraction PROPOSAL stage
@@ -206,8 +206,8 @@ export function useAutoSaveProposals(
           // Stage-aware write target (Layer 2 of the multi-reviewer
           // blind fix). ``stage='review'`` means every reviewer is
           // making per-user decisions on top of the same Run — the
-          // write must be a ReviewerDecision so the read path's
-          // ``loadValuesForUser`` filter holds. Any other stage
+          // write must be a ReviewerDecision so the run view's
+          // reviewer-scoped read (``currentValues``) holds. Any other stage
           // (proposal, undefined) keeps writing ``human`` proposals,
           // preserving the QA publish flow and the extraction
           // PROPOSAL stage where one user (or AI) builds the initial

--- a/frontend/hooks/runs/useRun.ts
+++ b/frontend/hooks/runs/useRun.ts
@@ -1,15 +1,15 @@
 /**
- * Hook to fetch the aggregate detail for an extraction run from `/api/v1/runs/{runId}`.
+ * Hook to fetch the aggregate detail for an extraction run from `/api/v1/runs/{runId}/view`.
  *
  * Returns the run summary alongside its proposals, reviewer decisions,
- * consensus decisions and published states.
+ * consensus decisions, published states, entity types, and current values.
  */
 
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "@/integrations/api";
 
-import { runsKeys, type RunDetailResponse } from "./types";
+import { runsKeys, type RunViewResponse } from "./types";
 
 export interface UseRunOptions {
   enabled?: boolean;
@@ -18,13 +18,13 @@ export interface UseRunOptions {
 export function useRun(runId: string | null | undefined, options: UseRunOptions = {}) {
   const { enabled = true } = options;
 
-  return useQuery<RunDetailResponse>({
+  return useQuery<RunViewResponse>({
     queryKey: runId ? runsKeys.detail(runId) : ["runs", "disabled"],
     queryFn: async () => {
       if (!runId) {
         throw new Error("Missing run ID");
       }
-      return apiClient<RunDetailResponse>(`/api/v1/runs/${runId}`);
+      return apiClient<RunViewResponse>(`/api/v1/runs/${runId}/view`);
     },
     enabled: enabled && Boolean(runId),
     staleTime: 30_000,

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -168,6 +168,7 @@ export default function ExtractionFullScreen() {
     runId: activeRunId,
     stage,
     proposals,
+    currentValues: runDetail?.current_values,
     currentUserId,
     enabled: !!activeRunId,
   });
@@ -319,8 +320,8 @@ export default function ExtractionFullScreen() {
     // and per-user ``ReviewerDecision`` rows (decision='edit') during
     // REVIEW stage. The stage-aware target preserves the blind-review
     // contract for multi-reviewer runs: each reviewer's typing during
-    // REVIEW lands in their own decision stream and the read path
-    // (``loadValuesForUser``) filters by reviewer_id (Layer 2 of the
+    // REVIEW lands in their own decision stream and the run view's
+    // ``currentValues`` are resolved per reviewer_id (Layer 2 of the
     // multi-reviewer blind fix).
     //
     // No-op until the session is open and the run is in a writable

--- a/frontend/services/extractionValueService.ts
+++ b/frontend/services/extractionValueService.ts
@@ -32,15 +32,6 @@ export interface RunRef {
   template_id: string;
 }
 
-export interface DecisionValueRow {
-  instanceId: string;
-  fieldId: string;
-  value: unknown;
-  decision: string;
-  reviewerId: string;
-  decidedAt: string;
-}
-
 export interface OtherUserDecisions {
   reviewerId: string;
   reviewerName: string;
@@ -62,7 +53,7 @@ interface ReviewerStateRow {
   } | null;
 }
 
-function unwrapValue(raw: unknown): unknown {
+export function unwrapValue(raw: unknown): unknown {
   if (raw === null || raw === undefined) return null;
   if (typeof raw === 'object' && raw !== null && 'value' in raw) {
     return (raw as { value: unknown }).value ?? null;
@@ -212,111 +203,6 @@ export const ExtractionValueService = {
       if (!result.has(articleId)) result.set(articleId, runId);
     }
     return result;
-  },
-
-  /**
-   * Load the current value per (instance, field) for the given user
-   * within a run.
-   *
-   * Two layers are read in parallel and merged by precedence:
-   * 1. ``extraction_reviewer_states`` (joined to
-   *    ``extraction_reviewer_decisions``) — the user's formal review
-   *    decisions (latest per coord via the materialized pointer).
-   * 2. ``extraction_proposal_records`` (source=human, source_user_id=user)
-   *    — the user's autosaved input, the raw layer that always reflects
-   *    what they typed.
-   *
-   * Precedence: reviewer_decision wins where it exists; otherwise the
-   * latest human proposal_record fills in. Reject decisions clear the
-   * coord (the row stays in the output with ``decision='reject'`` so
-   * the consumer can distinguish "explicitly rejected" from "never set").
-   *
-   * Why fallback matters: ``useAutoSaveProposals`` writes proposals
-   * regardless of run stage. When a run advances PROPOSAL→REVIEW (via
-   * AI extraction or explicit "Submit for review") before any
-   * ``reviewer_decision`` exists for the user's typed values, the form
-   * would otherwise render blank — even though the proposal is alive.
-   */
-  async loadValuesForUser(
-    runId: string,
-    reviewerId: string,
-  ): Promise<DecisionValueRow[]> {
-    const [decisionsResult, proposalsResult] = await Promise.all([
-      supabase
-        .from('extraction_reviewer_states')
-        .select(
-          `run_id, reviewer_id, instance_id, field_id, current_decision_id,
-           reviewer_decision:extraction_reviewer_decisions!fk_extraction_reviewer_states_decision_run_match (
-             decision, value, created_at
-           )`,
-        )
-        .eq('run_id', runId)
-        .eq('reviewer_id', reviewerId),
-      supabase
-        .from('extraction_proposal_records')
-        .select('instance_id, field_id, proposed_value, created_at')
-        .eq('run_id', runId)
-        .eq('source', 'human')
-        .eq('source_user_id', reviewerId)
-        .order('created_at', { ascending: false }),
-    ]);
-
-    if (decisionsResult.error) {
-      throw new APIError(
-        `Failed to load reviewer values: ${decisionsResult.error.message}`,
-        undefined,
-        { error: decisionsResult.error },
-      );
-    }
-    if (proposalsResult.error) {
-      throw new APIError(
-        `Failed to load reviewer values: ${proposalsResult.error.message}`,
-        undefined,
-        { error: proposalsResult.error },
-      );
-    }
-
-    const merged = new Map<string, DecisionValueRow>();
-    const key = (instanceId: string, fieldId: string) => `${instanceId}_${fieldId}`;
-
-    // Layer 1 — human proposals (lowest precedence). Latest-first sort
-    // means the first occurrence per (instance, field) is the latest.
-    const proposalRows = (proposalsResult.data ?? []) as Array<{
-      instance_id: string;
-      field_id: string;
-      proposed_value: unknown;
-      created_at: string | null;
-    }>;
-    for (const p of proposalRows) {
-      const k = key(p.instance_id, p.field_id);
-      if (merged.has(k)) continue;
-      merged.set(k, {
-        instanceId: p.instance_id,
-        fieldId: p.field_id,
-        value: unwrapValue(p.proposed_value),
-        decision: 'human_proposal',
-        reviewerId,
-        decidedAt: p.created_at ?? '',
-      });
-    }
-
-    // Layer 2 — reviewer decisions (overrides proposals). Non-null
-    // decisions only — null reviewer_decision means the state row exists
-    // but no decision is current (cleared / never set).
-    const decisionRows = (decisionsResult.data ?? []) as unknown as ReviewerStateRow[];
-    for (const r of decisionRows) {
-      if (r.reviewer_decision === null) continue;
-      merged.set(key(r.instance_id, r.field_id), {
-        instanceId: r.instance_id,
-        fieldId: r.field_id,
-        value: unwrapValue(r.reviewer_decision.value),
-        decision: r.reviewer_decision.decision ?? 'edit',
-        reviewerId: r.reviewer_id,
-        decidedAt: r.reviewer_decision.created_at ?? '',
-      });
-    }
-
-    return [...merged.values()];
   },
 
   /**

--- a/frontend/test/hooks-runs.test.tsx
+++ b/frontend/test/hooks-runs.test.tsx
@@ -54,7 +54,7 @@ afterEach(() => {
 });
 
 describe("useRun", () => {
-  it("issues GET /api/v1/runs/{runId} and exposes the detail payload", async () => {
+  it("issues GET /api/v1/runs/{runId}/view and exposes the detail payload", async () => {
     const detail: Pick<RunDetailResponse, "run"> = {
       run: {
         id: "run-1",
@@ -86,7 +86,7 @@ describe("useRun", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(apiClientMock).toHaveBeenCalledTimes(1);
-    expect(apiClientMock).toHaveBeenCalledWith("/api/v1/runs/run-1");
+    expect(apiClientMock).toHaveBeenCalledWith("/api/v1/runs/run-1/view");
     expect(result.current.data?.run.id).toBe("run-1");
   });
 

--- a/frontend/test/hooks/useAutoSaveProposals.test.tsx
+++ b/frontend/test/hooks/useAutoSaveProposals.test.tsx
@@ -187,11 +187,11 @@ describe('useAutoSaveProposals — basic write semantics', () => {
 describe('useAutoSaveProposals — stage-aware write target (Layer 2 fix)', () => {
   // Bug B (multi-reviewer blind review): during stage='review' every
   // reviewer's edit must land as a per-user ``ReviewerDecision`` so the
-  // load path (``loadValuesForUser``) keeps them blinded from each
-  // other. The previous unified write to /proposals appended the value
-  // as a shared ProposalRecord, which broke the per-user contract and
-  // also wasted writes that ``useExtractedValues``' review branch would
-  // never read back. Fix: when the caller passes ``stage='review'``,
+  // run view's reviewer-scoped read (``currentValues``) keeps them
+  // blinded from each other. The previous unified write to /proposals
+  // appended the value as a shared ProposalRecord, which broke the
+  // per-user contract and also wasted writes that ``useExtractedValues``'
+  // review branch would never read back. Fix: when the caller passes ``stage='review'``,
   // POST to /decisions with decision='edit'.
 
   it("writes an 'edit' ReviewerDecision per dirty coord when stage='review'", async () => {

--- a/frontend/test/hooks/useExtractedValues.test.tsx
+++ b/frontend/test/hooks/useExtractedValues.test.tsx
@@ -4,9 +4,9 @@
  * The hook now branches by ``run.stage``:
  *  - ``proposal``: hydrate from ``runDetail.proposals`` (newest-per-coord,
  *    any source). No DB call. Mirrors QA.
- *  - ``review`` / ``consensus`` / ``finalized``: hydrate from
- *    ``ExtractionValueService.loadValuesForUser`` (current decision per
- *    coord, scoped to the active reviewer).
+ *  - ``review`` / ``consensus`` / ``finalized``: hydrate from the
+ *    ``currentValues`` embedded in the run view (current decision per
+ *    coord, resolved + reviewer-scoped server-side). No DB call.
  *  - missing run / pending / unknown: empty.
  *
  * The legacy ``save()`` method is gone — the autosave is the sole
@@ -25,8 +25,12 @@ vi.mock('@/integrations/supabase/client', () => ({
 }));
 
 vi.mock('@/services/extractionValueService', () => ({
-  ExtractionValueService: {
-    loadValuesForUser: vi.fn(async () => []),
+  unwrapValue: (raw: unknown) => {
+    if (raw === null || raw === undefined) return null;
+    if (typeof raw === 'object' && raw !== null && 'value' in raw) {
+      return (raw as { value: unknown }).value ?? null;
+    }
+    return raw;
   },
 }));
 
@@ -38,7 +42,6 @@ vi.mock('@/lib/copy', () => ({
   t: (_ns: string, key: string) => key,
 }));
 
-import { ExtractionValueService } from '@/services/extractionValueService';
 import { useExtractedValues } from '@/hooks/extraction/useExtractedValues';
 import type { ProposalRecordResponse } from '@/hooks/runs/types';
 
@@ -103,9 +106,7 @@ describe('useExtractedValues — stage=proposal', () => {
     expect(result.current.values['inst-2_field-2']).toEqual({
       value: 'A',
       unit: 'mg',
-    });
-    expect(ExtractionValueService.loadValuesForUser).not.toHaveBeenCalled();
-  });
+    });  });
 
   it('returns empty when no proposals are provided', async () => {
     const { result } = renderHook(() =>
@@ -281,49 +282,82 @@ describe('useExtractedValues — stage=proposal blinding (multi-reviewer)', () =
   });
 });
 
-describe('useExtractedValues — stage=review and beyond', () => {
-  it('routes through loadValuesForUser and skips reject decisions', async () => {
-    (ExtractionValueService.loadValuesForUser as any).mockResolvedValueOnce([
-      {
-        instanceId: 'inst-1',
-        fieldId: 'field-1',
-        value: 42,
-        decision: 'edit',
-        reviewerId: 'user-1',
-        decidedAt: '2026-04-28T10:00:00Z',
-      },
-      {
-        instanceId: 'inst-2',
-        fieldId: 'field-2',
-        value: 'should-not-show',
-        decision: 'reject',
-        reviewerId: 'user-1',
-        decidedAt: '2026-04-28T10:00:00Z',
-      },
-      {
-        instanceId: 'inst-3',
-        fieldId: 'field-3',
-        value: { value: 'A', unit: 'mg' },
-        decision: 'edit',
-        reviewerId: 'user-1',
-        decidedAt: '2026-04-28T10:00:00Z',
-      },
-    ]);
+describe('useExtractedValues — stage=review via currentValues', () => {
+  it('hydrates from currentValues and skips reject decisions', async () => {
+    const i1 = 'inst-1';
+    const f1 = 'field-1';
+    const f2 = 'field-2';
 
     const { result } = renderHook(() =>
       useExtractedValues({
         currentUserId: 'user-1',
         runId: 'run-1',
         stage: 'review',
+        currentValues: [
+          {
+            instance_id: i1,
+            field_id: f1,
+            value: { value: 'X', unit: null },
+            decision: 'edit',
+          },
+          {
+            instance_id: i1,
+            field_id: f2,
+            value: { value: 'Y' },
+            decision: 'reject',
+          },
+        ],
       }),
     );
 
     await waitFor(() => expect(result.current.initialized).toBe(true));
-    expect(ExtractionValueService.loadValuesForUser).toHaveBeenCalledWith(
-      'run-1',
-      'user-1',
+    // (a) edit decision is included with correct value
+    expect(result.current.values[`${i1}_${f1}`]).toBe('X');
+    // (b) reject decision is excluded
+    expect(result.current.values[`${i1}_${f2}`]).toBeUndefined();
+  });
+});
+
+describe('useExtractedValues — stage=review and beyond', () => {
+  it('hydrates scalar and unit-bearing currentValues, skipping rejects', async () => {
+    // The review branch now reads from the pre-computed currentValues
+    // embedded in the run view rather than issuing its own PostgREST query.
+    // cv.value is the RAW server envelope: { value: <inner> }.
+    // For a plain scalar: cv.value = { value: 42 } → unwrapped = 42
+    // For a unit-bearing value: cv.value = { value: { value: 'A', unit: 'mg' } }
+    //   → unwrapped = { value: 'A', unit: 'mg' }, unit = 'mg'
+    //   → extractValueFromDb returns { value: 'A', unit: 'mg' }
+    const { result } = renderHook(() =>
+      useExtractedValues({
+        currentUserId: 'user-1',
+        runId: 'run-1',
+        stage: 'review',
+        currentValues: [
+          {
+            instance_id: 'inst-1',
+            field_id: 'field-1',
+            value: { value: 42 },
+            decision: 'edit',
+          },
+          {
+            instance_id: 'inst-2',
+            field_id: 'field-2',
+            value: { value: 'should-not-show' },
+            decision: 'reject',
+          },
+          {
+            instance_id: 'inst-3',
+            field_id: 'field-3',
+            // double-envelope: outer { value: ... } stripped by unwrapValue,
+            // inner { value: 'A', unit: 'mg' } is the unwrapped form
+            value: { value: { value: 'A', unit: 'mg' } },
+            decision: 'edit',
+          },
+        ],
+      }),
     );
-    expect(result.current.values['inst-1_field-1']).toBe(42);
+
+    await waitFor(() => expect(result.current.initialized).toBe(true));    expect(result.current.values['inst-1_field-1']).toBe(42);
     expect(result.current.values['inst-2_field-2']).toBeUndefined();
     expect(result.current.values['inst-3_field-3']).toEqual({
       value: 'A',
@@ -342,9 +376,7 @@ describe('useExtractedValues — missing run / no auth', () => {
       }),
     );
     await waitFor(() => expect(result.current.initialized).toBe(true));
-    expect(result.current.values).toEqual({});
-    expect(ExtractionValueService.loadValuesForUser).not.toHaveBeenCalled();
-  });
+    expect(result.current.values).toEqual({});  });
 
   it('returns empty when there is no authenticated user (review path)', async () => {
     const { result } = renderHook(() =>
@@ -355,9 +387,7 @@ describe('useExtractedValues — missing run / no auth', () => {
       }),
     );
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(ExtractionValueService.loadValuesForUser).not.toHaveBeenCalled();
-    expect(result.current.values).toEqual({});
+    await waitFor(() => expect(result.current.loading).toBe(false));    expect(result.current.values).toEqual({});
   });
 });
 
@@ -383,9 +413,7 @@ describe('useExtractedValues — disabled state (no run yet)', () => {
     );
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.initialized).toBe(true);
-    expect(result.current.values).toEqual({});
-    expect(ExtractionValueService.loadValuesForUser).not.toHaveBeenCalled();
-  });
+    expect(result.current.values).toEqual({});  });
 
   it('does not get stuck even when runId is set but enabled is explicitly false', async () => {
     const { result } = renderHook(() =>
@@ -397,11 +425,17 @@ describe('useExtractedValues — disabled state (no run yet)', () => {
         enabled: false,
       }),
     );
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(ExtractionValueService.loadValuesForUser).not.toHaveBeenCalled();
-  });
+    await waitFor(() => expect(result.current.loading).toBe(false));  });
 
-  it('starts fetching once enabled flips from false to true', async () => {
+  it('becomes initialized once enabled flips from false to true', async () => {
+    const currentValues = [
+      {
+        instance_id: 'inst-1',
+        field_id: 'field-1',
+        value: { value: 'hydrated' },
+        decision: 'edit',
+      },
+    ];
     const { result, rerender } = renderHook(
       ({ enabled }: { enabled: boolean }) =>
         useExtractedValues({
@@ -409,24 +443,17 @@ describe('useExtractedValues — disabled state (no run yet)', () => {
           runId: 'run-1',
           stage: 'review',
           proposals: [],
+          currentValues,
           enabled,
         }),
       { initialProps: { enabled: false } },
     );
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(ExtractionValueService.loadValuesForUser).not.toHaveBeenCalled();
-
     rerender({ enabled: true });
-    // After re-enabling the hook must trigger the reviewer-state load
-    // (the page wouldn't otherwise hydrate the form once the session
-    // resolves).
-    await waitFor(() =>
-      expect(ExtractionValueService.loadValuesForUser).toHaveBeenCalledWith(
-        'run-1',
-        'user-1',
-      ),
-    );
-  });
+    // After re-enabling the hook must hydrate the form from currentValues
+    // (the page wouldn't otherwise show values once the session resolves).
+    await waitFor(() => expect(result.current.initialized).toBe(true));
+    expect(result.current.values['inst-1_field-1']).toBe('hydrated');  });
 });
 
 describe('useExtractedValues — local update', () => {

--- a/frontend/test/hooks/useExtractionSession.test.tsx
+++ b/frontend/test/hooks/useExtractionSession.test.tsx
@@ -5,7 +5,9 @@
  * surfaces the run / template / instance map the form needs.
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/integrations/api', () => ({
@@ -14,8 +16,25 @@ vi.mock('@/integrations/api', () => ({
 
 import { apiClient } from '@/integrations/api';
 import { useExtractionSession } from '@/hooks/extraction/useExtractionSession';
+import { runsKeys, type RunViewResponse } from '@/hooks/runs/types';
 
 const apiClientMock = apiClient as unknown as ReturnType<typeof vi.fn>;
+
+function createWrapper(): {
+  wrapper: (props: { children: ReactNode }) => JSX.Element;
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
 
 const OPEN_RESPONSE = {
   run_id: 'run-1',
@@ -25,6 +44,32 @@ const OPEN_RESPONSE = {
     'et-aaa': 'inst-aaa',
     'et-bbb': 'inst-bbb',
   },
+  run_view: null,
+};
+
+/** Minimal RunViewResponse fixture that satisfies the TS type. */
+const RUN_VIEW_FIXTURE: RunViewResponse = {
+  run: {
+    id: 'run-1',
+    project_id: 'proj-1',
+    article_id: 'art-1',
+    template_id: 'tpl-1',
+    kind: 'extraction',
+    version_id: 'ver-1',
+    stage: 'proposal',
+    status: 'active',
+    hitl_config_snapshot: {},
+    parameters: {},
+    results: {},
+    created_at: '2026-01-01T00:00:00Z',
+    created_by: 'user-1',
+  },
+  proposals: [],
+  decisions: [],
+  consensus_decisions: [],
+  published_states: [],
+  entity_types: [],
+  current_values: [],
 };
 
 beforeEach(() => {
@@ -37,14 +82,17 @@ afterEach(() => {
 
 describe('useExtractionSession', () => {
   it('POSTs to /api/v1/hitl/sessions with kind=extraction and project_template_id', async () => {
+    const { wrapper } = createWrapper();
     apiClientMock.mockResolvedValueOnce(OPEN_RESPONSE);
 
-    const { result } = renderHook(() =>
-      useExtractionSession({
-        projectId: 'proj-1',
-        articleId: 'art-1',
-        projectTemplateId: 'tpl-1',
-      }),
+    const { result } = renderHook(
+      () =>
+        useExtractionSession({
+          projectId: 'proj-1',
+          articleId: 'art-1',
+          projectTemplateId: 'tpl-1',
+        }),
+      { wrapper },
     );
 
     await waitFor(() => expect(result.current.session).not.toBeNull());
@@ -68,12 +116,16 @@ describe('useExtractionSession', () => {
   });
 
   it('does not call the API while inputs are missing', async () => {
-    const { result } = renderHook(() =>
-      useExtractionSession({
-        projectId: 'proj-1',
-        articleId: undefined,
-        projectTemplateId: 'tpl-1',
-      }),
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useExtractionSession({
+          projectId: 'proj-1',
+          articleId: undefined,
+          projectTemplateId: 'tpl-1',
+        }),
+      { wrapper },
     );
 
     // Give the effect a tick to run
@@ -83,27 +135,34 @@ describe('useExtractionSession', () => {
   });
 
   it('respects enabled=false', async () => {
-    renderHook(() =>
-      useExtractionSession({
-        projectId: 'proj-1',
-        articleId: 'art-1',
-        projectTemplateId: 'tpl-1',
-        enabled: false,
-      }),
+    const { wrapper } = createWrapper();
+
+    renderHook(
+      () =>
+        useExtractionSession({
+          projectId: 'proj-1',
+          articleId: 'art-1',
+          projectTemplateId: 'tpl-1',
+          enabled: false,
+        }),
+      { wrapper },
     );
     await new Promise((r) => setTimeout(r, 0));
     expect(apiClientMock).not.toHaveBeenCalled();
   });
 
   it('surfaces error message when the open call fails', async () => {
+    const { wrapper } = createWrapper();
     apiClientMock.mockRejectedValueOnce(new Error('boom'));
 
-    const { result } = renderHook(() =>
-      useExtractionSession({
-        projectId: 'proj-1',
-        articleId: 'art-1',
-        projectTemplateId: 'tpl-1',
-      }),
+    const { result } = renderHook(
+      () =>
+        useExtractionSession({
+          projectId: 'proj-1',
+          articleId: 'art-1',
+          projectTemplateId: 'tpl-1',
+        }),
+      { wrapper },
     );
 
     await waitFor(() => expect(result.current.error).toBe('boom'));
@@ -111,14 +170,17 @@ describe('useExtractionSession', () => {
   });
 
   it('refetch re-opens the session on demand', async () => {
+    const { wrapper } = createWrapper();
     apiClientMock.mockResolvedValue(OPEN_RESPONSE);
 
-    const { result } = renderHook(() =>
-      useExtractionSession({
-        projectId: 'proj-1',
-        articleId: 'art-1',
-        projectTemplateId: 'tpl-1',
-      }),
+    const { result } = renderHook(
+      () =>
+        useExtractionSession({
+          projectId: 'proj-1',
+          articleId: 'art-1',
+          projectTemplateId: 'tpl-1',
+        }),
+      { wrapper },
     );
 
     await waitFor(() => expect(result.current.session).not.toBeNull());
@@ -127,6 +189,7 @@ describe('useExtractionSession', () => {
   });
 
   it('discards a stale in-flight response when the article changes mid-fetch (#23)', async () => {
+    const { wrapper } = createWrapper();
     // Article A's open() will hang until we release it. Article B fires
     // straight away and resolves with its own response. Without the
     // generation guard, A's later-resolving response would overwrite
@@ -153,6 +216,7 @@ describe('useExtractionSession', () => {
           projectTemplateId,
         }),
       {
+        wrapper,
         initialProps: { articleId: 'art-A', projectTemplateId: 'tpl-A' },
       },
     );
@@ -172,5 +236,56 @@ describe('useExtractionSession', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(result.current.session?.runId).toBe('run-B');
     expect(result.current.session?.projectTemplateId).toBe('tpl-B');
+  });
+
+  it('seeds the TanStack Query run-detail cache when run_view is present', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    apiClientMock.mockResolvedValueOnce({
+      ...OPEN_RESPONSE,
+      run_view: RUN_VIEW_FIXTURE,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useExtractionSession({
+          projectId: 'proj-1',
+          articleId: 'art-1',
+          projectTemplateId: 'tpl-1',
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+
+    // The hook should have pre-seeded the run-detail cache entry so that
+    // useRun can serve it without a network GET on first paint.
+    expect(queryClient.getQueryData(runsKeys.detail('run-1'))).toEqual(
+      RUN_VIEW_FIXTURE,
+    );
+  });
+
+  it('does NOT seed the cache when run_view is null (QA-style response)', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    apiClientMock.mockResolvedValueOnce({
+      ...OPEN_RESPONSE,
+      run_view: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useExtractionSession({
+          projectId: 'proj-1',
+          articleId: 'art-1',
+          projectTemplateId: 'tpl-1',
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+
+    // session should still be set (runId present)
+    expect(result.current.session?.runId).toBe('run-1');
+    // but no cache entry should have been written
+    expect(queryClient.getQueryData(runsKeys.detail('run-1'))).toBeUndefined();
   });
 });

--- a/frontend/test/services/extractionValueService.test.ts
+++ b/frontend/test/services/extractionValueService.test.ts
@@ -86,11 +86,9 @@ function chain(payload: { data: unknown; error?: { message: string } | null }): 
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // ``loadValuesForUser`` now reads two layers in parallel (reviewer_states
-  // + human proposal_records) and merges by precedence. Most tests only
-  // care about one layer, so anything not explicitly mocked falls through
-  // to an empty chain. ``mockReturnValueOnce`` overrides this for the
-  // first call as before.
+  // Default ``supabase.from`` to an empty chain so any query a test
+  // doesn't explicitly stub falls through harmlessly. Individual tests
+  // override the relevant call(s) with ``mockReturnValueOnce``.
   (supabase.from as any).mockReturnValue(chain({ data: [] }));
 });
 
@@ -302,154 +300,6 @@ describe('ExtractionValueService.findLatestFinalizedRun', () => {
     (supabase.from as any).mockReturnValueOnce(c);
     await ExtractionValueService.findLatestFinalizedRun('article-1', null);
     expect(c.__calls.eqs.find(([col]) => col === 'template_id')).toBeUndefined();
-  });
-});
-
-describe('ExtractionValueService.loadValuesForUser', () => {
-  it('maps reviewer_states + decisions into DecisionValueRow entries', async () => {
-    (supabase.from as any).mockReturnValueOnce(
-      chain({
-        data: [
-          {
-            run_id: 'run-1',
-            reviewer_id: 'user-1',
-            instance_id: 'inst-1',
-            field_id: 'field-1',
-            current_decision_id: 'dec-1',
-            reviewer_decision: {
-              decision: 'edit',
-              value: { value: 42 },
-              created_at: '2026-04-28T10:00:00Z',
-            },
-          },
-          {
-            run_id: 'run-1',
-            reviewer_id: 'user-1',
-            instance_id: 'inst-2',
-            field_id: 'field-2',
-            current_decision_id: null,
-            reviewer_decision: null,
-          },
-        ],
-      }),
-    );
-    const rows = await ExtractionValueService.loadValuesForUser('run-1', 'user-1');
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      instanceId: 'inst-1',
-      fieldId: 'field-1',
-      value: 42,
-      decision: 'edit',
-      reviewerId: 'user-1',
-    });
-  });
-
-  it('unwraps {value: X} JSONB on the way out', async () => {
-    (supabase.from as any).mockReturnValueOnce(
-      chain({
-        data: [
-          {
-            run_id: 'run-1',
-            reviewer_id: 'user-1',
-            instance_id: 'inst-1',
-            field_id: 'field-1',
-            current_decision_id: 'dec-1',
-            reviewer_decision: {
-              decision: 'edit',
-              value: { value: { value: 'nested', unit: 'mg' } },
-              created_at: '2026-04-28T10:00:00Z',
-            },
-          },
-        ],
-      }),
-    );
-    const rows = await ExtractionValueService.loadValuesForUser('run-1', 'user-1');
-    expect(rows[0].value).toEqual({ value: 'nested', unit: 'mg' });
-  });
-
-  it('keeps reject decisions in the returned rows (consumer filters them)', async () => {
-    // The service is the source of truth for decision history; the
-    // ``useExtractedValues`` consumer is responsible for skipping rejects
-    // when populating the form. Don't filter at the service layer.
-    (supabase.from as any).mockReturnValueOnce(
-      chain({
-        data: [
-          {
-            run_id: 'run-1',
-            reviewer_id: 'user-1',
-            instance_id: 'inst-1',
-            field_id: 'field-1',
-            current_decision_id: 'dec-1',
-            reviewer_decision: {
-              decision: 'reject',
-              value: null,
-              created_at: '2026-04-28T10:00:00Z',
-            },
-          },
-        ],
-      }),
-    );
-    const rows = await ExtractionValueService.loadValuesForUser('run-1', 'user-1');
-    expect(rows).toHaveLength(1);
-    expect(rows[0].decision).toBe('reject');
-  });
-
-  it("scopes the query to (run_id, reviewer_id)", async () => {
-    const c = chain({ data: [] });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await ExtractionValueService.loadValuesForUser('run-1', 'user-1');
-    expect(c.__calls.eqs).toContainEqual(['run_id', 'run-1']);
-    expect(c.__calls.eqs).toContainEqual(['reviewer_id', 'user-1']);
-  });
-
-  it('throws APIError when Supabase reports an error', async () => {
-    (supabase.from as any).mockReturnValueOnce(
-      chain({ data: null, error: { message: 'states down' } }),
-    );
-    await expect(
-      ExtractionValueService.loadValuesForUser('run-1', 'user-1'),
-    ).rejects.toThrow(/states down/);
-  });
-
-  it('falls back to the user’s latest human proposal_record when no reviewer_decision exists (H1)', async () => {
-    // Production scenario reproduced from article 5573e7f3 / run 154cd860:
-    // - run is in REVIEW stage (advanced after AI extraction)
-    // - 0 reviewer_decisions for the current user
-    // - 1 human proposal_record (source=human, source_user_id=current user)
-    //
-    // Pre-fix: hook reads ONLY extraction_reviewer_states → empty rows →
-    // form renders blank even though the user typed "Case series".
-    // Post-fix: precedence read falls back to the user's human proposal,
-    // so the form renders the typed value until an explicit decision is
-    // recorded (or auto-materialized on the next stage advance).
-    //
-    // Call order in the new impl: reviewer_states first (empty), then
-    // human proposals (returns 1 row).
-    (supabase.from as any)
-      .mockReturnValueOnce(chain({ data: [] }))
-      .mockReturnValueOnce(
-        chain({
-          data: [
-            {
-              instance_id: 'inst-source-of-data',
-              field_id: 'field-data-source',
-              proposed_value: { value: 'Case series' },
-              created_at: '2026-05-26T19:44:29Z',
-            },
-          ],
-        }),
-      );
-
-    const rows = await ExtractionValueService.loadValuesForUser(
-      'run-154cd860',
-      'user-352ec3f8',
-    );
-
-    expect(rows).toHaveLength(1);
-    expect(rows[0].instanceId).toBe('inst-source-of-data');
-    expect(rows[0].fieldId).toBe('field-data-source');
-    expect(rows[0].value).toBe('Case series');
-    expect(rows[0].reviewerId).toBe('user-352ec3f8');
   });
 });
 


### PR DESCRIPTION
Routine dev → main promotion.

Brings the single new commit on dev to main:
- **#228** feat(extraction): Phase 2 — RunView server-side collapse (RunView read path, embedded current_values, dead `loadValuesForUser` removal, + CI fixes: ruff SIM300/format, migration 0026 revision-id length).

All checks passed on #228 against dev before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)