### PR TITLE
refactor(frontend): rename flex-shrink-0 to shrink-0 for tailwind-merge v3

### DIFF
--- a/frontend/components/articles/ArticleDetailDialog.tsx
+++ b/frontend/components/articles/ArticleDetailDialog.tsx
@@ -319,7 +319,7 @@ export function ArticleDetailDialog({ open, onOpenChange, articleId }: ArticleDe
                       className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors"
                     >
                       <div className="flex items-center gap-3 flex-1 min-w-0">
-                        <FileText className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+                        <FileText className="h-5 w-5 text-muted-foreground shrink-0" />
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium truncate">
                             {file.original_filename || "document.pdf"}

--- a/frontend/components/articles/ArticleFileUploadDialogNew.tsx
+++ b/frontend/components/articles/ArticleFileUploadDialogNew.tsx
@@ -452,14 +452,14 @@ export function ArticleFileUploadDialogNew({
                             className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4 p-3 border rounded-lg"
                           >
                             <div className="flex items-center gap-3 w-full sm:w-auto">
-                              <div className="flex-shrink-0">
+                              <div className="shrink-0">
                                 {getStatusIcon(fileWithRole.status)}
                               </div>
 
                               <div className="flex-1 min-w-0">
                                 <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 mb-1 sm:mb-0">
                                   <div className="flex items-center gap-2 min-w-0">
-                                    <FileText className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                                    <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
                                     <span className="font-medium text-sm truncate">
                                       {fileWithRole.file.name}
                                     </span>
@@ -514,7 +514,7 @@ export function ArticleFileUploadDialogNew({
                                 )}
                               </div>
 
-                              <div className="flex-shrink-0 sm:ml-auto">
+                              <div className="shrink-0 sm:ml-auto">
                                 <Button
                                   variant="ghost"
                                   size="sm"

--- a/frontend/components/articles/ArticleForm.tsx
+++ b/frontend/components/articles/ArticleForm.tsx
@@ -670,7 +670,7 @@ export function ArticleForm({
 
             <div className="flex flex-1 flex-col overflow-hidden min-h-0 lg:flex-row">
                 <aside
-                    className="w-full flex-shrink-0 border-b border-border/40 bg-[#fafafa] dark:bg-[#0c0c0c] lg:w-56 lg:border-b-0 lg:border-r overflow-x-auto lg:overflow-y-auto">
+                    className="w-full shrink-0 border-b border-border/40 bg-[#fafafa] dark:bg-[#0c0c0c] lg:w-56 lg:border-b-0 lg:border-r overflow-x-auto lg:overflow-y-auto">
                     <nav
                         role="navigation"
                         aria-label={t('articles', 'formStepsAria')}
@@ -694,7 +694,7 @@ export function ArticleForm({
                                             : 'text-muted-foreground border-l-2 border-l-transparent pl-1.5'
                                     )}
                                 >
-                                    <Icon className="h-4 w-4 flex-shrink-0" strokeWidth={1.5}/>
+                                    <Icon className="h-4 w-4 shrink-0" strokeWidth={1.5}/>
                                     <span className="whitespace-nowrap lg:whitespace-normal">{step.label}</span>
                                     {isActive && step.id === 'basic' && !isStepValid('basic') && (
                                         <AlertCircle className="ml-auto h-3.5 w-3.5 shrink-0 text-warning"/>

--- a/frontend/components/articles/ZoteroImportDialog.tsx
+++ b/frontend/components/articles/ZoteroImportDialog.tsx
@@ -221,7 +221,7 @@ export function ZoteroImportDialog({
     <>
       <Dialog open={open} onOpenChange={handleClose}>
         <DialogContent className="max-w-3xl max-h-[85vh] flex flex-col">
-        <DialogHeader className="flex-shrink-0">
+        <DialogHeader className="shrink-0">
             <DialogTitle>{t('articles', 'zoteroTitle')}</DialogTitle>
           <DialogDescription>
               {currentStep === 'select-collection' && t('articles', 'zoteroSelectCollection')}
@@ -270,7 +270,7 @@ export function ZoteroImportDialog({
                           />
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2">
-                              <FolderOpen className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                              <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
                               <p className="font-medium truncate">
                                 {collection.data.name}
                               </p>
@@ -386,7 +386,7 @@ export function ZoteroImportDialog({
               <div className="space-y-2">
                 <div className="flex items-center justify-between text-sm gap-2">
                   <span className="truncate flex-1">{progress.message}</span>
-                  <span className="text-muted-foreground flex-shrink-0">
+                  <span className="text-muted-foreground shrink-0">
                     {progress.total > 0 ? `${progress.current}/${progress.total}` : "—"}
                   </span>
                 </div>
@@ -397,7 +397,7 @@ export function ZoteroImportDialog({
               <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
                 <div className="p-3 rounded-lg border bg-muted/50">
                   <div className="flex items-center gap-1 text-xs text-muted-foreground mb-1">
-                    <CheckCircle2 className="h-3 w-3 flex-shrink-0" />
+                    <CheckCircle2 className="h-3 w-3 shrink-0" />
                       <span>{t('articles', 'zoteroImported')}</span>
                   </div>
                   <p className="text-xl font-bold">{progress.stats.imported}</p>
@@ -405,7 +405,7 @@ export function ZoteroImportDialog({
 
                 <div className="p-3 rounded-lg border bg-muted/50">
                   <div className="flex items-center gap-1 text-xs text-muted-foreground mb-1">
-                    <Download className="h-3 w-3 flex-shrink-0" />
+                    <Download className="h-3 w-3 shrink-0" />
                       <span>{t('articles', 'zoteroUpdated')}</span>
                   </div>
                   <p className="text-xl font-bold">{progress.stats.updated}</p>
@@ -413,7 +413,7 @@ export function ZoteroImportDialog({
 
                 <div className="p-3 rounded-lg border bg-muted/50">
                   <div className="flex items-center gap-1 text-xs text-muted-foreground mb-1">
-                    <AlertCircle className="h-3 w-3 flex-shrink-0" />
+                    <AlertCircle className="h-3 w-3 shrink-0" />
                       <span>{t('articles', 'zoteroSkipped')}</span>
                   </div>
                   <p className="text-xl font-bold">{progress.stats.skipped}</p>
@@ -421,7 +421,7 @@ export function ZoteroImportDialog({
 
                 <div className="p-3 rounded-lg border bg-muted/50">
                   <div className="flex items-center gap-1 text-xs text-muted-foreground mb-1">
-                    <XCircle className="h-3 w-3 flex-shrink-0" />
+                    <XCircle className="h-3 w-3 shrink-0" />
                       <span>{t('articles', 'zoteroErrors')}</span>
                   </div>
                   <p className="text-xl font-bold">{progress.stats.errors}</p>
@@ -431,7 +431,7 @@ export function ZoteroImportDialog({
                 {progress.stats.pdfsDownloaded !== undefined && progress.stats.pdfsDownloaded > 0 && (
                   <div className="p-3 rounded-lg border bg-primary/5">
                     <div className="flex items-center gap-1 text-xs text-primary mb-1">
-                      <Download className="h-3 w-3 flex-shrink-0" />
+                      <Download className="h-3 w-3 shrink-0" />
                       <span>PDFs</span>
                     </div>
                     <p className="text-xl font-bold text-primary">{progress.stats.pdfsDownloaded}</p>
@@ -478,7 +478,7 @@ export function ZoteroImportDialog({
         </ScrollArea>
 
             {/* Footer with buttons */}
-        <div className="flex justify-between pt-4 border-t flex-shrink-0">
+        <div className="flex justify-between pt-4 border-t shrink-0">
           <div>
             {currentStep === 'configure-options' && (
               <Button variant="outline" onClick={handleBack} disabled={importing}>

--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -997,7 +997,7 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <div className="flex items-center gap-1 cursor-help">
-                                        <User className="h-3 w-3 text-muted-foreground flex-shrink-0"/>
+                                        <User className="h-3 w-3 text-muted-foreground shrink-0"/>
                                         <span className="truncate block min-w-0">
                                           {article.authors.slice(0, 1).join(', ')}
                                             {article.authors.length > 1 && ` +${article.authors.length - 1}`}

--- a/frontend/components/extraction/ExtractionHeader.tsx
+++ b/frontend/components/extraction/ExtractionHeader.tsx
@@ -148,7 +148,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
                 />
               </div>
               
-              <div className="flex items-center gap-2 flex-shrink-0">
+              <div className="flex items-center gap-2 shrink-0">
                 <HeaderStatusBadges
                   userRole={userRole}
                   isBlindMode={isBlindMode}
@@ -162,7 +162,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
                 />
               </div>
               
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <HeaderFinalizeButton
                   isComplete={isComplete}
                   onSubmit={onFinalize}
@@ -229,7 +229,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
             </div>
 
                 {/* Zone 2: View controls (center-left) */}
-            <div className="flex items-center gap-1 flex-shrink-0">
+            <div className="flex items-center gap-1 shrink-0">
               <HeaderPDFControls
                 showPDF={showPDF}
                 onTogglePDF={onTogglePDF}
@@ -244,7 +244,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
             </div>
 
             {/* Zona 3: Status e Feedback (Centro) */}
-            <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="flex items-center gap-2 shrink-0">
               <HeaderStatusBadges
                 userRole={userRole}
                 isBlindMode={isBlindMode}
@@ -259,7 +259,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
             </div>
 
                 {/* Zone 4: Secondary actions (center-right) */}
-            <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="flex items-center gap-2 shrink-0">
               <HeaderAIActions
                 suggestions={aiSuggestions}
                 onClick={onAISuggestionsClick}
@@ -280,7 +280,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
             </div>
 
                 {/* Zone 5: Primary action (far right) */}
-            <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="flex items-center gap-2 shrink-0">
               <HeaderFinalizeButton
                 isComplete={isComplete}
                 onSubmit={onFinalize}

--- a/frontend/components/extraction/ExtractionInterface.tsx
+++ b/frontend/components/extraction/ExtractionInterface.tsx
@@ -217,7 +217,7 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
               <CardContent className="pt-4 pb-4 px-4">
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex items-start space-x-3">
-                  <Settings className="h-4 w-4 text-info mt-0.5 flex-shrink-0" strokeWidth={1.5}/>
+                  <Settings className="h-4 w-4 text-info mt-0.5 shrink-0" strokeWidth={1.5}/>
                 <div>
                     <p className="text-[13px] font-medium text-foreground">{t('extraction', 'dashboardConfigureTitle')}</p>
                     <p className="text-[13px] text-muted-foreground mt-1">
@@ -275,7 +275,7 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
             <Card className="border-border/40 shadow-elev-popover rounded-md w-full">
                 <CardContent className="pt-6 pb-6">
                     <div className="flex items-start gap-3 text-[13px] text-muted-foreground">
-                        <AlertCircle className="h-5 w-5 text-muted-foreground flex-shrink-0 mt-0.5" strokeWidth={1.5}/>
+                        <AlertCircle className="h-5 w-5 text-muted-foreground shrink-0 mt-0.5" strokeWidth={1.5}/>
                         <p>{t('extraction', 'configContactManagerToConfigure')}</p>
                     </div>
             </CardContent>
@@ -328,7 +328,7 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
                     {/* 2. Manager info */}
                     <div className="bg-info/5 border border-info/30 rounded-lg p-4">
                 <div className="flex items-start space-x-3">
-                    <AlertCircle className="h-4 w-4 text-info mt-0.5 flex-shrink-0" strokeWidth={1.5}/>
+                    <AlertCircle className="h-4 w-4 text-info mt-0.5 shrink-0" strokeWidth={1.5}/>
                     <div className="text-[13px] text-foreground">
                         <p className="font-medium mb-1">{t('extraction', 'configManagersNote')}</p>
                     <p className="text-muted-foreground">
@@ -416,7 +416,7 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
             <Card className="border-border/40 shadow-elev-popover rounded-md w-full">
                 <CardContent className="pt-6 pb-6">
                     <div className="flex items-start gap-3 text-[13px] text-muted-foreground">
-                        <AlertCircle className="h-5 w-5 text-muted-foreground flex-shrink-0 mt-0.5" strokeWidth={1.5}/>
+                        <AlertCircle className="h-5 w-5 text-muted-foreground shrink-0 mt-0.5" strokeWidth={1.5}/>
                         <p>{t('extraction', 'configContactManagerToConfigure')}</p>
                     </div>
                 </CardContent>

--- a/frontend/components/extraction/config/ConfigureTemplateFirst.tsx
+++ b/frontend/components/extraction/config/ConfigureTemplateFirst.tsx
@@ -38,7 +38,7 @@ export function ConfigureTemplateFirst({
                 <div className="flex flex-col items-center gap-2">
                     <div className="bg-muted/50 rounded-lg p-3 w-full max-w-md space-y-2 text-left">
                         <div className="flex items-start space-x-2">
-                            <Download className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" strokeWidth={1.5}/>
+                            <Download className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" strokeWidth={1.5}/>
                             <div>
                                 <p className="text-[13px] font-medium">{t('extraction', 'configImportCharms')}</p>
                                 <p className="text-[13px] text-muted-foreground">
@@ -47,7 +47,7 @@ export function ConfigureTemplateFirst({
                             </div>
                         </div>
                         <div className="flex items-start space-x-2">
-                            <PlusCircle className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0"
+                            <PlusCircle className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0"
                                         strokeWidth={1.5}/>
                             <div>
                                 <p className="text-[13px] font-medium">{t('extraction', 'configCreateCustom')}</p>

--- a/frontend/components/extraction/dialogs/AddFieldDialog.tsx
+++ b/frontend/components/extraction/dialogs/AddFieldDialog.tsx
@@ -426,7 +426,7 @@ export function AddFieldDialog({
             {/* Info adicional */}
             <div className="rounded-lg border border-info/30 bg-info/5 p-3 text-sm text-foreground">
               <div className="flex items-start gap-2">
-                <Info className="h-4 w-4 mt-0.5 flex-shrink-0 text-info" />
+                <Info className="h-4 w-4 mt-0.5 shrink-0 text-info" />
                 <div>
                     <p className="font-medium">{t('extraction', 'addFieldTipsTitle')}</p>
                   <ul className="mt-1 list-disc list-inside space-y-1 text-xs text-muted-foreground">

--- a/frontend/components/extraction/dialogs/AddSectionDialog.tsx
+++ b/frontend/components/extraction/dialogs/AddSectionDialog.tsx
@@ -280,7 +280,7 @@ export function AddSectionDialog({
                     </SelectContent>
                   </Select>
                   <FormDescription className="flex items-start gap-2">
-                    <Info className="h-4 w-4 mt-0.5 text-info flex-shrink-0" />
+                    <Info className="h-4 w-4 mt-0.5 text-info shrink-0" />
                     <span>
                       Single section for data that appears once per article.
                       Multiple section allows several instances (e.g. a list or table).

--- a/frontend/components/extraction/dialogs/AllowedUnitsList.tsx
+++ b/frontend/components/extraction/dialogs/AllowedUnitsList.tsx
@@ -222,10 +222,10 @@ export function AllowedUnitsList({
                     : "bg-background hover:bg-accent"
                 )}
               >
-                <GripVertical className="h-4 w-4 text-muted-foreground/40 flex-shrink-0" />
+                <GripVertical className="h-4 w-4 text-muted-foreground/40 shrink-0" />
                 
                 {index === 0 && (
-                  <Star className="h-3 w-3 text-primary flex-shrink-0" />
+                  <Star className="h-3 w-3 text-primary shrink-0" />
                 )}
                 
                 <span className={cn(

--- a/frontend/components/extraction/dialogs/AllowedValuesList.tsx
+++ b/frontend/components/extraction/dialogs/AllowedValuesList.tsx
@@ -240,7 +240,7 @@ export function AllowedValuesList({
                   key={`${value}-${index}`}
                   className="flex items-center gap-2 bg-background rounded-md px-3 py-2 group hover:bg-accent transition-colors border"
                 >
-                  <GripVertical className="h-4 w-4 text-muted-foreground/40 flex-shrink-0" />
+                  <GripVertical className="h-4 w-4 text-muted-foreground/40 shrink-0" />
                   <span className="flex-1 text-sm">{value}</span>
                   <Badge variant="secondary" className="text-xs">
                     {index + 1}

--- a/frontend/components/extraction/dialogs/DeleteFieldConfirm.tsx
+++ b/frontend/components/extraction/dialogs/DeleteFieldConfirm.tsx
@@ -98,7 +98,7 @@ export function DeleteFieldConfirm({
               {canDelete ? (
                 <div className="rounded-lg border border-warning/30 bg-warning/10 p-4">
                   <div className="flex items-start gap-2">
-                    <AlertTriangle className="h-5 w-5 text-warning mt-0.5 flex-shrink-0" />
+                    <AlertTriangle className="h-5 w-5 text-warning mt-0.5 shrink-0" />
                     <div className="flex-1">
                         <p className="font-medium text-foreground">{t('common', 'attention')}</p>
                       <ul className="mt-2 list-disc list-inside space-y-1 text-sm text-foreground/80">
@@ -113,7 +113,7 @@ export function DeleteFieldConfirm({
               ) : (
                 <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-4">
                   <div className="flex items-start gap-2">
-                    <AlertCircle className="h-5 w-5 text-destructive mt-0.5 flex-shrink-0" />
+                    <AlertCircle className="h-5 w-5 text-destructive mt-0.5 shrink-0" />
                     <div className="flex-1">
                         <p className="font-medium text-destructive">{t('extraction', 'impossibleToDelete')}</p>
                       <ul className="mt-2 list-disc list-inside space-y-1 text-sm text-destructive/90">

--- a/frontend/components/extraction/header/HeaderFinalizeButton.tsx
+++ b/frontend/components/extraction/header/HeaderFinalizeButton.tsx
@@ -33,7 +33,7 @@ export function HeaderFinalizeButton({
       onClick={onSubmit}
       disabled={!isComplete || submitting}
       className={`
-        flex-shrink-0 font-medium 
+        shrink-0 font-medium 
         shadow-sm hover:shadow-md hover:scale-[1.02]
         transition-all duration-150 ease-out
         disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100

--- a/frontend/components/extraction/header/HeaderNavigation.tsx
+++ b/frontend/components/extraction/header/HeaderNavigation.tsx
@@ -66,7 +66,7 @@ export function HeaderNavigation({
         variant="ghost" 
         size="sm" 
         onClick={onBack}
-        className="flex-shrink-0 h-8 px-2 -ml-2 hover:bg-muted/50 transition-colors duration-150"
+        className="shrink-0 h-8 px-2 -ml-2 hover:bg-muted/50 transition-colors duration-150"
       >
         <ArrowLeft className={`${showBackText ? 'mr-1.5' : ''} h-4 w-4`} />
           {showBackText && <span className="text-sm font-medium hidden sm:inline">{t('extraction', 'back')}</span>}
@@ -106,7 +106,7 @@ export function HeaderNavigation({
 
         {/* Navegação entre artigos ao lado direito do nome */}
         {hasArticleNavigation && (
-          <div className="flex items-center gap-1 flex-shrink-0">
+          <div className="flex items-center gap-1 shrink-0">
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button

--- a/frontend/components/extraction/hierarchy/ModelSelector.tsx
+++ b/frontend/components/extraction/hierarchy/ModelSelector.tsx
@@ -173,7 +173,7 @@ export function ModelSelector({
               {t('extraction', 'modelSelectorDesc')}
           </p>
         </div>
-        <div className="flex gap-2 flex-shrink-0">
+        <div className="flex gap-2 shrink-0">
           {onExtractModels && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -248,7 +248,7 @@ export function ModelSelector({
             variant="ghost"
             onClick={() => onRemoveModel(activeModelId)}
             title={t('extraction', 'modelRemoveActiveTitle')}
-            className="flex-shrink-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+            className="shrink-0 text-destructive hover:text-destructive hover:bg-destructive/10"
           >
             <Trash2 className="h-4 w-4" />
           </Button>
@@ -263,7 +263,7 @@ export function ModelSelector({
                 <p className="text-xs text-muted-foreground">{t('extraction', 'modelActiveLabel')}</p>
               <p className="font-medium text-foreground mt-0.5 truncate">{activeModel.modelName}</p>
             </div>
-            <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="flex items-center gap-2 shrink-0">
               {activeModel.progress && (
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium text-foreground">

--- a/frontend/components/feedback/FeedbackButton.tsx
+++ b/frontend/components/feedback/FeedbackButton.tsx
@@ -22,7 +22,7 @@ export function FeedbackButton() {
               size="icon"
               onClick={() => setDialogOpen(true)}
               aria-label={t('navigation', 'sendFeedback')}
-              className="flex-shrink-0 h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors duration-75"
+              className="shrink-0 h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors duration-75"
             >
                 <MessageCircle className="h-4 w-4" strokeWidth={1.5}/>
             </Button>

--- a/frontend/components/layout/AppLayout.tsx
+++ b/frontend/components/layout/AppLayout.tsx
@@ -50,7 +50,7 @@ export const ProjectLayout: React.FC<AppLayoutProps> = ({children, className}) =
 
   return (
     <div className={cn('h-screen flex flex-col overflow-hidden bg-background', className)}>
-      <div className="flex-shrink-0">
+      <div className="shrink-0">
         <Topbar />
       </div>
 

--- a/frontend/components/layout/MobileSidebar.tsx
+++ b/frontend/components/layout/MobileSidebar.tsx
@@ -30,7 +30,7 @@ export const MobileSidebar: React.FC<MobileSidebarProps> = ({open, onOpenChange,
         <div className="flex flex-col h-full">
           <SheetHeader className="px-3 py-3 pr-12 border-b border-border/40 shrink-0">
             <div className="flex items-center gap-2.5">
-              <div className="h-5 w-5 rounded bg-primary/10 flex items-center justify-center flex-shrink-0 border border-primary/15">
+              <div className="h-5 w-5 rounded bg-primary/10 flex items-center justify-center shrink-0 border border-primary/15">
                 <span className="text-[10px] font-semibold text-primary leading-none">
                   {(projectName || 'P')[0].toUpperCase()}
                 </span>
@@ -60,7 +60,7 @@ export const MobileSidebar: React.FC<MobileSidebarProps> = ({open, onOpenChange,
                           : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
                       )}
                     >
-                      <Icon className={cn('h-4 w-4 flex-shrink-0', active && 'text-foreground')} strokeWidth={1.5} />
+                      <Icon className={cn('h-4 w-4 shrink-0', active && 'text-foreground')} strokeWidth={1.5} />
                       <span className="text-[13px]">{item.label}</span>
                     </Button>
                   );

--- a/frontend/components/layout/SidebarHeader.tsx
+++ b/frontend/components/layout/SidebarHeader.tsx
@@ -61,7 +61,7 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({projectName, open, 
             aria-keyshortcuts="G P"
             className="w-full justify-start gap-2 h-8 px-2 rounded-md hover:bg-muted/50 transition-colors group"
           >
-            <div className="h-5 w-5 rounded bg-primary/10 flex items-center justify-center flex-shrink-0 border border-primary/15">
+            <div className="h-5 w-5 rounded bg-primary/10 flex items-center justify-center shrink-0 border border-primary/15">
               <span className="text-[10px] font-semibold text-primary leading-none">
                 {(projectName || 'P')[0].toUpperCase()}
               </span>
@@ -88,7 +88,7 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({projectName, open, 
                   onClick={() => switchProject(project.id)}
                   className="px-2 py-1.5 rounded-md text-[13px] focus:bg-muted/60"
                 >
-                  <div className="h-4 w-4 rounded bg-primary/10 flex items-center justify-center flex-shrink-0 border border-primary/15 mr-2">
+                  <div className="h-4 w-4 rounded bg-primary/10 flex items-center justify-center shrink-0 border border-primary/15 mr-2">
                     <span className="text-[9px] font-semibold text-primary leading-none">
                       {project.name[0].toUpperCase()}
                     </span>

--- a/frontend/components/layout/UserMenu.tsx
+++ b/frontend/components/layout/UserMenu.tsx
@@ -45,14 +45,14 @@ export const UserMenu: React.FC<UserMenuProps> = ({collapsed}) => {
           aria-haspopup="menu"
           className="flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors duration-75"
         >
-          <Avatar className="h-6 w-6 flex-shrink-0 border border-border/40">
+          <Avatar className="h-6 w-6 shrink-0 border border-border/40">
             <AvatarImage src={user.avatar} alt={user.name} />
             <AvatarFallback className="text-[9px] bg-muted">{user.initials}</AvatarFallback>
           </Avatar>
           {!collapsed && (
             <>
               <span className="text-[13px] truncate flex-1 min-w-0">{user.name}</span>
-              <ChevronDown className="h-3.5 w-3.5 ml-auto text-muted-foreground/50 flex-shrink-0" strokeWidth={1.5} />
+              <ChevronDown className="h-3.5 w-3.5 ml-auto text-muted-foreground/50 shrink-0" strokeWidth={1.5} />
             </>
           )}
         </button>

--- a/frontend/components/navigation/NotificationCenter.tsx
+++ b/frontend/components/navigation/NotificationCenter.tsx
@@ -320,7 +320,7 @@ function NotificationItem({ job, onRemove, onClick }: NotificationItemProps) {
     >
       <div className="flex items-start gap-3">
           {/* Icon */}
-        <div className="flex-shrink-0 mt-0.5">
+        <div className="shrink-0 mt-0.5">
           {icon}
         </div>
 
@@ -334,7 +334,7 @@ function NotificationItem({ job, onRemove, onClick }: NotificationItemProps) {
             <Button
               variant="ghost"
               size="icon"
-              className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+              className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
               onClick={(e) => onRemove(job.id, e)}
             >
               <X className="h-3 w-3" />
@@ -352,7 +352,7 @@ function NotificationItem({ job, onRemove, onClick }: NotificationItemProps) {
                 <span className="text-muted-foreground truncate flex-1">
                   {job.progress.message}
                 </span>
-                <span className="text-muted-foreground ml-2 flex-shrink-0">
+                <span className="text-muted-foreground ml-2 shrink-0">
                   {job.progress.total > 0 ? `${job.progress.current}/${job.progress.total}` : '—'}
                 </span>
               </div>

--- a/frontend/components/navigation/Topbar.tsx
+++ b/frontend/components/navigation/Topbar.tsx
@@ -42,8 +42,8 @@ export const Topbar: React.FC<TopbarProps> = ({
             className={cn("sticky top-0 z-40 w-full border-b border-border/40 bg-background/80 backdrop-blur-md", className)}>
             <div className="flex h-12 w-full items-center justify-between px-4 sm:px-6">
                 <div className="flex items-center gap-2 min-w-0 flex-1">
-              <div className="h-5 w-5 rounded bg-muted animate-pulse flex-shrink-0"/>
-              <div className="h-[13px] w-28 bg-muted animate-pulse rounded flex-shrink-0"/>
+              <div className="h-5 w-5 rounded bg-muted animate-pulse shrink-0"/>
+              <div className="h-[13px] w-28 bg-muted animate-pulse rounded shrink-0"/>
           </div>
         </div>
       </header>
@@ -68,7 +68,7 @@ export const Topbar: React.FC<TopbarProps> = ({
   return (
       <header
           className={cn("z-40 w-full border-b border-border/40 bg-background/80 backdrop-blur-md sticky top-0", className)}>
-          <div className="flex h-12 w-full items-center justify-between px-4 sm:px-6 flex-shrink-0">
+          <div className="flex h-12 w-full items-center justify-between px-4 sm:px-6 shrink-0">
               {/* Left Section - Toggle + title (min-w-0 so title can truncate) */}
               <div className="flex items-center gap-2 min-w-0 flex-1">
                   {/* Hamburger Menu - Mobile/Tablet only */}
@@ -78,7 +78,7 @@ export const Topbar: React.FC<TopbarProps> = ({
                           size="icon"
                           onClick={sidebarContext.toggleMobile}
                           aria-label={t('navigation', 'ariaOpenMenu')}
-                          className="flex lg:hidden flex-shrink-0 h-8 w-8 hover:bg-muted/50 transition-colors duration-75"
+                          className="flex lg:hidden shrink-0 h-8 w-8 hover:bg-muted/50 transition-colors duration-75"
                       >
                           <Menu className="h-4 w-4 text-muted-foreground"/>
                       </Button>
@@ -92,7 +92,7 @@ export const Topbar: React.FC<TopbarProps> = ({
               aria-label={t('layout', 'sidebarToggleAriaLabel')}
               aria-pressed={!sidebarContext.sidebarCollapsed}
               aria-keyshortcuts="Meta+B"
-              className="hidden lg:flex flex-shrink-0 h-8 w-8 hover:bg-muted/50 transition-colors duration-75 relative"
+              className="hidden lg:flex shrink-0 h-8 w-8 hover:bg-muted/50 transition-colors duration-75 relative"
             >
               <span className="relative h-4 w-4 block">
                 <PanelLeftClose
@@ -129,7 +129,7 @@ export const Topbar: React.FC<TopbarProps> = ({
         </div>
 
         {/* Right Section - Notifications + Feedback */}
-              <div className="flex items-center gap-1.5 flex-shrink-0">
+              <div className="flex items-center gap-1.5 shrink-0">
           <NotificationCenter />
           <FeedbackButton />
         </div>

--- a/frontend/components/patterns/DetailSheet.tsx
+++ b/frontend/components/patterns/DetailSheet.tsx
@@ -60,7 +60,7 @@ export function DetailSheet({
 
           {/* Fixed footer */}
         {footer && (
-          <div className="border-t pt-4 flex justify-end gap-2 flex-shrink-0">
+          <div className="border-t pt-4 flex justify-end gap-2 shrink-0">
             {footer}
           </div>
         )}

--- a/frontend/components/patterns/PageHeader.tsx
+++ b/frontend/components/patterns/PageHeader.tsx
@@ -25,12 +25,12 @@ export function PageHeader({title, description, leading, actions, className}: Pa
   return (
       <div
           className={cn(
-              'h-12 flex items-center justify-between border-b border-border/40 bg-background/80 backdrop-blur-md px-6 flex-shrink-0',
+              'h-12 flex items-center justify-between border-b border-border/40 bg-background/80 backdrop-blur-md px-6 shrink-0',
               className
           )}
       >
           <div className="flex items-center gap-4 flex-1 min-w-0">
-              {leading && <div className="flex-shrink-0">{leading}</div>}
+              {leading && <div className="shrink-0">{leading}</div>}
               <div className="flex items-baseline gap-3 min-w-0">
                   {title && (
                       <span className="text-[13px] font-medium text-foreground truncate">{title}</span>
@@ -41,7 +41,7 @@ export function PageHeader({title, description, leading, actions, className}: Pa
               </div>
           </div>
           {actions && (
-              <div className="flex items-center gap-2 flex-shrink-0">
+              <div className="flex items-center gap-2 shrink-0">
                   {actions}
               </div>
           )}

--- a/frontend/components/patterns/PageToolbar.tsx
+++ b/frontend/components/patterns/PageToolbar.tsx
@@ -35,7 +35,7 @@ export function PageToolbar({
       
       {children}
       
-      <div className="flex items-center gap-2 flex-shrink-0">
+      <div className="flex items-center gap-2 shrink-0">
         {rightActions}
       </div>
     </div>

--- a/frontend/components/project/ProjectSettings.tsx
+++ b/frontend/components/project/ProjectSettings.tsx
@@ -85,7 +85,7 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
 
       <div className="flex-1 flex overflow-hidden">
           <aside
-              className="w-56 flex-shrink-0 border-r border-border/40 bg-[#fafafa] dark:bg-[#0c0c0c] overflow-y-auto">
+              className="w-56 shrink-0 border-r border-border/40 bg-[#fafafa] dark:bg-[#0c0c0c] overflow-y-auto">
               <nav className="py-4 px-2 space-y-0.5">
             {TABS.map((tab) => {
               const Icon = tab.icon;
@@ -101,7 +101,7 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
                       isActive ? 'bg-muted text-foreground' : 'text-muted-foreground'
                   )}
                 >
-                    <Icon className="h-4 w-4 flex-shrink-0" strokeWidth={1.5}/>
+                    <Icon className="h-4 w-4 shrink-0" strokeWidth={1.5}/>
                     {tab.label}
                 </button>
               );

--- a/frontend/components/project/settings/TeamMembersSection.tsx
+++ b/frontend/components/project/settings/TeamMembersSection.tsx
@@ -202,7 +202,7 @@ export function TeamMembersSection({ projectId }: TeamMembersSectionProps) {
                               <div className="flex items-center justify-between py-1.5">
                                   <div className="flex items-center gap-3 min-w-0">
                                       <div
-                                          className="h-9 w-9 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 overflow-hidden">
+                                          className="h-9 w-9 rounded-full bg-primary/10 flex items-center justify-center shrink-0 overflow-hidden">
                                           {member.user_avatar_url ? (
                                               <img
                                                   src={member.user_avatar_url}
@@ -226,7 +226,7 @@ export function TeamMembersSection({ projectId }: TeamMembersSectionProps) {
                                           </p>
                                       </div>
                                   </div>
-                                  <div className="flex items-center gap-1.5 flex-shrink-0">
+                                  <div className="flex items-center gap-1.5 shrink-0">
                                       {editingMemberId === member.id ? (
                                           <>
                                               <Select

--- a/frontend/components/project/settings/TemplateConsensusOverride.tsx
+++ b/frontend/components/project/settings/TemplateConsensusOverride.tsx
@@ -126,9 +126,9 @@ export function TemplateConsensusOverride({
       >
         <span className="flex items-center gap-2 min-w-0">
           {expanded ? (
-            <ChevronDown className="h-4 w-4 flex-shrink-0" strokeWidth={1.5} />
+            <ChevronDown className="h-4 w-4 shrink-0" strokeWidth={1.5} />
           ) : (
-            <ChevronRight className="h-4 w-4 flex-shrink-0" strokeWidth={1.5} />
+            <ChevronRight className="h-4 w-4 shrink-0" strokeWidth={1.5} />
           )}
           <span className="font-medium truncate">{template.name}</span>
           {template.framework && (
@@ -140,7 +140,7 @@ export function TemplateConsensusOverride({
         {config.isLoading ? (
           <Skeleton className="h-5 w-24" />
         ) : (
-          <Badge variant={isOverridden ? 'default' : 'outline'} className="text-[11px] flex-shrink-0">
+          <Badge variant={isOverridden ? 'default' : 'outline'} className="text-[11px] shrink-0">
             {isOverridden
               ? t('consensus', 'templatesOverriddenBadge')
               : t('consensus', 'templatesInheritsBadge')}

--- a/frontend/components/settings/TagInput.tsx
+++ b/frontend/components/settings/TagInput.tsx
@@ -127,7 +127,7 @@ export function TagInput({
                                 type="button"
                                 size="icon"
                                 variant="ghost"
-                                className="h-6 w-6 flex-shrink-0"
+                                className="h-6 w-6 shrink-0"
                                 onClick={() => onRemove(index)}
                                 aria-label="Remover"
                             >

--- a/frontend/components/shared/list/ListRowCard.tsx
+++ b/frontend/components/shared/list/ListRowCard.tsx
@@ -29,7 +29,7 @@ export function ListRowCard({
     const content = (
         <>
             {leading && (
-                <div className="flex-shrink-0 flex items-center" onClick={(e) => e.stopPropagation()}>
+                <div className="shrink-0 flex items-center" onClick={(e) => e.stopPropagation()}>
                     {leading}
                 </div>
             )}
@@ -44,7 +44,7 @@ export function ListRowCard({
                     </div>
                 )}
             </div>
-            <div className="flex-shrink-0 flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            <div className="shrink-0 flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
                 {primaryAction}
                 {secondaryActions}
             </div>

--- a/frontend/components/ui/file-drop-zone.tsx
+++ b/frontend/components/ui/file-drop-zone.tsx
@@ -385,7 +385,7 @@ const FilePreviewCard: React.FC<FilePreviewCardProps> = ({ file, onRemove, disab
   return (
     <div className="flex items-center gap-3 p-3 border rounded-lg bg-card hover:bg-accent/50 transition-colors">
       {/* Ícone ou preview */}
-      <div className="flex-shrink-0 w-12 h-12 rounded bg-muted flex items-center justify-center overflow-hidden">
+      <div className="shrink-0 w-12 h-12 rounded bg-muted flex items-center justify-center overflow-hidden">
         {file.preview ? (
           <img src={file.preview} alt={file.name} className="w-full h-full object-cover" />
         ) : (
@@ -410,7 +410,7 @@ const FilePreviewCard: React.FC<FilePreviewCardProps> = ({ file, onRemove, disab
           if (file.id) onRemove(file.id);
         }}
         disabled={disabled}
-        className="flex-shrink-0"
+        className="shrink-0"
         aria-label={t('ui', 'removeFileAria').replace('{{name}}', file.name)}
       >
         <X className="h-4 w-4" />

--- a/frontend/components/ui/resizable-panel.tsx
+++ b/frontend/components/ui/resizable-panel.tsx
@@ -254,7 +254,7 @@ export const ResizablePanel: React.FC<ResizablePanelProps> = ({
   return (
     <aside
       className={cn(
-        'relative flex-shrink-0 overflow-hidden',
+        'relative shrink-0 overflow-hidden',
         // Disable the smooth transition during active drag — the cursor drives width directly.
         isDragging ? '' : 'transition-[width,opacity] duration-200 ease-out motion-reduce:duration-0',
         className,

--- a/frontend/pages/Dashboard.tsx
+++ b/frontend/pages/Dashboard.tsx
@@ -79,13 +79,13 @@ export default function Dashboard() {
           <div className="divide-y divide-border/30">
             {[0, 1, 2, 3, 4].map((i) => (
               <div key={i} className={cn("flex items-center gap-3 py-3 sm:gap-4", SHELL_PADDING_X)}>
-                <Skeleton className="h-9 w-9 flex-shrink-0 rounded-lg"/>
+                <Skeleton className="h-9 w-9 shrink-0 rounded-lg"/>
                 <div className="min-w-0 flex-1 space-y-2">
                   <Skeleton className="h-3.5 w-1/3 max-w-[180px]"/>
                   <Skeleton className="h-3 w-1/2 max-w-[280px]"/>
                 </div>
-                <Skeleton className="hidden h-7 w-16 flex-shrink-0 rounded md:block"/>
-                <Skeleton className="h-8 w-8 flex-shrink-0 rounded-md"/>
+                <Skeleton className="hidden h-7 w-16 shrink-0 rounded md:block"/>
+                <Skeleton className="h-8 w-8 shrink-0 rounded-md"/>
               </div>
             ))}
           </div>
@@ -158,7 +158,7 @@ export default function Dashboard() {
                 }}
               >
                 <div
-                  className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-border/50 bg-muted/20 transition-all duration-150 group-hover:border-border group-hover:shadow-sm motion-reduce:transition-none">
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border/50 bg-muted/20 transition-all duration-150 group-hover:border-border group-hover:shadow-sm motion-reduce:transition-none">
                   <BookOpen
                     className="h-4 w-4 text-muted-foreground/60 transition-colors group-hover:text-foreground motion-reduce:transition-none"
                     strokeWidth={1.75}
@@ -174,7 +174,7 @@ export default function Dashboard() {
                     {project.is_active && (
                       <span
                         aria-hidden="true"
-                        className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-success shadow-[0_0_8px_hsl(var(--success)/0.45)]"
+                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-success shadow-[0_0_8px_hsl(var(--success)/0.45)]"
                       />
                     )}
                   </div>
@@ -183,7 +183,7 @@ export default function Dashboard() {
                   </p>
                 </div>
 
-                <div className="hidden flex-shrink-0 flex-col items-end pl-2 md:flex">
+                <div className="hidden shrink-0 flex-col items-end pl-2 md:flex">
                   <span
                     className="mb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/40">
                     {t('pages', 'dashboardCreatedDate')}
@@ -194,7 +194,7 @@ export default function Dashboard() {
                 </div>
 
                 <div
-                  className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground/30 transition-all duration-150 group-hover:bg-muted/50 group-hover:text-foreground/80 motion-reduce:transition-none">
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground/30 transition-all duration-150 group-hover:bg-muted/50 group-hover:text-foreground/80 motion-reduce:transition-none">
                   <ChevronRight className="h-4 w-4" aria-hidden="true"/>
                 </div>
               </div>

--- a/frontend/pages/ProjectView.tsx
+++ b/frontend/pages/ProjectView.tsx
@@ -285,14 +285,14 @@ export default function ProjectView() {
           {/* Sticky action bar — stack on narrow (flex-col md:flex-row), single row from md */}
         {!isFullBleed && (
             <div
-                className="flex-shrink-0 min-h-12 md:h-12 flex flex-col md:flex-row md:items-center md:justify-between items-stretch gap-2 md:gap-0 py-3 md:py-0 border-b border-border/40 bg-background/80 backdrop-blur-sm px-6 lg:px-10">
+                className="shrink-0 min-h-12 md:h-12 flex flex-col md:flex-row md:items-center md:justify-between items-stretch gap-2 md:gap-0 py-3 md:py-0 border-b border-border/40 bg-background/80 backdrop-blur-sm px-6 lg:px-10">
           <span className="text-[13px] text-muted-foreground/70 w-full min-w-0 md:flex-1 md:truncate">
             {activeTab === 'articles'
                 ? 'Articles'
                 : (TAB_DESCRIPTIONS[activeTab] ?? '')}
           </span>
                 {activeTab === 'extraction' && (
-                    <div className="flex items-center gap-0.5 w-full md:w-auto flex-shrink-0" role="tablist"
+                    <div className="flex items-center gap-0.5 w-full md:w-auto shrink-0" role="tablist"
                          aria-label="Extraction views">
                         {[
                             {value: 'extraction' as const, label: t('extraction', 'tabExtraction')},
@@ -319,7 +319,7 @@ export default function ProjectView() {
                     </div>
                 )}
                 {activeTab === 'quality' && (
-                    <div className="flex items-center gap-0.5 w-full md:w-auto flex-shrink-0" role="tablist"
+                    <div className="flex items-center gap-0.5 w-full md:w-auto shrink-0" role="tablist"
                          aria-label="Quality assessment views">
                         {[
                             {value: 'assessment' as const, label: t('qa', 'tabAssessment')},
@@ -347,7 +347,7 @@ export default function ProjectView() {
                     </div>
                 )}
               {activeTab === 'articles' && (
-                  <div className="flex items-center gap-1.5 w-full md:w-auto flex-shrink-0 flex-wrap">
+                  <div className="flex items-center gap-1.5 w-full md:w-auto shrink-0 flex-wrap">
                       <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                               <Button
@@ -374,7 +374,7 @@ export default function ProjectView() {
                                   className="flex items-center gap-2.5 rounded-md py-2 px-2.5 cursor-pointer focus:bg-muted/60"
                               >
                           <span
-                              className="h-5 w-5 rounded bg-primary/10 flex items-center justify-center flex-shrink-0 border border-primary/15">
+                              className="h-5 w-5 rounded bg-primary/10 flex items-center justify-center shrink-0 border border-primary/15">
                             <span className="text-[9px] font-semibold text-primary leading-none">Z</span>
                           </span>
                                   From Zotero
@@ -384,7 +384,7 @@ export default function ProjectView() {
                                   className="flex items-center gap-2.5 rounded-md py-2 px-2.5 cursor-pointer focus:bg-muted/60"
                               >
                           <span
-                              className="h-5 w-5 rounded bg-primary/10 flex items-center justify-center flex-shrink-0 border border-primary/15">
+                              className="h-5 w-5 rounded bg-primary/10 flex items-center justify-center shrink-0 border border-primary/15">
                             <FileText className="h-2.5 w-2.5 text-primary"/>
                           </span>
                                   From RIS file

--- a/frontend/pages/UserSettings.tsx
+++ b/frontend/pages/UserSettings.tsx
@@ -99,7 +99,7 @@ export default function UserSettings() {
 
         <div className="flex-1 overflow-hidden flex w-full">
             <aside
-                className="w-56 flex-shrink-0 border-r border-border/40 bg-[#fafafa] dark:bg-[#0c0c0c] overflow-y-auto">
+                className="w-56 shrink-0 border-r border-border/40 bg-[#fafafa] dark:bg-[#0c0c0c] overflow-y-auto">
                 <nav role="tablist" aria-label="Settings sections" className="py-4 px-2 space-y-0.5">
               {TABS.map((tab) => {
                 const Icon = tab.icon;
@@ -117,7 +117,7 @@ export default function UserSettings() {
                         isActive ? 'bg-muted text-foreground' : 'text-muted-foreground'
                     )}
                   >
-                      <Icon className="h-4 w-4 flex-shrink-0" strokeWidth={1.5}/>
+                      <Icon className="h-4 w-4 shrink-0" strokeWidth={1.5}/>
                       {tab.label}
                   </button>
                 );


### PR DESCRIPTION
## Summary

tailwind-merge v3 (bumped in #254) targets Tailwind v4 naming and dropped the legacy `flex-shrink-*` class group, so `flex-shrink-0` silently stopped participating in `cn()` deduplication (`frontend/lib/utils.ts`). Verified empirically against the installed tailwind-merge:

- `twMerge('flex-shrink-0 shrink')` → `"flex-shrink-0 shrink"` (no dedup — bug surface)
- `twMerge('shrink-0 shrink')` → `"shrink"` (correct)

This renames all **91 occurrences across 36 files** to `shrink-0`, which is supported since Tailwind v3.0 (repo is on 3.4.17) and recognized by tailwind-merge v3. The built CSS declaration is identical (`.shrink-0{flex-shrink:0}`), so rendering is unchanged.

Also grepped for the other legacy names tailwind-merge v3 dropped — `flex-grow-*`, `decoration-slice`/`decoration-clone`, `overflow-ellipsis` — zero usages in the repo.

## Verification

From repo root: `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run test:run` ✅ (73 files / 468 tests) · `npm run build` ✅ (React Compiler `all_errors` gate) · built stylesheet contains `.shrink-0{flex-shrink:0}` and zero `flex-shrink-0` class rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)