### PR TITLE
feat(frontend): upgrade react-router-dom to v7

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -62,12 +62,7 @@ const App = () => {
         <TooltipProvider>
           <Toaster />
           <Sonner />
-            <BrowserRouter
-              future={{
-                v7_startTransition: true,
-                v7_relativeSplatPath: true,
-              }}
-            >
+            <BrowserRouter>
                 <ErrorBoundary context={t('common', 'errorContextAuth')}>
                 <AuthProvider>
                   <Suspense fallback={<PageLoader />}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.78.0",
         "react-resizable-panels": "^2.1.9",
-        "react-router-dom": "^6.30.1",
+        "react-router-dom": "^7.17.0",
         "sonner": "^1.7.4",
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
@@ -3099,15 +3099,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -4782,7 +4773,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8255,36 +8245,48 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.17.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
+    },
+    "node_modules/react-router/node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.78.0",
     "react-resizable-panels": "^2.1.9",
-    "react-router-dom": "^6.30.1",
+    "react-router-dom": "^7.17.0",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(({mode: _mode}) => ({
                         return "radix-vendor";
                     }
 
-                    if (id.includes("react-router-dom")) {
+                    if (id.includes("react-router")) {
                         return "router-vendor";
                     }
 


### PR DESCRIPTION
## Summary

Supersedes dependabot #277 (react-router-dom 6.30 → 7.17), whose bare version bump fails the typecheck gate. Evaluated in an isolated worktree with full local gates before landing.

**Why it's safe:** the repo uses only the classic component API — `BrowserRouter`/`Routes`/`Route`/`Link`/`Navigate`/`Outlet` plus `useNavigate`/`useParams`/`useSearchParams`/`useLocation` (38 import sites) — all unchanged in v7, and `react-router-dom@7` is still published as a re-export shim, so no import rewrites. The APIs v7 removed (`json()`, `defer()`, `fallbackElement`, lowercase `formMethod`) are not used anywhere (grep-verified; all `json()` hits are `fetch` `Response.json()`).

**The two code changes:**
- `frontend/App.tsx`: removed the `future={{ v7_startTransition: true, v7_relativeSplatPath: true }}` prop — both flags are v7 defaults and the app had already opted in on v6, so behavior is identical; the prop type no longer exists in v7 (this was the CI breaker in #277).
- `vite.config.ts`: `manualChunks` now matches `"react-router"` instead of `"react-router-dom"` — in v7 the shim package is empty and the real code lives in `react-router`, which silently folded the router into `react-vendor`; this restores the dedicated `router-vendor` chunk (41.03 kB).

## Verification

From repo root: `npm install` clean (no ERESOLVE) · `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run test:run` ✅ (73 files / 468 tests, identical to v6 baseline including stderr noise parity) · `npm run build` ✅ (React Compiler `all_errors`, router-vendor chunk restored).

Residual risk noted: real `popstate`/history behavior and lazy-route Suspense transitions are exercised only under jsdom/MemoryRouter in unit tests; the PR's Vercel preview is the place for a final click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)