### PR TITLE
chore(lint): promote react-hooks compiler rules from warn back to error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,22 +21,12 @@ export default tseslint.config(
       "react-refresh": reactRefresh,
     },
     rules: {
+      // React Compiler rules from eslint-plugin-react-hooks 7 run at their
+      // recommended error level. The 94-finding debt that once held them at
+      // "warn" was burned down in PRs #260–#265 — keep them at error so new
+      // violations fail CI instead of accumulating.
       ...reactHooks.configs.recommended.rules,
         "react-hooks/exhaustive-deps": "off",
-        // eslint-plugin-react-hooks 7 ships the React Compiler rules at
-        // error level. 94 pre-existing findings (52x set-state-in-effect,
-        // 16x immutability, 9x refs, ...) are real but predate the gate —
-        // surfaced as warnings while the debt burns down (same posture as
-        // the documented mypy debt). New code should not add warnings.
-        "react-hooks/set-state-in-effect": "warn",
-        "react-hooks/immutability": "warn",
-        "react-hooks/refs": "warn",
-        "react-hooks/incompatible-library": "warn",
-        "react-hooks/purity": "warn",
-        "react-hooks/preserve-manual-memoization": "warn",
-        "react-hooks/use-memo": "warn",
-        "react-hooks/static-components": "warn",
-        "react-hooks/globals": "warn",
         "react-refresh/only-export-components": "off",
         "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unused-vars": ["warn", { 


### PR DESCRIPTION
## Why

Closes out the react-hooks compiler lint burn-down. The nine `react-hooks/*` rules were temporarily downgraded to `warn` while the 94 pre-existing findings were fixed; with #260–#265 all merged, `eslint .` is clean repo-wide, so the rules return to their recommended `error` level. From here, any new violation fails CI instead of accumulating as debt.

## What changed

- `eslint.config.js`: removed the nine per-rule `warn` overrides (the rules now inherit `error` from `reactHooks.configs.recommended.rules`) and replaced the debt comment. `exhaustive-deps` stays `off` and the non-react-hooks rules are untouched.

## Risk

None at runtime — config-only. The only failure mode is a latent warning somewhere lint doesn't currently see, and `eslint .` exits 0 on this branch.

## Test plan

- [x] `npm run lint` — exits clean, 0 problems, with rules at error level
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 451/451 passed
- [x] `npm run build` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)