### PR TITLE
docs(frontend): update ComparisonTable JSDoc to reflect compiler memoization

### DIFF
--- a/frontend/components/shared/comparison/ComparisonTable.tsx
+++ b/frontend/components/shared/comparison/ComparisonTable.tsx
@@ -9,7 +9,7 @@
  * - Configurable columns
  * - Automatic consensus detection
  * - Visual highlights for match/divergence
- * - Optimized performance (useMemo)
+ * - Optimized performance (React Compiler memoization)
  * - Full accessibility
  *
  * @component


### PR DESCRIPTION
One-line follow-up to #270 — the file-header JSDoc still credited `useMemo` after all manual memoization was removed (final-review nit that missed the merge window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)