### PR TITLE
feat(frontend): upgrade pdfjs-dist to v6

### DIFF
--- a/frontend/pdf-viewer/core/engine.ts
+++ b/frontend/pdf-viewer/core/engine.ts
@@ -9,7 +9,7 @@ export type PageRotation = 0 | 90 | 180 | 270;
 /**
  * The PDF engine — abstracts the underlying rendering library.
  *
- * Phase 1b implements this against pdfjs-dist v5. A future plan may
+ * Phase 1b implements this against pdfjs-dist (v6). A future plan may
  * implement it against PDFium-WASM (EmbedPDF or similar). Consumers
  * never see the underlying library directly.
  */

--- a/frontend/pdf-viewer/engines/pdfjs/document.ts
+++ b/frontend/pdf-viewer/engines/pdfjs/document.ts
@@ -1,7 +1,6 @@
-// NOTE: react-pdf bundles its own pdfjs-dist (currently v5.4) while the top-level
-// pdfjs-dist in this project is v5.7. The two are structurally compatible but
-// TypeScript sees them as distinct nominal types. We import types from the
-// top-level package for editor tooling, and cast through unknown at the boundary.
+// NOTE: types are imported from the top-level pdfjs-dist package for editor
+// tooling; casts through unknown at the boundary tolerate structurally
+// compatible proxies from other pdfjs-dist copies if one ever reappears.
 import type {PDFDocumentProxy} from 'pdfjs-dist';
 import type {
   OutlineNode,
@@ -86,6 +85,8 @@ export class PdfJsDocumentHandle implements PDFDocumentHandle {
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
-    void this.proxy.destroy();
+    // pdfjs-dist v6 removed PDFDocumentProxy.destroy() (it was an alias);
+    // loadingTask.destroy() has the same semantics and also stops the worker.
+    void this.proxy.loadingTask.destroy();
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "lucide-react": "^0.462.0",
         "next-themes": "^0.4.6",
         "pdf-lib": "^1.17.1",
-        "pdfjs-dist": "^5.7.0",
+        "pdfjs-dist": "^6.0.227",
         "react": "^19.2.7",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
@@ -1276,9 +1276,9 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
-      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
+      "integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -1292,23 +1292,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-x64": "0.1.100",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+        "@napi-rs/canvas-android-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-x64": "1.0.0",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.0",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.0",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
-      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
       "cpu": [
         "arm64"
       ],
@@ -1326,9 +1326,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
-      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
       "cpu": [
         "arm64"
       ],
@@ -1346,9 +1346,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
-      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
       "cpu": [
         "x64"
       ],
@@ -1366,9 +1366,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
-      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
       "cpu": [
         "arm"
       ],
@@ -1386,11 +1386,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
-      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1406,11 +1409,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
-      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1426,11 +1432,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
-      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1446,11 +1455,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
-      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1466,11 +1478,14 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
-      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1486,9 +1501,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
-      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
       "cpu": [
         "arm64"
       ],
@@ -1506,9 +1521,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
-      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
       "cpu": [
         "x64"
       ],
@@ -7780,15 +7795,15 @@
       "license": "0BSD"
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.7.284",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
-      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "version": "6.0.227",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
+      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.100"
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lucide-react": "^0.462.0",
     "next-themes": "^0.4.6",
     "pdf-lib": "^1.17.1",
-    "pdfjs-dist": "^5.7.0",
+    "pdfjs-dist": "^6.0.227",
     "react": "^19.2.7",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",


### PR DESCRIPTION
## Summary

Supersedes dependabot #279 (pdfjs-dist 5.7 → 6.0.227), whose bare version bump fails the typecheck gate. Evaluated in an isolated worktree, then **verified in a real browser** before landing.

**The one breaking change that touches us:** v6 removed `PDFDocumentProxy.destroy()` (it was an alias) — `frontend/pdf-viewer/engines/pdfjs/document.ts` now calls `loadingTask.destroy()`, which has identical semantics and also terminates the worker (mozilla/pdf.js#21245).

**Everything else the viewer uses is unchanged in v6** (mapped API-by-API): `getDocument` with a `{url|data}` params object (the bare-string form v6 dropped was never used here — `sourceToGetDocumentParams` always builds an object), `GlobalWorkerOptions.workerSrc` via the Vite `?url` worker import, `getViewport`/`render`, `getTextContent`, outline traversal, fingerprints, `page.cleanup()`. Also refreshed stale comments referencing react-pdf (no longer a dependency).

## Verification

- Local gates (repo root): `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run test:run` ✅ (73 files / 468 tests, incl. the pdf-viewer engine suite parsing real PDFs) · `npm run build` ✅ (React Compiler `all_errors`; v6 worker emitted, pdf-vendor 422 kB).
- **Real-browser proof (the part vitest cannot give):** via the Vite dev server with this branch's node_modules in Chrome — real worker handshake, page rasterized to canvas (**4,988 inked pixels at 800×1200**), text layer extracted ("Page 1: lorem ipsum…"), 3 pages recognized, `loadingTask.destroy()` clean. This exercises the production worker boundary and canvas path directly.
- Gates re-run after rebasing onto dev with react-router 7 (#281) — first combined run also fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)