### PR TITLE
fix(backend): validate API-key provider at the schema layer

### DIFF
--- a/backend/app/schemas/user_api_key.py
+++ b/backend/app/schemas/user_api_key.py
@@ -6,7 +6,7 @@ Schemas Pydantic for gerenciamento de API keys of the usuarios.
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.user_api_key import SUPPORTED_PROVIDERS
 
@@ -47,6 +47,20 @@ class CreateAPIKeyRequest(BaseModel):
     )
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("provider")
+    @classmethod
+    def _provider_must_be_supported(cls, value: str) -> str:
+        """Reject unsupported providers at the schema boundary (422).
+
+        ``SUPPORTED_PROVIDERS`` (the same tuple the DB CHECK constraint
+        enforces) is the single source of truth — a bad provider fails here
+        with a clean ValidationError instead of leaking out as a DB/500 at
+        INSERT time.
+        """
+        if value not in SUPPORTED_PROVIDERS:
+            raise ValueError(f"Provider '{value}' is not supported. Use: {SUPPORTED_PROVIDERS}")
+        return value
 
 
 class UpdateAPIKeyRequest(BaseModel):

--- a/backend/tests/unit/test_user_api_key_schemas.py
+++ b/backend/tests/unit/test_user_api_key_schemas.py
@@ -1,0 +1,42 @@
+"""Schema-layer validation tests for the user-API-key request DTOs.
+
+``CreateAPIKeyRequest.provider`` is constrained to ``SUPPORTED_PROVIDERS``
+(the single source of truth, shared with the DB CHECK constraint) so an
+unsupported provider fails with a clean 422 ``ValidationError`` at the
+boundary instead of leaking out as a DB/500 at INSERT time — the repo's
+"clean ApiResponse error envelope" incident class.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.user_api_key import SUPPORTED_PROVIDERS
+from app.schemas.user_api_key import CreateAPIKeyRequest
+
+
+class TestProviderValidation:
+    @pytest.mark.parametrize("provider", SUPPORTED_PROVIDERS)
+    def test_supported_provider_is_accepted(self, provider: str) -> None:
+        """Every provider in the allow-list passes schema validation."""
+        request = CreateAPIKeyRequest(provider=provider, apiKey="sk-1234567890")
+        assert request.provider == provider
+
+    def test_unsupported_provider_is_rejected_by_schema(self) -> None:
+        """An unsupported provider fails at the Pydantic layer (→ 422).
+
+        Pins the constrained behavior: the schema is the gate, not the DB
+        CHECK constraint. (Flipped from the former permissive
+        ``test_unsupported_provider_is_not_rejected_by_schema``.)
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            CreateAPIKeyRequest(provider="not-a-real-provider", apiKey="sk-1234567890")
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("provider",) for error in errors)
+
+    def test_supported_providers_is_the_single_source_of_truth(self) -> None:
+        """The validator rejects a value just outside the allow-list."""
+        bogus = "openai-typo"
+        assert bogus not in SUPPORTED_PROVIDERS
+        with pytest.raises(ValidationError):
+            CreateAPIKeyRequest(provider=bogus, apiKey="sk-1234567890")


### PR DESCRIPTION
## Summary

- `CreateAPIKeyRequest.provider` was a plain `str`: an unsupported value (e.g. `not-a-real-provider`) passed Pydantic validation and was only rejected downstream (service `ValueError` → 400, or the DB CHECK constraint), the repo's "clean ApiResponse error envelope" incident class.
- Add a `field_validator` that rejects anything outside the imported `SUPPORTED_PROVIDERS` tuple, so a bad provider now fails with a clean **422 ValidationError** at the request boundary, before touching the service or DB.
- `SUPPORTED_PROVIDERS` stays the **single source of truth** — it's imported from `app.models.user_api_key` (the same tuple the DB CHECK constraint enforces); the list is not duplicated.

I used a `field_validator` rather than a `Literal`/`Enum` precisely to keep one source of truth — `Literal[...]` can't be derived from a runtime tuple without re-typing the values.

## Linked issues / specs

None. Hardening follow-up in the BYOK API-key path.

## How to verify

From `backend/`:

```bash
uv run pytest tests/unit/test_user_api_key_schemas.py -q   # 6 passed
uv run ruff check                                          # All checks passed!
```

Behaviourally: `POST /api/v1/user-api-keys` with `{"provider": "not-a-real-provider", "apiKey": "..."}` now returns 422 (was a 400 from the service layer) — rejected at the schema boundary.

## Test plan

- [x] Backend: new `tests/unit/test_user_api_key_schemas.py` passes (6 tests); related api-key suites green (64 passed: endpoint, service, typed-envelope, schemas)
- [ ] Frontend: not touched
- [ ] E2E: no UI change
- [x] Lints: `uv run ruff check` clean, `ruff format` reports no changes

## Migration safety (if applicable)

N/A — no model/schema DB change. The DB CHECK constraint already enforced this set; the change only moves the gate earlier (schema layer) for a clean error envelope.

## Docs

- N/A — internal validation hardening, no doc surface changed.

## Notes for reviewer

- The runtime symptom was a **400** (service `save_key` already raised `ValueError` before INSERT), not a raw 500. The value here is moving the guard to the declarative schema boundary (422, defense-in-depth) so it can't drift from the allow-list — not fixing a live 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)