### PR TITLE
refactor(frontend): fix react-hooks compiler warnings in domain hooks

### DIFF
--- a/frontend/hooks/extraction/ai/useAISuggestions.ts
+++ b/frontend/hooks/extraction/ai/useAISuggestions.ts
@@ -119,7 +119,8 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
     // useEffect AFTER loadSuggestions declaration
   useEffect(() => {
     if (!enabled || !articleId) return;
-    loadSuggestions();
+    // Microtask so the loader's setState calls run in an async callback.
+    queueMicrotask(() => void loadSuggestions());
   }, [articleId, enabled, loadSuggestions]);
 
   const acceptSuggestionCore = useCallback(async (instanceId: string, fieldId: string, silent: boolean): Promise<boolean> => {

--- a/frontend/hooks/extraction/colaboracao/useAllUserInstances.ts
+++ b/frontend/hooks/extraction/colaboracao/useAllUserInstances.ts
@@ -30,21 +30,17 @@ export function useAllUserInstances(props: UseAllUserInstancesProps): UseAllUser
   const { articleId, enabled = true } = props;
 
   const [instances, setInstances] = useState<InstanceWithCreator[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Only show the loader when there is actually something to load.
+  const [loading, setLoading] = useState(() => Boolean(enabled && articleId));
   const [error, setError] = useState<string | null>(null);
   const generationRef = useRef(0);
 
-  useEffect(() => {
-    if (!enabled || !articleId) {
-      setLoading(false);
-      return;
-    }
-
-    loadInstances();
-    return () => {
-      generationRef.current += 1;
-    };
-  }, [articleId, enabled]);
+  // Params cleared after mount: stop the loader (during render, not via effect).
+  const [prevKey, setPrevKey] = useState({ articleId, enabled });
+  if (articleId !== prevKey.articleId || enabled !== prevKey.enabled) {
+    setPrevKey({ articleId, enabled });
+    if (!enabled || !articleId) setLoading(false);
+  }
 
   const loadInstances = async () => {
     const myGeneration = ++generationRef.current;
@@ -74,6 +70,15 @@ export function useAllUserInstances(props: UseAllUserInstancesProps): UseAllUser
       if (myGeneration === generationRef.current) setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (!enabled || !articleId) return;
+    // Microtask so the loader's setState calls run in an async callback.
+    queueMicrotask(() => void loadInstances());
+    return () => {
+      generationRef.current += 1;
+    };
+  }, [articleId, enabled]);
 
   const refresh = async () => {
     await loadInstances();

--- a/frontend/hooks/extraction/colaboracao/useOtherExtractions.ts
+++ b/frontend/hooks/extraction/colaboracao/useOtherExtractions.ts
@@ -47,20 +47,22 @@ export function useOtherExtractions(
   } = props;
 
   const [otherExtractions, setOtherExtractions] = useState<OtherExtraction[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Only show the loader when there is actually something to load.
+  const [loading, setLoading] = useState(() => Boolean(enabled && articleId && currentUserId));
   const [error, setError] = useState<string | null>(null);
   const generationRef = useRef(0);
 
-  useEffect(() => {
-    if (!enabled || !articleId || !currentUserId) {
-      setLoading(false);
-      return;
-    }
-    void loadOtherExtractions();
-    return () => {
-      generationRef.current += 1;
-    };
-  }, [articleId, currentUserId, enabled, templateId]);
+  // Params cleared after mount: stop the loader (during render, not via effect).
+  const [prevKey, setPrevKey] = useState({ articleId, currentUserId, enabled, templateId });
+  if (
+    articleId !== prevKey.articleId ||
+    currentUserId !== prevKey.currentUserId ||
+    enabled !== prevKey.enabled ||
+    templateId !== prevKey.templateId
+  ) {
+    setPrevKey({ articleId, currentUserId, enabled, templateId });
+    if (!enabled || !articleId || !currentUserId) setLoading(false);
+  }
 
   const loadOtherExtractions = async () => {
     const myGeneration = ++generationRef.current;
@@ -105,6 +107,15 @@ export function useOtherExtractions(
       if (myGeneration === generationRef.current) setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (!enabled || !articleId || !currentUserId) return;
+    // Microtask so the loader's setState calls run in an async callback.
+    queueMicrotask(() => void loadOtherExtractions());
+    return () => {
+      generationRef.current += 1;
+    };
+  }, [articleId, currentUserId, enabled, templateId]);
 
   const refresh = async () => {
     await loadOtherExtractions();

--- a/frontend/hooks/extraction/useExtractedValues.ts
+++ b/frontend/hooks/extraction/useExtractedValues.ts
@@ -272,12 +272,16 @@ export function useExtractedValues(
       // the spinner forever. Treat ``initialized = true`` here as
       // "we know there are no values to show" (the empty map below).
       hydratedRunIdRef.current = runId ?? null;
-      resetValuesIfNeeded(setValues);
-      setLoading(false);
-      setInitialized(true);
+      // Microtask so the reset's setState calls run in an async callback.
+      queueMicrotask(() => {
+        resetValuesIfNeeded(setValues);
+        setLoading(false);
+        setInitialized(true);
+      });
       return;
     }
-    void loadValues();
+    // Microtask so the loader's setState calls run in an async callback.
+    queueMicrotask(() => void loadValues());
   }, [enabled, loadValues]);
 
   const updateValue = useCallback((instanceId: string, fieldId: string, value: any) => {

--- a/frontend/hooks/extraction/useExtractionData.ts
+++ b/frontend/hooks/extraction/useExtractionData.ts
@@ -254,7 +254,8 @@ export function useExtractionData({
 
     // Load initial data
   useEffect(() => {
-    loadData();
+    // Microtask so the loader's setState calls run in an async callback.
+    queueMicrotask(() => void loadData());
   }, [loadData]);
 
     // Refresh function
@@ -262,12 +263,14 @@ export function useExtractionData({
     await loadData();
   }, [loadData]);
 
-    // Refresh instances only (no new creation)
+    // Refresh instances only (no new creation). Plain-identifier dep —
+    // optional-chained deps defeat compiler memoization preservation.
+  const activeTemplateId = template?.id;
   const refreshInstances = useCallback(async () => {
-    if (template?.id) {
-      await loadInstances(template.id);
+    if (activeTemplateId) {
+      await loadInstances(activeTemplateId);
     }
-  }, [template?.id, loadInstances]);
+  }, [activeTemplateId, loadInstances]);
 
   return {
     article,

--- a/frontend/hooks/extraction/useExtractionSession.ts
+++ b/frontend/hooks/extraction/useExtractionSession.ts
@@ -66,11 +66,35 @@ export function useExtractionSession({
   const generationRef = useRef(0);
   const queryClient = useQueryClient();
 
-  const open = useCallback(async () => {
+  const willOpen = Boolean(enabled && projectId && articleId && projectTemplateId);
+
+  // Show the loader for effect-triggered opens during render, so openCore
+  // performs no synchronous setState when the effect kicks it off (the POST
+  // itself still starts synchronously — autosave relies on the generation
+  // bump ordering). The null sentinel covers the mount load.
+  const [prevOpenKey, setPrevOpenKey] = useState<{
+    enabled: boolean;
+    projectId: string | undefined;
+    articleId: string | undefined;
+    projectTemplateId: string | undefined;
+  } | null>(null);
+  if (
+    !prevOpenKey ||
+    enabled !== prevOpenKey.enabled ||
+    projectId !== prevOpenKey.projectId ||
+    articleId !== prevOpenKey.articleId ||
+    projectTemplateId !== prevOpenKey.projectTemplateId
+  ) {
+    setPrevOpenKey({ enabled, projectId, articleId, projectTemplateId });
+    if (willOpen) {
+      setLoading(true);
+      setError(null);
+    }
+  }
+
+  const openCore = useCallback(async () => {
     if (!enabled || !projectId || !articleId || !projectTemplateId) return;
     const myGeneration = ++generationRef.current;
-    setLoading(true);
-    setError(null);
     try {
       const data = await apiClient<OpenResponse>("/api/v1/hitl/sessions", {
         method: "POST",
@@ -117,15 +141,31 @@ export function useExtractionSession({
     }
   }, [enabled, projectId, articleId, projectTemplateId, queryClient]);
 
+  // Manual refetch (event-handler context): show the loader, then reopen.
+  const refetch = useCallback(async () => {
+    if (!enabled || !projectId || !articleId || !projectTemplateId) return;
+    setLoading(true);
+    setError(null);
+    await openCore();
+  }, [enabled, projectId, articleId, projectTemplateId, openCore]);
+
+  const openCoreRef = useRef(openCore);
   useEffect(() => {
-    void open();
+    openCoreRef.current = openCore;
+  }, [openCore]);
+
+  useEffect(() => {
+    // The POST must start synchronously (in-flight generation ordering);
+    // openCore's setState calls all happen after its first await, and the
+    // loader reset happens during render above.
+    void openCoreRef.current();
     return () => {
       // Bump the generation so any in-flight open() resolves into a
       // no-op when this effect tears down (component unmount or
       // dependency change).
       generationRef.current += 1;
     };
-  }, [open]);
+  }, [openCore]);
 
-  return { session, loading, error, refetch: open };
+  return { session, loading, error, refetch };
 }

--- a/frontend/hooks/extraction/useFieldManagement.ts
+++ b/frontend/hooks/extraction/useFieldManagement.ts
@@ -504,8 +504,11 @@ export function useFieldManagement({
     // Load permissions and fields on mount
   useEffect(() => {
     if (projectId && entityTypeId) {
-      checkPermissions();
-      loadFields();
+      // Microtask so the loaders' setState calls run in async callbacks.
+      queueMicrotask(() => {
+        void checkPermissions();
+        void loadFields();
+      });
     }
   }, [projectId, entityTypeId, checkPermissions, loadFields]);
 

--- a/frontend/hooks/extraction/useFinalizedExtractionRun.ts
+++ b/frontend/hooks/extraction/useFinalizedExtractionRun.ts
@@ -61,7 +61,8 @@ export function useFinalizedExtractionRun(
 
   useEffect(() => {
     if (!enabled) return;
-    void load();
+    // Microtask so the loader's setState calls run in an async callback.
+    queueMicrotask(() => void load());
   }, [enabled, load]);
 
   return { finalizedRun, loading, error, refresh: load };

--- a/frontend/hooks/extraction/useGlobalTemplates.ts
+++ b/frontend/hooks/extraction/useGlobalTemplates.ts
@@ -110,7 +110,8 @@ export function useGlobalTemplates(): UseGlobalTemplatesReturn {
 
   useEffect(() => {
     isMountedRef.current = true;
-    loadTemplates();
+    // Microtask so the loader's setState calls run in an async callback.
+    queueMicrotask(() => void loadTemplates());
 
     return () => {
       isMountedRef.current = false;

--- a/frontend/hooks/extraction/useModelManagement.ts
+++ b/frontend/hooks/extraction/useModelManagement.ts
@@ -193,9 +193,12 @@ export function useModelManagement({
     }
   }, [enabled, modelParentEntityTypeId, articleId, getModelProgress]);
 
-    // FIX: Sync ref with loadModels right after definition
-    // Ensures ref is available when useEffect tries to use it
-  loadModelsRef.current = loadModels;
+    // Sync ref with loadModels in an effect (refs must not be written
+    // during render). Declared before the mount-load effect below so the
+    // ref is populated by the time that effect runs.
+  useEffect(() => {
+    loadModelsRef.current = loadModels;
+  }, [loadModels]);
 
     // Create new model (using service - simplified)
   const createModel = useCallback(async (

--- a/frontend/hooks/hitl/useHITLProjectTemplates.ts
+++ b/frontend/hooks/hitl/useHITLProjectTemplates.ts
@@ -84,8 +84,28 @@ export function useHITLProjectTemplates({
 }: UseHITLProjectTemplatesProps): UseHITLProjectTemplatesResult {
   const [templates, setTemplates] = useState<ProjectTemplate[]>([]);
   const [globalTemplates, setGlobalTemplates] = useState<GlobalTemplate[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Only show the loader when there is actually something to load.
+  const [loading, setLoading] = useState(() => Boolean(projectId));
   const [error, setError] = useState<string | null>(null);
+
+  // Reset when the query coordinates change (during render, so the fetch
+  // effect below never sets state synchronously).
+  const [prevKey, setPrevKey] = useState({ projectId, kind, includeInactive });
+  if (
+    projectId !== prevKey.projectId ||
+    kind !== prevKey.kind ||
+    includeInactive !== prevKey.includeInactive
+  ) {
+    setPrevKey({ projectId, kind, includeInactive });
+    if (projectId) {
+      setLoading(true);
+      setError(null);
+    } else {
+      setTemplates([]);
+      setGlobalTemplates([]);
+      setLoading(false);
+    }
+  }
 
   const fetchProjectTemplates = useCallback(async (): Promise<ProjectTemplate[]> => {
     let query = supabase
@@ -114,15 +134,12 @@ export function useHITLProjectTemplates({
 
   useEffect(() => {
     if (!projectId) {
-      setTemplates([]);
-      setGlobalTemplates([]);
-      setLoading(false);
       return;
     }
     let cancelled = false;
-    setLoading(true);
-    setError(null);
-    void (async () => {
+    // Microtask so the fetch's setState calls run in async callbacks
+    // (the loading/error reset happens during render above).
+    queueMicrotask(() => void (async () => {
       try {
         const [project, global] = await Promise.all([
           fetchProjectTemplates(),
@@ -139,7 +156,7 @@ export function useHITLProjectTemplates({
       } finally {
         if (!cancelled) setLoading(false);
       }
-    })();
+    })());
     return () => {
       cancelled = true;
     };

--- a/frontend/hooks/qa/useQAAssessmentSession.ts
+++ b/frontend/hooks/qa/useQAAssessmentSession.ts
@@ -67,12 +67,40 @@ export function useQAAssessmentSession({
   // (#109). Mirrors useExtractionSession.
   const generationRef = useRef(0);
 
-  const open = useCallback(async () => {
+  const willOpen = Boolean(
+    enabled && projectId && articleId && (globalTemplateId || projectTemplateId),
+  );
+
+  // Show the loader for effect-triggered opens during render, so openCore
+  // performs no synchronous setState when the effect kicks it off (the POST
+  // itself still starts synchronously). The null sentinel covers the mount
+  // load. Mirrors useExtractionSession.
+  const [prevOpenKey, setPrevOpenKey] = useState<{
+    enabled: boolean;
+    projectId: string | undefined;
+    articleId: string | undefined;
+    globalTemplateId: string | undefined;
+    projectTemplateId: string | undefined;
+  } | null>(null);
+  if (
+    !prevOpenKey ||
+    enabled !== prevOpenKey.enabled ||
+    projectId !== prevOpenKey.projectId ||
+    articleId !== prevOpenKey.articleId ||
+    globalTemplateId !== prevOpenKey.globalTemplateId ||
+    projectTemplateId !== prevOpenKey.projectTemplateId
+  ) {
+    setPrevOpenKey({ enabled, projectId, articleId, globalTemplateId, projectTemplateId });
+    if (willOpen) {
+      setLoading(true);
+      setError(null);
+    }
+  }
+
+  const openCore = useCallback(async () => {
     if (!enabled || !projectId || !articleId) return;
     if (!globalTemplateId && !projectTemplateId) return;
     const myGeneration = ++generationRef.current;
-    setLoading(true);
-    setError(null);
     try {
       const data = await apiClient<OpenResponse>("/api/v1/hitl/sessions", {
         method: "POST",
@@ -106,14 +134,31 @@ export function useQAAssessmentSession({
     }
   }, [enabled, projectId, articleId, globalTemplateId, projectTemplateId]);
 
+  // Manual refetch (event-handler context): show the loader, then reopen.
+  const refetch = useCallback(async () => {
+    if (!enabled || !projectId || !articleId) return;
+    if (!globalTemplateId && !projectTemplateId) return;
+    setLoading(true);
+    setError(null);
+    await openCore();
+  }, [enabled, projectId, articleId, globalTemplateId, projectTemplateId, openCore]);
+
+  const openCoreRef = useRef(openCore);
   useEffect(() => {
-    void open();
+    openCoreRef.current = openCore;
+  }, [openCore]);
+
+  useEffect(() => {
+    // The POST must start synchronously (in-flight generation ordering);
+    // openCore's setState calls all happen after its first await, and the
+    // loader reset happens during render above.
+    void openCoreRef.current();
     return () => {
       // Bump the generation so any in-flight open() resolves into a no-op
       // when this effect tears down (unmount or dependency change).
       generationRef.current += 1;
     };
-  }, [open]);
+  }, [openCore]);
 
-  return { session, loading, error, refetch: open };
+  return { session, loading, error, refetch };
 }

--- a/frontend/hooks/runs/useAutoSaveProposals.ts
+++ b/frontend/hooks/runs/useAutoSaveProposals.ts
@@ -123,24 +123,32 @@ export function useAutoSaveProposals(
 
   // Refs mirror the latest props so lifecycle handlers (pagehide,
   // unmount cleanup) read fresh values without closing over a stale
-  // render snapshot.
+  // render snapshot. Written in an effect (refs must not be written
+  // during render) — declared before the effects below so they always
+  // read the current commit's values.
   const valuesRef = useRef(values);
   const runIdRef = useRef(runId);
   const enabledRef = useRef(enabled);
   const stageRef = useRef(stage);
-  valuesRef.current = values;
-  runIdRef.current = runId;
-  enabledRef.current = enabled;
-  stageRef.current = stage;
   // Server-persisted baseline (see prop docs). Mirrored in a ref so the
   // diff sees the latest hydrated map without re-creating callbacks.
   const baselineRef = useRef<Record<string, unknown>>(baselineValues ?? {});
-  baselineRef.current = baselineValues ?? {};
+  useEffect(() => {
+    valuesRef.current = values;
+    runIdRef.current = runId;
+    enabledRef.current = enabled;
+    stageRef.current = stage;
+    baselineRef.current = baselineValues ?? {};
+  });
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   // Stringified last successful write per `${instanceId}_${fieldId}` —
-  // the diff check against the current values map.
+  // the diff check against the current values map. The ref is the live
+  // map updated per write; the state mirror below lets render-phase
+  // consumers (dirty badge, hasUnsavedChanges) recompute without
+  // reading a ref during render.
   const lastSavedByKeyRef = useRef<Record<string, string>>({});
+  const [lastSavedByKey, setLastSavedByKey] = useState<Record<string, string>>({});
   // React state is async, so ``saveState === 'saving'`` cannot be used
   // as a synchronous lock across overlapping ``performSave`` invocations.
   const activeSavePromiseRef = useRef<Promise<void> | null>(null);
@@ -242,6 +250,10 @@ export function useAutoSaveProposals(
         }),
       );
 
+      // Mirror the diff map into state — partial successes updated the
+      // ref even when some writes failed.
+      setLastSavedByKey({ ...lastSavedByKeyRef.current });
+
       const failures = results.filter(
         (r): r is PromiseRejectedResult => r.status === 'rejected',
       );
@@ -280,13 +292,30 @@ export function useAutoSaveProposals(
   // when ``values`` changes so the next keystroke restarts the
   // countdown; the dedicated unmount-flush effect below handles the
   // route-change case.
+  // The badge flips to 'dirty' as soon as a render sees newly-typed
+  // entries — adjusted during render (the effect below only schedules the
+  // debounce). Keyed by content, not identity: callers may rebuild the
+  // values map every render, and an identity-keyed adjustment would
+  // re-render forever.
+  const valuesKey = useMemo(() => JSON.stringify(values), [values]);
+  const [prevValuesKey, setPrevValuesKey] = useState(valuesKey);
+  if (valuesKey !== prevValuesKey) {
+    setPrevValuesKey(valuesKey);
+    if (
+      enabled &&
+      runId &&
+      isWritableStage(stage) &&
+      selectDirtyEntries(values, lastSavedByKey, baselineValues ?? {}).length > 0
+    ) {
+      setSaveState('dirty');
+    }
+  }
+
   useEffect(() => {
     if (!enabled || !runId || !isWritableStage(stage)) return;
 
     const dirty = computeDirtyEntries();
     if (dirty.length === 0) return;
-
-    setSaveState('dirty');
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
@@ -345,13 +374,11 @@ export function useAutoSaveProposals(
   }, [performSave]);
 
   // Re-evaluate the dirty diff whenever ``values`` changes (user typed)
-  // or ``lastSavedAt`` advances (a save just acknowledged and updated
-  // the ``lastSavedByKeyRef`` map). Reading the ref directly inside
-  // ``useMemo`` is fine because those two triggers cover every state
-  // transition that could flip the answer.
+  // or a save acknowledges (``lastSavedByKey`` advances). Computed from
+  // render-safe state — never from the mutable refs.
   const hasUnsavedChanges = useMemo(
-    () => computeDirtyEntries().length > 0,
-    [values, lastSavedAt, computeDirtyEntries],
+    () => selectDirtyEntries(values, lastSavedByKey, baselineValues ?? {}).length > 0,
+    [values, lastSavedByKey, baselineValues],
   );
 
   return { saveState, lastSavedAt, error, hasUnsavedChanges, saveNow };


### PR DESCRIPTION
## Why

Final batch (6/6) of the react-hooks compiler lint burn-down: all 22 warnings under `frontend/hooks/{extraction,hitl,qa,runs}` — the HITL/extraction data-path hooks. Together with #260–#264 this takes the repo from 94 warnings to **0**.

## What changed

- **`useAutoSaveProposals` (8 warnings)** — the riskiest file, please read first:
  - latest-prop ref mirrors (`valuesRef` etc.) written in an effect declared before their consumers;
  - the `'dirty'` badge flips via adjust-during-render keyed by values **content** (`JSON.stringify`) — identity-keyed tracking re-renders forever when a caller rebuilds the map每render (the hook's own test harness does);
  - `hasUnsavedChanges` is now a `useMemo` over a new `lastSavedByKey` **state** mirror (updated when saves acknowledge) instead of reading the mutable ref during render.
- **Session hooks (`useExtractionSession`, `useQAAssessmentSession`)** — `open()` split into a render-phase loader reset + `openCore` with no setState before its first `await`. The POST still starts synchronously inside the effect — the stale-generation tests (#23/#109) encode that ordering — via the same ref indirection `useModelManagement` already used. Manual `refetch` keeps its synchronous spinner.
- **Fetch-on-mount/param-change loaders** (`useAISuggestions`, `useExtractedValues`, `useExtractionData`, `useFieldManagement`, `useFinalizedExtractionRun`, `useGlobalTemplates`, `useHITLProjectTemplates`, both colaboracao hooks) — param-clear resets adjusted during render with lazy initial loading state; loader kickoff deferred one microtask so their setState calls run in async callbacks.
- **`useModelManagement`** — only the render-phase ref write moved into an effect; the synchronous mount load is untouched (`createModel`'s optimistic ordering depends on it).
- **`useExtractionData`** — `template?.id` dep hoisted to a plain identifier (preserve-manual-memoization).

## Risk

Moderate — this is the autosave/session heart of the HITL stack. Mitigations: the existing test suite is dense here (41 tests across the three riskiest hooks, including the stale-generation and state-machine contracts) and caught two intermediate regressions during development (microtask-deferred POST start; identity-keyed render loop), both fixed by restoring the original synchronous semantics. Generation-bump ordering in the session hooks is byte-identical.

## Test plan

- [x] `npm run lint` — `hooks/{extraction,hitl,qa,runs}` clean; 72 warnings on this branch (94 − 22), 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 451/451 passed (including useAutoSaveProposals state-machine + useExtractionSession #23 stale-response tests)
- [x] `npm run build` — success

## Out of scope

Nothing — this completes the 94-warning burn-down. Once all six PRs merge, the `warn` downgrades in `eslint.config.js` can be promoted back to `error` (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)