### PR TITLE
refactor(frontend): fix react-hooks compiler warnings in extraction components

### DIFF
--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -144,6 +144,29 @@ const EXTRACTION_DEFAULT_COLUMN_WIDTHS: Record<string, number> = {
     actions: 96,
 };
 const RESIZABLE_COLUMN_ORDER = ['title', 'authors', 'year', 'progress', 'status', 'actions'] as const;
+// Header checkbox component with indeterminate support. Module scope so its
+// identity is stable across renders (react-hooks/static-components).
+const HeaderCheckbox = React.memo(({
+  checked,
+  indeterminate,
+  onCheckedChange,
+  ...props
+}: {
+  checked: boolean;
+  indeterminate: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  'aria-label'?: string;
+}) => {
+  return (
+    <Checkbox
+      checked={indeterminate ? false : checked}
+      onCheckedChange={onCheckedChange}
+      className={indeterminate ? 'data-[state=checked]:bg-primary/50' : ''}
+      {...props}
+    />
+  );
+});
+
 export function ArticleExtractionTable({ projectId, templateId }: ArticleExtractionTableProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -269,7 +292,8 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
 
     // Load current user ID
   useEffect(() => {
-    loadCurrentUser();
+    // Microtask so the loader's setState calls run in an async callback.
+    queueMicrotask(() => void loadCurrentUser());
   }, [loadCurrentUser]);
 
     // Load project articles
@@ -492,28 +516,6 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
       });
     }
   }, [selectedIds, filteredAndSortedArticles, projectId, templateId, extractFullAI, deselectAll]);
-
-    // Header checkbox component with indeterminate support
-  const HeaderCheckbox = React.memo(({ 
-    checked, 
-    indeterminate, 
-    onCheckedChange, 
-    ...props 
-  }: { 
-    checked: boolean; 
-    indeterminate: boolean; 
-    onCheckedChange: (checked: boolean) => void;
-    'aria-label'?: string;
-  }) => {
-    return (
-      <Checkbox
-        checked={indeterminate ? false : checked}
-        onCheckedChange={onCheckedChange}
-        className={indeterminate ? 'data-[state=checked]:bg-primary/50' : ''}
-        {...props}
-      />
-    );
-  });
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {

--- a/frontend/components/extraction/ExtractionExportDialog.tsx
+++ b/frontend/components/extraction/ExtractionExportDialog.tsx
@@ -109,20 +109,36 @@ export function ExtractionExportDialog({
     const abortRef = useRef<AbortController | null>(null);
 
     // Re-apply smart default + reset transient state each time the
-    // dialog opens (FR-029).
-    useEffect(() => {
-        if (!open) return;
-        setArticleScope(
-            defaultArticleScope ??
-            (selectedIds.length > 0 ? "selected_only" : "current_list"),
-        );
-        setIncludeAiMetadata(false);
-        setAnonymizeReviewerNames(false);
-        setMode("consensus");
-        setReviewerId(user?.id ?? null);
-        setError(null);
-        setSubmitting(false);
-    }, [open, defaultArticleScope, selectedIds.length, user?.id]);
+    // dialog opens (FR-029). Adjusted during render instead of via effect;
+    // the null sentinel makes the first render perform the initial reset.
+    const userId = user?.id;
+    const [prevResetKey, setPrevResetKey] = useState<{
+        open: boolean;
+        defaultArticleScope: typeof defaultArticleScope;
+        selectedCount: number;
+        userId: string | undefined;
+    } | null>(null);
+    if (
+        !prevResetKey ||
+        open !== prevResetKey.open ||
+        defaultArticleScope !== prevResetKey.defaultArticleScope ||
+        selectedIds.length !== prevResetKey.selectedCount ||
+        userId !== prevResetKey.userId
+    ) {
+        setPrevResetKey({open, defaultArticleScope, selectedCount: selectedIds.length, userId});
+        if (open) {
+            setArticleScope(
+                defaultArticleScope ??
+                (selectedIds.length > 0 ? "selected_only" : "current_list"),
+            );
+            setIncludeAiMetadata(false);
+            setAnonymizeReviewerNames(false);
+            setMode("consensus");
+            setReviewerId(userId ?? null);
+            setError(null);
+            setSubmitting(false);
+        }
+    }
 
     // US2 reviewer picker source. Only fetched when the dialog is open.
     const reviewersQuery = useEligibleReviewers(projectId, templateId, {
@@ -134,11 +150,10 @@ export function ExtractionExportDialog({
     );
 
     // Default reviewer to "me" when entering single_user mode.
-    useEffect(() => {
-        if (mode !== "single_user") return;
-        if (reviewerId) return;
-        if (user?.id) setReviewerId(user.id);
-    }, [mode, reviewerId, user?.id]);
+    // Render-phase invariant — the guard guarantees termination.
+    if (mode === "single_user" && !reviewerId && userId) {
+        setReviewerId(userId);
+    }
 
     // Abort any in-flight request if the dialog closes while submitting.
     useEffect(() => {

--- a/frontend/components/extraction/ExtractionInterface.tsx
+++ b/frontend/components/extraction/ExtractionInterface.tsx
@@ -91,8 +91,12 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
 
     const {isManager, loading: roleLoading} = useProjectMemberRole(projectId);
 
-    // Load active template when templates are loaded
-  useEffect(() => {
+    // Keep the active template in sync with the template list (adjusted
+    // during render instead of via effect; the null sentinel makes the
+    // first render perform the initial selection).
+  const [prevTemplates, setPrevTemplates] = useState<ProjectTemplate[] | null>(null);
+  if (templates !== prevTemplates) {
+    setPrevTemplates(templates);
     if (templates.length > 0) {
       if (!activeTemplate) {
           // If no active template, select the default
@@ -110,24 +114,25 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
         }
       }
     }
-  }, [templates]);
+  }
 
-    // Non-manager cannot access Configuration: redirect to extraction if they had configuration selected
-    useEffect(() => {
-        if (roleLoading) return;
-        if (!isManager && activeTab === 'configuration') {
-            setActiveTab('extraction');
-        }
-    }, [isManager, roleLoading, activeTab]);
+    // Non-manager cannot access Configuration: clamp back to extraction.
+    // Render-phase invariant — the guard guarantees termination.
+    if (!roleLoading && !isManager && activeTab === 'configuration') {
+        setActiveTab('extraction');
+    }
 
     // Sync activeTab FROM URL when bar (ProjectView) changes extractionTab param
-    useEffect(() => {
+    // (adjusted during render instead of via effect).
+    const [prevSearchParams, setPrevSearchParams] = useState(searchParams);
+    if (searchParams !== prevSearchParams) {
+        setPrevSearchParams(searchParams);
         const urlTab = searchParams.get('extractionTab') as 'extraction' | 'dashboard' | 'configuration' | null;
         const valid = urlTab && ['extraction', 'dashboard', 'configuration'].includes(urlTab);
         if (valid && urlTab !== activeTab) {
             setActiveTab(urlTab);
         }
-    }, [searchParams]);
+    }
 
     // Sync active tab with URL
   useEffect(() => {
@@ -140,15 +145,6 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
   const handleTabChange = (tab: 'extraction' | 'dashboard' | 'configuration') => {
     setActiveTab(tab);
   };
-
-    // Load articles and statistics
-  useEffect(() => {
-    if (projectId) {
-      loadArticles();
-    }
-  }, [projectId]);
-
-
 
   const loadArticles = async () => {
     try {
@@ -165,6 +161,14 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
         toast.error(t('extraction', 'errorLoadArticles'));
     }
   };
+
+    // Load articles and statistics
+  useEffect(() => {
+    if (projectId) {
+      // Microtask so the loader's setState calls run in an async callback.
+      queueMicrotask(() => void loadArticles());
+    }
+  }, [projectId]);
 
 
     // Render Dashboard tab

--- a/frontend/components/extraction/InstanceCard.tsx
+++ b/frontend/components/extraction/InstanceCard.tsx
@@ -55,9 +55,18 @@ export function InstanceCard(props: InstanceCardProps) {
   const [isEditingLabel, setIsEditingLabel] = useState(false);
   const [editedLabel, setEditedLabel] = useState(instance.label);
   const [saving, setSaving] = useState(false);
+  // Saved label shown on the card. Local state instead of mutating the
+  // `instance` prop in place (react-hooks/immutability); re-synced if the
+  // prop changes from outside.
+  const [savedLabel, setSavedLabel] = useState(instance.label);
+  const [prevPropLabel, setPrevPropLabel] = useState(instance.label);
+  if (instance.label !== prevPropLabel) {
+    setPrevPropLabel(instance.label);
+    setSavedLabel(instance.label);
+  }
 
   const handleSaveLabel = async () => {
-    if (editedLabel.trim() === instance.label) {
+    if (editedLabel.trim() === savedLabel) {
       setIsEditingLabel(false);
       return;
     }
@@ -72,21 +81,21 @@ export function InstanceCard(props: InstanceCardProps) {
 
       if (error) throw error;
 
-        instance.label = editedLabel.trim(); // Update local
+      setSavedLabel(editedLabel.trim()); // Update local
       setIsEditingLabel(false);
         toast.success(t('extraction', 'labelUpdatedSuccess'));
 
     } catch (error: any) {
         console.error('Error updating label:', error);
         toast.error(t('extraction', 'errors_updateLabel'));
-        setEditedLabel(instance.label); // Revert
+        setEditedLabel(savedLabel); // Revert
     } finally {
       setSaving(false);
     }
   };
 
   const handleCancelEdit = () => {
-    setEditedLabel(instance.label);
+    setEditedLabel(savedLabel);
     setIsEditingLabel(false);
   };
 
@@ -139,9 +148,9 @@ export function InstanceCard(props: InstanceCardProps) {
                 type="button"
                 className="text-sm font-semibold cursor-pointer hover:text-primary transition-colors duration-75 flex items-center gap-2 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 onClick={() => setIsEditingLabel(true)}
-                title={instance.label}
+                title={savedLabel}
               >
-                {instance.label}
+                {savedLabel}
                 <Edit2 className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
               </button>
             )}

--- a/frontend/components/extraction/TemplateConfigEditor.tsx
+++ b/frontend/components/extraction/TemplateConfigEditor.tsx
@@ -37,12 +37,6 @@ export function TemplateConfigEditor({ projectId, templateId }: TemplateConfigEd
   const [removingSectionName, setRemovingSectionName] = useState('');
   const [showImportDialog, setShowImportDialog] = useState(false);
 
-  useEffect(() => {
-    if (projectId && templateId) {
-      loadEntityTypes();
-    }
-  }, [projectId, templateId]);
-
   const loadEntityTypes = async () => {
     setLoading(true);
     
@@ -90,6 +84,13 @@ export function TemplateConfigEditor({ projectId, templateId }: TemplateConfigEd
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (projectId && templateId) {
+      // Microtask so the loader's setState calls run in an async callback.
+      queueMicrotask(() => void loadEntityTypes());
+    }
+  }, [projectId, templateId]);
 
   const handleStartEdit = (entityType: ExtractionEntityType) => {
     setEditingId(entityType.id);

--- a/frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx
+++ b/frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx
@@ -83,12 +83,20 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
     }
   }, [instanceId, fieldId, getHistory]);
 
+  // Clear history on close so next open has fresh data (adjusted during
+  // render instead of via effect).
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (!open) {
+      setHistory([]);
+    }
+  }
+
   useEffect(() => {
     if (open) {
-      loadHistory();
-    } else {
-        // Clear history on close so next open has fresh data
-      setHistory([]);
+      // Microtask so the loader's setState calls run in an async callback.
+      queueMicrotask(() => void loadHistory());
     }
   }, [open, loadHistory]);
 

--- a/frontend/components/extraction/comparison/ModelLevelComparison.tsx
+++ b/frontend/components/extraction/comparison/ModelLevelComparison.tsx
@@ -17,7 +17,7 @@
  * @component
  */
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import {
@@ -65,12 +65,11 @@ export function ModelLevelComparison(props: ModelLevelComparisonProps) {
     // My models (instances of type prediction_models)
   const myModels = myInstances[modelParentType.id] || [];
 
-    // Auto-select first model of current user
-  useEffect(() => {
-    if (myModels.length > 0 && !mySelectedModelId) {
-      setMySelectedModelId(myModels[0].id);
-    }
-  }, [myModels, mySelectedModelId]);
+    // Auto-select first model of current user — render-phase invariant
+    // (the guard guarantees termination).
+  if (myModels.length > 0 && !mySelectedModelId) {
+    setMySelectedModelId(myModels[0].id);
+  }
 
     // Extract models from other users
     // NOTE: otherExtractions.values contains flat extracted_values data
@@ -113,17 +112,23 @@ export function ModelLevelComparison(props: ModelLevelComparisonProps) {
     return grouped;
   }, [otherExtractions]);
 
-    // Reset selected model when user changes
-  useEffect(() => {
+    // Reset selected model when the compared user (or their model list)
+    // changes — adjusted during render instead of via effect.
+  const [prevOtherKey, setPrevOtherKey] = useState<{
+    userId: string | null;
+    models: typeof modelsByUser;
+  } | null>(null);
+  if (
+    !prevOtherKey ||
+    otherSelectedUserId !== prevOtherKey.userId ||
+    modelsByUser !== prevOtherKey.models
+  ) {
+    setPrevOtherKey({ userId: otherSelectedUserId, models: modelsByUser });
     if (otherSelectedUserId) {
       const userModels = modelsByUser.get(otherSelectedUserId);
-      if (userModels && userModels.length > 0) {
-        setOtherSelectedModelId(userModels[0].id);
-      } else {
-        setOtherSelectedModelId(null);
-      }
+      setOtherSelectedModelId(userModels && userModels.length > 0 ? userModels[0].id : null);
     }
-  }, [otherSelectedUserId, modelsByUser]);
+  }
 
     // Get child entity types of model (Candidate Predictors, Performance, etc)
   const modelChildTypes = useMemo(() => 

--- a/frontend/components/extraction/dialogs/AddFieldDialog.tsx
+++ b/frontend/components/extraction/dialogs/AddFieldDialog.tsx
@@ -12,7 +12,7 @@
  */
 
 import {useEffect, useState} from 'react';
-import {useForm} from 'react-hook-form';
+import {useForm, useWatch} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {
     Dialog,
@@ -88,8 +88,10 @@ export function AddFieldDialog({
     },
   });
 
-  const fieldType = form.watch('field_type');
-  const label = form.watch('label');
+  // useWatch instead of form.watch — the latter is incompatible with the
+  // React Compiler (react-hooks/incompatible-library).
+  const fieldType = useWatch({control: form.control, name: 'field_type'});
+  const label = useWatch({control: form.control, name: 'label'});
 
     // Auto-generate name when label changes
   useEffect(() => {

--- a/frontend/components/extraction/dialogs/AddSectionDialog.tsx
+++ b/frontend/components/extraction/dialogs/AddSectionDialog.tsx
@@ -13,7 +13,7 @@
  */
 
 import {useEffect, useState} from 'react';
-import {useForm} from 'react-hook-form';
+import {useForm, useWatch} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {z} from 'zod';
 import {
@@ -107,7 +107,9 @@ export function AddSectionDialog({
     },
   });
 
-  const label = form.watch('label');
+  // useWatch instead of form.watch — the latter is incompatible with the
+  // React Compiler (react-hooks/incompatible-library).
+  const label = useWatch({control: form.control, name: 'label'});
 
     // Auto-generate name when label changes
   useEffect(() => {

--- a/frontend/components/extraction/dialogs/EditFieldDialog.tsx
+++ b/frontend/components/extraction/dialogs/EditFieldDialog.tsx
@@ -12,7 +12,7 @@
  */
 
 import {useEffect, useState} from 'react';
-import {useForm} from 'react-hook-form';
+import {useForm, useWatch} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {
     Dialog,
@@ -77,7 +77,21 @@ export function EditFieldDialog({
     },
   });
 
-  const fieldType = form.watch('field_type');
+  // useWatch instead of form.watch — the latter is incompatible with the
+  // React Compiler (react-hooks/incompatible-library).
+  const fieldType = useWatch({control: form.control, name: 'field_type'});
+  const allowOther = useWatch({control: form.control, name: 'allow_other'});
+
+  const loadValidation = async () => {
+    if (!field) return;
+
+    try {
+      const result = await onValidate(field.id);
+      setValidation(result);
+    } catch (err) {
+        console.error('Error validating field:', err);
+    }
+  };
 
     // Load field data when opening
   useEffect(() => {
@@ -97,21 +111,11 @@ export function EditFieldDialog({
         other_placeholder: field.other_placeholder || null,
       });
 
-        // Fetch field validation
-      loadValidation();
+        // Fetch field validation (microtask so its setState calls run in an
+        // async callback)
+      queueMicrotask(() => void loadValidation());
     }
   }, [field, open, form]);
-
-  const loadValidation = async () => {
-    if (!field) return;
-    
-    try {
-      const result = await onValidate(field.id);
-      setValidation(result);
-    } catch (err) {
-        console.error('Error validating field:', err);
-    }
-  };
 
   const handleTypeChange = async (newType: string) => {
     if (!field || !validation) return;
@@ -412,7 +416,7 @@ export function EditFieldDialog({
                           />
                         </div>
 
-                        {form.watch('allow_other') && (
+                        {allowOther && (
                           <div className="grid grid-cols-2 gap-3">
                             <FormField
                               control={form.control}

--- a/frontend/components/extraction/dialogs/ImportTemplateDialog.tsx
+++ b/frontend/components/extraction/dialogs/ImportTemplateDialog.tsx
@@ -6,7 +6,7 @@
  * feedback.
  */
 
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import {
     Dialog,
     DialogContent,
@@ -54,15 +54,28 @@ export function ImportTemplateDialog({
 
   const selectedTemplate = templates.find(t => t.id === selectedTemplateId);
 
-    // Sync selection when dialog opens with initialTemplateId (e.g. from config page list)
-    useEffect(() => {
-        if (!open) return;
-        if (initialTemplateId && templates.some(t => t.id === initialTemplateId)) {
-            setSelectedTemplateId(initialTemplateId);
-        } else if (!initialTemplateId) {
-            setSelectedTemplateId(null);
+    // Sync selection when dialog opens with initialTemplateId (e.g. from
+    // config page list) — adjusted during render instead of via effect.
+    const [prevSyncKey, setPrevSyncKey] = useState<{
+        open: boolean;
+        initialTemplateId: typeof initialTemplateId;
+        templates: typeof templates;
+    } | null>(null);
+    if (
+        !prevSyncKey ||
+        open !== prevSyncKey.open ||
+        initialTemplateId !== prevSyncKey.initialTemplateId ||
+        templates !== prevSyncKey.templates
+    ) {
+        setPrevSyncKey({open, initialTemplateId, templates});
+        if (open) {
+            if (initialTemplateId && templates.some(t => t.id === initialTemplateId)) {
+                setSelectedTemplateId(initialTemplateId);
+            } else if (!initialTemplateId) {
+                setSelectedTemplateId(null);
+            }
         }
-    }, [open, initialTemplateId, templates]);
+    }
 
   const handleImport = async () => {
     if (!selectedTemplate) {

--- a/frontend/components/extraction/dialogs/RemoveSectionDialog.tsx
+++ b/frontend/components/extraction/dialogs/RemoveSectionDialog.tsx
@@ -87,15 +87,15 @@ export function RemoveSectionDialog({
     },
   });
 
-    // Analyze impact when dialog opens
-  useEffect(() => {
-    if (open && sectionId) {
-      analyzeImpact();
-    } else {
+    // Clear the analyzed impact when the dialog closes (during render, so
+    // the effect below never sets state synchronously).
+  const [prevResetKey, setPrevResetKey] = useState({ open, sectionId });
+  if (open !== prevResetKey.open || sectionId !== prevResetKey.sectionId) {
+    setPrevResetKey({ open, sectionId });
+    if (!(open && sectionId)) {
       setImpact(null);
-      form.reset();
     }
-  }, [open, sectionId]);
+  }
 
   const analyzeImpact = async () => {
     if (!sectionId) return;
@@ -193,6 +193,16 @@ export function RemoveSectionDialog({
       setAnalyzing(false);
     }
   };
+
+    // Analyze impact when dialog opens; reset the form when it closes.
+  useEffect(() => {
+    if (open && sectionId) {
+      // Microtask so the analyzer's setState calls run in an async callback.
+      queueMicrotask(() => void analyzeImpact());
+    } else {
+      form.reset();
+    }
+  }, [open, sectionId]);
 
     const handleSubmit = async (_data: RemoveSectionInput) => {
     if (!sectionId || !impact) return;

--- a/frontend/components/extraction/hierarchy/AddModelDialog.tsx
+++ b/frontend/components/extraction/hierarchy/AddModelDialog.tsx
@@ -13,7 +13,7 @@
  * @component
  */
 
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import {
     Dialog,
     DialogContent,
@@ -51,15 +51,17 @@ export function AddModelDialog({
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-    // Reset on open/close
-  useEffect(() => {
+    // Reset on close — adjusted during render instead of via effect.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
     if (!open) {
       setModelName('');
       setModellingMethod('');
       setError(null);
       setLoading(false);
     }
-  }, [open]);
+  }
 
     // Validation
   const validate = (): boolean => {


### PR DESCRIPTION
## Why

Batch 5 of the react-hooks compiler lint burn-down. Clears all 20 warnings under `frontend/components/extraction/**` (one extra surfaced in `EditFieldDialog` once the file became compilable). With #260–#263 the repo count goes 94 → 22.

## What changed

- **incompatible-library (3)** — `AddFieldDialog`, `AddSectionDialog`, `EditFieldDialog`: `form.watch(...)` → `useWatch({control, name})` (incl. the inline `watch('allow_other')` in EditFieldDialog's JSX).
- **set-state-in-effect (11)** — three sub-patterns, consistent with the earlier batches:
  - dialog open/close resets and selection syncs → adjust-during-render (`ExtractionExportDialog`, `ImportTemplateDialog`, `RemoveSectionDialog`, `AddModelDialog`, `AISuggestionHistoryPopover`, `ExtractionInterface` URL/template syncs);
  - "auto-select first item" → render-phase invariants with terminating guards (`ModelLevelComparison`, `ExtractionExportDialog` reviewer default, `ExtractionInterface` non-manager tab clamp);
  - async loaders kicked off from microtasks (`ExtractionInterface`, `TemplateConfigEditor`, `ArticleExtractionTable`, `AISuggestionHistoryPopover`, `RemoveSectionDialog`, `EditFieldDialog`).
- **immutability (5)** — TDZ effect/loader ordering fixes, plus one real fix: `InstanceCard` was mutating the `instance` prop in place after a label save ([InstanceCard.tsx:75](frontend/components/extraction/InstanceCard.tsx) before); the saved label now lives in local state, re-synced if the prop changes from outside. Rendered output is identical.
- **static-components (1)** — `ArticleExtractionTable`'s `HeaderCheckbox` was a `React.memo` created *inside* the component body — a new component type every render, which defeats the memo and remounts the node. Hoisted to module scope (it captured nothing).

## Risk

Low-moderate: this is the extraction surface, so the dialogs and table were the focus of the test pass. The `InstanceCard` change is the only semantic candidate — the prop mutation never triggered re-renders elsewhere, so replacing it with card-local state is observably equivalent.

## Test plan

- [x] `npm run lint` — extraction directory clean; 74 warnings on this branch (94 − 20), 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 451/451 passed
- [x] `npm run build` — success

## Out of scope

Final batch: `frontend/hooks/{extraction,hitl,qa,runs}/**` (22 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)