### PR TITLE
test(qa): stub supabase.auth in fullscreen test, silence false error toast

### DIFF
--- a/frontend/test/QualityAssessmentFullScreen.test.tsx
+++ b/frontend/test/QualityAssessmentFullScreen.test.tsx
@@ -74,6 +74,16 @@ vi.mock("@/integrations/supabase/client", () => {
 
   return {
     supabase: {
+      // useAISuggestions → AISuggestionService.loadSuggestions resolves the
+      // current reviewer via supabase.auth.getUser(); without this stub every
+      // render surfaces an "Error loading suggestions" toast that drowns out
+      // the assertions below.
+      auth: {
+        getUser: async () => ({
+          data: { user: { id: "qa-test-reviewer-id" } },
+          error: null,
+        }),
+      },
       from: (table: string) => {
         if (table === "project_extraction_templates") {
           return makeQuery(PROBAST_TEMPLATE);
@@ -288,6 +298,12 @@ describe("QualityAssessmentFullScreen", () => {
         expect.stringMatching(/at least one signaling question/i),
       );
     });
+
+    // Regression (#252 follow-up): the background suggestions load must not
+    // surface its own error toast — only the publish preflight message.
+    expect(toast.error).not.toHaveBeenCalledWith(
+      expect.stringMatching(/error loading suggestions/i),
+    );
 
     // Crucially, no advance / consensus calls were made.
     const sideEffects = apiClient.mock.calls.filter(([url]) =>


### PR DESCRIPTION
## Why

The supabase client mock in `frontend/test/QualityAssessmentFullScreen.test.tsx` stubbed `.from()` but not `.auth`, so every render crashed the background AI-suggestions load (`supabase.auth.getUser()` of `undefined`) — producing a console.error and an "Error loading suggestions" toast in all 8 tests. The noise nearly masked the real publish-toast failure during the React 19 upgrade (#252).

## What changed

- Added an `auth.getUser` stub returning the `{ data: { user }, error: null }` shape `aiSuggestionService.loadSuggestions` expects (frontend/services/aiSuggestionService.ts:153); the downstream `extraction_reviewer_states` query is already covered by the mock's default-table branch.
- The publish preflight test now also asserts the suggestions error toast does NOT fire, pinning the regression.

## Risk

Test-only change; no production code touched.

## Test plan

- `npx vitest run frontend/test/QualityAssessmentFullScreen.test.tsx` — 8/8, zero getUser/suggestions noise in output
- `npm run test:run` — 451/451
- `npm run typecheck` clean; `npm run lint` — 0 errors, 94 warnings (baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)