### PR TITLE
chore(deps-dev): bump globals from 15.15.0 to 17.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "eslint": "^10.5.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
-        "globals": "^15.15.0",
+        "globals": "^17.6.0",
         "jsdom": "^29.1.1",
         "markdownlint-cli2": "^0.22.1",
         "msw": "^2.14.6",
@@ -5543,9 +5543,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint": "^10.5.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
-    "globals": "^15.15.0",
+    "globals": "^17.6.0",
     "jsdom": "^29.1.1",
     "markdownlint-cli2": "^0.22.1",
     "msw": "^2.14.6",


### PR DESCRIPTION
## Summary

Supersedes dependabot #276, which went stale against today's merge train and ended up with a `package-lock.json` conflict. `globals` is a data-only package (the `globals.browser` / `globals.node` name lists used in `eslint.config.js`), so the lint pass is the meaningful gate.

## Verification

From repo root: `npm install` clean · `npm run lint` ✅ (eslint 10) · `npm run typecheck` ✅ · `npm run test:run` ✅ (73 files / 468 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)