### PR TITLE
perf(frontend): remove manual memoization unlocked by zero bailouts

### DIFF
--- a/frontend/components/articles/ArticleFileUploadDialogNew.tsx
+++ b/frontend/components/articles/ArticleFileUploadDialogNew.tsx
@@ -10,7 +10,7 @@
  * - Modern responsive UI
  */
 
-import {useCallback, useEffect, useState} from "react";
+import {useEffect, useState} from "react";
 import {
     Dialog,
     DialogContent,
@@ -95,18 +95,18 @@ export function ArticleFileUploadDialogNew({
   }, [open, articleId]);
 
   // Drag & Drop handlers
-  const handleDragOver = useCallback((e: React.DragEvent) => {
+  const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(true);
-  }, []);
+  };
 
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
+  const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
-  }, []);
+  };
 
     // Update statistics
-  const updateStats = useCallback(() => {
+  const updateStats = () => {
     setFiles(currentFiles => {
       const stats = {
         total: currentFiles.length,
@@ -118,10 +118,10 @@ export function ArticleFileUploadDialogNew({
       setUploadStats(stats);
       return currentFiles;
     });
-  }, []);
+  };
 
     // Add files
-  const addFiles = useCallback((newFiles: File[]) => {
+  const addFiles = (newFiles: File[]) => {
     const validFiles = newFiles.filter(file => {
       const validation = validateFile(file);
       if (!validation.valid) {
@@ -143,28 +143,28 @@ export function ArticleFileUploadDialogNew({
 
     setFiles(prev => [...prev, ...filesWithRoles]);
     updateStats();
-  }, [hasMainFile, updateStats]);
+  };
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
+  const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
-    
+
     const droppedFiles = Array.from(e.dataTransfer.files);
     addFiles(droppedFiles);
-  }, [addFiles]);
+  };
 
     // Remove file
-  const removeFile = useCallback((fileId: string) => {
+  const removeFile = (fileId: string) => {
     setFiles(prev => prev.filter(f => f.id !== fileId));
     updateStats();
-  }, [updateStats]);
+  };
 
     // Update file role
-  const updateFileRole = useCallback((fileId: string, role: FileRole) => {
-    setFiles(prev => prev.map(f => 
+  const updateFileRole = (fileId: string, role: FileRole) => {
+    setFiles(prev => prev.map(f =>
       f.id === fileId ? { ...f, role } : f
     ));
-  }, []);
+  };
 
   // Upload individual de arquivo
   const uploadFile = async (fileWithRole: FileWithRole): Promise<void> => {

--- a/frontend/components/articles/ArticleForm.tsx
+++ b/frontend/components/articles/ArticleForm.tsx
@@ -3,7 +3,7 @@
  * and a section nav that syncs with scroll (IntersectionObserver). Use variant "panel" inside a Sheet.
  */
 
-import {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {Button} from "@/components/ui/button";
 import {Input} from "@/components/ui/input";
@@ -331,9 +331,9 @@ export function ArticleForm({
 
     const scrollRef = useRef<HTMLDivElement>(null);
 
-    const scrollToSection = useCallback((step: FormStep) => {
+    const scrollToSection = (step: FormStep) => {
         document.getElementById(`article-section-${step}`)?.scrollIntoView({behavior: 'smooth', block: 'start'});
-    }, []);
+    };
 
     useEffect(() => {
         if (loading) return;
@@ -571,12 +571,12 @@ export function ArticleForm({
     setTimeout(() => URL.revokeObjectURL(url), 10000);
   };
 
-    const itemTypeSelectValue = useMemo(() => {
+    const itemTypeSelectValue = (() => {
         const v = formData.article_type.trim();
         if (!v) return ITEM_TYPE_NONE_SELECT_VALUE;
         if (isKnownZoteroItemType(v)) return v;
         return ITEM_TYPE_CUSTOM_SELECT_VALUE;
-    }, [formData.article_type]);
+    })();
 
     const onItemTypeSelectChange = (value: string) => {
         if (value === ITEM_TYPE_NONE_SELECT_VALUE) {

--- a/frontend/components/articles/ArticlesList.tsx
+++ b/frontend/components/articles/ArticlesList.tsx
@@ -1,5 +1,5 @@
 import type {CSSProperties} from "react";
-import {forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState} from "react";
+import {forwardRef, useEffect, useImperativeHandle, useRef, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {Button} from "@/components/ui/button";
 import {Badge} from "@/components/ui/badge";
@@ -336,13 +336,9 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
         }
         return {...DEFAULT_COLUMN_WIDTHS};
     });
-    const renderedResizableColumns = useMemo(
-        () =>
-            TABLE_COLUMNS
-                .filter((col) => col.visibleKey == null || visibleColumns[col.visibleKey] === true)
-                .map((col) => col.id),
-        [visibleColumns]
-    );
+    const renderedResizableColumns = TABLE_COLUMNS
+        .filter((col) => col.visibleKey == null || visibleColumns[col.visibleKey] === true)
+        .map((col) => col.id);
     const {registerHeaderRef, startResize} = useResizableTableColumns({
         columnWidths,
         setColumnWidths,
@@ -371,7 +367,7 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
   };
 
     // Clear single filter field (for chip clear)
-    const clearFilterField = useCallback((fieldId: string) => {
+    const clearFilterField = (fieldId: string) => {
         const field = ARTICLES_FILTER_FIELDS.find(f => f.id === fieldId);
         if (!field) return;
         setFilterValues(prev => ({
@@ -383,15 +379,15 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
                         ? {}
                         : '',
         }));
-    }, []);
+    };
 
-    const clearAllFilters = useCallback(() => {
+    const clearAllFilters = () => {
         setSearchTerm('');
         setFilterValues(INITIAL_ARTICLES_FILTER_VALUES);
-    }, []);
+    };
 
     // Faceted values for Filter suggestions (derived from articles)
-    const facetedValues = useMemo(() => {
+    const facetedValues = (() => {
         const years = new Map<number, number>();
         const journals = new Map<string, number>();
         const authors = new Map<string, number>();
@@ -435,9 +431,9 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
                 count
             })),
     };
-    }, [articles]);
+    })();
 
-    const ARTICLES_FILTER_LABELS: Record<string, string> = useMemo(() => ({
+    const ARTICLES_FILTER_LABELS: Record<string, string> = {
         title: 'Title',
         authors: 'Authors',
         journal_title: 'Journal',
@@ -446,12 +442,9 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
         has_main_file: 'PDF',
         ingestion_source: 'Source',
         sync_state: 'Sync state',
-    }), []);
+    };
 
-    const activeFiltersList = useMemo(
-        () => buildActiveFiltersList(ARTICLES_FILTER_FIELDS, filterValues, ARTICLES_FILTER_LABELS),
-        [filterValues, ARTICLES_FILTER_LABELS]
-    );
+    const activeFiltersList = buildActiveFiltersList(ARTICLES_FILTER_FIELDS, filterValues, ARTICLES_FILTER_LABELS);
 
     // Visible columns toggle
     const toggleColumn = (column: string) => {
@@ -527,8 +520,8 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
     setUploadDialogOpen(true);
   };
 
-  // Filtrar e ordenar artigos com useMemo
-  const filteredArticles = useMemo(() => {
+  // Filtrar e ordenar artigos
+  const filteredArticles = (() => {
     const filtered = articles.filter(article => {
       // Filtro global de busca
       if (searchTerm) {
@@ -650,7 +643,7 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
     });
 
     return filtered;
-  }, [articles, searchTerm, filterValues, sortField, sortDirection, articlesWithMainFile]);
+  })();
 
     // Latest-value refs read only by the imperative `openExportDialog` handle
     // (never during render), so the handle can stay stable across data changes.

--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -9,7 +9,7 @@
  */
 
 import type {CSSProperties} from 'react';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useLocation, useNavigate} from 'react-router-dom';
 import {Button} from '@/components/ui/button';
 import {Badge} from '@/components/ui/badge';
@@ -145,9 +145,8 @@ const EXTRACTION_DEFAULT_COLUMN_WIDTHS: Record<string, number> = {
     actions: 96,
 };
 const RESIZABLE_COLUMN_ORDER = ['title', 'authors', 'year', 'progress', 'status', 'actions'] as const;
-// Header checkbox component with indeterminate support. Module scope so its
-// identity is stable across renders (react-hooks/static-components).
-const HeaderCheckbox = React.memo(({
+// Header checkbox component with indeterminate support.
+function HeaderCheckbox({
   checked,
   indeterminate,
   onCheckedChange,
@@ -157,7 +156,7 @@ const HeaderCheckbox = React.memo(({
   indeterminate: boolean;
   onCheckedChange: (checked: boolean) => void;
   'aria-label'?: string;
-}) => {
+}) {
   return (
     <Checkbox
       checked={indeterminate ? false : checked}
@@ -166,7 +165,7 @@ const HeaderCheckbox = React.memo(({
       {...props}
     />
   );
-});
+}
 
 export function ArticleExtractionTable({ projectId, templateId }: ArticleExtractionTableProps) {
   const navigate = useNavigate();
@@ -229,15 +228,15 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
   });
 
     // Declare loadCurrentUser before any use to avoid TDZ
-  const loadCurrentUser = useCallback(async () => {
+  const loadCurrentUser = async () => {
     const result = await getCurrentUserId();
     if (result.ok && result.data) {
       setCurrentUserId(result.data);
     }
-  }, []);
+  };
 
     // Declare loadArticles before any use to avoid TDZ
-  const loadArticles = useCallback(async () => {
+  const loadArticles = async () => {
     if (!projectId || !templateId || !currentUserId) {
       return;
     }
@@ -274,7 +273,7 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
     await queryClient.invalidateQueries({ queryKey: articleExtractionValuesKeys.all });
     setLoading(false);
     // queryClient is referentially stable across renders (useQueryClient).
-  }, [projectId, templateId, currentUserId, queryClient]);
+  };
 
     // Update loadArticles ref when it changes (must be before any use)
   useEffect(() => {
@@ -334,26 +333,23 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
   }, [location.pathname, projectId, templateId, currentUserId]); // Reload when route changes
 
     // Compute extraction progress
-  // Per-article completion %, memoized once per (articles, entityTypes). Uses
-  // the canonical required-field metric (computeRowProgress) so this table
-  // shows the same percentage as the form header and the QA list.
-  const progressByArticle = useMemo(() => {
+  // Per-article completion %, computed once per render. Uses the canonical
+  // required-field metric (computeRowProgress) so this table shows the same
+  // percentage as the form header and the QA list.
+  const progressByArticle = (() => {
     const map = new Map<string, number>();
     for (const article of articles) {
       const d = valuesByArticle.get(article.id);
       map.set(article.id, d ? computeRowProgress(d.instances, d.values, entityTypes) : 0);
     }
     return map;
-  }, [articles, valuesByArticle, entityTypes]);
+  })();
 
-  const getProgress = useCallback(
-    (article: ArticleWithExtraction): number =>
-      progressByArticle.get(article.id) ?? 0,
-    [progressByArticle],
-  );
+  const getProgress = (article: ArticleWithExtraction): number =>
+    progressByArticle.get(article.id) ?? 0;
 
     // Filter and sort articles
-  const filteredAndSortedArticles = useMemo(() => {
+  const filteredAndSortedArticles = (() => {
     const filtered = articles.filter(article => {
         // Global filter
       if (globalFilter) {
@@ -452,15 +448,14 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
       }
     });
 
+    // getProgress and valuesByArticle are read inside the filter/sort;
+    // including them keeps progress-based filtering reactive to value changes.
     return filtered;
-    // getProgress (stable, keyed on progressByArticle) and valuesByArticle are
-    // read inside the filter/sort; including them keeps progress-based filtering
-    // and sorting reactive to value changes that don't replace the articles array.
-  }, [articles, globalFilter, filterValues, sortField, sortDirection, getProgress, valuesByArticle]);
+  })();
 
     // Article selection
-  const allArticleIds = useMemo(() => articles.map(a => a.id), [articles]);
-  const visibleArticleIds = useMemo(() => filteredAndSortedArticles.map(a => a.id), [filteredAndSortedArticles]);
+  const allArticleIds = articles.map(a => a.id);
+  const visibleArticleIds = filteredAndSortedArticles.map(a => a.id);
   
   const {
     selectedIds,
@@ -479,7 +474,7 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
   });
 
     // Batch AI extraction handler
-  const handleBatchAIExtraction = useCallback(async () => {
+  const handleBatchAIExtraction = async () => {
     if (selectedIds.size === 0) {
         toast.error(t('extraction', 'tableSelectAtLeastOne'));
       return;
@@ -512,7 +507,7 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
     }
 
     if (!failed) deselectAll();
-  }, [selectedIds, filteredAndSortedArticles, projectId, templateId, extractFullAI, deselectAll]);
+  };
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -602,12 +597,12 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
     );
   };
 
-    const clearListFilters = useCallback(() => {
+    const clearListFilters = () => {
         setGlobalFilter('');
         setFilterValues(INITIAL_EXTRACTION_FILTER_VALUES);
-    }, []);
+    };
 
-    const clearFilterField = useCallback((fieldId: string) => {
+    const clearFilterField = (fieldId: string) => {
         const field = EXTRACTION_FILTER_FIELDS.find((f) => f.id === fieldId);
         if (!field) return;
         setFilterValues((prev) => ({
@@ -619,33 +614,25 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
                         ? {}
                         : '',
         }));
-    }, []);
+    };
 
-    const extractionFilterLabels = useMemo(
-        () =>
-            Object.fromEntries(
-                EXTRACTION_FILTER_FIELDS.map((f) => [f.id, f.label])
-            ) as Record<string, string>,
-        []
+    const extractionFilterLabels = Object.fromEntries(
+        EXTRACTION_FILTER_FIELDS.map((f) => [f.id, f.label])
+    ) as Record<string, string>;
+
+    const activeFiltersList = buildActiveFiltersList(
+        EXTRACTION_FILTER_FIELDS,
+        filterValues,
+        extractionFilterLabels
     );
 
-    const activeFiltersList = useMemo(
-        () =>
-            buildActiveFiltersList(
-                EXTRACTION_FILTER_FIELDS,
-                filterValues,
-                extractionFilterLabels
-            ),
-        [filterValues, extractionFilterLabels]
-    );
-
-    const activeFiltersCount = useMemo(() => {
+    const activeFiltersCount = (() => {
         let n = globalFilter.trim() ? 1 : 0;
         EXTRACTION_FILTER_FIELDS.forEach((f) => {
             if (!isFilterValueEmpty(filterValues[f.id])) n += 1;
         });
         return n;
-    }, [globalFilter, filterValues]);
+    })();
 
     useListKeyboardShortcuts({
         searchInputRef,

--- a/frontend/components/extraction/EmptyFieldsState.tsx
+++ b/frontend/components/extraction/EmptyFieldsState.tsx
@@ -6,7 +6,6 @@
  * @component
  */
 
-import {memo} from 'react';
 import {Card, CardContent} from '@/components/ui/card';
 import {Button} from '@/components/ui/button';
 import {Plus} from 'lucide-react';
@@ -17,8 +16,7 @@ interface EmptyFieldsStateProps {
   onAddField: () => void;
 }
 
-// kept: parent component (FieldsManager) bails out of compilation — memo is load-bearing here
-export const EmptyFieldsState = memo(function EmptyFieldsState({ canCreate, onAddField }: EmptyFieldsStateProps) {
+export function EmptyFieldsState({ canCreate, onAddField }: EmptyFieldsStateProps) {
   return (
     <Card role="region" aria-labelledby="empty-state-title">
       <CardContent className="pt-6">
@@ -41,4 +39,4 @@ export const EmptyFieldsState = memo(function EmptyFieldsState({ canCreate, onAd
       </CardContent>
     </Card>
   );
-});
+}

--- a/frontend/components/extraction/ExtractionExportDialog.tsx
+++ b/frontend/components/extraction/ExtractionExportDialog.tsx
@@ -7,7 +7,7 @@
  * the browser; async uploads dispatch a BackgroundJob + toast.
  */
 
-import {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import {
     Dialog,
     DialogContent,
@@ -144,10 +144,7 @@ export function ExtractionExportDialog({
     const reviewersQuery = useEligibleReviewers(projectId, templateId, {
         enabled: open,
     });
-    const reviewers = useMemo(
-        () => reviewersQuery.data ?? [],
-        [reviewersQuery.data],
-    );
+    const reviewers = reviewersQuery.data ?? [];
 
     // Default reviewer to "me" when entering single_user mode.
     // Render-phase invariant — the guard guarantees termination.
@@ -187,7 +184,7 @@ export function ExtractionExportDialog({
     })();
 
     // Build the request payload from the current state.
-    const buildRequest = useCallback((): ExtractionExportRequest => ({
+    const buildRequest = (): ExtractionExportRequest => ({
         template_id: templateId,
         mode,
         reviewer_id: mode === "single_user" ? reviewerId : null,
@@ -195,17 +192,9 @@ export function ExtractionExportDialog({
         article_ids: articleIds,
         include_ai_metadata: includeAiMetadata,
         anonymize_reviewer_names: anonymizeReviewerNames,
-    }), [
-        templateId,
-        mode,
-        reviewerId,
-        articleScope,
-        articleIds,
-        includeAiMetadata,
-        anonymizeReviewerNames,
-    ]);
+    });
 
-    const submit = useCallback(async () => {
+    const submit = async () => {
         if (!canSubmit) return;
         setSubmitting(true);
         setError(null);
@@ -247,25 +236,12 @@ export function ExtractionExportDialog({
 
         setSubmitting(false);
         abortRef.current = null;
-    }, [
-        canSubmit,
-        buildRequest,
-        projectId,
-        addJob,
-        projectName,
-        templateId,
-        templateName,
-        mode,
-        articleCount,
-        includeAiMetadata,
-        anonymizeReviewerNames,
-        onOpenChange,
-    ]);
+    };
 
-    const dismiss = useCallback(() => {
+    const dismiss = () => {
         if (abortRef.current) abortRef.current.abort();
         onOpenChange(false);
-    }, [onOpenChange]);
+    };
 
     // Cmd/Ctrl + Enter to submit (FR-006 / FR-035).
     useEffect(() => {

--- a/frontend/components/extraction/ExtractionInterface.tsx
+++ b/frontend/components/extraction/ExtractionInterface.tsx
@@ -5,7 +5,7 @@
  * including templates, instances and values.
  */
 
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card';
 import {Button} from '@/components/ui/button';
@@ -59,7 +59,7 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
   );
   const { entityTypes } = useTemplateEntityTypes(activeTemplate?.id);
 
-  const extractionStats = useMemo(() => {
+  const extractionStats = (() => {
     const totalArticles = articles.length;
     let completed = 0;
     let sum = 0;
@@ -75,7 +75,7 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
       extractionsCompleted: completed,
       progressPercentage: totalArticles > 0 ? Math.round(sum / totalArticles) : 0,
     };
-  }, [articles, valuesByArticle, entityTypes]);
+  })();
 
     // Hook to manage templates
   const {

--- a/frontend/components/extraction/FieldsHeader.tsx
+++ b/frontend/components/extraction/FieldsHeader.tsx
@@ -6,7 +6,6 @@
  * @component
  */
 
-import {memo} from 'react';
 import {Button} from '@/components/ui/button';
 import {Badge} from '@/components/ui/badge';
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from '@/components/ui/tooltip';
@@ -20,8 +19,7 @@ interface FieldsHeaderProps {
   onAddField: () => void;
 }
 
-// kept: parent component (FieldsManager) bails out of compilation — memo is load-bearing here
-export const FieldsHeader = memo(function FieldsHeader({
+export function FieldsHeader({
   fieldsCount,
   userRole,
   canCreate,
@@ -87,4 +85,4 @@ export const FieldsHeader = memo(function FieldsHeader({
       </TooltipProvider>
     </div>
   );
-});
+}

--- a/frontend/components/extraction/FieldsManager.tsx
+++ b/frontend/components/extraction/FieldsManager.tsx
@@ -14,7 +14,6 @@
  * @component
  */
 
-import {useCallback, useMemo} from 'react';
 import {Loader2} from 'lucide-react';
 import {useFieldManagement} from '@/hooks/extraction/useFieldManagement';
 import {useFieldsManagerState} from '@/hooks/extraction/useFieldsManagerState';
@@ -70,11 +69,11 @@ export function FieldsManager({ entityTypeId, sectionName }: FieldsManagerProps)
   // Tratamento de erros
   const { handleFieldOperationError, handleFieldValidationError } = useErrorHandler();
 
-  const handleStartEdit = useCallback((field: ExtractionField) => {
+  const handleStartEdit = (field: ExtractionField) => {
     actions.startEdit(field);
-  }, [actions]);
+  };
 
-  const handleSaveEdit = useCallback(async (fieldId: string) => {
+  const handleSaveEdit = async (fieldId: string) => {
     actions.setSavingEdit(true);
     const result = await updateField(fieldId, editData).catch((error: unknown) => {
       handleFieldOperationError(error, 'edit');
@@ -84,17 +83,17 @@ export function FieldsManager({ entityTypeId, sectionName }: FieldsManagerProps)
       actions.cancelEdit();
     }
     actions.setSavingEdit(false);
-  }, [actions, updateField, editData, handleFieldOperationError]);
+  };
 
-  const handleCancelEdit = useCallback(() => {
+  const handleCancelEdit = () => {
     actions.cancelEdit();
-  }, [actions]);
+  };
 
-  const handleOpenEditDialog = useCallback((field: ExtractionField) => {
+  const handleOpenEditDialog = (field: ExtractionField) => {
     actions.openEditDialog(field);
-  }, [actions]);
+  };
 
-  const handleOpenDeleteDialog = useCallback(async (field: ExtractionField) => {
+  const handleOpenDeleteDialog = async (field: ExtractionField) => {
     actions.openDeleteDialog(field);
 
     const validation = await validateField(field.id).catch((error: unknown) => {
@@ -115,9 +114,9 @@ export function FieldsManager({ entityTypeId, sectionName }: FieldsManagerProps)
       });
     }
     actions.setValidatingDelete(null);
-  }, [actions, validateField, handleFieldValidationError]);
+  };
 
-  const handleConfirmDelete = useCallback(async (fieldId: string) => {
+  const handleConfirmDelete = async (fieldId: string) => {
     const success = await deleteField(fieldId).catch((error: unknown) => {
       handleFieldOperationError(error, 'delete');
       return false;
@@ -126,9 +125,9 @@ export function FieldsManager({ entityTypeId, sectionName }: FieldsManagerProps)
       actions.closeDeleteDialog();
     }
     return success;
-  }, [actions, deleteField, handleFieldOperationError]);
+  };
 
-  const getFieldTypeLabel = useCallback((type: string) => {
+  const getFieldTypeLabel = (type: string) => {
     const labels: Record<string, string> = {
         text: t('extraction', 'fieldTypeText'),
         number: t('extraction', 'fieldTypeNumber'),
@@ -138,13 +137,11 @@ export function FieldsManager({ entityTypeId, sectionName }: FieldsManagerProps)
         boolean: t('extraction', 'fieldTypeBoolean'),
     };
     return labels[type] || type;
-  }, []);
+  };
 
-  // Memoizar valores computados
-  const hasFields = useMemo(() => fields.length > 0, [fields.length]);
+  const hasFields = fields.length > 0;
 
-    // Dialog handlers - fixed to avoid closing inadvertently
-  const dialogHandlers = useMemo(() => ({
+  const dialogHandlers = {
     addDialog: (open: boolean) => {
       if (!open) actions.closeAddDialog();
     },
@@ -154,7 +151,7 @@ export function FieldsManager({ entityTypeId, sectionName }: FieldsManagerProps)
     deleteDialog: (open: boolean) => {
       if (!open) actions.closeDeleteDialog();
     },
-  }), [actions]);
+  };
 
   if (loading) {
     return (

--- a/frontend/components/extraction/FieldsTable.tsx
+++ b/frontend/components/extraction/FieldsTable.tsx
@@ -7,7 +7,6 @@
  * @component
  */
 
-import {memo} from 'react';
 import {Badge} from '@/components/ui/badge';
 import {Input} from '@/components/ui/input';
 import {Textarea} from '@/components/ui/textarea';
@@ -43,8 +42,7 @@ interface FieldsTableProps {
   getFieldTypeLabel: (type: string) => string;
 }
 
-// kept: parent component (FieldsManager) bails out of compilation — memo is load-bearing here
-export const FieldsTable = memo(function FieldsTable({
+export function FieldsTable({
   fields,
   editingId,
   editData,
@@ -254,4 +252,4 @@ export const FieldsTable = memo(function FieldsTable({
       </TableBody>
     </Table>
   );
-});
+}

--- a/frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx
+++ b/frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx
@@ -7,7 +7,7 @@
  * @component
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {Popover, PopoverContent, PopoverTrigger,} from '@/components/ui/popover';
 import {ScrollArea} from '@/components/ui/scroll-area';
 import {Badge} from '@/components/ui/badge';
@@ -63,7 +63,7 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
 
-  const loadHistory = useCallback(async () => {
+  const loadHistory = async () => {
     if (!instanceId || !fieldId) {
         console.warn('[AISuggestionHistoryPopover] instanceId or fieldId not provided');
       return;
@@ -80,7 +80,7 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
     console.warn('[AISuggestionHistoryPopover] History loaded:', {count: data.length, data});
     setHistory(data);
     setLoading(false);
-  }, [instanceId, fieldId, getHistory]);
+  };
 
   // Clear history on close so next open has fresh data (adjusted during
   // render instead of via effect).

--- a/frontend/components/extraction/dialogs/CreateCustomTemplateDialog.tsx
+++ b/frontend/components/extraction/dialogs/CreateCustomTemplateDialog.tsx
@@ -4,7 +4,7 @@
  * manually via the configuration UI.
  */
 
-import {useState, useMemo} from 'react';
+import {useState} from 'react';
 import {useForm} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {z} from 'zod';
@@ -58,7 +58,7 @@ export function CreateCustomTemplateDialog({
 }: CreateCustomTemplateDialogProps) {
   const { user } = useAuth();
   const [loading, setLoading] = useState(false);
-    const CustomTemplateSchema = useMemo(() => buildCustomTemplateSchema(), []);
+    const CustomTemplateSchema = buildCustomTemplateSchema();
 
   const form = useForm<CustomTemplateInput>({
     resolver: zodResolver(CustomTemplateSchema),

--- a/frontend/components/hitl/HITLArticleTable.tsx
+++ b/frontend/components/hitl/HITLArticleTable.tsx
@@ -17,7 +17,7 @@
  * and the structural parity the user asked for.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AlertCircle, CheckCircle2, Circle, FileText } from "lucide-react";
 import { toast } from "sonner";
@@ -202,10 +202,9 @@ export function HITLArticleTable({
     };
   }, [projectId, templateId, currentUserId]);
 
-  // Memoize per-article progress once per (articles, entityTypes) change —
-  // getProgress is read in the sort comparator and several render paths, so
-  // recomputing per call would be O(values × fields) × N on every keystroke.
-  const progressByArticle = useMemo(() => {
+  // Per-article completion %, computed once per render.
+  // getProgress is read in the sort comparator and several render paths.
+  const progressByArticle = (() => {
     const map = new Map<string, number>();
     for (const article of articles) {
       const d = valuesByArticle.get(article.id);
@@ -215,14 +214,11 @@ export function HITLArticleTable({
       );
     }
     return map;
-  }, [articles, valuesByArticle, entityTypes]);
+  })();
 
-  const getProgress = useCallback(
-    (article: Article): number => progressByArticle.get(article.id) ?? 0,
-    [progressByArticle],
-  );
+  const getProgress = (article: Article): number => progressByArticle.get(article.id) ?? 0;
 
-  const filteredAndSorted = useMemo(() => {
+  const filteredAndSorted = (() => {
     const visible = articles.filter((article) => {
       if (globalFilter) {
         const q = globalFilter.toLowerCase();
@@ -307,32 +303,24 @@ export function HITLArticleTable({
       return aVal > bVal ? -1 : aVal < bVal ? 1 : 0;
     });
 
+    // getProgress and valuesByArticle are read inside the filter/sort;
+    // including them keeps progress-based filtering reactive to value changes.
     return visible;
-    // getProgress (stable, keyed on progressByArticle) and valuesByArticle are
-    // read inside the filter/sort; including them keeps progress-based filtering
-    // and sorting reactive to value changes that don't replace the articles array.
-  }, [articles, globalFilter, filterValues, sortField, sortDirection, getProgress, valuesByArticle]);
+  })();
 
-  const activeFiltersCount = useMemo(() => {
+  const activeFiltersCount = (() => {
     let n = globalFilter.trim() ? 1 : 0;
     FILTER_FIELDS.forEach((f) => {
       if (!isFilterValueEmpty(filterValues[f.id])) n += 1;
     });
     return n;
-  }, [globalFilter, filterValues]);
+  })();
 
-  const filterLabels = useMemo(
-    () =>
-      Object.fromEntries(FILTER_FIELDS.map((f) => [f.id, f.label])) as Record<
-        string,
-        string
-      >,
-    [],
-  );
-  const activeFiltersList = useMemo(
-    () => buildActiveFiltersList(FILTER_FIELDS, filterValues, filterLabels),
-    [filterValues, filterLabels],
-  );
+  const filterLabels = Object.fromEntries(
+    FILTER_FIELDS.map((f) => [f.id, f.label])
+  ) as Record<string, string>;
+
+  const activeFiltersList = buildActiveFiltersList(FILTER_FIELDS, filterValues, filterLabels);
 
   const clearFilterField = (fieldId: string) => {
     const f = FILTER_FIELDS.find((field) => field.id === fieldId);

--- a/frontend/components/navigation/NotificationCenter.tsx
+++ b/frontend/components/navigation/NotificationCenter.tsx
@@ -56,6 +56,8 @@ export function NotificationCenter() {
   const [open, setOpen] = useState(false);
     const {jobs, removeJob, clearCompletedJobs, getRecentJobs, updateJob} = useBackgroundJobs();
   
+  // kept: extra dep (jobs) forces recompute on any job-list change, even when
+  // getRecentJobs identity is stable — removing it would miss new job additions (zero-bailouts spec).
   const recentJobs = useMemo(() => getRecentJobs(20), [jobs, getRecentJobs]);
 
     useEffect(() => {
@@ -179,15 +181,11 @@ export function NotificationCenter() {
   });
 
     // Count unread notifications (jobs that finished recently)
-  const unreadCount = useMemo(() => countRecentlyFinished(recentJobs), [recentJobs]);
+  const unreadCount = countRecentlyFinished(recentJobs);
 
-    const hasActiveBackgroundJobs = useMemo(
-        () =>
-            jobs.some(
-                (job) => job.status === 'pending' || job.status === 'running'
-            ),
-        [jobs]
-    );
+  const hasActiveBackgroundJobs = jobs.some(
+    (job) => job.status === 'pending' || job.status === 'running'
+  );
 
   const handleRemoveJob = (jobId: string, e: React.MouseEvent) => {
     e.stopPropagation();

--- a/frontend/components/quality/QualityAssessmentConfiguration.tsx
+++ b/frontend/components/quality/QualityAssessmentConfiguration.tsx
@@ -15,7 +15,7 @@
  * the tool brings it back to the article table without losing work.
  */
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Loader2, ShieldCheck } from "lucide-react";
 
 import {
@@ -59,10 +59,7 @@ export function QualityAssessmentConfiguration({
 
   const [pendingId, setPendingId] = useState<string | null>(null);
 
-  const enabledCount = useMemo(
-    () => templates.filter((tpl) => tpl.is_active).length,
-    [templates],
-  );
+  const enabledCount = templates.filter((tpl) => tpl.is_active).length;
 
   const findInactiveClone = (
     globalTemplateId: string,

--- a/frontend/components/shared/comparison/ComparisonTable.tsx
+++ b/frontend/components/shared/comparison/ComparisonTable.tsx
@@ -15,7 +15,6 @@
  * @component
  */
 
-import {useMemo} from 'react';
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table';
 import {ScrollArea} from '@/components/ui/scroll-area';
 import {Badge} from '@/components/ui/badge';
@@ -96,65 +95,50 @@ export function ComparisonTable<T = any>({
   maxHeight = '600px'
 }: ComparisonTableProps<T>) {
   
-  const allUsers = useMemo(() => 
-    [currentUser, ...otherUsers], 
-    [currentUser, otherUsers]
-  );
+  const allUsers = [currentUser, ...otherUsers];
 
-  // Pre-computar grid data (memoizado para performance)
-  const gridData = useMemo(() => {
-    return rows.map(rowId => {
-        // Collect value from each user for this row
-      const userValues = allUsers.map(user => {
-        const userData = data[user.userId] || {};
-          // Assuming row represents a single field
-        return userData[rowId];
-      });
-
-        // Detect consensus for this row
-      const consensus = detectConsensus(userValues, consensusThreshold);
-
-      return {
-        rowId,
-        userValues: allUsers.map((user, idx) => ({
-          userId: user.userId,
-          value: userValues[idx]
-        })),
-        consensus
-      };
+  // Pre-compute grid data
+  const gridData = rows.map(rowId => {
+      // Collect value from each user for this row
+    const userValues = allUsers.map(user => {
+      const userData = data[user.userId] || {};
+        // Assuming row represents a single field
+      return userData[rowId];
     });
-  }, [rows, allUsers, data, consensusThreshold]);
 
-    // Overall statistics
-  const stats = useMemo(() => {
-    const totalRows = gridData.length;
-    const consensusRows = gridData.filter(
-      row => row.consensus?.hasConsensus
-    ).length;
+      // Detect consensus for this row
+    const consensus = detectConsensus(userValues, consensusThreshold);
 
     return {
-      total: totalRows,
-      consensus: consensusRows,
-      divergent: totalRows - consensusRows,
-      consensusPercentage: totalRows > 0 
-        ? Math.round((consensusRows / totalRows) * 100)
-        : 0
+      rowId,
+      userValues: allUsers.map((user, idx) => ({
+        userId: user.userId,
+        value: userValues[idx]
+      })),
+      consensus
     };
-  }, [gridData]);
+  });
+
+    // Overall statistics
+  const statsTotal = gridData.length;
+  const statsConsensus = gridData.filter(row => row.consensus?.hasConsensus).length;
+  const stats = {
+    total: statsTotal,
+    consensus: statsConsensus,
+    divergent: statsTotal - statsConsensus,
+    consensusPercentage: statsTotal > 0
+      ? Math.round((statsConsensus / statsTotal) * 100)
+      : 0,
+  };
 
     // Compute dynamic height based on number of rows
-  const tableHeight = useMemo(() => {
-    const headerHeight = 50; // px
-    const statsHeight = showConsensus && stats.total > 0 ? 45 : 0; // px
-      const rowHeight = 60; // px approximate per row
-    const padding = 20; // px
-
-    const calculatedHeight = headerHeight + statsHeight + (rows.length * rowHeight) + padding;
-    const maxHeightPx = parseInt(maxHeight.replace('px', '')); // Parse '600px' → 600
-
-      // Return min of calculated and max (for scroll on large tables)
-    return Math.min(calculatedHeight, maxHeightPx);
-  }, [rows.length, showConsensus, stats.total, maxHeight]);
+  const headerHeight = 50; // px
+  const statsHeight = showConsensus && stats.total > 0 ? 45 : 0; // px
+  const rowHeight = 60; // px approximate per row
+  const padding = 20; // px
+  const calculatedHeight = headerHeight + statsHeight + (rows.length * rowHeight) + padding;
+  const maxHeightPx = parseInt(maxHeight.replace('px', '')); // Parse '600px' → 600
+  const tableHeight = Math.min(calculatedHeight, maxHeightPx);
 
   if (rows.length === 0) {
     return (

--- a/frontend/components/shared/comparison/EntitySelectorComparison.tsx
+++ b/frontend/components/shared/comparison/EntitySelectorComparison.tsx
@@ -16,7 +16,7 @@
  * | Number of preds    | 5       | 3       | 5       |
  */
 
-import {useCallback, useMemo, useState} from 'react';
+import {useState} from 'react';
 import {Label} from '@/components/ui/label';
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select';
 import {Card, CardContent} from '@/components/ui/card';
@@ -46,14 +46,11 @@ export function EntitySelectorComparison(props: ComparisonSectionViewProps) {
   const currentUserId = currentUser.userId;
 
     // Group instances by label (use real DB instances)
-  const groupedEntities = useMemo(() =>
-    groupInstancesByLabel(
-      instances,
-      currentUserId,
-        allUserInstances,
-      entityType.id
-    ),
-    [instances, currentUserId, allUserInstances, entityType.id]
+  const groupedEntities = groupInstancesByLabel(
+    instances,
+    currentUserId,
+    allUserInstances,
+    entityType.id
   );
 
     // State: entity explicitly picked by the user; defaults to the first
@@ -62,27 +59,21 @@ export function EntitySelectorComparison(props: ComparisonSectionViewProps) {
   const selectedEntityLabel = pickedEntityLabel ?? groupedEntities[0]?.label ?? null;
 
     // Active entity
-  const activeEntity = useMemo(() => 
-    groupedEntities.find(e => e.label === selectedEntityLabel),
-    [groupedEntities, selectedEntityLabel]
-  );
+  const activeEntity = groupedEntities.find(e => e.label === selectedEntityLabel);
 
     // Prepare columns
-  const columns = useMemo<ComparisonColumn[]>(() =>
-    entityType.fields.map((field: ExtractionField) => ({
-      id: field.id,
-      label: field.label,
-      getValue: (fieldId: string, userData: Record<string, any>) => userData[fieldId],
-      isRequired: field.is_required,
-        field: field
-    })),
-    [entityType.fields]
-  );
+  const columns: ComparisonColumn[] = entityType.fields.map((field: ExtractionField) => ({
+    id: field.id,
+    label: field.label,
+    getValue: (fieldId: string, userData: Record<string, any>) => userData[fieldId],
+    isRequired: field.is_required,
+    field: field,
+  }));
 
     // Prepare data for selected entity
-  const comparisonData = useMemo(() => {
+  const comparisonData = (() => {
     if (!activeEntity) return {};
-    
+
     const data: Record<string, Record<string, any>> = {};
 
       // For each user that has this entity, extract values
@@ -98,10 +89,10 @@ export function EntitySelectorComparison(props: ComparisonSectionViewProps) {
     });
 
     return data;
-  }, [activeEntity, currentUserId, myValues, otherExtractions]);
+  })();
 
     // Prepare user list (only those who have this entity)
-  const usersWithEntity = useMemo<ComparisonUser[]>(() => {
+  const usersWithEntity: ComparisonUser[] = (() => {
     if (!activeEntity) return [];
 
     const users: ComparisonUser[] = [];
@@ -116,24 +107,24 @@ export function EntitySelectorComparison(props: ComparisonSectionViewProps) {
             userId: ext.userId,
             userName: ext.userName,
             userAvatar: ext.userAvatar,
-            isCurrentUser: false
+            isCurrentUser: false,
           });
         }
       }
     });
 
     return users;
-  }, [activeEntity, currentUserId, currentUser, otherExtractions]);
+  })();
 
     // Edit handler
-  const handleValueChange = useCallback((fieldId: string, newValue: any) => {
+  const handleValueChange = (fieldId: string, newValue: any) => {
     if (activeEntity && onValueUpdate) {
       const myInstanceId = activeEntity.instancesByUser.get(currentUserId);
       if (myInstanceId) {
         onValueUpdate(myInstanceId, fieldId, newValue);
       }
     }
-  }, [activeEntity, currentUserId, onValueUpdate]);
+  };
 
     // Validations
   if (instances.length === 0) {

--- a/frontend/components/shared/comparison/SingleInstanceComparison.tsx
+++ b/frontend/components/shared/comparison/SingleInstanceComparison.tsx
@@ -6,7 +6,6 @@
  * - Compares values from all users side by side
  */
 
-import {useCallback, useMemo} from 'react';
 import {type ComparisonColumn, ComparisonTable, type ComparisonUser} from './ComparisonTable';
 import {extractInstanceValuesForUser} from '@/lib/comparison/grouping';
 import type {ComparisonSectionViewProps} from './ComparisonSectionView';
@@ -31,19 +30,16 @@ export function SingleInstanceComparison(props: ComparisonSectionViewProps) {
 
     // IMPORTANT: All hooks must be called BEFORE any early return
     // Prepare columns (each field is a row)
-  const columns = useMemo<ComparisonColumn[]>(() =>
-    entityType.fields.map((field: ExtractionField) => ({
-      id: field.id,
-      label: field.label,
-      getValue: (fieldId: string, userData: Record<string, any>) => userData[fieldId],
-      isRequired: field.is_required,
-        field: field // Pass field to column
-    })),
-    [entityType.fields]
-  );
+  const columns: ComparisonColumn[] = entityType.fields.map((field: ExtractionField) => ({
+    id: field.id,
+    label: field.label,
+    getValue: (fieldId: string, userData: Record<string, any>) => userData[fieldId],
+    isRequired: field.is_required,
+      field: field // Pass field to column
+  }));
 
     // Prepare data (userId -> fieldId -> value)
-  const comparisonData = useMemo(() => {
+  const comparisonData = (() => {
     if (!instance) return {};
 
     const data: Record<string, Record<string, any>> = {};
@@ -65,25 +61,22 @@ export function SingleInstanceComparison(props: ComparisonSectionViewProps) {
     });
 
     return data;
-  }, [currentUserId, myValues, otherExtractions, instance]);
+  })();
 
     // Prepare list of other users
-  const otherUsers = useMemo<ComparisonUser[]>(() =>
-    otherExtractions.map(ext => ({
-      userId: ext.userId,
-      userName: ext.userName,
-      userAvatar: ext.userAvatar,
-      isCurrentUser: false
-    })),
-    [otherExtractions]
-  );
+  const otherUsers: ComparisonUser[] = otherExtractions.map(ext => ({
+    userId: ext.userId,
+    userName: ext.userName,
+    userAvatar: ext.userAvatar,
+    isCurrentUser: false,
+  }));
 
     // Edit handler
-  const handleValueChange = useCallback((fieldId: string, newValue: any) => {
+  const handleValueChange = (fieldId: string, newValue: any) => {
     if (onValueUpdate && instance) {
       onValueUpdate(instance.id, fieldId, newValue);
     }
-  }, [instance, onValueUpdate]);
+  };
   
   // Early return APÓS todos os hooks
   if (!instance) {

--- a/frontend/components/ui/file-drop-zone.tsx
+++ b/frontend/components/ui/file-drop-zone.tsx
@@ -9,7 +9,7 @@
  * - Accessibility (keyboard navigation)
  */
 
-import React, {useCallback, useRef, useState} from 'react';
+import React, {useRef, useState} from 'react';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
 import {AlertCircle, FileIcon, Upload, X} from 'lucide-react';
@@ -116,7 +116,7 @@ export const FileDropZone: React.FC<FileDropZoneProps> = ({
   /**
    * Valida um arquivo individual
    */
-  const validateFile = useCallback((file: File): { valid: boolean; error?: string } => {
+  const validateFile = (file: File): { valid: boolean; error?: string } => {
     // Validar tamanho
     if (file.size > maxFileSize) {
       return {
@@ -138,12 +138,12 @@ export const FileDropZone: React.FC<FileDropZoneProps> = ({
     }
 
     return { valid: true };
-  }, [maxFileSize, acceptedTypes, acceptedExtensions]);
+  };
 
   /**
    * Processa arquivos selecionados
    */
-  const processFiles = useCallback((fileList: FileList | null) => {
+  const processFiles = (fileList: FileList | null) => {
     if (!fileList) return;
 
     const files = Array.from(fileList);
@@ -187,20 +187,20 @@ export const FileDropZone: React.FC<FileDropZoneProps> = ({
     if (validFiles.length > 0) {
       onFilesSelected(validFiles);
     }
-  }, [selectedFiles.length, maxFiles, validateFile, onFilesSelected, onError]);
+  };
 
   /**
    * Handler para drag events
    */
-  const handleDragEnter = useCallback((e: React.DragEvent) => {
+  const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     if (!disabled && !isUploading) {
       setIsDragging(true);
     }
-  }, [disabled, isUploading]);
+  };
 
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
+  const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
 
@@ -208,14 +208,14 @@ export const FileDropZone: React.FC<FileDropZoneProps> = ({
     if (dropZoneRef.current && !dropZoneRef.current.contains(e.relatedTarget as Node)) {
       setIsDragging(false);
     }
-  }, []);
+  };
 
-  const handleDragOver = useCallback((e: React.DragEvent) => {
+  const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-  }, []);
+  };
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
+  const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setIsDragging(false);
@@ -224,29 +224,29 @@ export const FileDropZone: React.FC<FileDropZoneProps> = ({
 
     const { files } = e.dataTransfer;
     processFiles(files);
-  }, [disabled, isUploading, processFiles]);
+  };
 
   /**
    * Handler for click selection
    */
-  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     processFiles(e.target.files);
     // Limpar input para permitir selecionar o mesmo arquivo novamente
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-  }, [processFiles]);
+  };
 
   /**
    * Handler para remover arquivo
    */
-  const handleRemoveFile = useCallback((fileId: string) => {
+  const handleRemoveFile = (fileId: string) => {
     const file = selectedFiles.find(f => f.id === fileId);
     if (file?.preview) {
       URL.revokeObjectURL(file.preview);
     }
     onFileRemove?.(fileId);
-  }, [selectedFiles, onFileRemove]);
+  };
 
   /**
    * Limpar previews ao desmontar

--- a/frontend/components/ui/resizable-panel.tsx
+++ b/frontend/components/ui/resizable-panel.tsx
@@ -9,7 +9,7 @@
  * - Smooth animated close (width + opacity to 0) instead of instant unmount.
  * See docs/superpowers/design-system/sidebar-and-panels.md §1.
  */
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {cn} from '@/lib/utils';
 
 export interface ResizablePanelProps {
@@ -84,19 +84,19 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
   // Compiler's mutation-aliasing inference cannot model).
   const listenersRef = useRef<{move: EventListener; up: EventListener} | null>(null);
 
-  const persist = useCallback((w: number) => {
+  const persist = (w: number) => {
     writeStoredWidth(id, w);
-  }, [id]);
+  };
 
-  const flushPending = useCallback(() => {
+  const flushPending = () => {
     rafRef.current = null;
     if (pendingRef.current != null) {
       setVisualWidth(pendingRef.current.visual);
       pendingRef.current = null;
     }
-  }, []);
+  };
 
-  const onPointerMove = useCallback((e: PointerEvent | MouseEvent | TouchEvent) => {
+  const onPointerMove = (e: PointerEvent | MouseEvent | TouchEvent) => {
     const start = dragStartRef.current;
     if (!start) return;
     if ('preventDefault' in e) e.preventDefault();
@@ -112,14 +112,14 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
     if (rafRef.current == null) {
       rafRef.current = requestAnimationFrame(flushPending);
     }
-  }, [flushPending, maxWidth, minWidth, side]);
+  };
 
   // Detaches whatever move/up listeners are currently registered. Reading the
   // identities back from a ref means the up handler never has to reference its
   // own binding (which the compiler cannot reason about). Both event-name pairs
   // are removed regardless of which input started the drag — matching the
   // original handler, which always cleaned up all four.
-  const detachListeners = useCallback(() => {
+  const detachListeners = () => {
     const listeners = listenersRef.current;
     if (!listeners) return;
     document.removeEventListener('mousemove', listeners.move);
@@ -127,9 +127,9 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
     document.removeEventListener('touchmove', listeners.move);
     document.removeEventListener('touchend', listeners.up);
     listenersRef.current = null;
-  }, []);
+  };
 
-  const onPointerUp = useCallback(() => {
+  const onPointerUp = () => {
     const start = dragStartRef.current;
     dragStartRef.current = null;
     detachListeners();
@@ -162,9 +162,9 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
     setWidth(finalWidth);
     setVisualWidth(finalWidth);
     persist(finalWidth);
-  }, [defaultWidth, detachListeners, minWidth, maxWidth, onCollapse, persist, snapCollapseAt]);
+  };
 
-  const attachListeners = useCallback((kind: 'mouse' | 'touch') => {
+  const attachListeners = (kind: 'mouse' | 'touch') => {
     const move = onPointerMove as EventListener;
     const up = onPointerUp as EventListener;
     listenersRef.current = {move, up};
@@ -175,24 +175,24 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
       document.addEventListener('touchmove', move);
       document.addEventListener('touchend', up);
     }
-  }, [onPointerMove, onPointerUp]);
+  };
 
-  const onMouseDown = useCallback((e: React.MouseEvent) => {
+  const onMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     dragStartRef.current = {startX: e.clientX, startWidth: width, moved: false, rawFinal: width};
     setIsDragging(true);
     document.body.style.userSelect = 'none';
     document.body.style.cursor = 'col-resize';
     attachListeners('mouse');
-  }, [attachListeners, width]);
+  };
 
-  const onTouchStart = useCallback((e: React.TouchEvent) => {
+  const onTouchStart = (e: React.TouchEvent) => {
     dragStartRef.current = {startX: e.touches[0].clientX, startWidth: width, moved: false, rawFinal: width};
     setIsDragging(true);
     attachListeners('touch');
-  }, [attachListeners, width]);
+  };
 
-  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
+  const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       onCollapse?.();
@@ -214,7 +214,7 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
       setVisualWidth(next);
       persist(next);
     }
-  }, [maxWidth, minWidth, onCollapse, persist, width]);
+  };
 
   useEffect(() => {
     function onStorage(e: StorageEvent) {

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -55,6 +55,7 @@ const SidebarProvider = React.forwardRef<
   // We use openProp and setOpenProp for control from outside the component.
   const [_open, _setOpen] = React.useState(defaultOpen);
   const open = openProp ?? _open;
+  // kept: identity feeds provider-value memo and keyboard-shortcut effect (deps-report flagged; zero-bailouts spec)
   const setOpen = (value: boolean | ((value: boolean) => boolean)) => {
     const openState = typeof value === "function" ? value(open) : value;
     if (setOpenProp) {
@@ -68,11 +69,13 @@ const SidebarProvider = React.forwardRef<
   };
 
   // Helper to toggle the sidebar.
+  // kept: identity feeds provider-value memo and keyboard-shortcut effect (deps-report flagged; zero-bailouts spec)
   const toggleSidebar = () => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
   };
 
   // Adds a keyboard shortcut to toggle the sidebar.
+  // kept: identity feeds provider-value memo and keyboard-shortcut effect (deps-report flagged; zero-bailouts spec)
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
@@ -89,6 +92,7 @@ const SidebarProvider = React.forwardRef<
   // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? "expanded" : "collapsed";
 
+  // kept: provider value — unmemoized value re-renders every consumer (zero-bailouts spec, exception class)
   const contextValue = React.useMemo<SidebarContext>(
     () => ({
       state,

--- a/frontend/components/user/ProfileSection.tsx
+++ b/frontend/components/user/ProfileSection.tsx
@@ -2,7 +2,7 @@
  * User profile section: view and edit profile information.
  */
 
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useForm, useWatch} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {z} from 'zod';
@@ -33,16 +33,12 @@ export function ProfileSection() {
     const [email, setEmail] = useState('');
     const [avatarUrl, setAvatarUrl] = useState('');
 
-    const schema = useMemo(
-        () =>
-            z.object({
-                full_name: z
-                    .string()
-                    .min(1, t('user', 'profileNameRequired'))
-                    .max(100, t('user', 'profileNameMaxLength')),
-            }),
-        []
-    );
+    const schema = z.object({
+        full_name: z
+            .string()
+            .min(1, t('user', 'profileNameRequired'))
+            .max(100, t('user', 'profileNameMaxLength')),
+    });
 
     const form = useForm<FormValues>({
         resolver: zodResolver(schema),

--- a/frontend/components/user/SecuritySection.tsx
+++ b/frontend/components/user/SecuritySection.tsx
@@ -2,7 +2,7 @@
  * Security section: change password and security settings.
  */
 
-import {useMemo, useState} from 'react';
+import {useState} from 'react';
 import {useForm, useWatch} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {z} from 'zod';
@@ -47,24 +47,20 @@ export function SecuritySection() {
     const [loading, setLoading] = useState(false);
     const [showPasswords, setShowPasswords] = useState({new: false, confirm: false});
 
-    const schema = useMemo(
-        () =>
-            z
-                .object({
-                    newPassword: z
-                        .string()
-                        .min(8, t('user', 'securitySchemaMin'))
-                        .regex(/[A-Z]/, t('user', 'securitySchemaUppercase'))
-                        .regex(/[a-z]/, t('user', 'securitySchemaLowercase'))
-                        .regex(/[0-9]/, t('user', 'securitySchemaNumber')),
-                    confirmPassword: z.string().min(1, t('user', 'securitySchemaConfirm')),
-                })
-                .refine((data) => data.newPassword === data.confirmPassword, {
-                    message: t('user', 'securitySchemaMismatch'),
-                    path: ['confirmPassword'],
-                }),
-        []
-    );
+    const schema = z
+        .object({
+            newPassword: z
+                .string()
+                .min(8, t('user', 'securitySchemaMin'))
+                .regex(/[A-Z]/, t('user', 'securitySchemaUppercase'))
+                .regex(/[a-z]/, t('user', 'securitySchemaLowercase'))
+                .regex(/[0-9]/, t('user', 'securitySchemaNumber')),
+            confirmPassword: z.string().min(1, t('user', 'securitySchemaConfirm')),
+        })
+        .refine((data) => data.newPassword === data.confirmPassword, {
+            message: t('user', 'securitySchemaMismatch'),
+            path: ['confirmPassword'],
+        });
 
     const form = useForm<FormValues>({
         resolver: zodResolver(schema),

--- a/frontend/hooks/extraction/ai/useAISuggestions.ts
+++ b/frontend/hooks/extraction/ai/useAISuggestions.ts
@@ -10,7 +10,7 @@
  * @hook
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
 import type {
@@ -57,7 +57,7 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
   const providedInstanceKey = providedInstanceIds?.join('|') ?? null;
 
     // Declare loadSuggestions BEFORE useEffect to avoid init error
-  const loadSuggestions = useCallback((): Promise<LoadSuggestionsResult> => {
+  const loadSuggestions = (): Promise<LoadSuggestionsResult> => {
     setLoading(true);
 
     // Prefer caller-provided instance ids when available (QA gets these
@@ -107,7 +107,7 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
         return { suggestions: {}, count: 0 } as LoadSuggestionsResult;
       })
       .finally(() => setLoading(false));
-  }, [articleId, runId, providedInstanceKey]);
+  };
 
     // useEffect AFTER loadSuggestions declaration
   useEffect(() => {
@@ -116,7 +116,7 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
     queueMicrotask(() => void loadSuggestions());
   }, [articleId, enabled, loadSuggestions]);
 
-  const acceptSuggestionCore = useCallback(async (instanceId: string, fieldId: string, silent: boolean): Promise<boolean> => {
+  const acceptSuggestionCore = async (instanceId: string, fieldId: string, silent: boolean): Promise<boolean> => {
     const key = getSuggestionKey(instanceId, fieldId);
     const suggestion = suggestions[key];
     if (!suggestion) return false;
@@ -193,18 +193,15 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
         return false;
       })
       .finally(clearLoading);
-  }, [suggestions, projectId, articleId, runId, acceptStrategy, onSuggestionAccepted]);
+  };
 
   // Public accept: surfaces its own toasts (silent=false) and keeps the
   // Promise<void> contract — only the batch path needs the success flag.
-  const acceptSuggestion = useCallback(
-    async (instanceId: string, fieldId: string): Promise<void> => {
-      await acceptSuggestionCore(instanceId, fieldId, false);
-    },
-    [acceptSuggestionCore],
-  );
+  const acceptSuggestion = async (instanceId: string, fieldId: string): Promise<void> => {
+    await acceptSuggestionCore(instanceId, fieldId, false);
+  };
 
-  const rejectSuggestion = useCallback(async (instanceId: string, fieldId: string) => {
+  const rejectSuggestion = async (instanceId: string, fieldId: string) => {
     const key = getSuggestionKey(instanceId, fieldId);
     const suggestion = suggestions[key];
     if (!suggestion) return;
@@ -276,9 +273,9 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
         toast.error(`${t('extraction', 'errors_rejectSuggestion')}: ${message}`);
       })
       .finally(clearLoading);
-  }, [suggestions, projectId, articleId, runId, acceptStrategy, onSuggestionRejected]);
+  };
 
-  const batchAccept = useCallback(async (threshold = 0.8) => {
+  const batchAccept = async (threshold = 0.8) => {
     const filtered = filterSuggestionsByConfidence(suggestions, threshold);
 
     if (filtered.length === 0) {
@@ -304,12 +301,12 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
       return;
     }
     toast.success(t('extraction', 'batchAcceptCountToast').replace('{{n}}', String(accepted)));
-  }, [suggestions, acceptSuggestionCore]);
+  };
 
   /**
    * Fetches full suggestion history for a specific field
    */
-  const getSuggestionsHistory = useCallback(async (
+  const getSuggestionsHistory = async (
     instanceId: string,
     fieldId: string
   ): Promise<AISuggestionHistoryItem[]> =>
@@ -318,25 +315,24 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
       const message = getErrorMessage(err);
       toast.error(`${t('extraction', 'errors_loadSuggestionsHistory')}: ${message}`);
       return [] as AISuggestionHistoryItem[];
-    })
-  , []);
+    });
 
   /**
    * Returns the latest suggestion for a field (if present in local state)
    */
-  const getLatestSuggestion = useCallback((
+  const getLatestSuggestion = (
     instanceId: string,
     fieldId: string
   ): AISuggestion | undefined => {
     const key = getSuggestionKey(instanceId, fieldId);
     return suggestions[key];
-  }, [suggestions]);
+  };
 
     // Helper to check if a suggestion is loading
-  const isActionLoading = useCallback((instanceId: string, fieldId: string): 'accept' | 'reject' | null => {
+  const isActionLoading = (instanceId: string, fieldId: string): 'accept' | 'reject' | null => {
     const key = getSuggestionKey(instanceId, fieldId);
     return actionLoading[key] || null;
-  }, [actionLoading]);
+  };
 
   return {
     suggestions,

--- a/frontend/hooks/extraction/ai/useRunAIExtraction.ts
+++ b/frontend/hooks/extraction/ai/useRunAIExtraction.ts
@@ -11,7 +11,7 @@
  * caller doesn't have to know whether the run is extraction or
  * quality_assessment, only that it exists and is in PROPOSAL stage.
  */
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { t } from "@/lib/copy";
@@ -35,8 +35,7 @@ export function useRunAIExtraction(options?: {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const extractForRun = useCallback(
-    async (params: ExtractForRunRequest): Promise<ExtractForRunResult> => {
+  const extractForRun = async (params: ExtractForRunRequest): Promise<ExtractForRunResult> => {
       setLoading(true);
       setError(null);
 
@@ -70,9 +69,7 @@ export function useRunAIExtraction(options?: {
           throw err;
         })
         .finally(() => setLoading(false));
-    },
-    [options],
-  );
+  };
 
   return { extractForRun, loading, error };
 }

--- a/frontend/hooks/extraction/useBatchAllModelsSectionsExtraction.ts
+++ b/frontend/hooks/extraction/useBatchAllModelsSectionsExtraction.ts
@@ -14,7 +14,7 @@
  * - Error handling (skips failed models)
  */
 
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import {t} from "@/lib/copy";
 import { getModelChildSections } from "./helpers/getModelChildSections";
@@ -83,8 +83,7 @@ export function useBatchAllModelsSectionsExtraction(options?: {
    * Extracts all sections from all existing models
    * @param params - Extraction params (projectId, articleId, templateId, models)
    */
-  const extractAllSectionsForAllModels = useCallback(
-    async (params: {
+  const extractAllSectionsForAllModels = async (params: {
       projectId: string;
       articleId: string;
       templateId: string;
@@ -262,9 +261,7 @@ export function useBatchAllModelsSectionsExtraction(options?: {
           throw err;
         })
         .finally(() => setLoading(false));
-    },
-    [options],
-  );
+  };
 
   return { extractAllSectionsForAllModels, loading, error, progress };
 }

--- a/frontend/hooks/extraction/useBatchSectionExtractionChunked.ts
+++ b/frontend/hooks/extraction/useBatchSectionExtractionChunked.ts
@@ -13,7 +13,7 @@
  * - Error handling (skip failed sections)
  */
 
-import {useCallback, useState} from "react";
+import {useState} from "react";
 // Note: a PDF-text cache used to be planned here (process once, reuse across
 // chunks), but it was never wired — the setter sat unused. Removed for now;
 // reintroduce only with a proper setter call inside `extractAllSections`.
@@ -86,8 +86,7 @@ export function useBatchSectionExtractionChunked(options?: {
    *
    * @param request - Extraction params (sectionIds and pdfText are generated)
    */
-  const extractAllSections = useCallback(
-    async (request: Omit<BatchSectionExtractionRequest, 'sectionIds' | 'pdfText'>) => {
+  const extractAllSections = async (request: Omit<BatchSectionExtractionRequest, 'sectionIds' | 'pdfText'>) => {
         console.warn('[useBatchSectionExtractionChunked] Starting extraction with chunking', request);
       setLoading(true);
       setError(null);
@@ -208,9 +207,7 @@ export function useBatchSectionExtractionChunked(options?: {
           throw err;
         })
         .finally(() => setLoading(false));
-    },
-    [options, chunkSize],
-  );
+  };
 
   return { extractAllSections, loading, error, progress };
 }

--- a/frontend/hooks/extraction/useErrorHandler.ts
+++ b/frontend/hooks/extraction/useErrorHandler.ts
@@ -7,7 +7,6 @@
  * @module hooks/extraction/useErrorHandler
  */
 
-import {useCallback} from 'react';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
 
@@ -18,7 +17,7 @@ interface ErrorHandlerOptions {
 }
 
 export function useErrorHandler() {
-  const handleError = useCallback((
+  const handleError = (
     error: unknown,
     context: string,
     options: ErrorHandlerOptions = {}
@@ -44,56 +43,56 @@ export function useErrorHandler() {
     }
 
     return errorMessage;
-  }, []);
+  };
 
-  const handleFieldValidationError = useCallback((error: unknown) => {
-      return handleError(error, t('extraction', 'errors_validateField'), {
-          fallbackMessage: t('extraction', 'fieldOperationValidateFallback')
+  const handleFieldValidationError = (error: unknown) => {
+    return handleError(error, t('extraction', 'errors_validateField'), {
+      fallbackMessage: t('extraction', 'fieldOperationValidateFallback')
     });
-  }, [handleError]);
+  };
 
-  const handleFieldOperationError = useCallback((
+  const handleFieldOperationError = (
     error: unknown,
     operation: 'create' | 'edit' | 'delete' | 'validate'
   ) => {
-      const contextMap: Record<typeof operation, string> = {
-          create: t('extraction', 'errors_addField'),
-          edit: t('extraction', 'errors_updateField'),
-          delete: t('extraction', 'errors_removeField'),
-          validate: t('extraction', 'errors_validateField')
-      };
-      const fallbackMap: Record<typeof operation, string> = {
-          create: t('extraction', 'fieldOperationCreateFallback'),
-          edit: t('extraction', 'fieldOperationEditFallback'),
-          delete: t('extraction', 'fieldOperationDeleteFallback'),
-          validate: t('extraction', 'fieldOperationValidateFallback')
+    const contextMap: Record<typeof operation, string> = {
+      create: t('extraction', 'errors_addField'),
+      edit: t('extraction', 'errors_updateField'),
+      delete: t('extraction', 'errors_removeField'),
+      validate: t('extraction', 'errors_validateField')
+    };
+    const fallbackMap: Record<typeof operation, string> = {
+      create: t('extraction', 'fieldOperationCreateFallback'),
+      edit: t('extraction', 'fieldOperationEditFallback'),
+      delete: t('extraction', 'fieldOperationDeleteFallback'),
+      validate: t('extraction', 'fieldOperationValidateFallback')
     };
 
     return handleError(error, contextMap[operation], {
-        fallbackMessage: fallbackMap[operation]
+      fallbackMessage: fallbackMap[operation]
     });
-  }, [handleError]);
+  };
 
-    const handlePermissionError = useCallback((_operation: string) => {
-      const message = t('extraction', 'permissionDeniedOperation');
+  const handlePermissionError = (_operation: string) => {
+    const message = t('extraction', 'permissionDeniedOperation');
     toast.error(message);
     return message;
-  }, []);
+  };
 
-  const handleValidationError = useCallback((error: unknown) => {
+  const handleValidationError = (error: unknown) => {
     if (error && typeof error === 'object' && 'name' in error && error.name === 'ZodError') {
       const zodError = error as any;
       const firstError = zodError.errors?.[0];
       if (firstError?.message) {
-          toast.error(t('extraction', 'errors_validationPrefix').replace('{{message}}', firstError.message));
+        toast.error(t('extraction', 'errors_validationPrefix').replace('{{message}}', firstError.message));
         return firstError.message;
       }
     }
 
-      return handleError(error, t('extraction', 'validationErrorTitle'), {
-          fallbackMessage: t('extraction', 'validationInvalidData')
+    return handleError(error, t('extraction', 'validationErrorTitle'), {
+      fallbackMessage: t('extraction', 'validationInvalidData')
     });
-  }, [handleError]);
+  };
 
   return {
     handleError,

--- a/frontend/hooks/extraction/useExtractedValues.ts
+++ b/frontend/hooks/extraction/useExtractedValues.ts
@@ -28,7 +28,6 @@
 import {
   type Dispatch,
   type SetStateAction,
-  useCallback,
   useEffect,
   useRef,
   useState,
@@ -137,36 +136,32 @@ export function useExtractedValues(
   const [error, setError] = useState<string | null>(null);
   const hydratedRunIdRef = useRef<string | null>(null);
 
-  const applyLoadedValues = useCallback(
-    (valuesMap: Record<string, any>) => {
-      // Expose the raw server map as the autosave baseline (see return docs)
-      // so the form never re-POSTs hydrated values on mount. Every hydration
-      // path (proposal + reviewer-state) routes through here, including the
-      // empty-map case, so switching runs replaces the baseline too. Keep the
-      // SAME reference when the content is unchanged: this runs on every
-      // ``loadValues`` (e.g. each ``proposals`` change), and emitting a fresh
-      // object each time churned re-renders (and, with an unstable proposals
-      // prop, looped to OOM).
-      setLoadedValues((prev) =>
-        JSON.stringify(prev) === JSON.stringify(valuesMap) ? prev : valuesMap,
-      );
-      setValues((prev) => {
-        if (hydratedRunIdRef.current !== runId) {
-          hydratedRunIdRef.current = runId ?? null;
-          const addedKeys = Object.keys(valuesMap);
-          if (addedKeys.length > 0) {
-            requestAnimationFrame(() => dispatchValueUpdates(addedKeys));
-          }
-          return valuesMap;
+  const applyLoadedValues = (valuesMap: Record<string, any>) => {
+    // Expose the raw server map as the autosave baseline (see return docs)
+    // so the form never re-POSTs hydrated values on mount. Every hydration
+    // path (proposal + reviewer-state) routes through here, including the
+    // empty-map case, so switching runs replaces the baseline too. Keep the
+    // SAME reference when the content is unchanged: this runs on every
+    // ``loadValues`` (e.g. each ``proposals`` change), and emitting a fresh
+    // object each time churned re-renders (and, with an unstable proposals
+    // prop, looped to OOM).
+    setLoadedValues((prev) =>
+      JSON.stringify(prev) === JSON.stringify(valuesMap) ? prev : valuesMap,
+    );
+    setValues((prev) => {
+      if (hydratedRunIdRef.current !== runId) {
+        hydratedRunIdRef.current = runId ?? null;
+        const addedKeys = Object.keys(valuesMap);
+        if (addedKeys.length > 0) {
+          requestAnimationFrame(() => dispatchValueUpdates(addedKeys));
         }
-        return mergeValuesById(prev, valuesMap);
-      });
-    },
-    [runId],
-  );
+        return valuesMap;
+      }
+      return mergeValuesById(prev, valuesMap);
+    });
+  };
 
-  const loadValues = useCallback(
-    (silent = false) => {
+  const loadValues = (silent = false) => {
       if (!silent) setLoading(true);
       setError(null);
 
@@ -259,9 +254,7 @@ export function useExtractedValues(
           toast.error(t('extraction', 'errors_loadExtractedValues'));
         })
         .finally(() => { if (!silent) setLoading(false); });
-    },
-    [runId, stage, proposals, currentValues, currentUserId, applyLoadedValues],
-  );
+  };
 
   useEffect(() => {
     if (!enabled) {
@@ -287,15 +280,15 @@ export function useExtractedValues(
     queueMicrotask(() => void loadValues());
   }, [enabled, loadValues]);
 
-  const updateValue = useCallback((instanceId: string, fieldId: string, value: any) => {
+  const updateValue = (instanceId: string, fieldId: string, value: any) => {
     const key = `${instanceId}_${fieldId}`;
     setValues((prev) => ({
       ...prev,
       [key]: value,
     }));
-  }, []);
+  };
 
-  const refresh = useCallback(() => loadValues(true), [loadValues]);
+  const refresh = () => loadValues(true);
 
   return {
     values,

--- a/frontend/hooks/extraction/useExtractionData.ts
+++ b/frontend/hooks/extraction/useExtractionData.ts
@@ -9,7 +9,7 @@
  * Reduces main component complexity (SRP).
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
 import {extractionInstanceService} from '@/services/extractionInstanceService';
@@ -124,7 +124,7 @@ export function useExtractionData({
     // change — only added/updated entries trigger downstream re-renders. This
     // removes the visual flash + scroll reset that came from replacing the
     // whole array on every refresh.
-  const loadInstances = useCallback(async (templateId: string) => {
+  const loadInstances = async (templateId: string) => {
     if (!articleId || !templateId) {
       setInstances([]);
       return;
@@ -137,10 +137,10 @@ export function useExtractionData({
       metadata: instance.metadata as unknown,
     }));
     setInstances(prev => mergeInstancesById(prev, normalised));
-  }, [articleId]);
+  };
 
     // Load all data
-  const loadData = useCallback(() => {
+  const loadData = () => {
     if (!enabled || !projectId || !articleId) {
       setLoading(false);
       return Promise.resolve();
@@ -205,7 +205,7 @@ export function useExtractionData({
         toast.error(message);
       })
       .finally(() => setLoading(false));
-  }, [projectId, articleId, enabled, loadInstances]);
+  };
 
     // Load initial data
   useEffect(() => {
@@ -214,18 +214,17 @@ export function useExtractionData({
   }, [loadData]);
 
     // Refresh function
-  const refresh = useCallback(async () => {
+  const refresh = async () => {
     await loadData();
-  }, [loadData]);
+  };
 
-    // Refresh instances only (no new creation). Plain-identifier dep —
-    // optional-chained deps defeat compiler memoization preservation.
+    // Refresh instances only (no new creation).
   const activeTemplateId = template?.id;
-  const refreshInstances = useCallback(async () => {
+  const refreshInstances = async () => {
     if (activeTemplateId) {
       await loadInstances(activeTemplateId);
     }
-  }, [activeTemplateId, loadInstances]);
+  };
 
   return {
     article,

--- a/frontend/hooks/extraction/useExtractionFormAIActions.ts
+++ b/frontend/hooks/extraction/useExtractionFormAIActions.ts
@@ -9,7 +9,6 @@
  * ``onRefreshInstances``, ``onExtractionComplete``) in one place so
  * any new AI action just plugs into the same callback chain.
  */
-import {useCallback} from 'react';
 
 import {useBatchAllModelsSectionsExtraction} from './useBatchAllModelsSectionsExtraction';
 import {useBatchSectionExtractionChunked} from './useBatchSectionExtractionChunked';
@@ -76,13 +75,13 @@ export function useExtractionFormAIActions(props: UseExtractionFormAIActionsProp
     },
   });
 
-  const handleExtractModels = useCallback(async () => {
+  const handleExtractModels = async () => {
     extractModels({projectId, articleId, templateId}).catch((error: unknown) => {
       console.error('[useExtractionFormAIActions] extractModels failed:', error);
     });
-  }, [extractModels, projectId, articleId, templateId]);
+  };
 
-  const handleExtractAllSections = useCallback(async () => {
+  const handleExtractAllSections = async () => {
     if (!activeModelId) {
       console.warn('[useExtractionFormAIActions] no active model; skipping');
       return;
@@ -96,9 +95,9 @@ export function useExtractionFormAIActions(props: UseExtractionFormAIActionsProp
     }).catch((error: unknown) => {
       console.error('[useExtractionFormAIActions] extractAllSections failed:', error);
     });
-  }, [extractAllSections, projectId, articleId, templateId, activeModelId]);
+  };
 
-  const handleExtractAllSectionsForAllModels = useCallback(async () => {
+  const handleExtractAllSectionsForAllModels = async () => {
     if (models.length === 0) {
       console.warn('[useExtractionFormAIActions] no models; skipping');
       return;
@@ -111,7 +110,7 @@ export function useExtractionFormAIActions(props: UseExtractionFormAIActionsProp
     }).catch((error: unknown) => {
       console.error('[useExtractionFormAIActions] extractAllSectionsForAllModels failed:', error);
     });
-  }, [extractAllSectionsForAllModels, projectId, articleId, templateId, models]);
+  };
 
   return {
     handleExtractModels,

--- a/frontend/hooks/extraction/useExtractionProgress.ts
+++ b/frontend/hooks/extraction/useExtractionProgress.ts
@@ -11,8 +11,6 @@
  * @hook
  */
 
-import { useMemo } from 'react';
-
 import {
   type ProgressEntityProjection,
   type RequiredFieldProgress,
@@ -25,8 +23,5 @@ export function useExtractionProgress(
   values: Record<string, any>,
   entityTypes: ProgressEntityProjection[],
 ): UseExtractionProgressReturn {
-  return useMemo(
-    () => computeRequiredFieldProgress(values, entityTypes),
-    [values, entityTypes],
-  );
+  return computeRequiredFieldProgress(values, entityTypes);
 }

--- a/frontend/hooks/extraction/useExtractionSession.ts
+++ b/frontend/hooks/extraction/useExtractionSession.ts
@@ -12,7 +12,7 @@
  * seeded for every top-level entity type, and is in PROPOSAL stage.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -84,7 +84,7 @@ export function useExtractionSession({
     }
   }
 
-  const openCore = useCallback(async () => {
+  const openCore = async () => {
     if (!enabled || !projectId || !articleId || !projectTemplateId) return;
     const myGeneration = ++generationRef.current;
 
@@ -123,15 +123,15 @@ export function useExtractionSession({
       instancesByEntityType: data.instances_by_entity_type,
     });
     setLoading(false);
-  }, [enabled, projectId, articleId, projectTemplateId, queryClient]);
+  };
 
   // Manual refetch (event-handler context): show the loader, then reopen.
-  const refetch = useCallback(async () => {
+  const refetch = async () => {
     if (!enabled || !projectId || !articleId || !projectTemplateId) return;
     setLoading(true);
     setError(null);
     await openCore();
-  }, [enabled, projectId, articleId, projectTemplateId, openCore]);
+  };
 
   const openCoreRef = useRef(openCore);
   useEffect(() => {

--- a/frontend/hooks/extraction/useFieldManagement.ts
+++ b/frontend/hooks/extraction/useFieldManagement.ts
@@ -12,7 +12,7 @@
  * @module hooks/extraction/useFieldManagement
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useAuth} from '@/contexts/AuthContext';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
@@ -58,7 +58,7 @@ export function useFieldManagement({
   /**
    * Check user permissions in project
    */
-  const checkPermissions = useCallback(async (): Promise<PermissionCheckResult> => {
+  const checkPermissions = async (): Promise<PermissionCheckResult> => {
     if (!user) {
       return {
         canView: false,
@@ -87,12 +87,12 @@ export function useFieldManagement({
 
     setPermissions(result.data);
     return result.data;
-  }, [user, projectId]);
+  };
 
   /**
    * Load section fields
    */
-  const loadFields = useCallback(async () => {
+  const loadFields = async () => {
     if (!entityTypeId) {
       console.warn('entityTypeId not provided');
       setFields([]);
@@ -110,12 +110,12 @@ export function useFieldManagement({
       setFields(result.data);
     }
     setLoading(false);
-  }, [entityTypeId]);
+  };
 
   /**
    * Validate field before operations (check impact)
    */
-  const validateField = useCallback(async (
+  const validateField = async (
     fieldId: string
   ): Promise<FieldValidationResult> => {
     const result = await validateFieldImpact(
@@ -139,12 +139,12 @@ export function useFieldManagement({
       };
     }
     return result.data;
-  }, []);
+  };
 
   /**
    * Add new field
    */
-  const addField = useCallback(async (
+  const addField = async (
     fieldData: ExtractionFieldInput
   ): Promise<ExtractionField | null> => {
       // Check permissions
@@ -201,12 +201,12 @@ export function useFieldManagement({
     setFields(prev => [...prev, createdField]);
     toast.success(t('extraction', 'fieldAddedSuccess').replace('{{label}}', createdField.label));
     return createdField;
-  }, [fields, entityTypeId, checkPermissions]);
+  };
 
   /**
    * Create "Other (specify)" field associated with a select field
    */
-  const createOtherSpecifyField = useCallback(async (
+  const createOtherSpecifyField = async (
     parentFieldName: string,
     parentFieldLabel: string,
     sortOrder: number
@@ -255,12 +255,12 @@ export function useFieldManagement({
     const createdField = result.data;
     setFields(prev => [...prev, createdField]);
     return createdField;
-  }, [fields, entityTypeId, checkPermissions]);
+  };
 
   /**
    * Update existing field
    */
-  const updateField = useCallback(async (
+  const updateField = async (
     fieldId: string,
     updates: ExtractionFieldUpdate
   ): Promise<ExtractionField | null> => {
@@ -296,12 +296,12 @@ export function useFieldManagement({
     );
     toast.success(t('extraction', 'fieldUpdatedSuccess'));
     return updatedField;
-  }, [fields, checkPermissions, validateField]);
+  };
 
   /**
    * Remove field (with impact validation)
    */
-  const deleteField = useCallback(async (
+  const deleteField = async (
     fieldId: string
   ): Promise<boolean> => {
     // Check permissions
@@ -328,12 +328,12 @@ export function useFieldManagement({
     setFields(prev => prev.filter(field => field.id !== fieldId));
     toast.success(t('extraction', 'fieldRemovedSuccess'));
     return true;
-  }, [checkPermissions, validateField]);
+  };
 
   /**
    * Remove associated "Other (specify)" field
    */
-  const removeOtherSpecifyField = useCallback(async (
+  const removeOtherSpecifyField = async (
     parentFieldName: string
   ): Promise<boolean> => {
     const perms = await checkPermissions();
@@ -361,12 +361,12 @@ export function useFieldManagement({
     }
 
     return deleteField(otherField.id);
-  }, [fields, checkPermissions, validateField, deleteField]);
+  };
 
   /**
    * Reorder fields (batch update)
    */
-  const reorderFields = useCallback(async (
+  const reorderFields = async (
     reorderedFields: { id: string; sort_order: number }[]
   ): Promise<boolean> => {
     // Check permissions
@@ -387,7 +387,7 @@ export function useFieldManagement({
     await loadFields();
     toast.success(t('extraction', 'fieldsReorderSuccess'));
     return true;
-  }, [checkPermissions, loadFields]);
+  };
 
     // Load permissions and fields on mount
   useEffect(() => {

--- a/frontend/hooks/extraction/useFinalizedExtractionRun.ts
+++ b/frontend/hooks/extraction/useFinalizedExtractionRun.ts
@@ -12,7 +12,7 @@
  * resolver.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { ExtractionValueService, type RunRef } from "@/services/extractionValueService";
 
@@ -38,7 +38,7 @@ export function useFinalizedExtractionRun(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const load = useCallback(async () => {
+  const load = async () => {
     if (!articleId) {
       setFinalizedRun(null);
       return;
@@ -55,7 +55,7 @@ export function useFinalizedExtractionRun(
         setFinalizedRun(null);
       })
       .finally(() => setLoading(false));
-  }, [articleId, projectTemplateId]);
+  };
 
   useEffect(() => {
     if (!enabled) return;

--- a/frontend/hooks/extraction/useFullAIExtraction.ts
+++ b/frontend/hooks/extraction/useFullAIExtraction.ts
@@ -15,7 +15,7 @@
  * - Success callback for refresh
  */
 
-import {useCallback, useState} from "react";
+import {useState} from "react";
 import {toast} from "sonner";
 import {t} from "@/lib/copy";
 import {useModelExtraction} from "./useModelExtraction";
@@ -109,7 +109,7 @@ export function useFullAIExtraction(options?: {
    * throws — failing fast is correct here: every caller assumes a
    * template that owns prediction models.
    */
-  const fetchModelParentEntityTypeId = useCallback(async (
+  const fetchModelParentEntityTypeId = async (
     templateId: string
   ): Promise<string> => {
     const results = await queryEntityTypesWithFallback<{ id: string }>({
@@ -123,15 +123,14 @@ export function useFullAIExtraction(options?: {
     }
 
     return results[0].id;
-  }, []);
+  };
 
   /**
    * Extracts models and then sections for each model
    *
    * @param params - Extraction parameters
    */
-  const extractFullAI = useCallback(
-    async (params: {
+  const extractFullAI = async (params: {
       projectId: string;
       articleId: string;
       templateId: string;
@@ -263,9 +262,7 @@ export function useFullAIExtraction(options?: {
           throw err;
         })
         .finally(() => setLoading(false));
-    },
-    [extractModelsHook, extractTopLevelSections, extractAllSectionsForAllModels, fetchModelParentEntityTypeId, options],
-  );
+  };
 
   return { extractFullAI, loading, error, progress };
 }

--- a/frontend/hooks/extraction/useModelExtraction.ts
+++ b/frontend/hooks/extraction/useModelExtraction.ts
@@ -13,7 +13,7 @@
  * - User-friendly error handling
  */
 
-import {useCallback, useState} from "react";
+import {useState} from "react";
 import {toast} from "sonner";
 import {t} from "@/lib/copy";
 import {type ModelExtractionRequest, SectionExtractionService,} from "@/services/sectionExtractionService";
@@ -59,8 +59,7 @@ export function useModelExtraction(options?: {
    * Extracts prediction models from the article
    * @param request - Extraction parameters
    */
-  const extractModels = useCallback(
-    async (request: ModelExtractionRequest) => {
+  const extractModels = async (request: ModelExtractionRequest) => {
         console.warn('[useModelExtraction] Starting model extraction', request);
       setLoading(true);
       setError(null);
@@ -131,9 +130,7 @@ export function useModelExtraction(options?: {
           throw err;
         })
         .finally(() => setLoading(false));
-    },
-    [options],
-  );
+  };
 
   return { extractModels, loading, error };
 }

--- a/frontend/hooks/extraction/useModelManagement.ts
+++ b/frontend/hooks/extraction/useModelManagement.ts
@@ -14,7 +14,7 @@
  * @module hooks/extraction/useModelManagement
  */
 
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {createManualModelHierarchy} from '@/integrations/api';
 import {useAuth} from '@/contexts/AuthContext';
 import {toast} from 'sonner';
@@ -82,13 +82,11 @@ export function useModelManagement({
   }, [activeModelId]);
 
     // Calculate progress for a model (using optimized SQL function).
-    // Declared BEFORE loadModels because loadModels depends on it.
-  const getModelProgress = useCallback(async (instanceId: string): Promise<Model['progress']> =>
-    fetchModelProgress(articleId, instanceId)
-  , [articleId]);
+  const getModelProgress = async (instanceId: string): Promise<Model['progress']> =>
+    fetchModelProgress(articleId, instanceId);
 
     // Load existing models
-  const loadModels = useCallback(async () => {
+  const loadModels = async () => {
     if (!enabled || !modelParentEntityTypeId) {
       console.warn('⏭️ loadModels: Skipped (enabled:', enabled, ', modelParentEntityTypeId:', modelParentEntityTypeId, ')');
       setModels([]);
@@ -144,7 +142,7 @@ export function useModelManagement({
     }
 
     setLoading(false);
-  }, [enabled, modelParentEntityTypeId, articleId, getModelProgress]);
+  };
 
     // Sync ref with loadModels in an effect (refs must not be written
     // during render). Declared before the mount-load effect below so the
@@ -154,7 +152,7 @@ export function useModelManagement({
   }, [loadModels]);
 
     // Create new model (using service - simplified)
-  const createModel = useCallback(async (
+  const createModel = async (
     modelName: string,
     modellingMethod: string
   ): Promise<CreateModelResult | null> => {
@@ -200,10 +198,10 @@ export function useModelManagement({
         label: child.label,
       })),
     };
-  }, [user, modelParentEntityTypeId, projectId, articleId, templateId]);
+  };
 
     // Remove model (using service - simplified)
-  const removeModel = useCallback(async (instanceId: string): Promise<void> => {
+  const removeModel = async (instanceId: string): Promise<void> => {
     console.warn('🗑️ Removing model:', instanceId);
 
     await extractionInstanceService.removeInstance(instanceId).catch((err: unknown) => {
@@ -248,12 +246,12 @@ export function useModelManagement({
 
     console.warn('✅ Modelo removido:', removedModelName);
     toast.success(t('extraction', 'modelRemovedSuccess').replace('{{label}}', removedModelName));
-  }, []); // No deps - uses only setters and functional callbacks
+  };
 
   // Refresh models
-  const refreshModels = useCallback(() => {
+  const refreshModels = () => {
     return loadModels();
-  }, [loadModels]);
+  };
 
     // Load models on mount
     // FIX: Remove loadModels from deps to avoid loops

--- a/frontend/hooks/extraction/useSectionExtraction.ts
+++ b/frontend/hooks/extraction/useSectionExtraction.ts
@@ -13,7 +13,7 @@
  * - User-friendly error handling
  */
 
-import {useCallback, useState} from "react";
+import {useState} from "react";
 import {toast} from "sonner";
 import {type SectionExtractionRequest, SectionExtractionService,} from "@/services/sectionExtractionService";
 import {
@@ -67,8 +67,7 @@ export function useSectionExtraction(options?: {
    * Extracts data from a specific section
    * @param request - Extraction parameters
    */
-  const extractSection = useCallback(
-    async (request: SectionExtractionRequest) => {
+  const extractSection = async (request: SectionExtractionRequest) => {
         console.warn('[useSectionExtraction] Starting extraction', request);
       setLoading(true);
       setError(null);
@@ -150,9 +149,7 @@ export function useSectionExtraction(options?: {
           throw err;
         })
         .finally(() => setLoading(false));
-    },
-    [options],
-  );
+  };
 
   return { extractSection, loading, error };
 }

--- a/frontend/hooks/extraction/useTopLevelSectionsExtraction.ts
+++ b/frontend/hooks/extraction/useTopLevelSectionsExtraction.ts
@@ -11,7 +11,7 @@
  * - Aggregated results
  */
 
-import {useCallback, useState} from "react";
+import {useState} from "react";
 import {toast} from "sonner";
 import {t} from "@/lib/copy";
 import {SectionExtractionService} from "@/services/sectionExtractionService";
@@ -69,8 +69,7 @@ export function useTopLevelSectionsExtraction(options?: {
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState<TopLevelSectionsProgress | null>(null);
 
-  const extractTopLevelSections = useCallback(
-    async (params: {
+  const extractTopLevelSections = async (params: {
       projectId: string;
       articleId: string;
       templateId: string;
@@ -221,9 +220,7 @@ export function useTopLevelSectionsExtraction(options?: {
           setLoading(false);
           setProgress(null);
         });
-    },
-    [options],
-  );
+  };
 
   return { extractTopLevelSections, loading, error, progress };
 }

--- a/frontend/hooks/hitl/useHITLProjectTemplates.ts
+++ b/frontend/hooks/hitl/useHITLProjectTemplates.ts
@@ -15,7 +15,7 @@
  *   of truth lives server-side in ``template_clone_service``.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { apiClient } from "@/integrations/api";
@@ -110,7 +110,7 @@ export function useHITLProjectTemplates({
     }
   }
 
-  const refresh = useCallback(async (): Promise<ProjectTemplate[]> => {
+  const refresh = async (): Promise<ProjectTemplate[]> => {
     if (!projectId) return [];
     const result = await fetchProjectTemplates(projectId, kind, includeInactive);
     if (result.ok) {
@@ -119,7 +119,7 @@ export function useHITLProjectTemplates({
     }
     setError(result.error.message);
     throw result.error;
-  }, [projectId, kind, includeInactive]);
+  };
 
   useEffect(() => {
     if (!projectId) {
@@ -148,8 +148,7 @@ export function useHITLProjectTemplates({
     };
   }, [projectId, kind, includeInactive, refresh]);
 
-  const cloneTemplate = useCallback(
-    async (globalTemplateId: string): Promise<ProjectTemplate | null> => {
+  const cloneTemplate = async (globalTemplateId: string): Promise<ProjectTemplate | null> => {
       const result = await (async () => {
         const data = await apiClient<CloneResponse>(
           `/api/v1/projects/${projectId}/templates/clone`,
@@ -178,12 +177,9 @@ export function useHITLProjectTemplates({
         toast.success(t("extraction", "templateClonedSuccess").replace("{{name}}", created?.name ?? ""));
       }
       return created ?? null;
-    },
-    [projectId, kind, refresh],
-  );
+  };
 
-  const setTemplateActive = useCallback(
-    async (templateId: string, isActive: boolean): Promise<boolean> => {
+  const setTemplateActive = async (templateId: string, isActive: boolean): Promise<boolean> => {
       const result = await apiClient<UpdateActiveResponse>(
         `/api/v1/projects/${projectId}/templates/${templateId}`,
         {
@@ -211,17 +207,12 @@ export function useHITLProjectTemplates({
         ),
       );
       return true;
-    },
-    [projectId, refresh],
-  );
+  };
 
-  const isTemplateImported = useCallback(
-    (globalTemplateId: string): boolean =>
-      templates.some(
-        (tpl) => tpl.global_template_id === globalTemplateId && tpl.is_active,
-      ),
-    [templates],
-  );
+  const isTemplateImported = (globalTemplateId: string): boolean =>
+    templates.some(
+      (tpl) => tpl.global_template_id === globalTemplateId && tpl.is_active,
+    );
 
   return {
     templates,

--- a/frontend/hooks/qa/useQAAssessmentSession.ts
+++ b/frontend/hooks/qa/useQAAssessmentSession.ts
@@ -15,7 +15,7 @@
  * Pass exactly one — the backend rejects both.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { openQASession } from "@/services/qaTemplateService";
 
@@ -89,7 +89,7 @@ export function useQAAssessmentSession({
     }
   }
 
-  const openCore = useCallback(async () => {
+  const openCore = async () => {
     if (!enabled || !projectId || !articleId) return;
     if (!globalTemplateId && !projectTemplateId) return;
     const myGeneration = ++generationRef.current;
@@ -121,16 +121,16 @@ export function useQAAssessmentSession({
       setError(result.error.message);
     }
     setLoading(false);
-  }, [enabled, projectId, articleId, globalTemplateId, projectTemplateId]);
+  };
 
   // Manual refetch (event-handler context): show the loader, then reopen.
-  const refetch = useCallback(async () => {
+  const refetch = async () => {
     if (!enabled || !projectId || !articleId) return;
     if (!globalTemplateId && !projectTemplateId) return;
     setLoading(true);
     setError(null);
     await openCore();
-  }, [enabled, projectId, articleId, globalTemplateId, projectTemplateId, openCore]);
+  };
 
   const openCoreRef = useRef(openCore);
   useEffect(() => {

--- a/frontend/hooks/runs/useAutoSaveProposals.ts
+++ b/frontend/hooks/runs/useAutoSaveProposals.ts
@@ -39,7 +39,7 @@
  * and the next natural refetch picks up the freshly written proposals.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { writeRunFieldValue } from '@/services/extractionRunService';
@@ -153,17 +153,14 @@ export function useAutoSaveProposals(
   // as a synchronous lock across overlapping ``performSave`` invocations.
   const activeSavePromiseRef = useRef<Promise<void> | null>(null);
 
-  const computeDirtyEntries = useCallback(
-    (): Array<[string, unknown]> =>
-      selectDirtyEntries(
-        valuesRef.current,
-        lastSavedByKeyRef.current,
-        baselineRef.current,
-      ),
-    [],
-  );
+  const computeDirtyEntries = (): Array<[string, unknown]> =>
+    selectDirtyEntries(
+      valuesRef.current,
+      lastSavedByKeyRef.current,
+      baselineRef.current,
+    );
 
-  const performSave = useCallback((): Promise<void> => {
+  const performSave = (): Promise<void> => {
     // Serialize concurrent saves: wait for any in-flight batch, swallowing
     // its error (the owner invocation surfaces it; queued calls still retry
     // dirty values that weren't acknowledged).
@@ -268,7 +265,7 @@ export function useAutoSaveProposals(
 
     activeSavePromiseRef.current = savePromise;
     return savePromise;
-  }, [computeDirtyEntries]);
+  };
 
   // (1) Debounced save on values change. The cleanup clears the timer
   // when ``values`` changes so the next keystroke restarts the
@@ -279,7 +276,7 @@ export function useAutoSaveProposals(
   // debounce). Keyed by content, not identity: callers may rebuild the
   // values map every render, and an identity-keyed adjustment would
   // re-render forever.
-  const valuesKey = useMemo(() => JSON.stringify(values), [values]);
+  const valuesKey = JSON.stringify(values);
   const [prevValuesKey, setPrevValuesKey] = useState(valuesKey);
   if (valuesKey !== prevValuesKey) {
     setPrevValuesKey(valuesKey);
@@ -347,21 +344,19 @@ export function useAutoSaveProposals(
     };
   }, [performSave]);
 
-  const saveNow = useCallback(async (): Promise<void> => {
+  const saveNow = async (): Promise<void> => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = undefined;
     }
     await performSave();
-  }, [performSave]);
+  };
 
   // Re-evaluate the dirty diff whenever ``values`` changes (user typed)
   // or a save acknowledges (``lastSavedByKey`` advances). Computed from
   // render-safe state — never from the mutable refs.
-  const hasUnsavedChanges = useMemo(
-    () => selectDirtyEntries(values, lastSavedByKey, baselineValues ?? {}).length > 0,
-    [values, lastSavedByKey, baselineValues],
-  );
+  const hasUnsavedChanges =
+    selectDirtyEntries(values, lastSavedByKey, baselineValues ?? {}).length > 0;
 
   return { saveState, lastSavedAt, error, hasUnsavedChanges, saveNow };
 }

--- a/frontend/hooks/runs/useReviewerSummary.ts
+++ b/frontend/hooks/runs/useReviewerSummary.ts
@@ -18,7 +18,6 @@
  * react-query cache and trivially testable.
  */
 
-import { useMemo } from "react";
 
 import type { ReviewerDecisionResponse, RunDetailResponse } from "./types";
 
@@ -101,8 +100,7 @@ function unwrap(raw: unknown): unknown {
 export function useReviewerSummary(
   runDetail: RunDetailResponse | null | undefined,
 ): ReviewerSummary {
-  return useMemo(() => {
-    if (!runDetail) return EMPTY_SUMMARY;
+  if (!runDetail) return EMPTY_SUMMARY;
 
     // Latest decision per (reviewer × coord) — `decisions` are append-only
     // so we keep the newest by created_at.
@@ -158,15 +156,14 @@ export function useReviewerSummary(
     );
     const ratio = Math.min(1, reviewers.size / required);
 
-    return {
-      reviewers: [...reviewers],
-      currentDecisions,
-      decisionsByCoord,
-      divergentCoords,
-      requiredReviewerCount: required,
-      completionRatio: ratio,
-      filledCoords,
-      touchedCoords,
-    };
-  }, [runDetail]);
+  return {
+    reviewers: [...reviewers],
+    currentDecisions,
+    decisionsByCoord,
+    divergentCoords,
+    requiredReviewerCount: required,
+    completionRatio: ratio,
+    filledCoords,
+    touchedCoords,
+  };
 }

--- a/frontend/hooks/shared/useComparisonPermissions.ts
+++ b/frontend/hooks/shared/useComparisonPermissions.ts
@@ -11,7 +11,7 @@
  * @hook
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {loadComparisonPermissions} from '@/services/projectSettingsService';
 import {type PermissionRules, type UserRole} from '@/lib/comparison/permissions';
 import {t} from '@/lib/copy';
@@ -71,7 +71,7 @@ export function useComparisonPermissions(
     }
   }
 
-  const fetchPermissions = useCallback(async () => {
+  const fetchPermissions = async () => {
     setPermissions(prev => ({ ...prev, loading: true, error: null }));
 
     const result = await loadComparisonPermissions(projectId, userId);
@@ -99,7 +99,7 @@ export function useComparisonPermissions(
         error: result.error.message || t('common', 'errors_loadPermissions'),
       });
     }
-  }, [projectId, userId]);
+  };
 
   useEffect(() => {
     if (!projectId || !userId) {

--- a/frontend/hooks/useMultiFileUpload.ts
+++ b/frontend/hooks/useMultiFileUpload.ts
@@ -10,7 +10,7 @@
  * - Real-time statistics
  */
 
-import {useCallback, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 import {uploadQueuedFile} from '@/services/fileUploadService';
 import {toast} from 'sonner';
 import {validateFile} from '@/lib/file-validation';
@@ -80,7 +80,7 @@ export function useMultiFileUpload(
   /**
    * Adds files to the queue
    */
-  const addFiles = useCallback((files: File[], fileRole: FileRole) => {
+  const addFiles = (files: File[], fileRole: FileRole) => {
     const newItems: UploadQueueItem[] = files.map(file => ({
       id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
       file,
@@ -92,12 +92,12 @@ export function useMultiFileUpload(
 
     setQueue(prev => [...prev, ...newItems]);
     return newItems;
-  }, []);
+  };
 
   /**
    * Uploads a single file — delegates IO (and try/finally) to the service.
    */
-  const uploadSingleFile = useCallback(async (item: UploadQueueItem): Promise<ArticleFile> => {
+  const uploadSingleFile = async (item: UploadQueueItem): Promise<ArticleFile> => {
     // Pre-validate so invalid files fail immediately without hitting the network.
     const validation = validateFile(item.file);
     if (!validation.valid) {
@@ -120,12 +120,12 @@ export function useMultiFileUpload(
         ));
       },
     });
-  }, [projectId, articleId]);
+  };
 
   /**
    * Processes the upload queue
    */
-  const processQueue = useCallback(async () => {
+  const processQueue = async () => {
     if (isUploading) return;
 
     setIsUploading(true);
@@ -237,12 +237,12 @@ export function useMultiFileUpload(
       }
     }
 
-  }, [queue, isUploading, maxConcurrent, maxRetries, uploadSingleFile, onComplete, onFileComplete, onProgress]);
+  };
 
   /**
    * Cancels a specific upload
    */
-  const cancelUpload = useCallback((itemId: string) => {
+  const cancelUpload = (itemId: string) => {
     const abortController = abortControllersRef.current.get(itemId);
     if (abortController) {
       abortController.abort();
@@ -253,21 +253,21 @@ export function useMultiFileUpload(
     ));
 
     activeUploadsRef.current.delete(itemId);
-  }, []);
+  };
 
   /**
    * Retries a failed upload
    */
-  const retryUpload = useCallback((itemId: string) => {
+  const retryUpload = (itemId: string) => {
     setQueue(prev => prev.map(q =>
       q.id === itemId ? { ...q, status: 'pending' as const, error: undefined, progress: 0 } : q
     ));
-  }, []);
+  };
 
   /**
    * Clears the queue
    */
-  const clearQueue = useCallback(() => {
+  const clearQueue = () => {
     // Cancel all active uploads
     abortControllersRef.current.forEach(controller => controller.abort());
     abortControllersRef.current.clear();
@@ -275,15 +275,15 @@ export function useMultiFileUpload(
 
     setQueue([]);
     setIsUploading(false);
-  }, []);
+  };
 
   /**
    * Removes an item from the queue
    */
-  const removeFromQueue = useCallback((itemId: string) => {
+  const removeFromQueue = (itemId: string) => {
     cancelUpload(itemId);
     setQueue(prev => prev.filter(q => q.id !== itemId));
-  }, [cancelUpload]);
+  };
 
   // Calculate statistics
   const stats = {

--- a/frontend/hooks/useNavigation.ts
+++ b/frontend/hooks/useNavigation.ts
@@ -3,7 +3,7 @@
  * Centralizes breadcrumbs, search and navigation logic
  */
 
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useLocation, useNavigate} from 'react-router-dom';
 import {useAuth} from '@/contexts/AuthContext';
 import {t} from '@/lib/copy';
@@ -18,8 +18,8 @@ export const useNavigation = () => {
   const [searchResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
 
-  // Gerar breadcrumbs baseado na rota atual
-  const generateBreadcrumbs = useCallback((): BreadcrumbItem[] => {
+  // Gerar breadcrumbs baseado na rota atual — pure derivation from location.pathname.
+  const breadcrumbs = (() => {
     try {
       const pathSegments = location.pathname.split('/').filter(Boolean);
       const items: BreadcrumbItem[] = [];
@@ -39,7 +39,7 @@ export const useNavigation = () => {
           let label = segment;
           let icon;
           let shouldSkip = false;
-          
+
           switch (segment) {
             case 'projects':
                 // Do not add "Projects" to breadcrumbs, skip to next
@@ -91,14 +91,10 @@ export const useNavigation = () => {
         console.error('Error generating breadcrumbs:', error);
       return [{ label: 'Dashboard', href: '/', isActive: true }];
     }
-  }, [location.pathname]);
-
-    // Breadcrumbs are a pure function of the route — derive instead of
-    // materializing through an effect.
-  const breadcrumbs = useMemo(() => generateBreadcrumbs(), [generateBreadcrumbs]);
+  })();
 
   // Busca global
-  const performSearch = useCallback(async (query: string): Promise<SearchResult[]> => {
+  const performSearch = async (query: string): Promise<SearchResult[]> => {
     if (!query.trim()) return [];
 
     setIsSearching(true);
@@ -139,13 +135,13 @@ export const useNavigation = () => {
     }
 
     return results;
-  }, []);
+  };
 
   // Navegar para resultado da busca
-  const navigateToSearchResult = useCallback((result: SearchResult) => {
+  const navigateToSearchResult = (result: SearchResult) => {
     navigate(result.href);
     setIsSearchOpen(false);
-  }, [navigate]);
+  };
 
   return {
     breadcrumbs,
@@ -163,7 +159,7 @@ export const useNotifications = () => {
   const [unreadCount, setUnreadCount] = useState(0);
 
     // Load user notifications
-  const loadNotifications = useCallback(() => {
+  const loadNotifications = () => {
     // For now, simulate notifications
     // In production, fetch from database
     const mockNotifications: NotificationItem[] = [
@@ -178,25 +174,25 @@ export const useNotifications = () => {
     ];
     setNotifications(mockNotifications);
     setUnreadCount(mockNotifications.filter(n => !n.isRead).length);
-  }, []);
+  };
 
     // Mark notification as read
-  const markAsRead = useCallback((notificationId: string) => {
-    setNotifications(prev => 
-      prev.map(n => 
+  const markAsRead = (notificationId: string) => {
+    setNotifications(prev =>
+      prev.map(n =>
         n.id === notificationId ? { ...n, isRead: true } : n
       )
     );
     setUnreadCount(prev => Math.max(0, prev - 1));
-  }, []);
+  };
 
   // Marcar todas como lidas
-  const markAllAsRead = useCallback(() => {
-    setNotifications(prev => 
+  const markAllAsRead = () => {
+    setNotifications(prev =>
       prev.map(n => ({ ...n, isRead: true }))
     );
     setUnreadCount(0);
-  }, []);
+  };
 
   useEffect(() => {
     // Microtask so the loader's setState calls run in an async callback.
@@ -218,7 +214,7 @@ export const useUserProfile = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const loadUserProfile = useCallback(async () => {
+  const loadUserProfile = async () => {
     if (!authUser) {
       setUser(null);
       setIsLoading(false);
@@ -260,7 +256,7 @@ export const useUserProfile = () => {
       });
     }
     setIsLoading(false);
-  }, [authUser]);
+  };
 
   useEffect(() => {
     // Microtask so the loader's setState calls run in an async callback.

--- a/frontend/hooks/usePreserveScroll.ts
+++ b/frontend/hooks/usePreserveScroll.ts
@@ -22,8 +22,6 @@
  *   - Containers missing on either snapshot or restore are silently skipped,
  *     so the helper is safe to share across pages.
  */
-import { useCallback } from "react";
-
 export type PreserveScroll = <T>(operation: () => Promise<T>) => Promise<T>;
 
 function snapshot(selectors: string[]): Map<string, { top: number; left: number }> {
@@ -72,11 +70,5 @@ async function runWithScrollPreserved<T>(
 }
 
 export function usePreserveScroll(selectors: string[]): PreserveScroll {
-  // selectors is intentionally treated as a stable identity by callers (we
-  // pass a module-level constant array), so the array itself is the dep —
-  // spreading it produced a non-literal dependency list the compiler rejects.
-  return useCallback(
-    (operation) => runWithScrollPreserved(selectors, operation),
-    [selectors]
-  );
+  return (operation) => runWithScrollPreserved(selectors, operation);
 }

--- a/frontend/hooks/useProjectMemberRole.ts
+++ b/frontend/hooks/useProjectMemberRole.ts
@@ -3,7 +3,7 @@
  * Used to condition UI (e.g. show Configuration tab only for managers).
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useAuth} from '@/contexts/AuthContext';
 import type {ProjectMemberRole} from '@/types/extraction';
 import {getProjectMemberRole} from '@/services/projectSettingsService';
@@ -19,10 +19,8 @@ export function useProjectMemberRole(projectId: string): UseProjectMemberRoleRet
     const [role, setRole] = useState<ProjectMemberRole | null>(null);
     const [loading, setLoading] = useState(true);
 
-    // Plain-identifier dep (`user?.id` in a dep array defeats compiler
-    // memoization preservation).
     const userId = user?.id;
-    const load = useCallback(async () => {
+    const load = async () => {
         if (!projectId || !userId) {
             setRole(null);
             setLoading(false);
@@ -32,7 +30,7 @@ export function useProjectMemberRole(projectId: string): UseProjectMemberRoleRet
         const result = await getProjectMemberRole(projectId, userId);
         setRole(result.ok ? result.data : null);
         setLoading(false);
-    }, [projectId, userId]);
+    };
 
     useEffect(() => {
         // Microtask so the loader's setState calls run in an async callback.

--- a/frontend/hooks/useProjectSettings.ts
+++ b/frontend/hooks/useProjectSettings.ts
@@ -3,7 +3,7 @@
  * Extracts data logic from ProjectSettings to keep the component focused on layout.
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
 import type {Project} from '@/types/project';
@@ -14,7 +14,7 @@ export function useProjectSettings(projectId: string) {
     const [loading, setLoading] = useState(true);
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
-    const loadProject = useCallback(async () => {
+    const loadProject = async () => {
         if (!projectId) return;
         setLoading(true);
         const result = await loadProjectForSettings(projectId);
@@ -26,19 +26,19 @@ export function useProjectSettings(projectId: string) {
         }
         setProject(result.data);
         setHasUnsavedChanges(false);
-    }, [projectId]);
+    };
 
     useEffect(() => {
         // Microtask so the loader's setState calls run in an async callback.
         queueMicrotask(() => void loadProject());
     }, [loadProject]);
 
-    const updateProject = useCallback((updates: Partial<Project>) => {
+    const updateProject = (updates: Partial<Project>) => {
         setProject((prev) => (prev ? {...prev, ...updates} : null));
         setHasUnsavedChanges(true);
-    }, []);
+    };
 
-    const saveProject = useCallback(async () => {
+    const saveProject = async () => {
         if (!project) return;
 
         setLoading(true);
@@ -66,7 +66,7 @@ export function useProjectSettings(projectId: string) {
         toast.success(t('project', 'settingsSaveSuccess'));
         setHasUnsavedChanges(false);
         await loadProject();
-    }, [project, projectId, loadProject]);
+    };
 
     return {
         project,

--- a/frontend/hooks/useProjectsList.ts
+++ b/frontend/hooks/useProjectsList.ts
@@ -3,7 +3,7 @@
  * Reusable between desktop and mobile sidebar
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
@@ -15,7 +15,7 @@ export const useProjectsList = () => {
   const [projects, setProjects] = useState<ProjectListItem[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const loadProjects = useCallback(async () => {
+  const loadProjects = async () => {
     setLoading(true);
     const result = await listProjects();
     if (result.ok) {
@@ -25,11 +25,11 @@ export const useProjectsList = () => {
       console.error(result.error);
     }
     setLoading(false);
-  }, []);
+  };
 
-  const switchProject = useCallback((projectId: string) => {
+  const switchProject = (projectId: string) => {
     navigate(`/projects/${projectId}`);
-  }, [navigate]);
+  };
 
   useEffect(() => {
     // Microtask so the loader's setState calls run in an async callback.

--- a/frontend/hooks/useScreenCapture.ts
+++ b/frontend/hooks/useScreenCapture.ts
@@ -3,7 +3,7 @@
  * webm clip. Accurate on the PDF.js viewer (unlike DOM-screenshot libs).
  * Each call prompts the browser's "share your screen" picker.
  */
-import { useCallback, useMemo, useState } from 'react';
+import { useState } from 'react';
 import {captureScreenStill, recordScreenClip} from '@/lib/screen-capture';
 
 export interface ScreenCapture {
@@ -16,34 +16,28 @@ export interface ScreenCapture {
 export function useScreenCapture(): ScreenCapture {
   const [capturing, setCapturing] = useState(false);
 
-  const isSupported = useMemo(
-    () =>
-      typeof navigator !== 'undefined' &&
-      !!navigator.mediaDevices &&
-      typeof navigator.mediaDevices.getDisplayMedia === 'function',
-    [],
-  );
+  const isSupported =
+    typeof navigator !== 'undefined' &&
+    !!navigator.mediaDevices &&
+    typeof navigator.mediaDevices.getDisplayMedia === 'function';
 
-  const captureStill = useCallback(async (): Promise<Blob | null> => {
+  const captureStill = async (): Promise<Blob | null> => {
     if (!isSupported) return null;
     setCapturing(true);
     // IO + try/catch/finally lives in lib/screen-capture.captureScreenStill
     const result = await captureScreenStill();
     setCapturing(false);
     return result;
-  }, [isSupported]);
+  };
 
-  const recordClip = useCallback(
-    async (maxSeconds = 30): Promise<Blob | null> => {
-      if (!isSupported) return null;
-      setCapturing(true);
-      // IO + try/catch/finally lives in lib/screen-capture.recordScreenClip
-      const result = await recordScreenClip(maxSeconds);
-      setCapturing(false);
-      return result;
-    },
-    [isSupported],
-  );
+  const recordClip = async (maxSeconds = 30): Promise<Blob | null> => {
+    if (!isSupported) return null;
+    setCapturing(true);
+    // IO + try/catch/finally lives in lib/screen-capture.recordScreenClip
+    const result = await recordScreenClip(maxSeconds);
+    setCapturing(false);
+    return result;
+  };
 
   return { isSupported, capturing, captureStill, recordClip };
 }

--- a/frontend/hooks/useZoteroImport.ts
+++ b/frontend/hooks/useZoteroImport.ts
@@ -2,7 +2,7 @@
  * Hook to manage the Zotero import process
  */
 
-import {useCallback, useState} from 'react';
+import {useState} from 'react';
 import {zoteroService, listZoteroCollections, importZoteroCollection} from '@/services/zoteroImportService';
 import type {ImportOptions, ImportProgress, ImportResult, ZoteroCollection} from '@/types/zotero';
 import {toast} from 'sonner';
@@ -19,7 +19,7 @@ export function useZoteroImport() {
    * Lists available collections in Zotero
    * IO + try/catch/finally relocated to zoteroImportService.listZoteroCollections
    */
-  const listCollections = useCallback(async () => {
+  const listCollections = async () => {
     setLoadingCollections(true);
     const result = await listZoteroCollections();
     setLoadingCollections(false);
@@ -30,13 +30,13 @@ export function useZoteroImport() {
     console.error('Error listing collections:', result.error);
     toast.error(result.error.message || t('extraction', 'errors_zoteroFetch'));
     return [];
-  }, []);
+  };
 
   /**
    * Starts import of a collection
    * IO + try/catch/finally relocated to zoteroImportService.importZoteroCollection
    */
-  const startImport = useCallback(async (
+  const startImport = async (
     projectId: string,
     collectionKey: string,
     options: ImportOptions,
@@ -118,25 +118,25 @@ export function useZoteroImport() {
     }
 
     return importResult;
-  }, []);
+  };
 
   /**
    * Cancels import in progress
    */
-  const cancelImport = useCallback(() => {
+  const cancelImport = () => {
     zoteroService.cancelImport();
     setImporting(false);
     setProgress(null);
     setCurrentJobId(null);
     toast.info(t('extraction', 'zoteroImportCancelled'));
-  }, []);
+  };
 
   /**
    * Resets progress state
    */
-  const resetProgress = useCallback(() => {
+  const resetProgress = () => {
     setProgress(null);
-  }, []);
+  };
 
   return {
     collections,

--- a/frontend/hooks/useZoteroIntegration.ts
+++ b/frontend/hooks/useZoteroIntegration.ts
@@ -2,7 +2,7 @@
  * Hook to manage user Zotero integration
  */
 
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {
   loadZoteroIntegration,
   saveZoteroCredentials,
@@ -23,7 +23,7 @@ export function useZoteroIntegration() {
    * Loads Zotero integration for the current user.
    * IO + try/catch/finally relocated to zoteroImportService.loadZoteroIntegration
    */
-  const loadIntegration = useCallback(async () => {
+  const loadIntegration = async () => {
     setLoading(true);
     const result = await loadZoteroIntegration();
     setLoading(false);
@@ -35,13 +35,13 @@ export function useZoteroIntegration() {
       setIntegration(null);
       setIsConfigured(false);
     }
-  }, []);
+  };
 
   /**
    * Saves Zotero credentials.
    * IO + try/catch/finally relocated to zoteroImportService.saveZoteroCredentials
    */
-  const saveCredentials = useCallback(async (credentials: ZoteroCredentialsInput) => {
+  const saveCredentials = async (credentials: ZoteroCredentialsInput) => {
     setLoading(true);
     const result = await saveZoteroCredentials(credentials);
     setLoading(false);
@@ -53,13 +53,13 @@ export function useZoteroIntegration() {
     console.error('Error saving credentials:', result.error);
     toast.error(result.error.message || t('extraction', 'zoteroCredentialsSaveError'));
     return false;
-  }, [loadIntegration]);
+  };
 
   /**
    * Tests Zotero connection.
    * IO + try/catch/finally relocated to zoteroImportService.testZoteroConnection
    */
-  const testConnection = useCallback(async (): Promise<ZoteroTestConnectionResult> => {
+  const testConnection = async (): Promise<ZoteroTestConnectionResult> => {
     setTesting(true);
     const result = await testZoteroConnection();
     setTesting(false);
@@ -75,13 +75,13 @@ export function useZoteroIntegration() {
       toast.error(connectionResult.error || t('extraction', 'zoteroConnectionFailed'));
     }
     return connectionResult;
-  }, []);
+  };
 
   /**
    * Removes Zotero integration.
    * IO + try/catch/finally relocated to zoteroImportService.disconnectZotero
    */
-  const disconnect = useCallback(async () => {
+  const disconnect = async () => {
     setLoading(true);
     const result = await disconnectZotero();
     setLoading(false);
@@ -94,7 +94,7 @@ export function useZoteroIntegration() {
     console.error('Error disconnecting Zotero:', result.error);
     toast.error(result.error.message || t('extraction', 'zoteroDisconnectError'));
     return false;
-  }, []);
+  };
 
   // Load integration on mount
   useEffect(() => {

--- a/frontend/hooks/zotero/useZoteroSyncStatus.ts
+++ b/frontend/hooks/zotero/useZoteroSyncStatus.ts
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import {fetchZoteroSyncStatus} from '@/services/zoteroImportService';
 import type {ZoteroSyncStatus} from '@/types/zotero';
@@ -53,10 +53,7 @@ export function useZoteroSyncStatus(syncRunId: string | null, pollingMs = 1500) 
         };
     }, [syncRunId, pollingMs]);
 
-    const isTerminal = useMemo(
-        () => !!data && ['completed', 'failed', 'cancelled'].includes(data.status),
-        [data]
-    );
+    const isTerminal = !!data && ['completed', 'failed', 'cancelled'].includes(data.status);
 
     return {data, loading, error, isTerminal};
 }

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -15,7 +15,7 @@
  * @page
  */
 
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
 import {toast} from 'sonner';
 import {extractionInstanceService, markInstancesCompleted} from '@/services/extractionInstanceService';
@@ -210,77 +210,63 @@ export default function ExtractionFullScreen() {
   // join lives in useExtractionData; for now we use the instance label
   // alone (entityType.label) plus the field label fetched off the run
   // detail's proposals/decisions when available.
-  const fieldLabelByCoord = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const inst of instances) {
-      const et = entityTypes.find((e) => e.id === inst.entity_type_id);
-      const sectionLabel = et?.label ?? et?.name ?? 'Section';
-      // Decisions + proposals carry the field id but not the label;
-      // fall back to the field id when nothing else is known. The
-      // ConsensusPanel still renders correctly — just shows the id.
-      const seenFields = new Set<string>();
-      for (const d of runDetail?.decisions ?? []) {
-        if (d.instance_id !== inst.id || seenFields.has(d.field_id)) continue;
-        seenFields.add(d.field_id);
-        map[`${inst.id}::${d.field_id}`] = `${sectionLabel} · ${d.field_id.slice(0, 8)}…`;
-      }
+  const fieldLabelByCoordMap: Record<string, string> = {};
+  for (const inst of instances) {
+    const et = entityTypes.find((e) => e.id === inst.entity_type_id);
+    const sectionLabel = et?.label ?? et?.name ?? 'Section';
+    // Decisions + proposals carry the field id but not the label;
+    // fall back to the field id when nothing else is known. The
+    // ConsensusPanel still renders correctly — just shows the id.
+    const seenFields = new Set<string>();
+    for (const d of runDetail?.decisions ?? []) {
+      if (d.instance_id !== inst.id || seenFields.has(d.field_id)) continue;
+      seenFields.add(d.field_id);
+      fieldLabelByCoordMap[`${inst.id}::${d.field_id}`] = `${sectionLabel} · ${d.field_id.slice(0, 8)}…`;
     }
-    return map;
-  }, [instances, entityTypes, runDetail?.decisions]);
+  }
+  const fieldLabelByCoord = fieldLabelByCoordMap;
 
-  const handleSelectExisting = useCallback(
-    async (params: {
-      instanceId: string;
-      fieldId: string;
-      decisionId: string;
-    }) => {
-      await consensusMutation.mutateAsync({
-        instance_id: params.instanceId,
-        field_id: params.fieldId,
-        mode: 'select_existing',
-        selected_decision_id: params.decisionId,
-      });
-      await refetchRun();
-    },
-    [consensusMutation, refetchRun],
-  );
+  const handleSelectExisting = async (params: {
+    instanceId: string;
+    fieldId: string;
+    decisionId: string;
+  }) => {
+    await consensusMutation.mutateAsync({
+      instance_id: params.instanceId,
+      field_id: params.fieldId,
+      mode: 'select_existing',
+      selected_decision_id: params.decisionId,
+    });
+    await refetchRun();
+  };
 
-  const handleManualOverride = useCallback(
-    async (params: {
-      instanceId: string;
-      fieldId: string;
-      value: unknown;
-      rationale: string;
-    }) => {
-      await consensusMutation.mutateAsync({
-        instance_id: params.instanceId,
-        field_id: params.fieldId,
-        mode: 'manual_override',
-        value: { value: params.value },
-        rationale: params.rationale,
-      });
-      await refetchRun();
-    },
-    [consensusMutation, refetchRun],
-  );
+  const handleManualOverride = async (params: {
+    instanceId: string;
+    fieldId: string;
+    value: unknown;
+    rationale: string;
+  }) => {
+    await consensusMutation.mutateAsync({
+      instance_id: params.instanceId,
+      field_id: params.fieldId,
+      mode: 'manual_override',
+      value: { value: params.value },
+      rationale: params.rationale,
+    });
+    await refetchRun();
+  };
 
-  const handleFinalizeFromConsensus = useCallback(async () => {
+  const handleFinalizeFromConsensus = async () => {
     if (!activeRunId) return;
     await advanceMutation.mutateAsync({ target_stage: 'finalized' });
     await Promise.all([refetchRun(), refreshValues(), refreshFinalizedRun()]);
     toast.success('Extraction finalized.');
-  }, [
-    activeRunId,
-    advanceMutation,
-    refetchRun,
-    refreshValues,
-    refreshFinalizedRun,
-  ]);
+  };
 
-  // Plain-identifier dep so the compiler can preserve this memoization
-  // (optional-chained deps like `finalizedRun?.id` defeat it).
+  // Plain-identifier dep so the compiler can track this dep without
+  // optional-chaining (optional-chained deps like `finalizedRun?.id` defeat it).
   const finalizedRunId = finalizedRun?.id;
-  const handleReopen = useCallback(async () => {
+  const handleReopen = async () => {
     if (!finalizedRunId) return;
     setReopening(true);
     await reopenMutation.mutateAsync(finalizedRunId).then(async () => {
@@ -299,14 +285,7 @@ export default function ExtractionFullScreen() {
       );
     });
     setReopening(false);
-  }, [
-    finalizedRunId,
-    reopenMutation,
-    sessionResult,
-    refreshValues,
-    refreshFinalizedRun,
-    refetchRun,
-  ]);
+  };
 
   // Hook para calcular progresso
   const { completedFields, totalFields, completionPercentage, isComplete } =
@@ -356,13 +335,13 @@ export default function ExtractionFullScreen() {
   // Declared after `useAutoSaveProposals` so the closure picks up the
   // already-initialized `saveNow` (avoids the temporal-dead-zone crash
   // on first render).
-  const handleSubmitForReview = useCallback(async () => {
+  const handleSubmitForReview = async () => {
     if (!activeRunId) return;
     await saveNow();
     await advanceMutation.mutateAsync({ target_stage: 'review' });
     await Promise.all([refetchRun(), refreshValues()]);
     toast.success('Submitted for review.');
-  }, [activeRunId, saveNow, advanceMutation, refetchRun, refreshValues]);
+  };
 
     // "Reconcile" — flush any pending edits and advance REVIEW →
     // CONSENSUS so the ``ConsensusPanel`` becomes reachable. This
@@ -371,13 +350,13 @@ export default function ExtractionFullScreen() {
     // ``handlePublish`` advanced past REVIEW). Gate at the call site
     // on ``permissions.canResolveConflicts`` (manager / consensus
     // roles) so reviewers don't accidentally trigger it.
-  const handleReconcile = useCallback(async () => {
+  const handleReconcile = async () => {
     if (!activeRunId) return;
     await saveNow();
     await advanceMutation.mutateAsync({ target_stage: 'consensus' });
     await Promise.all([refetchRun(), refreshValues()]);
     toast.success('Reviewers reconciled. Resolve any divergences below.');
-  }, [activeRunId, saveNow, advanceMutation, refetchRun, refreshValues]);
+  };
 
     // Permissions hook (controls comparison access)
   const permissions = useComparisonPermissions(
@@ -395,23 +374,23 @@ export default function ExtractionFullScreen() {
   });
 
     // Hook for AI suggestions with callbacks to fill/clear field
-  const handleAISuggestionAccepted = useCallback(async (instanceId: string, fieldId: string, value: any) => {
+  const handleAISuggestionAccepted = async (instanceId: string, fieldId: string, value: any) => {
       // Fill field automatically when suggestion is accepted
       console.warn('Accepting AI suggestion:', {instanceId, fieldId, value});
       // updateValue updates local state immediately
       // AISuggestionService.acceptSuggestion already saves to DB
       // No need to reload all values (refreshValues caused full page reload)
     updateValue(instanceId, fieldId, value);
-  }, [updateValue]);
+  };
 
-  const handleAISuggestionRejected = useCallback(async (instanceId: string, fieldId: string) => {
+  const handleAISuggestionRejected = async (instanceId: string, fieldId: string) => {
       // Clear field when suggestion is rejected
       console.warn('Rejecting AI suggestion - clearing field:', {instanceId, fieldId});
       // updateValue updates local state immediately
       // AISuggestionService.rejectSuggestion already updates status in DB
       // No need to reload all values (refreshValues caused full page reload)
     updateValue(instanceId, fieldId, null);
-  }, [updateValue]);
+  };
 
   const { 
     suggestions: aiSuggestions, 
@@ -485,18 +464,6 @@ export default function ExtractionFullScreen() {
     }
   }, [articleId, models, activeModelId, setActiveModelId]);
 
-  // =================== MEMOIZAÇÕES PARA PERFORMANCE ===================
-
-    // Memoize instance filter function (avoids recreating it)
-  const getInstancesForModel = useCallback((entityTypeId: string, modelId: string) => {
-    return instances.filter(
-      i => i.entity_type_id === entityTypeId && i.parent_instance_id === modelId
-    );
-  }, [instances]);
-
-    // Removed: SectionAccordion does not need memo, FieldInput is memoized individually
-
-
     // Redirect on critical error
   useEffect(() => {
     if (dataError && projectId) {
@@ -505,10 +472,16 @@ export default function ExtractionFullScreen() {
     }
   }, [dataError, projectId, navigate]);
 
+  const getInstancesForModel = (entityTypeId: string, modelId: string) => {
+    return instances.filter(
+      i => i.entity_type_id === entityTypeId && i.parent_instance_id === modelId
+    );
+  };
+
     // Function to reload instances (used after model extraction)
-  const handleRefreshInstances = useCallback(async () => {
+  const handleRefreshInstances = async () => {
     await refreshInstances();
-  }, [refreshInstances]);
+  };
 
   const handleBack = () => {
     navigate(`/projects/${projectId}?tab=extraction`);

--- a/frontend/pages/ProjectView.tsx
+++ b/frontend/pages/ProjectView.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import {useNavigate, useParams, useSearchParams} from "react-router-dom";
 import {loadProjectById, loadProjectArticles} from "@/services/projectsService";
 import {Button} from "@/components/ui/button";
@@ -81,7 +81,7 @@ export default function ProjectView() {
     const [articlesExportEnabled, setArticlesExportEnabled] = useState(false);
     const {isConfigured: hasZoteroConfigured} = useZoteroIntegration();
 
-    const closeArticleEditor = useCallback(() => {
+    const closeArticleEditor = () => {
         setSearchParams(
             (prev) => {
                 const next = new URLSearchParams(prev);
@@ -91,9 +91,9 @@ export default function ProjectView() {
             },
             {replace: true}
         );
-    }, [setSearchParams]);
+    };
 
-    const openArticleEditorAdd = useCallback(() => {
+    const openArticleEditorAdd = () => {
         setSearchParams(
             (prev) => {
                 const next = new URLSearchParams(prev);
@@ -104,23 +104,20 @@ export default function ProjectView() {
             },
             {replace: false}
         );
-    }, [setSearchParams]);
+    };
 
-    const openArticleEditorEdit = useCallback(
-        (articleId: string) => {
-            setSearchParams(
-                (prev) => {
-                    const next = new URLSearchParams(prev);
-                    next.set('tab', 'articles');
-                    next.set('articleEditor', 'edit');
-                    next.set('articleId', articleId);
-                    return next;
-                },
-                {replace: false}
-            );
-        },
-        [setSearchParams]
-    );
+    const openArticleEditorEdit = (articleId: string) => {
+        setSearchParams(
+            (prev) => {
+                const next = new URLSearchParams(prev);
+                next.set('tab', 'articles');
+                next.set('articleEditor', 'edit');
+                next.set('articleId', articleId);
+                return next;
+            },
+            {replace: false}
+        );
+    };
 
     useEffect(() => {
         if (activeTab !== 'articles') {

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -16,7 +16,7 @@
  * field to materialize PublishedState rows.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
@@ -192,32 +192,27 @@ export default function QualityAssessmentFullScreen() {
   // ``handleValueChange`` only needs to update local state. Lifecycle
   // handlers in the hook (unmount flush, ``pagehide``, visibility) carry
   // the write through any navigation that happens mid-debounce.
-  const handleValueChange = useCallback(
-    (instanceId: string, fieldId: string, value: unknown) => {
-      const k = keyOf({ instanceId, fieldId });
-      setValues((prev) => ({ ...prev, [k]: value }));
-    },
-    [],
-  );
+  const handleValueChange = (instanceId: string, fieldId: string, value: unknown) => {
+    const k = keyOf({ instanceId, fieldId });
+    setValues((prev) => ({ ...prev, [k]: value }));
+  };
 
   // Server baseline for autosave — the same per-coord map the hydration
   // effect applies, computed inline from ``runDetail`` so it is present when
   // the hydrated ``values`` arrive. Stops opening an assessment from
   // re-POSTing loaded values as fresh proposals.
-  const loadedValues = useMemo(() => {
-    const map: Record<string, unknown> = {};
-    for (const p of runDetail?.proposals ?? []) {
-      const k = keyOf({ instanceId: p.instance_id, fieldId: p.field_id });
-      const value =
-        p.proposed_value &&
-        typeof p.proposed_value === "object" &&
-        "value" in p.proposed_value
-          ? (p.proposed_value.value as unknown)
-          : (p.proposed_value as unknown);
-      map[k] = value;
-    }
-    return map;
-  }, [runDetail]);
+  const loadedValuesMap: Record<string, unknown> = {};
+  for (const p of runDetail?.proposals ?? []) {
+    const k = keyOf({ instanceId: p.instance_id, fieldId: p.field_id });
+    const value =
+      p.proposed_value &&
+      typeof p.proposed_value === "object" &&
+      "value" in p.proposed_value
+        ? (p.proposed_value.value as unknown)
+        : (p.proposed_value as unknown);
+    loadedValuesMap[k] = value;
+  }
+  const loadedValues = loadedValuesMap;
 
   const { saveState, lastSavedAt, hasUnsavedChanges, saveNow } =
     useAutoSaveProposals({
@@ -238,10 +233,7 @@ export default function QualityAssessmentFullScreen() {
   //    (no ReviewerDecision write). Accept just bubbles the value to
   //    ``handleValueChange``, which records a fresh ``human`` proposal
   //    via the existing form pipeline.
-  const sessionInstanceIds = useMemo(
-    () => Object.values(session?.instancesByEntityType ?? {}),
-    [session],
-  );
+  const sessionInstanceIds = Object.values(session?.instancesByEntityType ?? {});
 
   const {
     suggestions: aiSuggestions,
@@ -285,68 +277,62 @@ export default function QualityAssessmentFullScreen() {
   const [publishing, setPublishing] = useState(false);
   const [reopening, setReopening] = useState(false);
 
-  const fieldLabelByCoord = useMemo(() => {
-    const map: Record<string, string> = {};
-    if (!session) return map;
+  const fieldLabelByCoordMap: Record<string, string> = {};
+  if (session) {
     for (const domain of domains) {
       const instanceId = session.instancesByEntityType[domain.entityType.id];
-      if (!instanceId) continue;
-      for (const f of domain.fields) {
-        map[`${instanceId}::${f.id}`] = `${domain.entityType.label} · ${f.label}`;
+      if (instanceId) {
+        for (const f of domain.fields) {
+          fieldLabelByCoordMap[`${instanceId}::${f.id}`] = `${domain.entityType.label} · ${f.label}`;
+        }
       }
     }
-    return map;
-  }, [session, domains]);
+  }
+  const fieldLabelByCoord = fieldLabelByCoordMap;
 
   const inConsensusStage = runDetail?.run.stage === "consensus";
 
-  const handleSelectExisting = useCallback(
-    async (params: {
-      instanceId: string;
-      fieldId: string;
-      decisionId: string;
-    }) => {
-      await consensusMutation.mutateAsync({
-        instance_id: params.instanceId,
-        field_id: params.fieldId,
-        mode: "select_existing",
-        selected_decision_id: params.decisionId,
-      });
-      await refetchRun();
-    },
-    [consensusMutation, refetchRun],
-  );
+  const handleSelectExisting = async (params: {
+    instanceId: string;
+    fieldId: string;
+    decisionId: string;
+  }) => {
+    await consensusMutation.mutateAsync({
+      instance_id: params.instanceId,
+      field_id: params.fieldId,
+      mode: "select_existing",
+      selected_decision_id: params.decisionId,
+    });
+    await refetchRun();
+  };
 
-  const handleManualOverride = useCallback(
-    async (params: {
-      instanceId: string;
-      fieldId: string;
-      value: unknown;
-      rationale: string;
-    }) => {
-      await consensusMutation.mutateAsync({
-        instance_id: params.instanceId,
-        field_id: params.fieldId,
-        mode: "manual_override",
-        value: { value: params.value },
-        rationale: params.rationale,
-      });
-      await refetchRun();
-    },
-    [consensusMutation, refetchRun],
-  );
+  const handleManualOverride = async (params: {
+    instanceId: string;
+    fieldId: string;
+    value: unknown;
+    rationale: string;
+  }) => {
+    await consensusMutation.mutateAsync({
+      instance_id: params.instanceId,
+      field_id: params.fieldId,
+      mode: "manual_override",
+      value: { value: params.value },
+      rationale: params.rationale,
+    });
+    await refetchRun();
+  };
 
-  const handleFinalizeFromConsensus = useCallback(async () => {
+  const handleFinalizeFromConsensus = async () => {
     if (!session) return;
     await advanceMutation.mutateAsync({ target_stage: "finalized" });
     await refetchRun();
     toast.success("Assessment finalized.");
-  }, [session, advanceMutation, refetchRun]);
+  };
 
-  // Plain-identifier dep so the compiler can preserve this memoization
-  // (optional-chained deps like `session?.runId` defeat it).
+  // Plain-identifier dep so the compiler can track this dep without
+  // optional-chaining (optional-chained deps like `session?.runId` defeat it).
   const sessionRunId = session?.runId;
-  const handleReopen = useCallback(async () => {
+  const handleReopen = async () => {
     if (!sessionRunId) return;
     setReopening(true);
     await reopenMutation.mutateAsync(sessionRunId).then(async () => {
@@ -362,8 +348,8 @@ export default function QualityAssessmentFullScreen() {
       );
     });
     setReopening(false);
-  }, [sessionRunId, reopenMutation, refetchSession]);
-  const handlePublish = useCallback(async () => {
+  };
+  const handlePublish = async () => {
     if (!session || !runDetail) return;
 
     // Preflight: an empty publish has no semantic meaning — the run would
@@ -419,17 +405,9 @@ export default function QualityAssessmentFullScreen() {
       );
     });
     setPublishing(false);
-  }, [
-    session,
-    runDetail,
-    advanceMutation,
-    consensusMutation,
-    values,
-    refetchRun,
-    saveNow,
-  ]);
+  };
 
-  const sortedDomains = useMemo(() => domains, [domains]);
+  const sortedDomains = domains;
 
   if (!projectId || !articleId || !templateId) {
     return (


### PR DESCRIPTION
## Summary

Part 2 of the zero-bailouts work ([#269](https://github.com/raphaelfh/prumo/pull/269)): with every file now compiled by the React Compiler (`panicThreshold: 'all_errors'` permanent), this PR removes the manual memoization those bailouts had pinned. **Kept memo sites drop from 226 (pre-#269) to 7 — and every survivor now carries a `// kept:` comment naming its reason.**

Spec: `docs/superpowers/specs/2026-06-11-react-compiler-zero-bailouts-design.md` (PR B section).

## Method (same as #268)

1. Regenerated the memo inventory (214 sites post-#269) and ran a one-off `react-hooks/exhaustive-deps` report: **20 flagged** (audit cases), the rest mechanical.
2. Removal rules: unflagged `useMemo` → inline; unflagged `useCallback` → plain function (the compiler stabilizes identities, including those feeding `useEffect` dep arrays); plain `memo()` → unwrap; flagged sites kept with comments (narrower-deps / extra-dep classes); custom comparators stay; per-file post-edit audit (enumerator must stay at 0, suite green).
3. Three batches: components (~64 sites) → hooks + the two former-oddball ui files → pages + whole-tree kept audit.

## Final kept list (7 sites, all commented)

| Site | Reason |
| --- | --- |
| `FieldInput`, `ExtractionFormView`, `ExtractionPDFPanel` | custom comparators — compiler does not replicate `arePropsEqual` |
| `NotificationCenter` | extra `jobs` dep forces recompute of impure store read |
| `use-mobile` | `useSyncExternalStore` subscribe identity |
| `lib/extraction/entityTypeRoles` | compiled-no-memo class (#268 lesson — compiler emits no memoization for single free-function-call hook bodies) |
| `ui/sidebar` provider value | unmemoized provider value re-renders every consumer |

## Verification

- `npm run lint` 0/0 · `npm run typecheck` clean · `npm run test:run` **475/475** · `npm run build` green (`dist/assets` 3.6 MB, unchanged vs #269)
- `node scripts/enumerate_compiler_bailouts.mjs` — **0 of 484** after every batch (removal never reintroduced a bailout)
- `npm run test:e2e:local` — **51 passed / 9 skipped / 0 failed** (dev baseline profile)
- Timing-critical hook suites (autosave debounce/flush, session generation-token, extracted-values hydration) green after each touched file (126/126 hook tests)
- Manual perf smoke on ExtractionFullScreen (hottest path, now fully compiler-memoized): 41-char burst typed in 250 ms with zero dropped input, exactly one coalesced autosave `POST`, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
