### PR TITLE
refactor(frontend): fix react-hooks compiler warnings in pages, contexts, pdf-viewer

### DIFF
--- a/frontend/contexts/ProjectContext.tsx
+++ b/frontend/contexts/ProjectContext.tsx
@@ -18,6 +18,8 @@ export interface ProjectContextType {
 
 export const ProjectContext = createContext<ProjectContextType | undefined>(undefined);
 
+const VALID_TABS = ['articles', 'extraction', 'settings', 'overview', 'screening', 'prisma', 'quality'];
+
 interface ProjectProviderProps {
   children: ReactNode;
 }
@@ -28,22 +30,22 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({ children }) =>
 
     // Read tab from URL or use default
   const tabFromUrl = searchParams.get('tab');
-  const initialTab = (tabFromUrl && ['articles', 'extraction', 'settings', 'overview', 'screening', 'prisma', 'quality'].includes(tabFromUrl))
-    ? tabFromUrl 
+  const initialTab = (tabFromUrl && VALID_TABS.includes(tabFromUrl))
+    ? tabFromUrl
     : 'articles';
-  
+
   const [activeTab, setActiveTab] = useState<string>(initialTab);
 
-    // Sync activeTab when URL changes (coming from other pages)
-  useEffect(() => {
-    const tabFromUrl = searchParams.get('tab');
-    if (tabFromUrl && ['articles', 'extraction', 'settings', 'overview', 'screening', 'prisma', 'quality'].includes(tabFromUrl)) {
-        // Update only if different to avoid loops
-      setActiveTab(prevTab => {
-        return prevTab !== tabFromUrl ? tabFromUrl : prevTab;
-      });
+    // Sync activeTab when URL changes (coming from other pages) — adjusted
+    // during render instead of via effect to avoid a cascading render.
+  const [prevSearchParams, setPrevSearchParams] = useState(searchParams);
+  if (searchParams !== prevSearchParams) {
+    setPrevSearchParams(searchParams);
+    const urlTab = searchParams.get('tab');
+    if (urlTab && VALID_TABS.includes(urlTab) && urlTab !== activeTab) {
+      setActiveTab(urlTab);
     }
-  }, [searchParams]); // Only watch URL changes, do not create loop with activeTab
+  }
 
     // Sync URL when activeTab changes (internal navigation)
   useEffect(() => {

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -277,11 +277,14 @@ export default function ExtractionFullScreen() {
     refreshFinalizedRun,
   ]);
 
+  // Plain-identifier dep so the compiler can preserve this memoization
+  // (optional-chained deps like `finalizedRun?.id` defeat it).
+  const finalizedRunId = finalizedRun?.id;
   const handleReopen = useCallback(async () => {
-    if (!finalizedRun?.id) return;
+    if (!finalizedRunId) return;
     setReopening(true);
     try {
-      await reopenMutation.mutateAsync(finalizedRun.id);
+      await reopenMutation.mutateAsync(finalizedRunId);
       // The reopen endpoint creates a fresh REVIEW-stage run linked via
       // parameters.parent_run_id. We refetch the HITL session first so
       // activeRunId points at the new child run; only then do the
@@ -299,7 +302,7 @@ export default function ExtractionFullScreen() {
       setReopening(false);
     }
   }, [
-    finalizedRun?.id,
+    finalizedRunId,
     reopenMutation,
     sessionResult,
     refreshValues,

--- a/frontend/pages/ProjectView.tsx
+++ b/frontend/pages/ProjectView.tsx
@@ -209,20 +209,14 @@ export default function ProjectView() {
         }
     }, [activeTab, searchParams, setSearchParams]);
 
-  useEffect(() => {
-    if (!projectId) return;
-    // New project selected: bump the generation so any in-flight load for the
-    // previous project resolves into a no-op, and show the spinner again
-    // instead of leaving the old project's data on screen (#110).
-    projectLoadRef.current += 1;
-    setLoading(true);
-    void loadProject();
-    void loadArticles();
-    return () => {
-      // Invalidate in-flight loads on projectId change / unmount.
-      projectLoadRef.current += 1;
-    };
-  }, [projectId]);
+  // New project selected: show the spinner again instead of leaving the old
+  // project's data on screen (#110). Adjusted during render so the effect
+  // below never calls setState synchronously.
+  const [prevProjectId, setPrevProjectId] = useState(projectId);
+  if (projectId !== prevProjectId) {
+    setPrevProjectId(projectId);
+    if (projectId) setLoading(true);
+  }
 
   const loadProject = async () => {
     if (!projectId) return;
@@ -273,6 +267,21 @@ export default function ProjectView() {
     }
   };
 
+  useEffect(() => {
+    if (!projectId) return;
+    // New project selected: bump the generation so any in-flight load for the
+    // previous project resolves into a no-op (#110). The loaders run from a
+    // microtask so all their setState calls happen in async callbacks.
+    projectLoadRef.current += 1;
+    queueMicrotask(() => {
+      void loadProject();
+      void loadArticles();
+    });
+    return () => {
+      // Invalidate in-flight loads on projectId change / unmount.
+      projectLoadRef.current += 1;
+    };
+  }, [projectId]);
 
   if (loading) {
     return (

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -84,13 +84,19 @@ export default function QualityAssessmentFullScreen() {
     | null
   >(null);
 
+  // Reset the resolution whenever the URL segment changes (during render,
+  // so the lookup effect below never sets state synchronously).
+  const [prevTemplateId, setPrevTemplateId] = useState(templateId);
+  if (templateId !== prevTemplateId) {
+    setPrevTemplateId(templateId);
+    setResolvedTemplate(null);
+  }
+
   useEffect(() => {
-    let cancelled = false;
     if (!templateId) {
-      setResolvedTemplate(null);
       return;
     }
-    setResolvedTemplate(null);
+    let cancelled = false;
     void (async () => {
       const [projectRes, globalRes] = await Promise.all([
         supabase
@@ -168,29 +174,34 @@ export default function QualityAssessmentFullScreen() {
   // (instance, field) once the Run detail loads.
   const [values, setValues] = useState<Record<string, unknown>>({});
 
-  useEffect(() => {
-    if (!runDetail) return;
-    const latestByCoord = new Map<string, unknown>();
-    // Proposals are returned newest-first by the API; iterate so the LAST
-    // write wins per coord regardless of order.
-    for (const p of runDetail.proposals) {
-      const k = keyOf({ instanceId: p.instance_id, fieldId: p.field_id });
-      const value =
-        p.proposed_value &&
-        typeof p.proposed_value === "object" &&
-        "value" in p.proposed_value
-          ? (p.proposed_value.value as unknown)
-          : (p.proposed_value as unknown);
-      latestByCoord.set(k, value);
-    }
-    setValues((prev) => {
-      const next: Record<string, unknown> = { ...prev };
-      for (const [k, v] of latestByCoord) {
-        if (!(k in next)) next[k] = v;
+  // Hydrate during render when a new Run detail lands (instead of a
+  // synchronous setState in an effect).
+  const [prevRunDetail, setPrevRunDetail] = useState(runDetail);
+  if (runDetail !== prevRunDetail) {
+    setPrevRunDetail(runDetail);
+    if (runDetail) {
+      const latestByCoord = new Map<string, unknown>();
+      // Proposals are returned newest-first by the API; iterate so the LAST
+      // write wins per coord regardless of order.
+      for (const p of runDetail.proposals) {
+        const k = keyOf({ instanceId: p.instance_id, fieldId: p.field_id });
+        const value =
+          p.proposed_value &&
+          typeof p.proposed_value === "object" &&
+          "value" in p.proposed_value
+            ? (p.proposed_value.value as unknown)
+            : (p.proposed_value as unknown);
+        latestByCoord.set(k, value);
       }
-      return next;
-    });
-  }, [runDetail]);
+      setValues((prev) => {
+        const next: Record<string, unknown> = { ...prev };
+        for (const [k, v] of latestByCoord) {
+          if (!(k in next)) next[k] = v;
+        }
+        return next;
+      });
+    }
+  }
 
   // The autosave hook below watches ``values`` and debounces writes;
   // ``handleValueChange`` only needs to update local state. Lifecycle
@@ -347,11 +358,14 @@ export default function QualityAssessmentFullScreen() {
     toast.success("Assessment finalized.");
   }, [session, advanceMutation, refetchRun]);
 
+  // Plain-identifier dep so the compiler can preserve this memoization
+  // (optional-chained deps like `session?.runId` defeat it).
+  const sessionRunId = session?.runId;
   const handleReopen = useCallback(async () => {
-    if (!session?.runId) return;
+    if (!sessionRunId) return;
     setReopening(true);
     try {
-      await reopenMutation.mutateAsync(session.runId);
+      await reopenMutation.mutateAsync(sessionRunId);
       // The new run is now the latest non-terminal one for this triple,
       // so refetching the session picks it up. Local form state is reset
       // since the new run carries its own seeded proposals.
@@ -365,7 +379,7 @@ export default function QualityAssessmentFullScreen() {
     } finally {
       setReopening(false);
     }
-  }, [session?.runId, reopenMutation, refetchSession]);
+  }, [sessionRunId, reopenMutation, refetchSession]);
   const handlePublish = useCallback(async () => {
     if (!session || !runDetail) return;
 

--- a/frontend/pages/UserSettings.tsx
+++ b/frontend/pages/UserSettings.tsx
@@ -3,7 +3,7 @@
  * Layout with tabs for Profile, Security and Integrations
  */
 
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import {useNavigate, useSearchParams} from 'react-router-dom';
 import {Button} from '@/components/ui/button';
 import {cn} from '@/lib/utils';
@@ -55,13 +55,16 @@ export default function UserSettings() {
     const [activeTab, setActiveTab] = useState<TabId>(initialTab);
   const navigate = useNavigate();
 
-    // Sync tab when URL changes (e.g. direct link to ?tab=integrations)
-    useEffect(() => {
+    // Sync tab when URL changes (e.g. direct link to ?tab=integrations) —
+    // adjusted during render instead of via effect to avoid a cascading render.
+    const [prevSearchParams, setPrevSearchParams] = useState(searchParams);
+    if (searchParams !== prevSearchParams) {
+        setPrevSearchParams(searchParams);
         const tab = searchParams.get('tab');
-        if (tab && VALID_TAB_IDS.includes(tab as TabId)) {
+        if (tab && VALID_TAB_IDS.includes(tab as TabId) && tab !== activeTab) {
             setActiveTab(tab as TabId);
         }
-    }, [searchParams]);
+    }
 
     const handleTabChange = (tabId: TabId) => {
         setActiveTab(tabId);

--- a/frontend/pdf-viewer/__tests__/context.test.tsx
+++ b/frontend/pdf-viewer/__tests__/context.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, act} from '@testing-library/react';
+import {render, renderHook, screen, act} from '@testing-library/react';
 import {describe, expect, it, vi} from 'vitest';
 import {ViewerProvider, useViewerStore, useViewerStoreApi} from '../core/context';
 import {createViewerStore} from '../core/store';
@@ -54,20 +54,13 @@ describe('<ViewerProvider> + useViewerStore', () => {
   });
 
   it('useViewerStoreApi returns the underlying StoreApi', () => {
-    let captured: ReturnType<typeof useViewerStoreApi> | null = null;
-    function Capture() {
-      captured = useViewerStoreApi();
-      return null;
-    }
-    render(
-      <ViewerProvider>
-        <Capture />
-      </ViewerProvider>,
-    );
-    expect(captured).not.toBeNull();
-    expect(typeof captured!.getState).toBe('function');
-    expect(typeof captured!.setState).toBe('function');
-    expect(typeof captured!.subscribe).toBe('function');
+    const {result} = renderHook(() => useViewerStoreApi(), {
+      wrapper: ({children}) => <ViewerProvider>{children}</ViewerProvider>,
+    });
+    expect(result.current).not.toBeNull();
+    expect(typeof result.current.getState).toBe('function');
+    expect(typeof result.current.setState).toBe('function');
+    expect(typeof result.current.subscribe).toBe('function');
   });
 
   it('accepts an externally created store via the `store` prop', () => {

--- a/frontend/pdf-viewer/hooks/usePageHandle.ts
+++ b/frontend/pdf-viewer/hooks/usePageHandle.ts
@@ -6,9 +6,16 @@ export function usePageHandle(pageNumber: number): PDFPageHandle | null {
   const document = useViewerStore((s) => s.document);
   const [handle, setHandle] = useState<PDFPageHandle | null>(null);
 
+  // Drop the stale handle as soon as the document/page changes (during render,
+  // so the effect never needs a synchronous setState for the invalid case).
+  const [prevKey, setPrevKey] = useState({document, pageNumber});
+  if (prevKey.document !== document || prevKey.pageNumber !== pageNumber) {
+    setPrevKey({document, pageNumber});
+    setHandle(null);
+  }
+
   useEffect(() => {
     if (!document || pageNumber < 1 || pageNumber > document.numPages) {
-      setHandle(null);
       return;
     }
     let active = true;

--- a/frontend/pdf-viewer/ui/NavigationControls.tsx
+++ b/frontend/pdf-viewer/ui/NavigationControls.tsx
@@ -1,4 +1,4 @@
-import {useState, useEffect} from 'react';
+import {useState} from 'react';
 import {ChevronLeft, ChevronRight} from 'lucide-react';
 import {Button} from '@/components/ui/button';
 import {Input} from '@/components/ui/input';
@@ -10,9 +10,13 @@ export function NavigationControls({className}: {className?: string}) {
   const goToPage = useViewerStore((s) => s.actions.goToPage);
   const [local, setLocal] = useState(String(currentPage));
 
-  useEffect(() => {
+  // Mirror the store page into the input when it changes externally
+  // (adjust-during-render instead of an effect).
+  const [prevPage, setPrevPage] = useState(currentPage);
+  if (currentPage !== prevPage) {
+    setPrevPage(currentPage);
     setLocal(String(currentPage));
-  }, [currentPage]);
+  }
 
   const submit = () => {
     const n = parseInt(local, 10);


### PR DESCRIPTION
## Why

Batch 2 of the react-hooks compiler lint burn-down (94 pre-existing warnings held at `warn` in `eslint.config.js`). This batch clears all 12 warnings under `frontend/pages/**`, `frontend/contexts/**`, and `frontend/pdf-viewer/**`. Together with #260 the repo count is 94 → 72.

## What changed

Compiler-friendly patterns only, no `eslint-disable`:

- **set-state-in-effect (8)** — URL→tab sync (`ProjectContext`, `UserSettings`), spinner reset on project switch (`ProjectView`), template-resolution reset + proposal hydration (`QualityAssessmentFullScreen`), store→input mirrors (`NavigationControls`, `usePageHandle`): all moved to the [adjust-during-render pattern](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes). `ProjectView`'s load-kickoff effect now starts the loaders from a microtask so their setState calls run in async callbacks.
- **immutability (2)** — `ProjectView`: the kickoff effect referenced `loadProject`/`loadArticles` before their declarations; effect moved below them.
- **preserve-manual-memoization (2)** — `handleReopen` in both full-screen pages used optional-chained deps (`session?.runId`, `finalizedRun?.id`), which the compiler can't preserve; hoisted to plain identifiers.
- **globals (1)** — pdf-viewer context test captures the store api via `renderHook` instead of reassigning an outer `let` during render.

## Risk

Low. The adjust-during-render conversions fire on the same transitions the old effects watched; state lands one commit earlier (no behavior-visible difference, removes a cascading render). `ProjectView`'s generation-bump ordering is unchanged — the bump still happens in the effect body before the loaders capture it.

## Test plan

- [x] `npm run lint` — batch directories clean; repo 82 warnings on this branch (94 − 12; batch 1 merges separately), 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 451/451 passed
- [x] `npm run build` — success

## Out of scope

Remaining warnings in `frontend/hooks/**` and `frontend/components/**` — follow-up batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)