### PR TITLE
refactor(frontend): fix react-hooks compiler warnings in ui + shared components

### DIFF
--- a/frontend/components/shared/comparison/ComparisonCell.tsx
+++ b/frontend/components/shared/comparison/ComparisonCell.tsx
@@ -70,6 +70,18 @@ export function ComparisonCell({
   // ✅ NOVO: Detectar se é campo numérico
   const isNumberField = field?.field_type === 'number';
 
+  const handleSave = () => {
+    if (editValue !== value && onValueChange) {
+      onValueChange(editValue);
+    }
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditValue(value);
+    setIsEditing(false);
+  };
+
   // ✅ NOVO: Detectar clique fora do editor
   useEffect(() => {
     if (!isEditing) return;
@@ -101,18 +113,6 @@ export function ComparisonCell({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isEditing, editValue, value, onValueChange, isSelectOpen]);
-
-  const handleSave = () => {
-    if (editValue !== value && onValueChange) {
-      onValueChange(editValue);
-    }
-    setIsEditing(false);
-  };
-
-  const handleCancel = () => {
-    setEditValue(value);
-    setIsEditing(false);
-  };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/frontend/components/shared/comparison/EntitySelectorComparison.tsx
+++ b/frontend/components/shared/comparison/EntitySelectorComparison.tsx
@@ -16,7 +16,7 @@
  * | Number of preds    | 5       | 3       | 5       |
  */
 
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {Label} from '@/components/ui/label';
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select';
 import {Card, CardContent} from '@/components/ui/card';
@@ -41,15 +41,10 @@ export function EntitySelectorComparison(props: ComparisonSectionViewProps) {
     [props.instances, props.currentUser.userId, props.allUserInstances, props.entityType.id]
   );
 
-    // State: selected entity
-  const [selectedEntityLabel, setSelectedEntityLabel] = useState<string | null>(null);
-
-    // Auto-select first entity
-  useEffect(() => {
-    if (groupedEntities.length > 0 && !selectedEntityLabel) {
-      setSelectedEntityLabel(groupedEntities[0].label);
-    }
-  }, [groupedEntities, selectedEntityLabel]);
+    // State: entity explicitly picked by the user; defaults to the first
+    // grouped entity (derived during render instead of set via effect).
+  const [pickedEntityLabel, setSelectedEntityLabel] = useState<string | null>(null);
+  const selectedEntityLabel = pickedEntityLabel ?? groupedEntities[0]?.label ?? null;
 
     // Active entity
   const activeEntity = useMemo(() => 

--- a/frontend/components/shared/list/useResizableTableColumns.ts
+++ b/frontend/components/shared/list/useResizableTableColumns.ts
@@ -27,8 +27,12 @@ export function useResizableTableColumns({
     const [resizeAdjacentColumn, setResizeAdjacentColumn] = useState<string | null>(null);
     const [resizeAdjacentStartWidth, setResizeAdjacentStartWidth] = useState(0);
     const headerRefs = useRef<Record<string, HTMLTableCellElement | null>>({});
+    // Latest-value mirror so the mouseup handler can persist without
+    // re-subscribing; written in an effect (refs must not be written in render).
     const columnWidthsRef = useRef(columnWidths);
-    columnWidthsRef.current = columnWidths;
+    useEffect(() => {
+        columnWidthsRef.current = columnWidths;
+    }, [columnWidths]);
 
     const registerHeaderRef = useCallback((columnId: string, el: HTMLTableCellElement | null) => {
         headerRefs.current[columnId] = el;

--- a/frontend/components/ui/MultiSelectWithOther.tsx
+++ b/frontend/components/ui/MultiSelectWithOther.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState } from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -34,6 +34,22 @@ function normalizeMultiOption(opt: MultiSelectOption): { value: string; label: s
   return { value, label };
 }
 
+function splitMultiValue(
+  value: MultiSelectWithOtherProps['value'],
+): { selected: string[]; others: string[] } {
+  if (!value) {
+    return { selected: [], others: [] };
+  }
+  if (Array.isArray(value)) {
+    return { selected: value, others: [] };
+  }
+  if (isMultiOtherValue(value)) {
+    return { selected: value.selected || [], others: value.other_texts || [] };
+  }
+  // Fallback for compatibility
+  return { selected: [], others: [] };
+}
+
 export function MultiSelectWithOther(props: MultiSelectWithOtherProps) {
     const {
         options,
@@ -50,27 +66,19 @@ export function MultiSelectWithOther(props: MultiSelectWithOtherProps) {
     const resolvedPlaceholder = placeholder ?? t('ui', 'multiSelectPlaceholder');
 
   const [open, setOpen] = useState(false);
-  const [internalSelected, setInternalSelected] = useState<string[]>([]);
-  const [internalOthers, setInternalOthers] = useState<string[]>([]);
+  const [internalSelected, setInternalSelected] = useState<string[]>(() => splitMultiValue(value).selected);
+  const [internalOthers, setInternalOthers] = useState<string[]>(() => splitMultiValue(value).others);
 
-  useEffect(() => {
-    if (!value) {
-      setInternalSelected([]);
-      setInternalOthers([]);
-      return;
-    }
-    if (Array.isArray(value)) {
-      setInternalSelected(value);
-      setInternalOthers([]);
-    } else if (isMultiOtherValue(value)) {
-      setInternalSelected(value.selected || []);
-      setInternalOthers(value.other_texts || []);
-    } else {
-        // Fallback for compatibility
-      setInternalSelected([]);
-      setInternalOthers([]);
-    }
-  }, [value]);
+  // Re-sync the internal mirror when the controlled value changes
+  // (adjust-during-render instead of an effect, so "Add other" drafts
+  // survive renders that don't touch `value`).
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    const { selected, others } = splitMultiValue(value);
+    setInternalSelected(selected);
+    setInternalOthers(others);
+  }
 
   const summary = useMemo(() => {
     const parts = [...internalSelected];

--- a/frontend/components/ui/SelectWithOther.tsx
+++ b/frontend/components/ui/SelectWithOther.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useMemo, useState} from 'react';
 import {Input} from '@/components/ui/input';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
@@ -45,8 +45,6 @@ export function SelectWithOther(props: SelectWithOtherProps) {
         className
     } = props;
 
-  const [internalOtherText, setInternalOtherText] = useState('');
-
     // Detect if "Other" is selected (accepts empty other_text to show input immediately)
   const isOtherSelected = useMemo(() => {
     if (!allowOther || !value) return false;
@@ -54,21 +52,24 @@ export function SelectWithOther(props: SelectWithOtherProps) {
     return isOtherObject(value);
   }, [value, allowOther]);
 
-  // Sincronizar internalOtherText com value (garantir que sempre reflete o valor atual)
-  useEffect(() => {
+  const [internalOtherText, setInternalOtherText] = useState(() =>
+    isOtherSelected && isOtherObject(value) ? (value as any).other_text || '' : '',
+  );
+
+  // Keep internalOtherText mirroring the controlled value
+  // (adjust-during-render instead of an effect to avoid cascading renders).
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
     if (isOtherSelected && isOtherObject(value)) {
       const currentText = (value as any).other_text || '';
-        // Only update if different to avoid loops
       if (currentText !== internalOtherText) {
         setInternalOtherText(currentText);
       }
-    } else if (!isOtherSelected) {
-        // Clear only if really not selected
-      if (internalOtherText !== '') {
-        setInternalOtherText('');
-      }
+    } else if (!isOtherSelected && internalOtherText !== '') {
+      setInternalOtherText('');
     }
-  }, [value, isOtherSelected]); // Remover internalOtherText das deps para evitar loop
+  }
 
   const handleSelect = (val: string) => {
     if (allowOther && val === OTHER_OPTION_VALUE) {

--- a/frontend/components/ui/carousel.tsx
+++ b/frontend/components/ui/carousel.tsx
@@ -88,12 +88,22 @@ const Carousel = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEl
       setApi(api);
     }, [api, setApi]);
 
+    // Initialize scroll state as soon as the embla api lands (during render,
+    // instead of a synchronous setState in the effect below).
+    const [prevApi, setPrevApi] = React.useState<CarouselApi>(undefined);
+    if (api !== prevApi) {
+      setPrevApi(api);
+      if (api) {
+        setCanScrollPrev(api.canScrollPrev());
+        setCanScrollNext(api.canScrollNext());
+      }
+    }
+
     React.useEffect(() => {
       if (!api) {
         return;
       }
 
-      onSelect(api);
       api.on("reInit", onSelect);
       api.on("select", onSelect);
 

--- a/frontend/components/ui/file-upload-progress.tsx
+++ b/frontend/components/ui/file-upload-progress.tsx
@@ -178,6 +178,20 @@ interface FileUploadItemProps {
   onRetry?: (itemId: string) => void;
 }
 
+// Icon for the current upload status
+const StatusIcon: React.FC<{ status: FileUploadProgressItem['status'] }> = ({ status }) => {
+  switch (status) {
+    case 'success':
+      return <CheckCircle2 className="h-5 w-5 text-green-500 flex-shrink-0" />;
+    case 'error':
+      return <XCircle className="h-5 w-5 text-destructive flex-shrink-0" />;
+    case 'uploading':
+      return <Loader2 className="h-5 w-5 text-primary animate-spin flex-shrink-0" />;
+    default:
+      return <FileIcon className="h-5 w-5 text-muted-foreground flex-shrink-0" />;
+  }
+};
+
 const FileUploadItem: React.FC<FileUploadItemProps> = ({ item, onCancel, onRetry }) => {
   const formatBytes = (bytes: number): string => {
     if (bytes === 0) return '0 Bytes';
@@ -187,20 +201,6 @@ const FileUploadItem: React.FC<FileUploadItemProps> = ({ item, onCancel, onRetry
     return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
   };
 
-  // Ícone baseado no status
-  const StatusIcon = () => {
-    switch (item.status) {
-      case 'success':
-        return <CheckCircle2 className="h-5 w-5 text-green-500 flex-shrink-0" />;
-      case 'error':
-        return <XCircle className="h-5 w-5 text-destructive flex-shrink-0" />;
-      case 'uploading':
-        return <Loader2 className="h-5 w-5 text-primary animate-spin flex-shrink-0" />;
-      default:
-        return <FileIcon className="h-5 w-5 text-muted-foreground flex-shrink-0" />;
-    }
-  };
-
   return (
     <div className={cn(
       "flex items-start gap-3 p-3 rounded-lg border transition-colors",
@@ -208,7 +208,7 @@ const FileUploadItem: React.FC<FileUploadItemProps> = ({ item, onCancel, onRetry
       item.status === 'error' && "bg-destructive/10 border-destructive/20"
     )}>
       {/* Status icon */}
-      <StatusIcon />
+      <StatusIcon status={item.status} />
 
         {/* File info */}
       <div className="flex-1 min-w-0 space-y-2">

--- a/frontend/components/ui/resizable-panel.tsx
+++ b/frontend/components/ui/resizable-panel.tsx
@@ -109,13 +109,15 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
     }
   }, [flushPending, maxWidth, minWidth, side]);
 
-  const onPointerUp = useCallback(() => {
+  // Named function expression so the handler can unregister itself without
+  // referencing the outer `onPointerUp` binding inside its own initializer.
+  const onPointerUp = useCallback(function handlePointerUp() {
     const start = dragStartRef.current;
     dragStartRef.current = null;
     document.removeEventListener('mousemove', onPointerMove as EventListener);
-    document.removeEventListener('mouseup', onPointerUp as EventListener);
+    document.removeEventListener('mouseup', handlePointerUp as EventListener);
     document.removeEventListener('touchmove', onPointerMove as EventListener);
-    document.removeEventListener('touchend', onPointerUp as EventListener);
+    document.removeEventListener('touchend', handlePointerUp as EventListener);
     document.body.style.userSelect = '';
     document.body.style.cursor = '';
     if (rafRef.current != null) {
@@ -205,18 +207,18 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
   // Animate the open → close transition driven by the external `collapsed` prop.
   // We only kick the animation off when `collapsed` flips from false → true; an initial
   // render with `collapsed=true` should stay unmounted (no entry animation).
-  const prevCollapsedRef = useRef(collapsed);
+  // Adjusted during render (not in an effect) so the same <aside> node stays mounted
+  // across the flip and the width/opacity transition can actually play.
+  const [prevCollapsed, setPrevCollapsed] = useState(collapsed);
+  if (collapsed !== prevCollapsed) {
+    setPrevCollapsed(collapsed);
+    setIsClosing(!!collapsed);
+  }
   useEffect(() => {
-    const prev = prevCollapsedRef.current;
-    prevCollapsedRef.current = collapsed;
-    if (collapsed && !prev) {
-      setIsClosing(true);
-      const t = setTimeout(() => setIsClosing(false), CLOSE_ANIMATION_MS);
-      return () => clearTimeout(t);
-    }
-    if (!collapsed) setIsClosing(false);
-    return undefined;
-  }, [collapsed]);
+    if (!isClosing) return undefined;
+    const t = setTimeout(() => setIsClosing(false), CLOSE_ANIMATION_MS);
+    return () => clearTimeout(t);
+  }, [isClosing]);
 
   if (collapsed && !isClosing) return null;
 

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -531,10 +531,8 @@ const SidebarMenuSkeleton = React.forwardRef<
     showIcon?: boolean;
   }
 >(({ className, showIcon = false, ...props }, ref) => {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  // Random width between 50 to 90%, fixed once per mount.
+  const [width] = React.useState(() => `${Math.floor(Math.random() * 40) + 50}%`);
 
   return (
     <div


### PR DESCRIPTION
## Why

eslint-plugin-react-hooks 7 surfaces the React Compiler rules; the repo carries 94 pre-existing warnings held at `warn` (see `eslint.config.js`). This is batch 1 of the burn-down: all 10 warnings under `frontend/components/ui/**` and `frontend/components/shared/**`. Repo-wide count drops 94 → 84, 0 errors.

## What changed

All fixes use compiler-friendly patterns (lazy state init, adjust-during-render, derive-in-render) instead of `eslint-disable`:

- **set-state-in-effect (5)** — `SelectWithOther`, `MultiSelectWithOther`, `carousel`, `resizable-panel`, `EntitySelectorComparison`: prop→state mirrors moved from effects to `useState` initializers + the [adjust-during-render pattern](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes); `EntitySelectorComparison` now derives the default selection (`picked ?? first ?? null`) instead of auto-selecting via effect.
- **immutability (2)** — `ComparisonCell`: `handleSave`/`handleCancel` declared before the effect that closes over them; `resizable-panel`: `onPointerUp` unregisters itself via a named function expression instead of referencing its own `const` binding.
- **refs (1)** — `useResizableTableColumns`: latest-width ref written in an effect, not during render.
- **static-components (1)** — `file-upload-progress`: `StatusIcon` hoisted to module scope with a `status` prop (was re-created per render → remount).
- **purity (1)** — `sidebar` skeleton: `Math.random()` width via `useState` initializer (fixed once per mount, as before).

## Risk

Low; pure frontend refactor, no data-path or API changes. Two intentional micro-improvements to be aware of:

- `resizable-panel.tsx`: the close animation now actually plays. The old effect set `isClosing` only after the `collapsed=true` render had already returned `null` (unmounting the `<aside>`), so the documented width/opacity transition could never run on the same node. The render-phase adjustment keeps the node mounted across the flip — this is the behavior the file header and `docs/superpowers/design-system/sidebar-and-panels.md` describe.
- Mirrored state now initializes from props on mount (no one-frame empty flash before the old effects ran).

## Test plan

- [x] `npm run lint` — 84 problems (0 errors), all 10 batch warnings gone, none new
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 451/451 passed
- [x] `npm run build` — success

## Out of scope

The remaining 84 warnings (hooks/, components/extraction/, pages/, etc.) — follow-up batches in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)