### PR TITLE
release: promote dev → main (extraction loop fix #289)

### DIFF
--- a/backend/app/schemas/user_api_key.py
+++ b/backend/app/schemas/user_api_key.py
@@ -6,7 +6,7 @@ Schemas Pydantic for gerenciamento de API keys of the usuarios.
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.user_api_key import SUPPORTED_PROVIDERS
 
@@ -47,6 +47,20 @@ class CreateAPIKeyRequest(BaseModel):
     )
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("provider")
+    @classmethod
+    def _provider_must_be_supported(cls, value: str) -> str:
+        """Reject unsupported providers at the schema boundary (422).
+
+        ``SUPPORTED_PROVIDERS`` (the same tuple the DB CHECK constraint
+        enforces) is the single source of truth — a bad provider fails here
+        with a clean ValidationError instead of leaking out as a DB/500 at
+        INSERT time.
+        """
+        if value not in SUPPORTED_PROVIDERS:
+            raise ValueError(f"Provider '{value}' is not supported. Use: {SUPPORTED_PROVIDERS}")
+        return value
 
 
 class UpdateAPIKeyRequest(BaseModel):

--- a/backend/tests/unit/test_article_read_models.py
+++ b/backend/tests/unit/test_article_read_models.py
@@ -1,0 +1,190 @@
+"""Validation tests for ``app.schemas.read_models.article``.
+
+Pure Pydantic v2 validation: no DB, no async, no fixtures. Covers the
+from_attributes read models plus the two classmethods on
+``ArticleDetailReadModel`` that compute extraction progress/status.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.read_models.article import (
+    ArticleDetailReadModel,
+    ArticleFileReadModel,
+    ArticleListReadModel,
+)
+
+ARTICLE_ID = uuid4()
+PROJECT_ID = uuid4()
+FILE_ID = uuid4()
+
+
+# =================== ArticleFileReadModel ===================
+
+
+class TestArticleFileReadModel:
+    def test_from_attributes(self) -> None:
+        attrs = SimpleNamespace(
+            id=FILE_ID, file_type="pdf", storage_key="key/abc.pdf", size_bytes=1024
+        )
+        model = ArticleFileReadModel.model_validate(attrs)
+        assert model.id == FILE_ID
+        assert model.size_bytes == 1024
+
+    def test_size_bytes_defaults_none(self) -> None:
+        attrs = SimpleNamespace(id=FILE_ID, file_type="pdf", storage_key="k")
+        model = ArticleFileReadModel.model_validate(attrs)
+        assert model.size_bytes is None
+
+    def test_missing_required_rejected(self) -> None:
+        attrs = SimpleNamespace(id=FILE_ID, storage_key="k")
+        with pytest.raises(ValidationError):
+            ArticleFileReadModel.model_validate(attrs)
+
+
+# =================== ArticleListReadModel ===================
+
+
+def _list_attrs() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=ARTICLE_ID,
+        title="A Study",
+        authors="Doe J; Smith A",
+        publication_year=2020,
+        project_id=PROJECT_ID,
+        project_name="Review X",
+        files_count=2,
+        extractions_count=3,
+        has_pdf=True,
+        created_at=datetime(2026, 1, 1),
+        updated_at=datetime(2026, 1, 2),
+    )
+
+
+class TestArticleListReadModel:
+    def test_from_attributes(self) -> None:
+        model = ArticleListReadModel.model_validate(_list_attrs())
+        assert model.title == "A Study"
+        assert model.files_count == 2
+        assert model.has_pdf is True
+
+    def test_count_and_status_defaults(self) -> None:
+        attrs = _list_attrs()
+        del attrs.files_count
+        del attrs.extractions_count
+        del attrs.has_pdf
+        del attrs.updated_at
+        model = ArticleListReadModel.model_validate(attrs)
+        assert model.files_count == 0
+        assert model.extractions_count == 0
+        assert model.has_pdf is False
+        assert model.updated_at is None
+
+    def test_missing_required_rejected(self) -> None:
+        attrs = _list_attrs()
+        del attrs.created_at
+        with pytest.raises(ValidationError):
+            ArticleListReadModel.model_validate(attrs)
+
+
+# =================== ArticleDetailReadModel ===================
+
+
+def _detail_attrs() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=ARTICLE_ID,
+        title="A Study",
+        authors="Doe J",
+        publication_year=2020,
+        abstract=None,
+        doi=None,
+        journal=None,
+        volume=None,
+        issue=None,
+        pages=None,
+        project_id=PROJECT_ID,
+        project_name="Review X",
+        review_title=None,
+        files=[],
+        extractions_total=4,
+        extractions_completed=2,
+        models_extracted=1,
+        has_pdf=True,
+        extraction_progress=50.0,
+        overall_status="in_progress",
+        zotero_key=None,
+        created_at=datetime(2026, 1, 1),
+        updated_at=datetime(2026, 1, 2),
+    )
+
+
+class TestArticleDetailReadModel:
+    def test_from_attributes_with_nested_files(self) -> None:
+        attrs = _detail_attrs()
+        attrs.files = [SimpleNamespace(id=FILE_ID, file_type="pdf", storage_key="k", size_bytes=10)]
+        model = ArticleDetailReadModel.model_validate(attrs)
+        assert model.id == ARTICLE_ID
+        assert len(model.files) == 1
+        assert isinstance(model.files[0], ArticleFileReadModel)
+        assert model.extraction_progress == 50.0
+
+    def test_status_and_progress_defaults(self) -> None:
+        attrs = _detail_attrs()
+        del attrs.extractions_total
+        del attrs.extractions_completed
+        del attrs.models_extracted
+        del attrs.has_pdf
+        del attrs.extraction_progress
+        del attrs.overall_status
+        del attrs.updated_at
+        model = ArticleDetailReadModel.model_validate(attrs)
+        assert model.extractions_total == 0
+        assert model.extractions_completed == 0
+        assert model.models_extracted == 0
+        assert model.has_pdf is False
+        assert model.extraction_progress == 0.0
+        assert model.overall_status == "pending"
+        assert model.files == []
+        assert model.updated_at is None
+
+    def test_missing_required_rejected(self) -> None:
+        attrs = _detail_attrs()
+        del attrs.title
+        with pytest.raises(ValidationError):
+            ArticleDetailReadModel.model_validate(attrs)
+
+    # --- compute_progress ---
+
+    def test_compute_progress_zero_total_returns_zero(self) -> None:
+        assert ArticleDetailReadModel.compute_progress(completed=0, total=0) == 0.0
+
+    def test_compute_progress_half(self) -> None:
+        assert ArticleDetailReadModel.compute_progress(completed=1, total=2) == 50.0
+
+    def test_compute_progress_full(self) -> None:
+        assert ArticleDetailReadModel.compute_progress(completed=4, total=4) == 100.0
+
+    def test_compute_progress_rounds_to_one_decimal(self) -> None:
+        # 1/3 -> 33.333... rounds to 33.3
+        assert ArticleDetailReadModel.compute_progress(completed=1, total=3) == 33.3
+
+    # --- compute_overall_status ---
+
+    def test_compute_overall_status_pending_at_zero(self) -> None:
+        assert ArticleDetailReadModel.compute_overall_status(0.0) == "pending"
+
+    def test_compute_overall_status_in_progress(self) -> None:
+        assert ArticleDetailReadModel.compute_overall_status(50.0) == "in_progress"
+
+    def test_compute_overall_status_completed_at_hundred(self) -> None:
+        assert ArticleDetailReadModel.compute_overall_status(100.0) == "completed"
+
+    def test_compute_overall_status_completed_above_hundred(self) -> None:
+        assert ArticleDetailReadModel.compute_overall_status(150.0) == "completed"
+
+    def test_compute_overall_status_just_below_hundred(self) -> None:
+        assert ArticleDetailReadModel.compute_overall_status(99.9) == "in_progress"

--- a/backend/tests/unit/test_article_schemas.py
+++ b/backend/tests/unit/test_article_schemas.py
@@ -1,0 +1,663 @@
+"""Validation tests for ``app.schemas.article``.
+
+Pure Pydantic v2 validation: no DB, no async, no fixtures. These pin
+numeric bounds, Literal members, and the camelCase wire shape — the
+alias drift class that has caused production incidents in this repo.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.article import (
+    ArticleCreate,
+    ArticleFileCreate,
+    ArticleFileResponse,
+    ArticleListItem,
+    ArticleListResponse,
+    ArticleResponse,
+    ArticleSearchRequest,
+    ArticleUpdate,
+    ConfirmUploadRequest,
+    ExtractTextRequest,
+    ExtractTextResponse,
+    UploadUrlRequest,
+    UploadUrlResponse,
+)
+
+PROJECT_ID = uuid4()
+ARTICLE_ID = uuid4()
+FILE_ID = uuid4()
+
+
+# =================== ArticleCreate ===================
+
+
+class TestArticleCreate:
+    def test_minimal_valid_construction(self) -> None:
+        model = ArticleCreate(projectId=str(PROJECT_ID), title="A Study")
+        assert model.project_id == PROJECT_ID
+        assert model.title == "A Study"
+
+    def test_accepts_snake_case_field_names(self) -> None:
+        """populate_by_name=True allows the Python field names too."""
+        model = ArticleCreate(project_id=str(PROJECT_ID), title="X", publication_year=2020)
+        assert model.publication_year == 2020
+
+    def test_accepts_camel_case_aliases(self) -> None:
+        model = ArticleCreate(
+            projectId=str(PROJECT_ID),
+            title="X",
+            publicationYear=2020,
+            journalTitle="Nature",
+            arxivId="2401.00001",
+            meshTerms=["m1"],
+            urlPdf="https://x/p.pdf",
+        )
+        assert model.publication_year == 2020
+        assert model.journal_title == "Nature"
+        assert model.arxiv_id == "2401.00001"
+        assert model.mesh_terms == ["m1"]
+        assert model.url_pdf == "https://x/p.pdf"
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        model = ArticleCreate(
+            project_id=str(PROJECT_ID),
+            title="X",
+            publication_year=2020,
+            journal_issn="1234-5678",
+            open_access=True,
+            source_payload={"k": "v"},
+        )
+        wire = model.model_dump(by_alias=True)
+        assert "projectId" in wire
+        assert "publicationYear" in wire
+        assert "journalIssn" in wire
+        assert "openAccess" in wire
+        assert "sourcePayload" in wire
+        # Python names must NOT leak onto the wire.
+        assert "project_id" not in wire
+        assert "publication_year" not in wire
+
+    def test_title_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(projectId=str(PROJECT_ID))
+
+    def test_empty_title_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(projectId=str(PROJECT_ID), title="")
+
+    def test_single_char_title_accepted(self) -> None:
+        assert ArticleCreate(projectId=str(PROJECT_ID), title="X").title == "X"
+
+    def test_project_id_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(title="X")
+
+    # publication_year bounds (ge=1600, le=2500)
+    def test_year_lower_bound_inside(self) -> None:
+        assert ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationYear=1600)
+
+    def test_year_lower_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationYear=1599)
+
+    def test_year_upper_bound_inside(self) -> None:
+        assert ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationYear=2500)
+
+    def test_year_upper_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationYear=2501)
+
+    # publication_month bounds (ge=1, le=12)
+    def test_month_lower_bound_inside(self) -> None:
+        assert ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationMonth=1)
+
+    def test_month_lower_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationMonth=0)
+
+    def test_month_upper_bound_inside(self) -> None:
+        assert ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationMonth=12)
+
+    def test_month_upper_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationMonth=13)
+
+    # publication_day bounds (ge=1, le=31)
+    def test_day_lower_bound_inside(self) -> None:
+        assert ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationDay=1)
+
+    def test_day_lower_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationDay=0)
+
+    def test_day_upper_bound_inside(self) -> None:
+        assert ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationDay=31)
+
+    def test_day_upper_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleCreate(projectId=str(PROJECT_ID), title="X", publicationDay=32)
+
+    def test_optional_fields_default_to_none(self) -> None:
+        model = ArticleCreate(projectId=str(PROJECT_ID), title="X")
+        assert model.abstract is None
+        assert model.publication_year is None
+        assert model.doi is None
+        assert model.keywords is None
+
+    def test_collection_defaults(self) -> None:
+        model = ArticleCreate(projectId=str(PROJECT_ID), title="X")
+        assert model.registration == {}
+        assert model.funding == []
+        assert model.source_payload == {}
+
+
+# =================== ArticleUpdate ===================
+
+
+class TestArticleUpdate:
+    def test_empty_update_is_valid(self) -> None:
+        """All fields optional, so an empty update validates."""
+        model = ArticleUpdate()
+        assert model.title is None
+
+    def test_partial_update(self) -> None:
+        model = ArticleUpdate(title="New", studyDesign="RCT")
+        assert model.title == "New"
+        assert model.study_design == "RCT"
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ArticleUpdate(study_design="RCT", journal_title="Cell").model_dump(by_alias=True)
+        assert "studyDesign" in wire
+        assert "journalTitle" in wire
+        assert "study_design" not in wire
+
+    def test_empty_title_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleUpdate(title="")
+
+    def test_single_char_title_accepted(self) -> None:
+        assert ArticleUpdate(title="X").title == "X"
+
+    def test_year_bounds(self) -> None:
+        assert ArticleUpdate(publicationYear=1600)
+        assert ArticleUpdate(publicationYear=2500)
+        with pytest.raises(ValidationError):
+            ArticleUpdate(publicationYear=1599)
+        with pytest.raises(ValidationError):
+            ArticleUpdate(publicationYear=2501)
+
+    def test_month_bounds(self) -> None:
+        assert ArticleUpdate(publicationMonth=1)
+        assert ArticleUpdate(publicationMonth=12)
+        with pytest.raises(ValidationError):
+            ArticleUpdate(publicationMonth=0)
+        with pytest.raises(ValidationError):
+            ArticleUpdate(publicationMonth=13)
+
+    def test_day_bounds(self) -> None:
+        assert ArticleUpdate(publicationDay=1)
+        assert ArticleUpdate(publicationDay=31)
+        with pytest.raises(ValidationError):
+            ArticleUpdate(publicationDay=0)
+        with pytest.raises(ValidationError):
+            ArticleUpdate(publicationDay=32)
+
+
+# =================== ArticleResponse ===================
+
+
+def _article_response_attrs() -> SimpleNamespace:
+    """Attribute object mirroring an ORM row for from_attributes=True."""
+    return SimpleNamespace(
+        id=ARTICLE_ID,
+        project_id=PROJECT_ID,
+        title="A Study",
+        abstract=None,
+        language=None,
+        publication_year=2020,
+        publication_month=None,
+        publication_day=None,
+        journal_title="Nature",
+        journal_issn=None,
+        journal_publisher=None,
+        volume=None,
+        issue=None,
+        pages=None,
+        article_type=None,
+        publication_status=None,
+        open_access=None,
+        doi=None,
+        pmid=None,
+        pmcid=None,
+        arxiv_id=None,
+        keywords=None,
+        authors=None,
+        mesh_terms=None,
+        url_landing=None,
+        url_pdf=None,
+        study_design=None,
+        registration={},
+        funding=[],
+        ingestion_source=None,
+        zotero_item_key=None,
+        zotero_collection_key=None,
+        created_at=datetime(2026, 1, 1, 12, 0, 0),
+        updated_at=datetime(2026, 1, 2, 12, 0, 0),
+        files_count=2,
+        has_pdf=True,
+    )
+
+
+class TestArticleResponse:
+    def test_from_attributes(self) -> None:
+        model = ArticleResponse.model_validate(_article_response_attrs())
+        assert model.id == ARTICLE_ID
+        assert model.project_id == PROJECT_ID
+        assert model.files_count == 2
+        assert model.has_pdf is True
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        model = ArticleResponse.model_validate(_article_response_attrs())
+        wire = model.model_dump(by_alias=True)
+        assert "projectId" in wire
+        assert "publicationYear" in wire
+        assert "createdAt" in wire
+        assert "filesCount" in wire
+        assert "hasPdf" in wire
+        assert "project_id" not in wire
+
+    def test_optional_relationship_fields_default_none(self) -> None:
+        attrs = _article_response_attrs()
+        attrs.files_count = None
+        attrs.has_pdf = None
+        model = ArticleResponse.model_validate(attrs)
+        assert model.files_count is None
+        assert model.has_pdf is None
+
+    def test_missing_required_field_rejected(self) -> None:
+        attrs = _article_response_attrs()
+        del attrs.created_at
+        with pytest.raises(ValidationError):
+            ArticleResponse.model_validate(attrs)
+
+
+# =================== ArticleFileCreate ===================
+
+
+class TestArticleFileCreate:
+    def _kw(self, **kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "articleId": str(ARTICLE_ID),
+            "fileType": "pdf",
+            "storageKey": "key/abc.pdf",
+        }
+        base.update(kw)
+        return base
+
+    def test_valid_construction_default_role(self) -> None:
+        model = ArticleFileCreate(**self._kw())
+        assert model.file_role == "MAIN"
+        assert model.article_id == ARTICLE_ID
+
+    @pytest.mark.parametrize(
+        "role",
+        ["MAIN", "SUPPLEMENT", "PROTOCOL", "DATASET", "APPENDIX", "FIGURE", "OTHER"],
+    )
+    def test_all_valid_roles_accepted(self, role: str) -> None:
+        assert ArticleFileCreate(**self._kw(fileRole=role)).file_role == role
+
+    def test_invalid_role_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleFileCreate(**self._kw(fileRole="THUMBNAIL"))
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ArticleFileCreate(**self._kw()).model_dump(by_alias=True)
+        assert "articleId" in wire
+        assert "fileType" in wire
+        assert "storageKey" in wire
+        assert "fileRole" in wire
+        assert "article_id" not in wire
+
+    def test_accepts_snake_case(self) -> None:
+        model = ArticleFileCreate(
+            article_id=str(ARTICLE_ID), file_type="pdf", storage_key="k", file_role="MAIN"
+        )
+        assert model.storage_key == "k"
+
+    def test_missing_required_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleFileCreate(fileType="pdf", storageKey="k")
+
+
+# =================== ArticleFileResponse ===================
+
+
+def _file_response_attrs() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=FILE_ID,
+        project_id=PROJECT_ID,
+        article_id=ARTICLE_ID,
+        file_type="pdf",
+        storage_key="key/abc.pdf",
+        original_filename="abc.pdf",
+        bytes=1024,
+        file_role="MAIN",
+        extraction_status="pending",
+        extraction_error=None,
+        extracted_at=None,
+        has_text=False,
+        created_at=datetime(2026, 1, 1),
+        updated_at=datetime(2026, 1, 2),
+    )
+
+
+class TestArticleFileResponse:
+    def test_from_attributes(self) -> None:
+        model = ArticleFileResponse.model_validate(_file_response_attrs())
+        assert model.id == FILE_ID
+        assert model.file_role == "MAIN"
+
+    def test_defaults(self) -> None:
+        attrs = _file_response_attrs()
+        del attrs.extraction_status
+        del attrs.has_text
+        model = ArticleFileResponse.model_validate(attrs)
+        assert model.extraction_status == "pending"
+        assert model.has_text is False
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ArticleFileResponse.model_validate(_file_response_attrs()).model_dump(by_alias=True)
+        assert "projectId" in wire
+        assert "articleId" in wire
+        assert "fileRole" in wire
+        assert "extractionStatus" in wire
+        assert "hasText" in wire
+        assert "createdAt" in wire
+
+
+# =================== UploadUrlRequest / UploadUrlResponse ===================
+
+
+class TestUploadUrlRequest:
+    def _kw(self, **kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "articleId": str(ARTICLE_ID),
+            "filename": "paper.pdf",
+            "contentType": "application/pdf",
+        }
+        base.update(kw)
+        return base
+
+    def test_valid_default_role(self) -> None:
+        model = UploadUrlRequest(**self._kw())
+        assert model.file_role == "MAIN"
+        assert model.content_type == "application/pdf"
+
+    @pytest.mark.parametrize(
+        "role",
+        ["MAIN", "SUPPLEMENT", "PROTOCOL", "DATASET", "APPENDIX", "FIGURE", "OTHER"],
+    )
+    def test_all_roles_accepted(self, role: str) -> None:
+        assert UploadUrlRequest(**self._kw(fileRole=role)).file_role == role
+
+    def test_invalid_role_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            UploadUrlRequest(**self._kw(fileRole="BOGUS"))
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = UploadUrlRequest(**self._kw()).model_dump(by_alias=True)
+        assert "articleId" in wire
+        assert "contentType" in wire
+        assert "fileRole" in wire
+
+
+class TestUploadUrlResponse:
+    def test_valid_construction_and_alias_dump(self) -> None:
+        model = UploadUrlResponse(
+            uploadUrl="https://x/upload",
+            storageKey="key/abc.pdf",
+            expiresAt=datetime(2026, 1, 1, 12, 0, 0),
+        )
+        assert model.upload_url == "https://x/upload"
+        wire = model.model_dump(by_alias=True)
+        assert "uploadUrl" in wire
+        assert "storageKey" in wire
+        assert "expiresAt" in wire
+
+    def test_accepts_snake_case(self) -> None:
+        model = UploadUrlResponse(upload_url="u", storage_key="k", expires_at=datetime(2026, 1, 1))
+        assert model.storage_key == "k"
+
+    def test_missing_required_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            UploadUrlResponse(uploadUrl="u", storageKey="k")
+
+
+# =================== ConfirmUploadRequest ===================
+
+
+class TestConfirmUploadRequest:
+    def _kw(self, **kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "articleId": str(ARTICLE_ID),
+            "storageKey": "key/abc.pdf",
+            "originalFilename": "abc.pdf",
+            "contentType": "application/pdf",
+            "bytes": 2048,
+        }
+        base.update(kw)
+        return base
+
+    def test_valid_default_role(self) -> None:
+        model = ConfirmUploadRequest(**self._kw())
+        assert model.file_role == "MAIN"
+        assert model.bytes == 2048
+
+    def test_invalid_role_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ConfirmUploadRequest(**self._kw(fileRole="NOPE"))
+
+    def test_bytes_required(self) -> None:
+        kw = self._kw()
+        del kw["bytes"]
+        with pytest.raises(ValidationError):
+            ConfirmUploadRequest(**kw)
+
+    def test_bytes_coerced_from_int_string(self) -> None:
+        model = ConfirmUploadRequest(**self._kw(bytes="2048"))
+        assert model.bytes == 2048
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ConfirmUploadRequest(**self._kw()).model_dump(by_alias=True)
+        assert "articleId" in wire
+        assert "storageKey" in wire
+        assert "originalFilename" in wire
+        assert "contentType" in wire
+        assert "fileRole" in wire
+        assert "bytes" in wire
+
+
+# =================== ExtractTextRequest / ExtractTextResponse ===================
+
+
+class TestExtractTextRequest:
+    def test_valid_with_default_force(self) -> None:
+        model = ExtractTextRequest(fileId=str(FILE_ID))
+        assert model.file_id == FILE_ID
+        assert model.force is False
+
+    def test_force_override(self) -> None:
+        assert ExtractTextRequest(fileId=str(FILE_ID), force=True).force is True
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ExtractTextRequest(fileId=str(FILE_ID)).model_dump(by_alias=True)
+        assert "fileId" in wire
+        assert "file_id" not in wire
+
+    def test_missing_file_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractTextRequest()
+
+
+class TestExtractTextResponse:
+    @pytest.mark.parametrize("status", ["pending", "completed", "failed"])
+    def test_valid_statuses(self, status: str) -> None:
+        model = ExtractTextResponse(fileId=str(FILE_ID), status=status)
+        assert model.status == status
+
+    def test_invalid_status_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractTextResponse(fileId=str(FILE_ID), status="running")
+
+    def test_optional_fields_default_none(self) -> None:
+        model = ExtractTextResponse(fileId=str(FILE_ID), status="pending")
+        assert model.pages is None
+        assert model.characters is None
+        assert model.error is None
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ExtractTextResponse(fileId=str(FILE_ID), status="completed").model_dump(
+            by_alias=True
+        )
+        assert "fileId" in wire
+
+
+# =================== ArticleListItem / ArticleListResponse ===================
+
+
+def _list_item_attrs() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=ARTICLE_ID,
+        title="A Study",
+        authors=["Doe J"],
+        publication_year=2020,
+        journal_title="Nature",
+        doi="10.1/x",
+        has_pdf=True,
+        extraction_status="completed",
+        created_at=datetime(2026, 1, 1),
+    )
+
+
+class TestArticleListItem:
+    def test_from_attributes(self) -> None:
+        model = ArticleListItem.model_validate(_list_item_attrs())
+        assert model.title == "A Study"
+        assert model.has_pdf is True
+
+    def test_defaults(self) -> None:
+        attrs = _list_item_attrs()
+        del attrs.has_pdf
+        del attrs.extraction_status
+        model = ArticleListItem.model_validate(attrs)
+        assert model.has_pdf is False
+        assert model.extraction_status is None
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ArticleListItem.model_validate(_list_item_attrs()).model_dump(by_alias=True)
+        assert "publicationYear" in wire
+        assert "journalTitle" in wire
+        assert "hasPdf" in wire
+        assert "extractionStatus" in wire
+        assert "createdAt" in wire
+
+
+class TestArticleListResponse:
+    def test_valid_construction(self) -> None:
+        item = ArticleListItem.model_validate(_list_item_attrs())
+        model = ArticleListResponse(items=[item], total=1, pageSize=20, hasMore=False)
+        assert model.page == 1  # default
+        assert model.page_size == 20
+        assert model.has_more is False
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        item = ArticleListItem.model_validate(_list_item_attrs())
+        wire = ArticleListResponse(items=[item], total=1, pageSize=20, hasMore=True).model_dump(
+            by_alias=True
+        )
+        assert "pageSize" in wire
+        assert "hasMore" in wire
+        assert "page_size" not in wire
+
+    def test_missing_required_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleListResponse(items=[], total=0)
+
+
+# =================== ArticleSearchRequest ===================
+
+
+class TestArticleSearchRequest:
+    def test_defaults(self) -> None:
+        model = ArticleSearchRequest()
+        assert model.page == 1
+        assert model.page_size == 20
+        assert model.sort_by == "created_at"
+        assert model.sort_order == "desc"
+        assert model.query is None
+
+    # page bounds (ge=1)
+    def test_page_lower_bound_inside(self) -> None:
+        assert ArticleSearchRequest(page=1).page == 1
+
+    def test_page_lower_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleSearchRequest(page=0)
+
+    # page_size bounds (ge=1, le=100)
+    def test_page_size_lower_bound_inside(self) -> None:
+        assert ArticleSearchRequest(pageSize=1).page_size == 1
+
+    def test_page_size_lower_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleSearchRequest(pageSize=0)
+
+    def test_page_size_upper_bound_inside(self) -> None:
+        assert ArticleSearchRequest(pageSize=100).page_size == 100
+
+    def test_page_size_upper_bound_outside(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleSearchRequest(pageSize=101)
+
+    @pytest.mark.parametrize("sort_by", ["created_at", "title", "publication_year"])
+    def test_valid_sort_by(self, sort_by: str) -> None:
+        assert ArticleSearchRequest(sortBy=sort_by).sort_by == sort_by
+
+    def test_invalid_sort_by_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleSearchRequest(sortBy="updated_at")
+
+    @pytest.mark.parametrize("sort_order", ["asc", "desc"])
+    def test_valid_sort_order(self, sort_order: str) -> None:
+        assert ArticleSearchRequest(sortOrder=sort_order).sort_order == sort_order
+
+    def test_invalid_sort_order_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArticleSearchRequest(sortOrder="ascending")
+
+    def test_accepts_camel_aliases(self) -> None:
+        model = ArticleSearchRequest(
+            projectId=str(PROJECT_ID),
+            publicationYearMin=2000,
+            publicationYearMax=2020,
+            hasPdf=True,
+            ingestionSource="zotero",
+        )
+        assert model.project_id == PROJECT_ID
+        assert model.publication_year_min == 2000
+        assert model.has_pdf is True
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ArticleSearchRequest(publicationYearMin=2000).model_dump(by_alias=True)
+        assert "publicationYearMin" in wire
+        assert "publicationYearMax" in wire
+        assert "hasPdf" in wire
+        assert "pageSize" in wire
+        assert "sortBy" in wire
+        assert "sortOrder" in wire
+        assert "publication_year_min" not in wire

--- a/backend/tests/unit/test_articles_export_schemas.py
+++ b/backend/tests/unit/test_articles_export_schemas.py
@@ -1,0 +1,189 @@
+"""Unit tests for app.schemas.articles_export.
+
+Pure Pydantic validation tests: no DB, no async, no fixtures.
+These models carry no aliases or enums (free-form str fields), so the
+coverage focuses on construction, required vs optional fields, defaults,
+nested-model parsing, and model_dump wire shape.
+"""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.articles_export import (
+    ExportCancelResponse,
+    ExportProgress,
+    ExportRequest,
+    ExportStartedResponse,
+    ExportStatusResponse,
+    SkippedFileEntry,
+)
+
+
+class TestExportRequest:
+    def test_valid_construction(self) -> None:
+        pid = uuid4()
+        aids = [uuid4(), uuid4()]
+        req = ExportRequest(
+            project_id=pid,
+            article_ids=aids,
+            formats=["csv", "ris"],
+            file_scope="main_only",
+        )
+        assert req.project_id == pid
+        assert req.article_ids == aids
+        assert req.formats == ["csv", "ris"]
+        assert req.file_scope == "main_only"
+
+    def test_empty_article_ids_allowed(self) -> None:
+        # No min_length constraint declared on article_ids.
+        req = ExportRequest(
+            project_id=uuid4(),
+            article_ids=[],
+            formats=["csv"],
+            file_scope="none",
+        )
+        assert req.article_ids == []
+
+    def test_empty_formats_allowed(self) -> None:
+        # No min_length constraint declared on formats either.
+        req = ExportRequest(
+            project_id=uuid4(),
+            article_ids=[uuid4()],
+            formats=[],
+            file_scope="all",
+        )
+        assert req.formats == []
+
+    def test_project_id_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportRequest(article_ids=[], formats=["csv"], file_scope="none")  # type: ignore[call-arg]
+
+    def test_formats_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportRequest(project_id=uuid4(), article_ids=[], file_scope="none")  # type: ignore[call-arg]
+
+    def test_file_scope_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportRequest(project_id=uuid4(), article_ids=[], formats=["csv"])  # type: ignore[call-arg]
+
+    def test_invalid_uuid_in_article_ids_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportRequest(
+                project_id=uuid4(),
+                article_ids=["not-a-uuid"],  # type: ignore[list-item]
+                formats=["csv"],
+                file_scope="all",
+            )
+
+
+class TestSkippedFileEntry:
+    def test_construction(self) -> None:
+        aid = uuid4()
+        entry = SkippedFileEntry(
+            article_id=aid,
+            storage_key="bucket/key.pdf",
+            reason="missing",
+        )
+        assert entry.article_id == aid
+        assert entry.storage_key == "bucket/key.pdf"
+        assert entry.reason == "missing"
+
+    def test_all_fields_required(self) -> None:
+        with pytest.raises(ValidationError):
+            SkippedFileEntry(article_id=uuid4(), storage_key="k")  # type: ignore[call-arg]
+
+
+class TestExportProgress:
+    def test_construction(self) -> None:
+        prog = ExportProgress(current=2, total=5, stage="files")
+        assert prog.current == 2
+        assert prog.total == 5
+        assert prog.stage == "files"
+
+    def test_all_fields_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportProgress(current=1, total=2)  # type: ignore[call-arg]
+
+    def test_non_int_current_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportProgress(current="two", total=5, stage="files")  # type: ignore[arg-type]
+
+
+class TestExportStatusResponse:
+    def test_minimal_construction_defaults(self) -> None:
+        resp = ExportStatusResponse(job_id="j", status="pending")
+        assert resp.progress is None
+        assert resp.download_url is None
+        assert resp.expires_at is None
+        assert resp.skipped_files is None
+        assert resp.error is None
+
+    def test_full_construction_with_nested_models(self) -> None:
+        resp = ExportStatusResponse(
+            job_id="j",
+            status="completed",
+            progress=ExportProgress(current=5, total=5, stage="done"),
+            download_url="https://x/out.zip",
+            expires_at="2026-06-13T00:00:00Z",
+            skipped_files=[
+                SkippedFileEntry(
+                    article_id=uuid4(),
+                    storage_key="k",
+                    reason="too_large",
+                )
+            ],
+            error=None,
+        )
+        assert resp.progress is not None
+        assert resp.progress.stage == "done"
+        assert resp.skipped_files is not None
+        assert resp.skipped_files[0].reason == "too_large"
+
+    def test_nested_models_parsed_from_dicts(self) -> None:
+        resp = ExportStatusResponse.model_validate(
+            {
+                "job_id": "j",
+                "status": "running",
+                "progress": {"current": 1, "total": 3, "stage": "metadata"},
+                "skipped_files": [
+                    {
+                        "article_id": str(uuid4()),
+                        "storage_key": "k",
+                        "reason": "missing",
+                    }
+                ],
+            }
+        )
+        assert isinstance(resp.progress, ExportProgress)
+        assert resp.progress.current == 1
+        assert isinstance(resp.skipped_files[0], SkippedFileEntry)  # type: ignore[index]
+
+    def test_status_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportStatusResponse(job_id="j")  # type: ignore[call-arg]
+
+
+class TestExportStartedResponse:
+    def test_default_message(self) -> None:
+        resp = ExportStartedResponse(job_id="job-1")
+        assert resp.message == "Export started. Poll status for download link."
+
+    def test_message_override_and_null(self) -> None:
+        assert ExportStartedResponse(job_id="j", message="x").message == "x"
+        assert ExportStartedResponse(job_id="j", message=None).message is None
+
+    def test_job_id_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportStartedResponse()  # type: ignore[call-arg]
+
+
+class TestExportCancelResponse:
+    def test_construction(self) -> None:
+        assert ExportCancelResponse(cancelled=True).cancelled is True
+        assert ExportCancelResponse(cancelled=False).cancelled is False
+
+    def test_cancelled_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExportCancelResponse()  # type: ignore[call-arg]

--- a/backend/tests/unit/test_common_schemas.py
+++ b/backend/tests/unit/test_common_schemas.py
@@ -1,0 +1,218 @@
+"""Unit tests for app.schemas.common.
+
+Pure Pydantic validation tests: no DB, no async, no fixtures.
+Covers the generic ApiResponse/PaginatedResponse envelopes (a recurring
+wire-shape drift incident class), ErrorDetail, the ApiErrorCode StrEnum,
+and HealthResponse defaults.
+"""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from app.schemas.common import (
+    ApiErrorCode,
+    ApiResponse,
+    ErrorDetail,
+    HealthResponse,
+    PaginatedResponse,
+)
+
+
+class _Inner(BaseModel):
+    """Small concrete model for parametrizing the generics."""
+
+    name: str
+    count: int
+
+
+class TestApiErrorCode:
+    def test_is_str_enum_members_equal_their_values(self) -> None:
+        # StrEnum members compare equal to their string value.
+        assert ApiErrorCode.VALIDATION_ERROR == "VALIDATION_ERROR"
+        assert ApiErrorCode.NOT_FOUND == "NOT_FOUND"
+        assert ApiErrorCode.CONFLICT == "CONFLICT"
+        assert ApiErrorCode.UNEXPECTED_ERROR == "UNEXPECTED_ERROR"
+
+    def test_expected_members_present(self) -> None:
+        names = {member.name for member in ApiErrorCode}
+        assert {
+            "VALIDATION_ERROR",
+            "AUTHENTICATION_ERROR",
+            "AUTHORIZATION_ERROR",
+            "FORBIDDEN",
+            "NOT_FOUND",
+            "CONFLICT",
+            "RATE_LIMIT_EXCEEDED",
+            "SERVICE_UNAVAILABLE",
+            "EXTERNAL_SERVICE_ERROR",
+            "AI_EXTRACTION_ERROR",
+            "PDF_PROCESSING_ERROR",
+            "UNEXPECTED_ERROR",
+            "HTTP_ERROR",
+        } <= names
+
+    def test_value_equals_name_for_every_member(self) -> None:
+        for member in ApiErrorCode:
+            assert member.value == member.name
+
+
+class TestErrorDetail:
+    def test_construction_with_code_and_message(self) -> None:
+        detail = ErrorDetail(code="NOT_FOUND", message="missing")
+        assert detail.code == "NOT_FOUND"
+        assert detail.message == "missing"
+        assert detail.details is None
+
+    def test_construction_with_details(self) -> None:
+        detail = ErrorDetail(
+            code="VALIDATION_ERROR",
+            message="bad",
+            details={"field": "article_ids"},
+        )
+        assert detail.details == {"field": "article_ids"}
+
+    def test_accepts_api_error_code_enum_as_code(self) -> None:
+        detail = ErrorDetail(code=ApiErrorCode.CONFLICT, message="dup")
+        assert detail.code == "CONFLICT"
+
+    def test_code_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ErrorDetail(message="no code")  # type: ignore[call-arg]
+
+    def test_message_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ErrorDetail(code="NOT_FOUND")  # type: ignore[call-arg]
+
+
+class TestApiResponseSuccess:
+    def test_success_envelope_shape(self) -> None:
+        resp = ApiResponse[str].success("payload")
+        assert resp.ok is True
+        assert resp.data == "payload"
+        assert resp.error is None
+        assert resp.trace_id is None
+
+    def test_success_with_trace_id(self) -> None:
+        resp = ApiResponse[str].success("payload", trace_id="trace-1")
+        assert resp.trace_id == "trace-1"
+
+    def test_success_with_inner_model_dump_roundtrip(self) -> None:
+        resp = ApiResponse[_Inner].success(_Inner(name="a", count=2))
+        dumped = resp.model_dump()
+        assert dumped == {
+            "ok": True,
+            "data": {"name": "a", "count": 2},
+            "error": None,
+            "trace_id": None,
+        }
+
+    def test_success_data_validated_against_concrete_type(self) -> None:
+        # data typed as _Inner: a str payload is coerced/validated, so an
+        # int-only field that cannot coerce raises.
+        with pytest.raises(ValidationError):
+            ApiResponse[_Inner].success(_Inner(name="a", count="not-an-int"))  # type: ignore[arg-type]
+
+
+class TestApiResponseFailure:
+    def test_failure_envelope_shape(self) -> None:
+        resp = ApiResponse[str].failure("NOT_FOUND", "missing")
+        assert resp.ok is False
+        assert resp.data is None
+        assert resp.error is not None
+        assert resp.error.code == "NOT_FOUND"
+        assert resp.error.message == "missing"
+        assert resp.error.details is None
+
+    def test_failure_with_details_and_trace_id(self) -> None:
+        resp = ApiResponse[str].failure(
+            "VALIDATION_ERROR",
+            "bad",
+            details={"field": "x"},
+            trace_id="trace-9",
+        )
+        assert resp.error is not None
+        assert resp.error.details == {"field": "x"}
+        assert resp.trace_id == "trace-9"
+
+    def test_failure_model_dump_roundtrip(self) -> None:
+        resp = ApiResponse[_Inner].failure("CONFLICT", "dup", trace_id="t")
+        assert resp.model_dump() == {
+            "ok": False,
+            "data": None,
+            "error": {"code": "CONFLICT", "message": "dup", "details": None},
+            "trace_id": "t",
+        }
+
+
+class TestApiResponseDirectConstruction:
+    def test_defaults_when_only_ok_supplied(self) -> None:
+        resp = ApiResponse[str](ok=True)
+        assert resp.data is None
+        assert resp.error is None
+        assert resp.trace_id is None
+
+    def test_ok_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ApiResponse[str]()  # type: ignore[call-arg]
+
+
+class TestPaginatedResponse:
+    def _resp(self, total: int, page_size: int) -> PaginatedResponse[str]:
+        return PaginatedResponse[str](
+            items=[],
+            total=total,
+            page=1,
+            page_size=page_size,
+            has_more=False,
+        )
+
+    def test_total_pages_zero_total(self) -> None:
+        assert self._resp(total=0, page_size=10).total_pages == 0
+
+    def test_total_pages_exact_multiple(self) -> None:
+        assert self._resp(total=20, page_size=10).total_pages == 2
+
+    def test_total_pages_rounds_up_on_remainder(self) -> None:
+        # ceil(21 / 10) == 3
+        assert self._resp(total=21, page_size=10).total_pages == 3
+
+    def test_total_pages_single_partial_page(self) -> None:
+        assert self._resp(total=1, page_size=10).total_pages == 1
+
+    def test_total_pages_formula_matches_ceil_div(self) -> None:
+        for total, page_size, expected in [
+            (0, 5, 0),
+            (5, 5, 1),
+            (6, 5, 2),
+            (99, 10, 10),
+            (100, 10, 10),
+            (101, 10, 11),
+        ]:
+            assert self._resp(total, page_size).total_pages == expected
+
+    def test_construction_with_inner_items(self) -> None:
+        resp = PaginatedResponse[_Inner](
+            items=[_Inner(name="a", count=1)],
+            total=1,
+            page=1,
+            page_size=25,
+            has_more=False,
+        )
+        assert resp.items[0].name == "a"
+        assert resp.total_pages == 1
+
+    def test_required_fields_enforced(self) -> None:
+        with pytest.raises(ValidationError):
+            PaginatedResponse[str](items=[], total=0, page=1)  # type: ignore[call-arg]
+
+
+class TestHealthResponse:
+    def test_defaults(self) -> None:
+        health = HealthResponse()
+        assert health.status == "healthy"
+        assert health.version == "0.1.0"
+
+    def test_overrides(self) -> None:
+        health = HealthResponse(status="degraded", version="9.9.9")
+        assert health.status == "degraded"
+        assert health.version == "9.9.9"

--- a/backend/tests/unit/test_extraction_export_schemas.py
+++ b/backend/tests/unit/test_extraction_export_schemas.py
@@ -1,0 +1,233 @@
+"""Unit tests for app.schemas.extraction_export.
+
+Pure Pydantic validation tests: no DB, no async, no fixtures.
+Covers the two StrEnums, the request model's defaults / min_length /
+model_config, and the three response payloads.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.extraction_export import (
+    ExtractionArticleScope,
+    ExtractionExportCancelResponse,
+    ExtractionExportMode,
+    ExtractionExportRequest,
+    ExtractionExportStartedResponse,
+    ExtractionExportStatusResponse,
+)
+
+
+class TestExtractionExportMode:
+    def test_members_and_values(self) -> None:
+        assert ExtractionExportMode.CONSENSUS == "consensus"
+        assert ExtractionExportMode.SINGLE_USER == "single_user"
+        assert ExtractionExportMode.ALL_USERS == "all_users"
+
+    def test_member_set(self) -> None:
+        assert {m.value for m in ExtractionExportMode} == {
+            "consensus",
+            "single_user",
+            "all_users",
+        }
+
+
+class TestExtractionArticleScope:
+    def test_members_and_values(self) -> None:
+        assert ExtractionArticleScope.CURRENT_LIST == "current_list"
+        assert ExtractionArticleScope.SELECTED_ONLY == "selected_only"
+
+    def test_member_set(self) -> None:
+        assert {m.value for m in ExtractionArticleScope} == {
+            "current_list",
+            "selected_only",
+        }
+
+
+class TestExtractionExportRequestDefaults:
+    def test_minimal_construction_applies_defaults(self) -> None:
+        req = ExtractionExportRequest(
+            template_id=uuid4(),
+            article_ids=[uuid4()],
+        )
+        assert req.mode == ExtractionExportMode.CONSENSUS
+        assert req.article_scope == ExtractionArticleScope.CURRENT_LIST
+        assert req.reviewer_id is None
+        assert req.include_ai_metadata is False
+        assert req.anonymize_reviewer_names is False
+
+    def test_full_construction(self) -> None:
+        tid = uuid4()
+        rid = uuid4()
+        aid = uuid4()
+        req = ExtractionExportRequest(
+            template_id=tid,
+            mode=ExtractionExportMode.SINGLE_USER,
+            reviewer_id=rid,
+            article_scope=ExtractionArticleScope.SELECTED_ONLY,
+            article_ids=[aid],
+            include_ai_metadata=True,
+            anonymize_reviewer_names=True,
+        )
+        assert req.template_id == tid
+        assert req.reviewer_id == rid
+        assert req.article_ids == [aid]
+        assert req.mode == ExtractionExportMode.SINGLE_USER
+        assert req.article_scope == ExtractionArticleScope.SELECTED_ONLY
+
+
+class TestExtractionExportRequestArticleIds:
+    def test_empty_list_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionExportRequest(template_id=uuid4(), article_ids=[])
+
+    def test_single_item_accepted(self) -> None:
+        req = ExtractionExportRequest(template_id=uuid4(), article_ids=[uuid4()])
+        assert len(req.article_ids) == 1
+
+    def test_multiple_items_accepted(self) -> None:
+        ids = [uuid4(), uuid4(), uuid4()]
+        req = ExtractionExportRequest(template_id=uuid4(), article_ids=ids)
+        assert req.article_ids == ids
+
+    def test_article_ids_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionExportRequest(template_id=uuid4())  # type: ignore[call-arg]
+
+    def test_template_id_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionExportRequest(article_ids=[uuid4()])  # type: ignore[call-arg]
+
+
+class TestExtractionExportRequestEnums:
+    def test_invalid_mode_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionExportRequest(
+                template_id=uuid4(),
+                article_ids=[uuid4()],
+                mode="not_a_mode",
+            )
+
+    def test_invalid_article_scope_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionExportRequest(
+                template_id=uuid4(),
+                article_ids=[uuid4()],
+                article_scope="everything",
+            )
+
+    def test_mode_accepts_raw_string_value(self) -> None:
+        req = ExtractionExportRequest(
+            template_id=uuid4(),
+            article_ids=[uuid4()],
+            mode="all_users",
+        )
+        assert req.mode is ExtractionExportMode.ALL_USERS
+
+
+class TestExtractionExportRequestConfig:
+    def test_str_strip_whitespace_does_not_extend_to_uuid_coercion(self) -> None:
+        # str_strip_whitespace=True only trims fields validated *as* str.
+        # ExtractionExportRequest has no plain-str field, and the flag does
+        # NOT pre-trim before UUID parsing, so a padded UUID string is
+        # rejected. Documents the (correct) Pydantic v2 behavior so a future
+        # str field added to this model is the only place stripping kicks in.
+        raw = "11111111-1111-1111-1111-111111111111"
+        with pytest.raises(ValidationError):
+            ExtractionExportRequest(
+                template_id=f"  {raw}  ",  # type: ignore[arg-type]
+                article_ids=[uuid4()],
+            )
+
+    def test_clean_uuid_string_parses(self) -> None:
+        raw = "11111111-1111-1111-1111-111111111111"
+        req = ExtractionExportRequest(
+            template_id=raw,  # type: ignore[arg-type]
+            article_ids=[uuid4()],
+        )
+        assert req.template_id == UUID(raw)
+
+    def test_populate_by_name_does_not_break_snake_case_input(self) -> None:
+        # No camelCase aliases are declared on this model, so snake_case
+        # field names are the only accepted keys; populate_by_name=True is
+        # a forward-compat flag here.
+        req = ExtractionExportRequest.model_validate(
+            {
+                "template_id": str(uuid4()),
+                "article_ids": [str(uuid4())],
+                "include_ai_metadata": True,
+            }
+        )
+        assert req.include_ai_metadata is True
+
+    def test_model_dump_uses_snake_case_keys(self) -> None:
+        req = ExtractionExportRequest(template_id=uuid4(), article_ids=[uuid4()])
+        dumped = req.model_dump()
+        assert set(dumped) == {
+            "template_id",
+            "mode",
+            "reviewer_id",
+            "article_scope",
+            "article_ids",
+            "include_ai_metadata",
+            "anonymize_reviewer_names",
+        }
+
+
+class TestExtractionExportStartedResponse:
+    def test_default_message(self) -> None:
+        resp = ExtractionExportStartedResponse(job_id="job-1")
+        assert resp.job_id == "job-1"
+        assert resp.message == "Export started. Poll status for download link."
+
+    def test_message_override(self) -> None:
+        resp = ExtractionExportStartedResponse(job_id="job-1", message="custom")
+        assert resp.message == "custom"
+
+    def test_message_nullable(self) -> None:
+        resp = ExtractionExportStartedResponse(job_id="job-1", message=None)
+        assert resp.message is None
+
+    def test_job_id_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionExportStartedResponse()  # type: ignore[call-arg]
+
+
+class TestExtractionExportStatusResponse:
+    def test_minimal_construction_defaults(self) -> None:
+        resp = ExtractionExportStatusResponse(job_id="j", status="pending")
+        assert resp.download_url is None
+        assert resp.expires_at is None
+        assert resp.error is None
+
+    def test_full_construction(self) -> None:
+        resp = ExtractionExportStatusResponse(
+            job_id="j",
+            status="completed",
+            download_url="https://x/y.xlsx",
+            expires_at="2026-06-13T00:00:00Z",
+            error=None,
+        )
+        assert resp.status == "completed"
+        assert resp.download_url == "https://x/y.xlsx"
+        assert resp.expires_at == "2026-06-13T00:00:00Z"
+
+    def test_status_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionExportStatusResponse(job_id="j")  # type: ignore[call-arg]
+
+
+class TestExtractionExportCancelResponse:
+    def test_construction(self) -> None:
+        assert ExtractionExportCancelResponse(cancelled=True).cancelled is True
+        assert ExtractionExportCancelResponse(cancelled=False).cancelled is False
+
+    def test_cancelled_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionExportCancelResponse()  # type: ignore[call-arg]
+
+    def test_cancelled_coerces_truthy_int(self) -> None:
+        # Pydantic v2 bool coercion accepts 1/0 ints.
+        assert ExtractionExportCancelResponse(cancelled=1).cancelled is True  # type: ignore[arg-type]

--- a/backend/tests/unit/test_extraction_run_schemas.py
+++ b/backend/tests/unit/test_extraction_run_schemas.py
@@ -1,0 +1,667 @@
+"""Pure validation tests for app.schemas.extraction_run."""
+
+import types
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.extraction_run import (
+    AdvanceStageRequest,
+    ConsensusDecisionResponse,
+    ConsensusResultResponse,
+    CreateConsensusRequest,
+    CreateDecisionRequest,
+    CreateProposalRequest,
+    CreateRunRequest,
+    ProposalRecordResponse,
+    PublishedStateResponse,
+    ReviewerDecisionResponse,
+    RunDetailResponse,
+    RunReviewerProfile,
+    RunReviewersResponse,
+    RunSummaryResponse,
+    RunViewCurrentValue,
+    RunViewEntityType,
+    RunViewField,
+    RunViewResponse,
+)
+
+NOW = datetime(2026, 6, 13, 12, 0, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------- #
+# CreateRunRequest
+# --------------------------------------------------------------------------- #
+class TestCreateRunRequest:
+    def test_valid_minimal(self) -> None:
+        req = CreateRunRequest(
+            project_id=uuid4(),
+            article_id=uuid4(),
+            project_template_id=uuid4(),
+        )
+        assert req.parameters is None
+
+    def test_valid_with_parameters(self) -> None:
+        req = CreateRunRequest(
+            project_id=uuid4(),
+            article_id=uuid4(),
+            project_template_id=uuid4(),
+            parameters={"foo": "bar"},
+        )
+        assert req.parameters == {"foo": "bar"}
+
+    def test_missing_required_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateRunRequest(project_id=uuid4(), article_id=uuid4())  # type: ignore[call-arg]
+
+    def test_bad_uuid_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateRunRequest(
+                project_id="not-a-uuid",  # type: ignore[arg-type]
+                article_id=uuid4(),
+                project_template_id=uuid4(),
+            )
+
+
+# --------------------------------------------------------------------------- #
+# CreateProposalRequest  (source pattern ^(ai|human|system)$)
+# --------------------------------------------------------------------------- #
+class TestCreateProposalRequest:
+    @staticmethod
+    def _kwargs(**kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "instance_id": uuid4(),
+            "field_id": uuid4(),
+            "source": "ai",
+            "proposed_value": {"value": 1},
+        }
+        base.update(kw)
+        return base
+
+    @pytest.mark.parametrize("source", ["ai", "human", "system"])
+    def test_valid_sources_accepted(self, source: str) -> None:
+        req = CreateProposalRequest(**self._kwargs(source=source))
+        assert req.source == source
+
+    @pytest.mark.parametrize("source", ["robot", "AI", "human ", "", "ai|human"])
+    def test_invalid_source_rejected(self, source: str) -> None:
+        with pytest.raises(ValidationError):
+            CreateProposalRequest(**self._kwargs(source=source))
+
+    def test_optional_defaults(self) -> None:
+        req = CreateProposalRequest(**self._kwargs())
+        assert req.source_user_id is None
+        assert req.confidence_score is None
+        assert req.rationale is None
+
+    def test_all_optionals_populated(self) -> None:
+        uid = uuid4()
+        req = CreateProposalRequest(
+            **self._kwargs(source_user_id=uid, confidence_score=0.9, rationale="why")
+        )
+        assert req.source_user_id == uid
+        assert req.confidence_score == 0.9
+        assert req.rationale == "why"
+
+    def test_missing_proposed_value_rejected(self) -> None:
+        kwargs = self._kwargs()
+        del kwargs["proposed_value"]
+        with pytest.raises(ValidationError):
+            CreateProposalRequest(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CreateDecisionRequest  (decision pattern ^(accept_proposal|reject|edit)$)
+# --------------------------------------------------------------------------- #
+class TestCreateDecisionRequest:
+    @staticmethod
+    def _kwargs(**kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "instance_id": uuid4(),
+            "field_id": uuid4(),
+            "decision": "accept_proposal",
+        }
+        base.update(kw)
+        return base
+
+    @pytest.mark.parametrize("decision", ["accept_proposal", "reject", "edit"])
+    def test_valid_decisions_accepted(self, decision: str) -> None:
+        req = CreateDecisionRequest(**self._kwargs(decision=decision))
+        assert req.decision == decision
+
+    @pytest.mark.parametrize("decision", ["accept", "rejected", "EDIT", "", "accept_proposalx"])
+    def test_invalid_decision_rejected(self, decision: str) -> None:
+        with pytest.raises(ValidationError):
+            CreateDecisionRequest(**self._kwargs(decision=decision))
+
+    def test_optional_defaults(self) -> None:
+        req = CreateDecisionRequest(**self._kwargs())
+        assert req.proposal_record_id is None
+        assert req.value is None
+        assert req.rationale is None
+
+    def test_optionals_populated(self) -> None:
+        pid = uuid4()
+        req = CreateDecisionRequest(
+            **self._kwargs(decision="edit", proposal_record_id=pid, value={"v": 2}, rationale="r")
+        )
+        assert req.proposal_record_id == pid
+        assert req.value == {"v": 2}
+
+
+# --------------------------------------------------------------------------- #
+# CreateConsensusRequest  (mode pattern ^(select_existing|manual_override)$)
+# --------------------------------------------------------------------------- #
+class TestCreateConsensusRequest:
+    @staticmethod
+    def _kwargs(**kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "instance_id": uuid4(),
+            "field_id": uuid4(),
+            "mode": "select_existing",
+        }
+        base.update(kw)
+        return base
+
+    @pytest.mark.parametrize("mode", ["select_existing", "manual_override"])
+    def test_valid_modes_accepted(self, mode: str) -> None:
+        req = CreateConsensusRequest(**self._kwargs(mode=mode))
+        assert req.mode == mode
+
+    @pytest.mark.parametrize("mode", ["select", "override", "manual", "", "select_existingx"])
+    def test_invalid_mode_rejected(self, mode: str) -> None:
+        with pytest.raises(ValidationError):
+            CreateConsensusRequest(**self._kwargs(mode=mode))
+
+    def test_optional_defaults(self) -> None:
+        req = CreateConsensusRequest(**self._kwargs())
+        assert req.selected_decision_id is None
+        assert req.value is None
+        assert req.rationale is None
+
+    def test_optionals_populated(self) -> None:
+        did = uuid4()
+        req = CreateConsensusRequest(
+            **self._kwargs(mode="manual_override", selected_decision_id=did, value={"v": 3})
+        )
+        assert req.selected_decision_id == did
+        assert req.value == {"v": 3}
+
+
+# --------------------------------------------------------------------------- #
+# AdvanceStageRequest
+# (target_stage pattern ^(pending|proposal|review|consensus|finalized|cancelled)$)
+# --------------------------------------------------------------------------- #
+class TestAdvanceStageRequest:
+    @pytest.mark.parametrize(
+        "stage",
+        ["pending", "proposal", "review", "consensus", "finalized", "cancelled"],
+    )
+    def test_valid_stages_accepted(self, stage: str) -> None:
+        req = AdvanceStageRequest(target_stage=stage)
+        assert req.target_stage == stage
+
+    @pytest.mark.parametrize(
+        "stage",
+        ["canceled", "done", "PENDING", "", "finalised", "review "],
+    )
+    def test_invalid_stage_rejected(self, stage: str) -> None:
+        with pytest.raises(ValidationError):
+            AdvanceStageRequest(target_stage=stage)
+
+    def test_missing_target_stage_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AdvanceStageRequest()  # type: ignore[call-arg]
+
+
+# --------------------------------------------------------------------------- #
+# ProposalRecordResponse (from_attributes)
+# --------------------------------------------------------------------------- #
+class TestProposalRecordResponse:
+    @staticmethod
+    def _ns(**kw: object) -> types.SimpleNamespace:
+        base: dict[str, object] = {
+            "id": uuid4(),
+            "run_id": uuid4(),
+            "instance_id": uuid4(),
+            "field_id": uuid4(),
+            "source": "ai",
+            "source_user_id": None,
+            "proposed_value": {"value": 1},
+            "confidence_score": None,
+            "rationale": None,
+            "created_at": NOW,
+        }
+        base.update(kw)
+        return types.SimpleNamespace(**base)
+
+    def test_from_attributes(self) -> None:
+        resp = ProposalRecordResponse.model_validate(self._ns())
+        assert resp.source == "ai"
+        assert resp.proposed_value == {"value": 1}
+
+    def test_from_attributes_with_optionals(self) -> None:
+        uid = uuid4()
+        resp = ProposalRecordResponse.model_validate(
+            self._ns(source_user_id=uid, confidence_score=0.5, rationale="r")
+        )
+        assert resp.source_user_id == uid
+        assert resp.confidence_score == 0.5
+
+    def test_missing_required_attr_rejected(self) -> None:
+        ns = self._ns()
+        del ns.source
+        with pytest.raises(ValidationError):
+            ProposalRecordResponse.model_validate(ns)
+
+
+# --------------------------------------------------------------------------- #
+# ReviewerDecisionResponse (from_attributes)
+# --------------------------------------------------------------------------- #
+class TestReviewerDecisionResponse:
+    @staticmethod
+    def _ns(**kw: object) -> types.SimpleNamespace:
+        base: dict[str, object] = {
+            "id": uuid4(),
+            "run_id": uuid4(),
+            "instance_id": uuid4(),
+            "field_id": uuid4(),
+            "reviewer_id": uuid4(),
+            "decision": "accept_proposal",
+            "proposal_record_id": None,
+            "value": None,
+            "rationale": None,
+            "created_at": NOW,
+        }
+        base.update(kw)
+        return types.SimpleNamespace(**base)
+
+    def test_from_attributes(self) -> None:
+        resp = ReviewerDecisionResponse.model_validate(self._ns())
+        assert resp.decision == "accept_proposal"
+
+    def test_from_attributes_with_value(self) -> None:
+        resp = ReviewerDecisionResponse.model_validate(self._ns(value={"v": 1}, decision="edit"))
+        assert resp.value == {"v": 1}
+
+
+# --------------------------------------------------------------------------- #
+# ConsensusDecisionResponse (from_attributes)
+# --------------------------------------------------------------------------- #
+class TestConsensusDecisionResponse:
+    @staticmethod
+    def _ns(**kw: object) -> types.SimpleNamespace:
+        base: dict[str, object] = {
+            "id": uuid4(),
+            "run_id": uuid4(),
+            "instance_id": uuid4(),
+            "field_id": uuid4(),
+            "consensus_user_id": uuid4(),
+            "mode": "select_existing",
+            "selected_decision_id": None,
+            "value": None,
+            "rationale": None,
+            "created_at": NOW,
+        }
+        base.update(kw)
+        return types.SimpleNamespace(**base)
+
+    def test_from_attributes(self) -> None:
+        resp = ConsensusDecisionResponse.model_validate(self._ns())
+        assert resp.mode == "select_existing"
+
+
+# --------------------------------------------------------------------------- #
+# PublishedStateResponse (from_attributes)
+# --------------------------------------------------------------------------- #
+class TestPublishedStateResponse:
+    @staticmethod
+    def _ns(**kw: object) -> types.SimpleNamespace:
+        base: dict[str, object] = {
+            "id": uuid4(),
+            "run_id": uuid4(),
+            "instance_id": uuid4(),
+            "field_id": uuid4(),
+            "value": {"value": 7},
+            "published_at": NOW,
+            "published_by": uuid4(),
+            "version": 1,
+        }
+        base.update(kw)
+        return types.SimpleNamespace(**base)
+
+    def test_from_attributes(self) -> None:
+        resp = PublishedStateResponse.model_validate(self._ns())
+        assert resp.version == 1
+        assert resp.value == {"value": 7}
+
+    def test_version_coerced_from_str(self) -> None:
+        resp = PublishedStateResponse.model_validate(self._ns(version="3"))
+        assert resp.version == 3
+
+
+# --------------------------------------------------------------------------- #
+# ConsensusResultResponse (nested)
+# --------------------------------------------------------------------------- #
+def _consensus_resp() -> ConsensusDecisionResponse:
+    return ConsensusDecisionResponse.model_validate(
+        types.SimpleNamespace(
+            id=uuid4(),
+            run_id=uuid4(),
+            instance_id=uuid4(),
+            field_id=uuid4(),
+            consensus_user_id=uuid4(),
+            mode="manual_override",
+            selected_decision_id=None,
+            value={"v": 1},
+            rationale=None,
+            created_at=NOW,
+        )
+    )
+
+
+def _published_resp() -> PublishedStateResponse:
+    return PublishedStateResponse.model_validate(
+        types.SimpleNamespace(
+            id=uuid4(),
+            run_id=uuid4(),
+            instance_id=uuid4(),
+            field_id=uuid4(),
+            value={"value": 7},
+            published_at=NOW,
+            published_by=uuid4(),
+            version=2,
+        )
+    )
+
+
+class TestConsensusResultResponse:
+    def test_valid_construction(self) -> None:
+        result = ConsensusResultResponse(consensus=_consensus_resp(), published=_published_resp())
+        assert result.consensus.mode == "manual_override"
+        assert result.published.version == 2
+
+    def test_missing_published_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ConsensusResultResponse(consensus=_consensus_resp())  # type: ignore[call-arg]
+
+
+# --------------------------------------------------------------------------- #
+# RunSummaryResponse (from_attributes)
+# --------------------------------------------------------------------------- #
+def _run_summary_ns(**kw: object) -> types.SimpleNamespace:
+    base: dict[str, object] = {
+        "id": uuid4(),
+        "project_id": uuid4(),
+        "article_id": uuid4(),
+        "template_id": uuid4(),
+        "kind": "extraction",
+        "version_id": uuid4(),
+        "stage": "proposal",
+        "status": "running",
+        "hitl_config_snapshot": {"reviewer_count": 1},
+        "parameters": {},
+        "results": {},
+        "created_at": NOW,
+        "created_by": uuid4(),
+    }
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+class TestRunSummaryResponse:
+    def test_from_attributes(self) -> None:
+        resp = RunSummaryResponse.model_validate(_run_summary_ns())
+        assert resp.kind == "extraction"
+        assert resp.stage == "proposal"
+
+    def test_missing_required_attr_rejected(self) -> None:
+        ns = _run_summary_ns()
+        del ns.hitl_config_snapshot
+        with pytest.raises(ValidationError):
+            RunSummaryResponse.model_validate(ns)
+
+
+# --------------------------------------------------------------------------- #
+# RunDetailResponse (nested lists)
+# --------------------------------------------------------------------------- #
+class TestRunDetailResponse:
+    def test_valid_empty_lists(self) -> None:
+        resp = RunDetailResponse(
+            run=RunSummaryResponse.model_validate(_run_summary_ns()),
+            proposals=[],
+            decisions=[],
+            consensus_decisions=[],
+            published_states=[],
+        )
+        assert resp.proposals == []
+
+    def test_missing_run_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RunDetailResponse(  # type: ignore[call-arg]
+                proposals=[],
+                decisions=[],
+                consensus_decisions=[],
+                published_states=[],
+            )
+
+
+# --------------------------------------------------------------------------- #
+# RunViewField (from_attributes, defaults)
+# --------------------------------------------------------------------------- #
+class TestRunViewField:
+    @staticmethod
+    def _ns(**kw: object) -> types.SimpleNamespace:
+        base: dict[str, object] = {
+            "id": uuid4(),
+            "name": "age",
+            "label": "Age",
+            "field_type": "number",
+            "is_required": True,
+            "sort_order": 0,
+        }
+        base.update(kw)
+        return types.SimpleNamespace(**base)
+
+    def test_defaults(self) -> None:
+        field = RunViewField.model_validate(self._ns())
+        assert field.description is None
+        assert field.validation_schema is None
+        assert field.allowed_values is None
+        assert field.unit is None
+        assert field.allowed_units is None
+        assert field.llm_description is None
+        assert field.allow_other is False
+        assert field.other_label is None
+        assert field.other_placeholder is None
+
+    def test_full_population(self) -> None:
+        field = RunViewField.model_validate(
+            self._ns(
+                description="d",
+                validation_schema={"type": "number"},
+                allowed_values=["a", "b"],
+                unit="kg",
+                allowed_units=["kg", "g"],
+                llm_description="ll",
+                allow_other=True,
+                other_label="Other",
+                other_placeholder="Specify",
+            )
+        )
+        assert field.allow_other is True
+        assert field.allowed_units == ["kg", "g"]
+
+    def test_missing_required_rejected(self) -> None:
+        ns = self._ns()
+        del ns.field_type
+        with pytest.raises(ValidationError):
+            RunViewField.model_validate(ns)
+
+
+# --------------------------------------------------------------------------- #
+# RunViewEntityType (from_attributes, embedded fields)
+# --------------------------------------------------------------------------- #
+class TestRunViewEntityType:
+    @staticmethod
+    def _field_ns() -> types.SimpleNamespace:
+        return types.SimpleNamespace(
+            id=uuid4(),
+            name="age",
+            label="Age",
+            field_type="number",
+            is_required=True,
+            sort_order=0,
+        )
+
+    @staticmethod
+    def _ns(**kw: object) -> types.SimpleNamespace:
+        base: dict[str, object] = {
+            "id": uuid4(),
+            "name": "patient",
+            "label": "Patient",
+            "cardinality": "many",
+            "role": "study",
+            "sort_order": 0,
+            "is_required": True,
+            "fields": [],
+        }
+        base.update(kw)
+        return types.SimpleNamespace(**base)
+
+    def test_defaults(self) -> None:
+        et = RunViewEntityType.model_validate(self._ns())
+        assert et.description is None
+        assert et.parent_entity_type_id is None
+        assert et.fields == []
+
+    def test_with_embedded_fields(self) -> None:
+        et = RunViewEntityType.model_validate(self._ns(fields=[self._field_ns()]))
+        assert len(et.fields) == 1
+        assert isinstance(et.fields[0], RunViewField)
+        assert et.fields[0].name == "age"
+
+
+# --------------------------------------------------------------------------- #
+# RunViewCurrentValue (no from_attributes)
+# --------------------------------------------------------------------------- #
+class TestRunViewCurrentValue:
+    def test_valid_with_value(self) -> None:
+        cv = RunViewCurrentValue(
+            instance_id=uuid4(),
+            field_id=uuid4(),
+            value={"value": 1, "unit": "kg"},
+            decision="accept_proposal",
+        )
+        assert cv.value == {"value": 1, "unit": "kg"}
+
+    def test_valid_null_value(self) -> None:
+        cv = RunViewCurrentValue(
+            instance_id=uuid4(),
+            field_id=uuid4(),
+            value=None,
+            decision="pending",
+        )
+        assert cv.value is None
+
+    def test_missing_decision_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RunViewCurrentValue(  # type: ignore[call-arg]
+                instance_id=uuid4(),
+                field_id=uuid4(),
+                value=None,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# RunViewResponse (subclass of RunDetailResponse)
+# --------------------------------------------------------------------------- #
+class TestRunViewResponse:
+    def test_valid_construction(self) -> None:
+        resp = RunViewResponse(
+            run=RunSummaryResponse.model_validate(_run_summary_ns()),
+            proposals=[],
+            decisions=[],
+            consensus_decisions=[],
+            published_states=[],
+            entity_types=[],
+            current_values=[],
+        )
+        assert resp.entity_types == []
+        assert resp.current_values == []
+
+    def test_inherits_detail_requirements(self) -> None:
+        with pytest.raises(ValidationError):
+            RunViewResponse(  # type: ignore[call-arg]
+                run=RunSummaryResponse.model_validate(_run_summary_ns()),
+                proposals=[],
+                decisions=[],
+                consensus_decisions=[],
+                published_states=[],
+            )
+
+    def test_with_nested_view_data(self) -> None:
+        et = RunViewEntityType.model_validate(
+            types.SimpleNamespace(
+                id=uuid4(),
+                name="patient",
+                label="Patient",
+                cardinality="many",
+                role="study",
+                sort_order=0,
+                is_required=True,
+                fields=[],
+            )
+        )
+        cv = RunViewCurrentValue(
+            instance_id=uuid4(), field_id=uuid4(), value=None, decision="review"
+        )
+        resp = RunViewResponse(
+            run=RunSummaryResponse.model_validate(_run_summary_ns()),
+            proposals=[],
+            decisions=[],
+            consensus_decisions=[],
+            published_states=[],
+            entity_types=[et],
+            current_values=[cv],
+        )
+        assert resp.entity_types[0].name == "patient"
+        assert resp.current_values[0].decision == "review"
+
+
+# --------------------------------------------------------------------------- #
+# RunReviewerProfile (defaults)
+# --------------------------------------------------------------------------- #
+class TestRunReviewerProfile:
+    def test_defaults(self) -> None:
+        prof = RunReviewerProfile(id=uuid4())
+        assert prof.full_name is None
+        assert prof.avatar_url is None
+
+    def test_full_population(self) -> None:
+        prof = RunReviewerProfile(id=uuid4(), full_name="Jane", avatar_url="http://x/a.png")
+        assert prof.full_name == "Jane"
+        assert prof.avatar_url == "http://x/a.png"
+
+    def test_missing_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RunReviewerProfile()  # type: ignore[call-arg]
+
+
+# --------------------------------------------------------------------------- #
+# RunReviewersResponse
+# --------------------------------------------------------------------------- #
+class TestRunReviewersResponse:
+    def test_empty(self) -> None:
+        resp = RunReviewersResponse(reviewers=[])
+        assert resp.reviewers == []
+
+    def test_with_profiles(self) -> None:
+        resp = RunReviewersResponse(reviewers=[RunReviewerProfile(id=uuid4(), full_name="A")])
+        assert resp.reviewers[0].full_name == "A"
+
+    def test_missing_reviewers_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RunReviewersResponse()  # type: ignore[call-arg]

--- a/backend/tests/unit/test_extraction_schemas.py
+++ b/backend/tests/unit/test_extraction_schemas.py
@@ -1,0 +1,774 @@
+"""Pure-validation unit tests for ``app.schemas.extraction``.
+
+Targets the validation surface NOT already covered by
+``test_typed_envelope_schemas.py`` (which pins the discriminated
+``SectionExtractionResponseData`` union + wire shapes of
+``SingleSectionResult`` / ``BatchSectionResult`` / ``SectionOutcome`` /
+``ModelExtractionResult``). Here we exercise constraints, cross-field
+``model_validator``s, Literal fields, camelCase aliases, the
+``CitationAnchor`` discriminated union, ``PositionV1`` and the
+``parse_position`` helper.
+
+No DB, no async, no fixtures — these run in milliseconds.
+"""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from app.schemas.extraction import (
+    BatchSectionResult,
+    CitationAnchor,
+    CreatedModelInfo,
+    CreateInstanceRequest,
+    CreateModelHierarchyRequest,
+    CreateModelHierarchyResponse,
+    EvidencePassage,
+    ExtractionEntityTypeSchema,
+    ExtractionFieldSchema,
+    ExtractionOptions,
+    ExtractionTemplateSchema,
+    FieldSuggestion,
+    HybridCitationAnchor,
+    IdentifiedModel,
+    InstanceResponse,
+    ModelExtractionRequest,
+    ModelExtractionResult,
+    ModelExtractionRunStats,
+    ModelHierarchyChildResponse,
+    PDFRect,
+    PDFTextRange,
+    PositionV1,
+    RegionCitationAnchor,
+    ReviewSuggestionRequest,
+    SaveValueRequest,
+    SectionExtractionRequest,
+    SectionOutcome,
+    SingleSectionResult,
+    SuggestionResponse,
+    TextCitationAnchor,
+    ValueResponse,
+    parse_position,
+)
+
+CITATION_UNION = TypeAdapter(CitationAnchor)
+
+
+# =================== ExtractionOptions ===================
+
+
+class TestExtractionOptions:
+    def test_defaults(self) -> None:
+        opts = ExtractionOptions()
+        assert opts.model == "gpt-4o-mini"
+        assert opts.temperature == 0.1
+        assert opts.max_tokens is None
+
+    def test_temperature_bounds_just_inside(self) -> None:
+        assert ExtractionOptions(temperature=0).temperature == 0
+        assert ExtractionOptions(temperature=2).temperature == 2
+
+    def test_temperature_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionOptions(temperature=-0.0001)
+
+    def test_temperature_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionOptions(temperature=2.0001)
+
+    def test_max_tokens_bounds_just_inside(self) -> None:
+        assert ExtractionOptions(max_tokens=100).max_tokens == 100
+        assert ExtractionOptions(max_tokens=16000).max_tokens == 16000
+
+    def test_max_tokens_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionOptions(max_tokens=99)
+
+    def test_max_tokens_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionOptions(max_tokens=16001)
+
+
+# =================== EvidencePassage ===================
+
+
+class TestEvidencePassage:
+    def test_minimal_construction(self) -> None:
+        ev = EvidencePassage(text="hello")
+        assert ev.text == "hello"
+        assert ev.page_number is None
+        assert ev.confidence is None
+
+    def test_confidence_bounds_just_inside(self) -> None:
+        assert EvidencePassage(text="x", confidence=0).confidence == 0
+        assert EvidencePassage(text="x", confidence=1).confidence == 1
+
+    def test_confidence_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            EvidencePassage(text="x", confidence=-0.01)
+
+    def test_confidence_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            EvidencePassage(text="x", confidence=1.01)
+
+    def test_missing_text_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            EvidencePassage()  # type: ignore[call-arg]
+
+
+# =================== FieldSuggestion ===================
+
+
+class TestFieldSuggestion:
+    def test_construct_from_camel_alias(self) -> None:
+        fid = uuid4()
+        fs = FieldSuggestion(
+            fieldId=fid,
+            fieldName="age",
+            suggestedValue=42,
+            confidenceScore=0.9,
+        )
+        assert fs.field_id == fid
+        assert fs.field_name == "age"
+        assert fs.suggested_value == 42
+
+    def test_construct_from_snake_name(self) -> None:
+        fid = uuid4()
+        fs = FieldSuggestion(
+            field_id=fid,
+            field_name="age",
+            suggested_value=42,
+        )
+        assert fs.field_id == fid
+        assert fs.confidence_score is None
+        assert fs.evidence == []
+
+    def test_dump_by_alias_is_camel(self) -> None:
+        fs = FieldSuggestion(
+            field_id=uuid4(),
+            field_name="age",
+            suggested_value=42,
+            confidence_score=0.5,
+        )
+        wire = fs.model_dump(by_alias=True)
+        assert "fieldId" in wire
+        assert "fieldName" in wire
+        assert "suggestedValue" in wire
+        assert "confidenceScore" in wire
+
+    def test_confidence_bounds_just_inside(self) -> None:
+        base = {"field_id": uuid4(), "field_name": "x", "suggested_value": 1}
+        assert FieldSuggestion(**base, confidence_score=0).confidence_score == 0
+        assert FieldSuggestion(**base, confidence_score=1).confidence_score == 1
+
+    def test_confidence_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FieldSuggestion(
+                field_id=uuid4(),
+                field_name="x",
+                suggested_value=1,
+                confidence_score=-0.01,
+            )
+
+    def test_confidence_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FieldSuggestion(
+                field_id=uuid4(),
+                field_name="x",
+                suggested_value=1,
+                confidence_score=1.01,
+            )
+
+
+# =================== SectionExtractionRequest ===================
+
+
+def _section_req_base(**kw: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "projectId": uuid4(),
+        "articleId": uuid4(),
+        "templateId": uuid4(),
+    }
+    base.update(kw)
+    return base
+
+
+class TestSectionExtractionRequest:
+    def test_qa_mode_run_id_skips_other_checks(self) -> None:
+        # Branch (a): run_id present => QA mode, no entity_type_id /
+        # parent_instance_id required even with extract_all_sections=True.
+        req = SectionExtractionRequest(**_section_req_base(runId=uuid4(), extractAllSections=True))
+        assert req.run_id is not None
+        assert req.entity_type_id is None
+        assert req.parent_instance_id is None
+
+    def test_batch_requires_parent_instance_id(self) -> None:
+        # Branch (b) happy path.
+        req = SectionExtractionRequest(
+            **_section_req_base(extractAllSections=True, parentInstanceId=uuid4())
+        )
+        assert req.extract_all_sections is True
+        assert req.parent_instance_id is not None
+
+    def test_batch_missing_parent_instance_id_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            SectionExtractionRequest(**_section_req_base(extractAllSections=True))
+        assert "parentInstanceId is required" in str(exc.value)
+
+    def test_single_requires_entity_type_id(self) -> None:
+        # Branch (c) happy path.
+        req = SectionExtractionRequest(**_section_req_base(entityTypeId=uuid4()))
+        assert req.extract_all_sections is False
+        assert req.entity_type_id is not None
+
+    def test_single_missing_entity_type_id_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            SectionExtractionRequest(**_section_req_base())
+        assert "entityTypeId is required" in str(exc.value)
+
+    def test_alias_and_default_flags(self) -> None:
+        req = SectionExtractionRequest(**_section_req_base(entityTypeId=uuid4()))
+        assert req.auto_advance_to_review is True
+        assert req.skip_fields_with_human_proposals is False
+        assert req.model == "gpt-4o-mini"
+
+    def test_dump_by_alias_is_camel(self) -> None:
+        req = SectionExtractionRequest(**_section_req_base(entityTypeId=uuid4()))
+        wire = req.model_dump(by_alias=True)
+        assert "projectId" in wire
+        assert "extractAllSections" in wire
+        assert "autoAdvanceToReview" in wire
+        assert "skipFieldsWithHumanProposals" in wire
+
+
+# =================== PDFTextRange ===================
+
+
+class TestPDFTextRange:
+    def test_construct_from_camel_alias(self) -> None:
+        r = PDFTextRange(page=1, charStart=0, charEnd=10)
+        assert r.char_start == 0
+        assert r.char_end == 10
+
+    def test_construct_from_snake_name(self) -> None:
+        r = PDFTextRange(page=2, char_start=3, char_end=3)
+        assert r.char_start == 3
+
+    def test_page_min_just_inside(self) -> None:
+        assert PDFTextRange(page=1, charStart=0, charEnd=0).page == 1
+
+    def test_page_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PDFTextRange(page=0, charStart=0, charEnd=0)
+
+    def test_char_start_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PDFTextRange(page=1, charStart=-1, charEnd=0)
+
+    def test_char_end_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PDFTextRange(page=1, charStart=0, charEnd=-1)
+
+    def test_equal_range_accepted(self) -> None:
+        r = PDFTextRange(page=1, charStart=5, charEnd=5)
+        assert r.char_start == r.char_end
+
+    def test_greater_range_accepted(self) -> None:
+        r = PDFTextRange(page=1, charStart=5, charEnd=9)
+        assert r.char_end > r.char_start
+
+    def test_end_before_start_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            PDFTextRange(page=1, charStart=10, charEnd=9)
+        assert "charEnd must be >= charStart" in str(exc.value)
+
+    def test_dump_by_alias_is_camel(self) -> None:
+        wire = PDFTextRange(page=1, char_start=0, char_end=4).model_dump(by_alias=True)
+        assert "charStart" in wire
+        assert "charEnd" in wire
+
+
+# =================== PDFRect ===================
+
+
+class TestPDFRect:
+    def test_construction(self) -> None:
+        rect = PDFRect(x=1.0, y=2.0, width=3.0, height=4.0)
+        assert rect.x == 1.0
+        assert rect.height == 4.0
+
+    def test_missing_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PDFRect(x=1.0, y=2.0, width=3.0)  # type: ignore[call-arg]
+
+
+# =================== CitationAnchor discriminated union ===================
+
+
+class TestCitationAnchorUnion:
+    def test_text_kind_resolves(self) -> None:
+        anchor = CITATION_UNION.validate_python(
+            {
+                "kind": "text",
+                "range": {"page": 1, "charStart": 0, "charEnd": 5},
+                "quote": "hi",
+            }
+        )
+        assert isinstance(anchor, TextCitationAnchor)
+
+    def test_region_kind_resolves(self) -> None:
+        anchor = CITATION_UNION.validate_python(
+            {
+                "kind": "region",
+                "page": 2,
+                "rect": {"x": 0, "y": 0, "width": 1, "height": 1},
+            }
+        )
+        assert isinstance(anchor, RegionCitationAnchor)
+
+    def test_hybrid_kind_resolves(self) -> None:
+        anchor = CITATION_UNION.validate_python(
+            {
+                "kind": "hybrid",
+                "range": {"page": 1, "charStart": 0, "charEnd": 5},
+                "rect": {"x": 0, "y": 0, "width": 1, "height": 1},
+                "quote": "q",
+            }
+        )
+        assert isinstance(anchor, HybridCitationAnchor)
+
+    def test_unknown_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CITATION_UNION.validate_python({"kind": "nope"})
+
+    def test_missing_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CITATION_UNION.validate_python({"range": {"page": 1, "charStart": 0, "charEnd": 5}})
+
+    def test_region_page_min_just_inside(self) -> None:
+        anchor = CITATION_UNION.validate_python(
+            {
+                "kind": "region",
+                "page": 1,
+                "rect": {"x": 0, "y": 0, "width": 1, "height": 1},
+            }
+        )
+        assert isinstance(anchor, RegionCitationAnchor)
+        assert anchor.page == 1
+
+    def test_region_page_below_min_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CITATION_UNION.validate_python(
+                {
+                    "kind": "region",
+                    "page": 0,
+                    "rect": {"x": 0, "y": 0, "width": 1, "height": 1},
+                }
+            )
+
+    def test_hybrid_requires_quote(self) -> None:
+        with pytest.raises(ValidationError):
+            CITATION_UNION.validate_python(
+                {
+                    "kind": "hybrid",
+                    "range": {"page": 1, "charStart": 0, "charEnd": 5},
+                    "rect": {"x": 0, "y": 0, "width": 1, "height": 1},
+                }
+            )
+
+
+# =================== PositionV1 + parse_position ===================
+
+
+def _valid_position_dict() -> dict[str, object]:
+    return {
+        "version": 1,
+        "anchor": {
+            "kind": "text",
+            "range": {"page": 1, "charStart": 0, "charEnd": 5},
+        },
+    }
+
+
+class TestPositionV1:
+    def test_round_trip_valid(self) -> None:
+        pos = PositionV1.model_validate(_valid_position_dict())
+        assert pos.version == 1
+        assert isinstance(pos.anchor, TextCitationAnchor)
+        wire = pos.model_dump(by_alias=True)
+        assert wire["version"] == 1
+        assert wire["anchor"]["kind"] == "text"
+
+    def test_version_2_rejected(self) -> None:
+        bad = _valid_position_dict()
+        bad["version"] = 2
+        with pytest.raises(ValidationError):
+            PositionV1.model_validate(bad)
+
+    def test_bad_anchor_kind_rejected(self) -> None:
+        bad = _valid_position_dict()
+        bad["anchor"] = {"kind": "bogus"}
+        with pytest.raises(ValidationError):
+            PositionV1.model_validate(bad)
+
+
+class TestParsePosition:
+    def test_none_returns_none(self) -> None:
+        assert parse_position(None) is None
+
+    def test_valid_dict_returns_model(self) -> None:
+        pos = parse_position(_valid_position_dict())
+        assert isinstance(pos, PositionV1)
+        assert pos.version == 1
+
+    def test_invalid_dict_raises(self) -> None:
+        bad = _valid_position_dict()
+        bad["version"] = 99
+        with pytest.raises(ValidationError):
+            parse_position(bad)
+
+    def test_invalid_anchor_range_raises(self) -> None:
+        # charEnd < charStart propagates through the nested validator.
+        bad = {
+            "version": 1,
+            "anchor": {
+                "kind": "text",
+                "range": {"page": 1, "charStart": 10, "charEnd": 1},
+            },
+        }
+        with pytest.raises(ValidationError):
+            parse_position(bad)
+
+
+# =================== Literal fields ===================
+
+
+def _field_schema_kw(**kw: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "id": uuid4(),
+        "name": "f",
+        "label": "F",
+        "fieldType": "text",
+    }
+    base.update(kw)
+    return base
+
+
+def _entity_type_kw(**kw: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "id": uuid4(),
+        "name": "et",
+        "label": "ET",
+        "cardinality": "one",
+    }
+    base.update(kw)
+    return base
+
+
+class TestExtractionFieldSchema:
+    def test_sort_order_default(self) -> None:
+        f = ExtractionFieldSchema(**_field_schema_kw())
+        assert f.sort_order == 0
+        assert f.is_required is False
+
+    def test_construct_from_snake(self) -> None:
+        f = ExtractionFieldSchema(
+            id=uuid4(),
+            name="f",
+            label="F",
+            field_type="number",
+            is_required=True,
+            sort_order=3,
+        )
+        assert f.field_type == "number"
+        assert f.sort_order == 3
+
+    def test_dump_by_alias_is_camel(self) -> None:
+        wire = ExtractionFieldSchema(**_field_schema_kw()).model_dump(by_alias=True)
+        assert "fieldType" in wire
+        assert "sortOrder" in wire
+        assert "isRequired" in wire
+
+
+class TestExtractionEntityTypeSchema:
+    def test_cardinality_one_and_many(self) -> None:
+        assert ExtractionEntityTypeSchema(**_entity_type_kw(cardinality="one")).cardinality == "one"
+        assert (
+            ExtractionEntityTypeSchema(**_entity_type_kw(cardinality="many")).cardinality == "many"
+        )
+
+    def test_cardinality_invalid_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionEntityTypeSchema(**_entity_type_kw(cardinality="zero"))
+
+    def test_role_default(self) -> None:
+        et = ExtractionEntityTypeSchema(**_entity_type_kw())
+        assert et.role == "study_section"
+
+    def test_role_all_valid_literals(self) -> None:
+        for role in ("study_section", "model_container", "model_section"):
+            et = ExtractionEntityTypeSchema(**_entity_type_kw(role=role))
+            assert et.role == role
+
+    def test_role_invalid_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionEntityTypeSchema(**_entity_type_kw(role="unknown_role"))
+
+    def test_sort_order_default(self) -> None:
+        et = ExtractionEntityTypeSchema(**_entity_type_kw())
+        assert et.sort_order == 0
+        assert et.fields == []
+
+
+class TestExtractionTemplateSchema:
+    def test_framework_all_valid_literals(self) -> None:
+        for fw in ("CHARMS", "PICOS", "CUSTOM"):
+            tpl = ExtractionTemplateSchema(
+                id=uuid4(),
+                name="t",
+                framework=fw,
+                version="1.0",
+            )
+            assert tpl.framework == fw
+
+    def test_framework_invalid_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionTemplateSchema(
+                id=uuid4(),
+                name="t",
+                framework="GRADE",
+                version="1.0",
+            )
+
+    def test_entity_types_default_and_alias(self) -> None:
+        tpl = ExtractionTemplateSchema(
+            id=uuid4(),
+            name="t",
+            framework="CHARMS",
+            version="1.0",
+        )
+        assert tpl.entity_types == []
+        wire = tpl.model_dump(by_alias=True)
+        assert "entityTypes" in wire
+
+
+class TestSaveValueRequest:
+    def test_source_default_human(self) -> None:
+        v = SaveValueRequest(instanceId=uuid4(), fieldId=uuid4(), value="x")
+        assert v.source == "human"
+
+    def test_source_all_valid_literals(self) -> None:
+        for src in ("human", "ai", "rule"):
+            v = SaveValueRequest(
+                instanceId=uuid4(),
+                fieldId=uuid4(),
+                value="x",
+                source=src,
+            )
+            assert v.source == src
+
+    def test_source_invalid_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SaveValueRequest(
+                instanceId=uuid4(),
+                fieldId=uuid4(),
+                value="x",
+                source="machine",
+            )
+
+    def test_construct_from_snake(self) -> None:
+        v = SaveValueRequest(instance_id=uuid4(), field_id=uuid4(), value=1)
+        assert v.evidence == []
+
+
+class TestReviewSuggestionRequest:
+    def test_status_valid_literals(self) -> None:
+        for st in ("accepted", "rejected"):
+            req = ReviewSuggestionRequest(status=st)
+            assert req.status == st
+
+    def test_status_pending_rejected(self) -> None:
+        # ReviewSuggestionRequest only allows accepted/rejected (not pending).
+        with pytest.raises(ValidationError):
+            ReviewSuggestionRequest(status="pending")
+
+    def test_modified_value_alias(self) -> None:
+        req = ReviewSuggestionRequest(status="accepted", modifiedValue=42)
+        assert req.modified_value == 42
+        wire = req.model_dump(by_alias=True)
+        assert "modifiedValue" in wire
+
+
+# =================== Remaining public classes (construction coverage) ===================
+
+
+class TestRemainingConstruction:
+    def test_create_model_hierarchy_request(self) -> None:
+        req = CreateModelHierarchyRequest(
+            projectId=uuid4(),
+            articleId=uuid4(),
+            templateId=uuid4(),
+            modelName="Cox PH",
+        )
+        assert req.model_name == "Cox PH"
+        assert req.modelling_method is None
+
+    def test_model_hierarchy_child_response(self) -> None:
+        child = ModelHierarchyChildResponse(
+            id=uuid4(),
+            entityTypeId=uuid4(),
+            parentInstanceId=uuid4(),
+            label="Predictors",
+        )
+        assert child.label == "Predictors"
+
+    def test_create_model_hierarchy_response(self) -> None:
+        resp = CreateModelHierarchyResponse(
+            modelId=uuid4(),
+            modelLabel="Model A",
+            childInstances=[],
+        )
+        assert resp.proposal_run_id is None
+        assert resp.child_instances == []
+
+    def test_model_extraction_request(self) -> None:
+        req = ModelExtractionRequest(
+            projectId=uuid4(),
+            articleId=uuid4(),
+            templateId=uuid4(),
+        )
+        assert req.model == "gpt-4o-mini"
+        assert req.options is None
+
+    def test_identified_model(self) -> None:
+        m = IdentifiedModel(modelName="Logistic")
+        assert m.performance_metrics == {}
+        assert m.model_type is None
+
+    def test_created_model_info(self) -> None:
+        info = CreatedModelInfo(instanceId="i1", modelName="Cox")
+        assert info.instance_id == "i1"
+
+    def test_model_extraction_run_stats(self) -> None:
+        stats = ModelExtractionRunStats(
+            duration=1,
+            modelsFound=2,
+            tokensPrompt=3,
+            tokensCompletion=4,
+            tokensTotal=7,
+        )
+        assert stats.tokens_total == 7
+
+    def test_create_instance_request(self) -> None:
+        req = CreateInstanceRequest(
+            projectId=uuid4(),
+            articleId=uuid4(),
+            templateId=uuid4(),
+            entityTypeId=uuid4(),
+            label="Instance 1",
+        )
+        assert req.metadata == {}
+        assert req.parent_instance_id is None
+
+    def test_instance_response_from_camel(self) -> None:
+        now = "2026-06-13T00:00:00Z"
+        resp = InstanceResponse(
+            id=uuid4(),
+            projectId=uuid4(),
+            templateId=uuid4(),
+            entityTypeId=uuid4(),
+            label="L",
+            status="draft",
+            sortOrder=0,
+            createdAt=now,
+            updatedAt=now,
+        )
+        assert resp.article_id is None
+        assert resp.status == "draft"
+
+    def test_value_response_from_camel(self) -> None:
+        now = "2026-06-13T00:00:00Z"
+        resp = ValueResponse(
+            id=uuid4(),
+            instanceId=uuid4(),
+            fieldId=uuid4(),
+            value="v",
+            source="ai",
+            createdAt=now,
+            updatedAt=now,
+        )
+        assert resp.is_consensus is False
+        assert resp.confidence_score is None
+
+    def test_suggestion_response_status_literals(self) -> None:
+        now = "2026-06-13T00:00:00Z"
+        for st in ("pending", "accepted", "rejected"):
+            resp = SuggestionResponse(
+                id=uuid4(),
+                extractionRunId=uuid4(),
+                fieldId=uuid4(),
+                suggestedValue="v",
+                status=st,
+                createdAt=now,
+            )
+            assert resp.status == st
+
+    def test_suggestion_response_invalid_status_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SuggestionResponse(
+                id=uuid4(),
+                extractionRunId=uuid4(),
+                fieldId=uuid4(),
+                suggestedValue="v",
+                status="approved",
+                createdAt="2026-06-13T00:00:00Z",
+            )
+
+    def test_section_outcome_light_construction(self) -> None:
+        # Wire shape pinned in test_typed_envelope_schemas; just a smoke
+        # construction here for full-class coverage.
+        out = SectionOutcome(entity_type_id="et1", success=True)
+        assert out.suggestions_created == 0
+        assert out.skipped is False
+
+    def test_single_section_result_light_construction(self) -> None:
+        res = SingleSectionResult(
+            extractionRunId="r1",
+            suggestionsCreated=1,
+            entityTypeId="et1",
+            tokensPrompt=1,
+            tokensCompletion=1,
+            tokensTotal=2,
+            durationMs=1.0,
+        )
+        assert res.mode == "single"
+
+    def test_batch_section_result_light_construction(self) -> None:
+        res = BatchSectionResult(
+            extractionRunId="r1",
+            totalSections=0,
+            successfulSections=0,
+            failedSections=0,
+            totalSuggestionsCreated=0,
+            totalTokensUsed=0,
+            durationMs=1.0,
+        )
+        assert res.mode == "batch"
+        assert res.sections == []
+
+    def test_model_extraction_result_light_construction(self) -> None:
+        res = ModelExtractionResult(
+            extractionRunId="r1",
+            modelsCreated=[],
+            totalModels=0,
+            childInstancesCreated=0,
+            metadata=ModelExtractionRunStats(
+                duration=1,
+                modelsFound=0,
+                tokensPrompt=0,
+                tokensCompletion=0,
+                tokensTotal=0,
+            ),
+        )
+        assert res.total_models == 0

--- a/backend/tests/unit/test_hitl_config_schemas.py
+++ b/backend/tests/unit/test_hitl_config_schemas.py
@@ -1,0 +1,160 @@
+"""Pure validation tests for app.schemas.hitl_config."""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.hitl_config import (
+    HitlConfigPayload,
+    HitlConfigRead,
+    HitlConfigUpdateResponse,
+)
+
+
+# --------------------------------------------------------------------------- #
+# HitlConfigPayload
+# --------------------------------------------------------------------------- #
+class TestHitlConfigPayload:
+    def test_valid_unanimous(self) -> None:
+        payload = HitlConfigPayload(reviewer_count=1, consensus_rule="unanimous")
+        assert payload.consensus_rule == "unanimous"
+        assert payload.arbitrator_id is None
+
+    def test_valid_majority(self) -> None:
+        payload = HitlConfigPayload(reviewer_count=3, consensus_rule="majority")
+        assert payload.consensus_rule == "majority"
+
+    # --- reviewer_count boundaries (ge=1, le=20) --- #
+    def test_reviewer_count_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HitlConfigPayload(reviewer_count=0, consensus_rule="unanimous")
+
+    def test_reviewer_count_min_accepted(self) -> None:
+        assert HitlConfigPayload(reviewer_count=1, consensus_rule="majority").reviewer_count == 1
+
+    def test_reviewer_count_max_accepted(self) -> None:
+        assert HitlConfigPayload(reviewer_count=20, consensus_rule="majority").reviewer_count == 20
+
+    def test_reviewer_count_over_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HitlConfigPayload(reviewer_count=21, consensus_rule="majority")
+
+    def test_reviewer_count_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HitlConfigPayload(reviewer_count=-1, consensus_rule="majority")
+
+    # --- consensus_rule literal --- #
+    @pytest.mark.parametrize("rule", ["unanimous", "majority"])
+    def test_non_arbitrator_rules_without_arbitrator_id(self, rule: str) -> None:
+        payload = HitlConfigPayload(reviewer_count=2, consensus_rule=rule)
+        assert payload.arbitrator_id is None
+
+    def test_invalid_consensus_rule_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HitlConfigPayload(reviewer_count=2, consensus_rule="dictator")
+
+    # --- arbitrator cross-field validator --- #
+    def test_arbitrator_rule_without_id_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            HitlConfigPayload(reviewer_count=2, consensus_rule="arbitrator")
+        assert "arbitrator_id is required" in str(exc.value)
+
+    def test_arbitrator_rule_with_id_accepted(self) -> None:
+        aid = uuid4()
+        payload = HitlConfigPayload(
+            reviewer_count=2, consensus_rule="arbitrator", arbitrator_id=aid
+        )
+        assert payload.arbitrator_id == aid
+
+    def test_arbitrator_id_ignored_for_non_arbitrator_rule(self) -> None:
+        # Supplying arbitrator_id with a non-arbitrator rule is allowed.
+        aid = uuid4()
+        payload = HitlConfigPayload(reviewer_count=2, consensus_rule="majority", arbitrator_id=aid)
+        assert payload.arbitrator_id == aid
+
+    def test_missing_consensus_rule_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HitlConfigPayload(reviewer_count=2)  # type: ignore[call-arg]
+
+
+# --------------------------------------------------------------------------- #
+# HitlConfigRead
+# --------------------------------------------------------------------------- #
+class TestHitlConfigRead:
+    @staticmethod
+    def _kwargs(**kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "scope_kind": "project",
+            "scope_id": uuid4(),
+            "reviewer_count": 1,
+            "consensus_rule": "unanimous",
+            "arbitrator_id": None,
+            "inherited": False,
+        }
+        base.update(kw)
+        return base
+
+    @pytest.mark.parametrize("scope", ["project", "template", "system_default"])
+    def test_valid_scope_kinds(self, scope: str) -> None:
+        read = HitlConfigRead(**self._kwargs(scope_kind=scope))
+        assert read.scope_kind == scope
+
+    def test_invalid_scope_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HitlConfigRead(**self._kwargs(scope_kind="global"))
+
+    @pytest.mark.parametrize("rule", ["unanimous", "majority", "arbitrator"])
+    def test_valid_consensus_rules(self, rule: str) -> None:
+        # HitlConfigRead has no arbitrator cross-field validator; arbitrator
+        # without id is a valid read shape.
+        read = HitlConfigRead(**self._kwargs(consensus_rule=rule))
+        assert read.consensus_rule == rule
+
+    def test_invalid_consensus_rule_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HitlConfigRead(**self._kwargs(consensus_rule="dictator"))
+
+    def test_scope_id_none_accepted(self) -> None:
+        read = HitlConfigRead(**self._kwargs(scope_kind="system_default", scope_id=None))
+        assert read.scope_id is None
+
+    def test_default_scope_id_is_none(self) -> None:
+        kwargs = self._kwargs()
+        del kwargs["scope_id"]
+        read = HitlConfigRead(**kwargs)
+        assert read.scope_id is None
+
+    def test_default_arbitrator_id_is_none(self) -> None:
+        kwargs = self._kwargs()
+        del kwargs["arbitrator_id"]
+        read = HitlConfigRead(**kwargs)
+        assert read.arbitrator_id is None
+
+    def test_missing_inherited_rejected(self) -> None:
+        kwargs = self._kwargs()
+        del kwargs["inherited"]
+        with pytest.raises(ValidationError):
+            HitlConfigRead(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# HitlConfigUpdateResponse
+# --------------------------------------------------------------------------- #
+class TestHitlConfigUpdateResponse:
+    def test_valid_construction(self) -> None:
+        config = HitlConfigRead(
+            scope_kind="template",
+            scope_id=uuid4(),
+            reviewer_count=2,
+            consensus_rule="majority",
+            arbitrator_id=None,
+            inherited=True,
+        )
+        resp = HitlConfigUpdateResponse(config=config)
+        assert resp.config.scope_kind == "template"
+        assert resp.config.inherited is True
+
+    def test_missing_config_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HitlConfigUpdateResponse()  # type: ignore[call-arg]

--- a/backend/tests/unit/test_hitl_session_schemas.py
+++ b/backend/tests/unit/test_hitl_session_schemas.py
@@ -1,0 +1,198 @@
+"""Pure validation tests for app.schemas.hitl_session."""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.hitl_session import (
+    CloneTemplateRequest,
+    CloneTemplateResponse,
+    OpenHITLSessionRequest,
+    OpenHITLSessionResponse,
+    UpdateTemplateActiveRequest,
+    UpdateTemplateActiveResponse,
+)
+
+
+# --------------------------------------------------------------------------- #
+# OpenHITLSessionRequest
+# --------------------------------------------------------------------------- #
+class TestOpenHITLSessionRequest:
+    @staticmethod
+    def _kwargs(**kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "kind": "extraction",
+            "project_id": uuid4(),
+            "article_id": uuid4(),
+            "project_template_id": uuid4(),
+        }
+        base.update(kw)
+        return base
+
+    @pytest.mark.parametrize("kind", ["extraction", "quality_assessment"])
+    def test_valid_kinds_accepted(self, kind: str) -> None:
+        req = OpenHITLSessionRequest(**self._kwargs(kind=kind))
+        assert req.kind == kind
+
+    @pytest.mark.parametrize("kind", ["extract", "qa", "EXTRACTION", ""])
+    def test_invalid_kind_rejected(self, kind: str) -> None:
+        with pytest.raises(ValidationError):
+            OpenHITLSessionRequest(**self._kwargs(kind=kind))
+
+    def test_only_project_template_pointer_accepted(self) -> None:
+        req = OpenHITLSessionRequest(**self._kwargs(global_template_id=None))
+        assert req.project_template_id is not None
+        assert req.global_template_id is None
+
+    def test_only_global_template_pointer_accepted(self) -> None:
+        gid = uuid4()
+        req = OpenHITLSessionRequest(
+            **self._kwargs(project_template_id=None, global_template_id=gid)
+        )
+        assert req.project_template_id is None
+        assert req.global_template_id == gid
+
+    def test_both_pointers_accepted(self) -> None:
+        # The validator only forbids *neither* being set; both is allowed.
+        req = OpenHITLSessionRequest(**self._kwargs(global_template_id=uuid4()))
+        assert req.project_template_id is not None
+        assert req.global_template_id is not None
+
+    def test_no_template_pointer_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            OpenHITLSessionRequest(
+                **self._kwargs(project_template_id=None, global_template_id=None)
+            )
+        assert "project_template_id or global_template_id" in str(exc.value)
+
+    def test_missing_project_id_rejected(self) -> None:
+        kwargs = self._kwargs()
+        del kwargs["project_id"]
+        with pytest.raises(ValidationError):
+            OpenHITLSessionRequest(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# OpenHITLSessionResponse
+# --------------------------------------------------------------------------- #
+class TestOpenHITLSessionResponse:
+    @staticmethod
+    def _kwargs(**kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "run_id": uuid4(),
+            "kind": "extraction",
+            "project_template_id": uuid4(),
+            "instances_by_entity_type": {"et-1": "inst-1"},
+        }
+        base.update(kw)
+        return base
+
+    def test_valid_default_run_view_none(self) -> None:
+        resp = OpenHITLSessionResponse(**self._kwargs())
+        assert resp.run_view is None
+        assert resp.instances_by_entity_type == {"et-1": "inst-1"}
+
+    @pytest.mark.parametrize("kind", ["extraction", "quality_assessment"])
+    def test_valid_kinds(self, kind: str) -> None:
+        resp = OpenHITLSessionResponse(**self._kwargs(kind=kind))
+        assert resp.kind == kind
+
+    def test_invalid_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            OpenHITLSessionResponse(**self._kwargs(kind="bogus"))
+
+    def test_empty_instances_map_accepted(self) -> None:
+        resp = OpenHITLSessionResponse(**self._kwargs(instances_by_entity_type={}))
+        assert resp.instances_by_entity_type == {}
+
+    def test_missing_run_id_rejected(self) -> None:
+        kwargs = self._kwargs()
+        del kwargs["run_id"]
+        with pytest.raises(ValidationError):
+            OpenHITLSessionResponse(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CloneTemplateRequest
+# --------------------------------------------------------------------------- #
+class TestCloneTemplateRequest:
+    @pytest.mark.parametrize("kind", ["extraction", "quality_assessment"])
+    def test_valid_kinds_accepted(self, kind: str) -> None:
+        req = CloneTemplateRequest(global_template_id=uuid4(), kind=kind)
+        assert req.kind == kind
+
+    @pytest.mark.parametrize("kind", ["extract", "qa", "", "Extraction"])
+    def test_invalid_kind_rejected(self, kind: str) -> None:
+        with pytest.raises(ValidationError):
+            CloneTemplateRequest(global_template_id=uuid4(), kind=kind)
+
+    def test_missing_global_template_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CloneTemplateRequest(kind="extraction")  # type: ignore[call-arg]
+
+
+# --------------------------------------------------------------------------- #
+# CloneTemplateResponse
+# --------------------------------------------------------------------------- #
+class TestCloneTemplateResponse:
+    def test_valid_construction(self) -> None:
+        resp = CloneTemplateResponse(
+            project_template_id=uuid4(),
+            version_id=uuid4(),
+            entity_type_count=3,
+            field_count=10,
+            created=True,
+        )
+        assert resp.entity_type_count == 3
+        assert resp.created is True
+
+    def test_int_coercion_from_str(self) -> None:
+        resp = CloneTemplateResponse(
+            project_template_id=uuid4(),
+            version_id=uuid4(),
+            entity_type_count="2",  # type: ignore[arg-type]
+            field_count="5",  # type: ignore[arg-type]
+            created=False,
+        )
+        assert resp.entity_type_count == 2
+        assert resp.field_count == 5
+
+    def test_missing_created_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CloneTemplateResponse(  # type: ignore[call-arg]
+                project_template_id=uuid4(),
+                version_id=uuid4(),
+                entity_type_count=1,
+                field_count=1,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# UpdateTemplateActiveRequest
+# --------------------------------------------------------------------------- #
+class TestUpdateTemplateActiveRequest:
+    def test_valid_true(self) -> None:
+        assert UpdateTemplateActiveRequest(is_active=True).is_active is True
+
+    def test_valid_false(self) -> None:
+        assert UpdateTemplateActiveRequest(is_active=False).is_active is False
+
+    def test_missing_is_active_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateTemplateActiveRequest()  # type: ignore[call-arg]
+
+
+# --------------------------------------------------------------------------- #
+# UpdateTemplateActiveResponse
+# --------------------------------------------------------------------------- #
+class TestUpdateTemplateActiveResponse:
+    def test_valid_construction(self) -> None:
+        tid = uuid4()
+        resp = UpdateTemplateActiveResponse(project_template_id=tid, is_active=True)
+        assert resp.project_template_id == tid
+        assert resp.is_active is True
+
+    def test_missing_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateTemplateActiveResponse(is_active=True)  # type: ignore[call-arg]

--- a/backend/tests/unit/test_project_read_models.py
+++ b/backend/tests/unit/test_project_read_models.py
@@ -1,0 +1,202 @@
+"""Validation tests for ``app.schemas.read_models.project``.
+
+Pure Pydantic-v2 validation: no DB, no async, no fixtures. Covers
+``from_attributes`` construction, documented defaults, nested member
+lists, and the two ``compute_*`` classmethods.
+"""
+
+import types
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.schemas.read_models.project import (
+    ProjectDetailReadModel,
+    ProjectListReadModel,
+    ProjectMemberReadModel,
+)
+
+NOW = datetime(2026, 6, 13, tzinfo=UTC)
+
+
+# =================== ProjectMemberReadModel ===================
+
+
+class TestProjectMemberReadModel:
+    def test_from_attributes(self) -> None:
+        attrs = types.SimpleNamespace(
+            user_id=uuid4(),
+            role="reviewer",
+            user_name="Alice",
+            user_email="a@b.com",
+            joined_at=NOW,
+        )
+        m = ProjectMemberReadModel.model_validate(attrs)
+        assert m.user_id == attrs.user_id
+        assert m.role == "reviewer"
+        assert m.user_name == "Alice"
+        assert m.user_email == "a@b.com"
+        assert m.joined_at == NOW
+
+    def test_optional_fields_default_none(self) -> None:
+        m = ProjectMemberReadModel(user_id=uuid4(), role="viewer")
+        assert m.user_name is None
+        assert m.user_email is None
+        assert m.joined_at is None
+
+
+# =================== ProjectListReadModel ===================
+
+
+def _list_attrs(**overrides: object) -> types.SimpleNamespace:
+    base = {
+        "id": uuid4(),
+        "name": "Proj",
+        "review_title": None,
+        "description": None,
+        "status": "active",
+        "org_id": uuid4(),
+        "org_name": "Org",
+        "articles_count": 10,
+        "members_count": 3,
+        "instruments_count": 1,
+        "templates_count": 2,
+        "articles_completed": 4,
+        "completion_percentage": 40.0,
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+class TestProjectListReadModel:
+    def test_from_attributes(self) -> None:
+        attrs = _list_attrs()
+        model = ProjectListReadModel.model_validate(attrs)
+        assert model.id == attrs.id
+        assert model.name == "Proj"
+        assert model.org_name == "Org"
+        assert model.articles_count == 10
+        assert model.completion_percentage == 40.0
+
+    def test_defaults(self) -> None:
+        model = ProjectListReadModel(
+            id=uuid4(),
+            name="Proj",
+            org_id=uuid4(),
+            created_at=NOW,
+        )
+        assert model.status == "active"
+        assert model.org_name is None
+        assert model.articles_count == 0
+        assert model.members_count == 0
+        assert model.instruments_count == 0
+        assert model.templates_count == 0
+        assert model.articles_completed == 0
+        assert model.completion_percentage == 0.0
+        assert model.review_title is None
+        assert model.updated_at is None
+
+    def test_compute_completion_zero_total(self) -> None:
+        # guards against ZeroDivisionError
+        assert ProjectListReadModel.compute_completion(0, 0) == 0.0
+
+    def test_compute_completion_partial(self) -> None:
+        assert ProjectListReadModel.compute_completion(1, 3) == 33.3
+
+    def test_compute_completion_full(self) -> None:
+        assert ProjectListReadModel.compute_completion(5, 5) == 100.0
+
+    def test_compute_completion_rounds_to_one_decimal(self) -> None:
+        # 2/3 = 66.666... -> rounded to 1 decimal place
+        assert ProjectListReadModel.compute_completion(2, 3) == 66.7
+
+
+# =================== ProjectDetailReadModel ===================
+
+
+def _detail_attrs(**overrides: object) -> types.SimpleNamespace:
+    base = {
+        "id": uuid4(),
+        "name": "Proj",
+        "review_title": "Title",
+        "description": "Desc",
+        "condition_studied": "Cond",
+        "eligibility_criteria": "crit",
+        "study_design": "design",
+        "status": "active",
+        "org_id": uuid4(),
+        "org_name": "Org",
+        "created_by_id": uuid4(),
+        "created_by_name": "Alice",
+        "members": [
+            types.SimpleNamespace(
+                user_id=uuid4(),
+                role="manager",
+                user_name="Alice",
+                user_email="a@b.com",
+                joined_at=NOW,
+            )
+        ],
+        "articles_total": 10,
+        "articles_pending": 2,
+        "articles_in_progress": 3,
+        "articles_completed": 5,
+        "extractions_total": 8,
+        "extractions_completed": 4,
+        "models_extracted": 1,
+        "extraction_progress": 50.0,
+        "overall_progress": 50.0,
+        "default_instrument_id": uuid4(),
+        "default_template_id": uuid4(),
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+class TestProjectDetailReadModel:
+    def test_from_attributes_with_nested_members(self) -> None:
+        attrs = _detail_attrs()
+        model = ProjectDetailReadModel.model_validate(attrs)
+        assert model.id == attrs.id
+        assert model.review_title == "Title"
+        assert model.condition_studied == "Cond"
+        assert model.articles_total == 10
+        assert model.extraction_progress == 50.0
+        assert len(model.members) == 1
+        assert isinstance(model.members[0], ProjectMemberReadModel)
+        assert model.members[0].role == "manager"
+
+    def test_defaults(self) -> None:
+        model = ProjectDetailReadModel(
+            id=uuid4(),
+            name="Proj",
+            org_id=uuid4(),
+            created_at=NOW,
+        )
+        assert model.status == "active"
+        assert model.members == []
+        assert model.articles_total == 0
+        assert model.articles_pending == 0
+        assert model.articles_in_progress == 0
+        assert model.articles_completed == 0
+        assert model.extractions_total == 0
+        assert model.extractions_completed == 0
+        assert model.models_extracted == 0
+        assert model.extraction_progress == 0.0
+        assert model.overall_progress == 0.0
+        assert model.created_by_id is None
+        assert model.default_instrument_id is None
+        assert model.default_template_id is None
+        assert model.updated_at is None
+
+    def test_compute_overall_progress_rounds_to_one_decimal(self) -> None:
+        assert ProjectDetailReadModel.compute_overall_progress(66.666) == 66.7
+
+    def test_compute_overall_progress_passthrough(self) -> None:
+        assert ProjectDetailReadModel.compute_overall_progress(50.0) == 50.0
+
+    def test_compute_overall_progress_zero(self) -> None:
+        assert ProjectDetailReadModel.compute_overall_progress(0.0) == 0.0

--- a/backend/tests/unit/test_project_schemas.py
+++ b/backend/tests/unit/test_project_schemas.py
@@ -1,0 +1,569 @@
+"""Validation tests for ``app.schemas.project``.
+
+Pure Pydantic-v2 validation: no DB, no async, no fixtures. These cover
+constraints, Literal/enum membership, defaults, and — most importantly —
+the camelCase alias wire shape (``populate_by_name=True`` + ``by_alias``),
+which is a recurring drift incident class in this repo.
+"""
+
+import types
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.project import (
+    AddMemberRequest,
+    MemberResponse,
+    PICOTSConfig,
+    ProjectCreate,
+    ProjectListItem,
+    ProjectListResponse,
+    ProjectResponse,
+    ProjectSettings,
+    ProjectUpdate,
+    TimingConfig,
+    UpdateMemberRequest,
+)
+
+# =================== TimingConfig ===================
+
+
+class TestTimingConfig:
+    def test_defaults_are_empty_strings(self) -> None:
+        cfg = TimingConfig()
+        assert cfg.prediction_moment == ""
+        assert cfg.prediction_horizon == ""
+
+    def test_populate_by_snake_case_name(self) -> None:
+        cfg = TimingConfig(prediction_moment="baseline", prediction_horizon="5y")
+        assert cfg.prediction_moment == "baseline"
+        assert cfg.prediction_horizon == "5y"
+
+    def test_populate_by_camel_case_alias(self) -> None:
+        cfg = TimingConfig(predictionMoment="baseline", predictionHorizon="5y")
+        assert cfg.prediction_moment == "baseline"
+        assert cfg.prediction_horizon == "5y"
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = TimingConfig(prediction_moment="m", prediction_horizon="h").model_dump(by_alias=True)
+        assert wire == {"predictionMoment": "m", "predictionHorizon": "h"}
+
+
+# =================== PICOTSConfig ===================
+
+
+class TestPICOTSConfig:
+    def test_defaults(self) -> None:
+        cfg = PICOTSConfig()
+        assert cfg.population == ""
+        assert cfg.index_models == ""
+        assert cfg.comparator_models == ""
+        assert cfg.outcomes == ""
+        assert cfg.setting_and_intended_use == ""
+        # timing built via default_factory
+        assert isinstance(cfg.timing, TimingConfig)
+        assert cfg.timing.prediction_moment == ""
+
+    def test_populate_by_snake_case_name(self) -> None:
+        cfg = PICOTSConfig(
+            population="adults",
+            index_models="model A",
+            comparator_models="model B",
+            outcomes="mortality",
+            setting_and_intended_use="ICU",
+        )
+        assert cfg.index_models == "model A"
+        assert cfg.comparator_models == "model B"
+        assert cfg.setting_and_intended_use == "ICU"
+
+    def test_populate_by_camel_case_alias(self) -> None:
+        cfg = PICOTSConfig(
+            population="adults",
+            indexModels="model A",
+            comparatorModels="model B",
+            outcomes="mortality",
+            settingAndIntendedUse="ICU",
+            timing={"predictionMoment": "baseline"},
+        )
+        assert cfg.index_models == "model A"
+        assert cfg.comparator_models == "model B"
+        assert cfg.setting_and_intended_use == "ICU"
+        assert cfg.timing.prediction_moment == "baseline"
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = PICOTSConfig(
+            index_models="A",
+            comparator_models="B",
+            setting_and_intended_use="ICU",
+        ).model_dump(by_alias=True)
+        assert wire["indexModels"] == "A"
+        assert wire["comparatorModels"] == "B"
+        assert wire["settingAndIntendedUse"] == "ICU"
+        # nested model is also camelCased
+        assert wire["timing"] == {"predictionMoment": "", "predictionHorizon": ""}
+
+
+# =================== ProjectSettings ===================
+
+
+class TestProjectSettings:
+    def test_defaults(self) -> None:
+        s = ProjectSettings()
+        assert s.blind_mode is False
+        assert s.require_dual_review is True
+        assert s.auto_consensus is False
+
+    def test_populate_by_snake_case_name(self) -> None:
+        s = ProjectSettings(blind_mode=True, require_dual_review=False, auto_consensus=True)
+        assert s.blind_mode is True
+        assert s.require_dual_review is False
+        assert s.auto_consensus is True
+
+    def test_populate_by_camel_case_alias(self) -> None:
+        s = ProjectSettings(blindMode=True, requireDualReview=False, autoConsensus=True)
+        assert s.blind_mode is True
+        assert s.require_dual_review is False
+        assert s.auto_consensus is True
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ProjectSettings().model_dump(by_alias=True)
+        assert wire == {
+            "blindMode": False,
+            "requireDualReview": True,
+            "autoConsensus": False,
+        }
+
+
+# =================== ProjectCreate ===================
+
+
+class TestProjectCreate:
+    def test_minimal_valid_construction_and_defaults(self) -> None:
+        p = ProjectCreate(name="My Review")
+        assert p.name == "My Review"
+        assert p.description is None
+        assert p.review_keywords == []
+        assert p.eligibility_criteria == {}
+        assert p.study_design == {}
+        assert p.review_type == "interventional"
+        assert p.picots_config_ai_review is None
+        assert isinstance(p.settings, ProjectSettings)
+        assert p.settings.require_dual_review is True
+
+    def test_name_min_length_boundary(self) -> None:
+        # one char inside the lower bound is accepted
+        assert ProjectCreate(name="a").name == "a"
+        # empty string is below min_length=1
+        with pytest.raises(ValidationError):
+            ProjectCreate(name="")
+
+    def test_name_max_length_boundary(self) -> None:
+        assert ProjectCreate(name="a" * 255).name == "a" * 255
+        with pytest.raises(ValidationError):
+            ProjectCreate(name="a" * 256)
+
+    def test_name_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ProjectCreate()  # type: ignore[call-arg]
+
+    def test_review_type_valid_member(self) -> None:
+        for value in (
+            "interventional",
+            "predictive_model",
+            "diagnostic",
+            "prognostic",
+            "qualitative",
+            "other",
+        ):
+            assert ProjectCreate(name="x", review_type=value).review_type == value
+
+    def test_review_type_invalid_member_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ProjectCreate(name="x", review_type="systematic")
+
+    def test_populate_by_camel_case_aliases(self) -> None:
+        p = ProjectCreate(
+            name="x",
+            reviewTitle="Title",
+            conditionStudied="Cond",
+            reviewRationale="Why",
+            reviewContext="Ctx",
+            searchStrategy="Strat",
+            reviewKeywords=["k1", "k2"],
+            eligibilityCriteria={"min_age": 18},
+            studyDesign={"kind": "rct"},
+            reviewType="diagnostic",
+            picotsConfigAiReview={"population": "adults"},
+        )
+        assert p.review_title == "Title"
+        assert p.condition_studied == "Cond"
+        assert p.review_rationale == "Why"
+        assert p.review_context == "Ctx"
+        assert p.search_strategy == "Strat"
+        assert p.review_keywords == ["k1", "k2"]
+        assert p.eligibility_criteria == {"min_age": 18}
+        assert p.study_design == {"kind": "rct"}
+        assert p.review_type == "diagnostic"
+        assert isinstance(p.picots_config_ai_review, PICOTSConfig)
+        assert p.picots_config_ai_review.population == "adults"
+
+    def test_populate_by_snake_case_names(self) -> None:
+        p = ProjectCreate(
+            name="x",
+            review_title="Title",
+            condition_studied="Cond",
+            review_keywords=["k1"],
+            review_type="prognostic",
+        )
+        assert p.review_title == "Title"
+        assert p.condition_studied == "Cond"
+        assert p.review_keywords == ["k1"]
+        assert p.review_type == "prognostic"
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ProjectCreate(name="x", review_title="T").model_dump(by_alias=True)
+        assert wire["reviewTitle"] == "T"
+        assert "reviewKeywords" in wire
+        assert "eligibilityCriteria" in wire
+        assert "studyDesign" in wire
+        assert wire["reviewType"] == "interventional"
+        assert "picotsConfigAiReview" in wire
+        # nested settings model is camelCased too
+        assert wire["settings"]["requireDualReview"] is True
+
+
+# =================== ProjectUpdate ===================
+
+
+class TestProjectUpdate:
+    def test_all_fields_optional_empty_construction(self) -> None:
+        u = ProjectUpdate()
+        assert u.name is None
+        assert u.description is None
+        assert u.is_active is None
+        assert u.review_keywords is None
+        assert u.review_type is None
+        assert u.settings is None
+
+    def test_name_min_length_boundary(self) -> None:
+        assert ProjectUpdate(name="a").name == "a"
+        with pytest.raises(ValidationError):
+            ProjectUpdate(name="")
+
+    def test_name_max_length_boundary(self) -> None:
+        assert ProjectUpdate(name="a" * 255).name == "a" * 255
+        with pytest.raises(ValidationError):
+            ProjectUpdate(name="a" * 256)
+
+    def test_review_type_invalid_member_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ProjectUpdate(review_type="bogus")
+
+    def test_populate_by_camel_case_aliases(self) -> None:
+        u = ProjectUpdate(
+            isActive=False,
+            reviewTitle="T",
+            conditionStudied="C",
+            reviewKeywords=["k"],
+            eligibilityCriteria={"a": 1},
+            studyDesign={"b": 2},
+            reviewType="qualitative",
+        )
+        assert u.is_active is False
+        assert u.review_title == "T"
+        assert u.condition_studied == "C"
+        assert u.review_keywords == ["k"]
+        assert u.eligibility_criteria == {"a": 1}
+        assert u.study_design == {"b": 2}
+        assert u.review_type == "qualitative"
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ProjectUpdate(is_active=True, review_title="T").model_dump(by_alias=True)
+        assert wire["isActive"] is True
+        assert wire["reviewTitle"] == "T"
+
+
+# =================== ProjectResponse ===================
+
+
+def _project_response_attrs() -> types.SimpleNamespace:
+    """A plain attribute object mimicking the ORM row for from_attributes."""
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+    return types.SimpleNamespace(
+        id=uuid4(),
+        name="Proj",
+        description=None,
+        created_by_id=uuid4(),
+        is_active=True,
+        review_title=None,
+        condition_studied=None,
+        review_rationale=None,
+        review_context=None,
+        search_strategy=None,
+        review_keywords=["k"],
+        eligibility_criteria={"a": 1},
+        study_design={"b": 2},
+        review_type="interventional",
+        picots_config_ai_review=None,
+        settings={"blind_mode": False},
+        created_at=now,
+        updated_at=now,
+        articles_count=3,
+        members_count=2,
+    )
+
+
+class TestProjectResponse:
+    def test_from_attributes(self) -> None:
+        attrs = _project_response_attrs()
+        resp = ProjectResponse.model_validate(attrs)
+        assert resp.name == "Proj"
+        assert resp.created_by_id == attrs.created_by_id
+        assert resp.is_active is True
+        assert resp.review_keywords == ["k"]
+        assert resp.settings == {"blind_mode": False}
+        assert resp.articles_count == 3
+        assert resp.members_count == 2
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        resp = ProjectResponse.model_validate(_project_response_attrs())
+        wire = resp.model_dump(by_alias=True)
+        assert "createdById" in wire
+        assert "isActive" in wire
+        assert "reviewKeywords" in wire
+        assert "eligibilityCriteria" in wire
+        assert "studyDesign" in wire
+        assert "reviewType" in wire
+        assert "picotsConfigAiReview" in wire
+        assert "createdAt" in wire
+        assert "updatedAt" in wire
+        assert "articlesCount" in wire
+        assert "membersCount" in wire
+
+    def test_optional_counters_default_none(self) -> None:
+        attrs = _project_response_attrs()
+        attrs.articles_count = None
+        attrs.members_count = None
+        resp = ProjectResponse.model_validate(attrs)
+        assert resp.articles_count is None
+        assert resp.members_count is None
+
+
+# =================== AddMemberRequest ===================
+
+
+class TestAddMemberRequest:
+    def test_minimal_valid_construction_and_defaults(self) -> None:
+        m = AddMemberRequest(email="alice@example.com")
+        assert m.email == "alice@example.com"
+        assert m.role == "reviewer"
+        assert m.permissions == {"can_export": False}
+        assert m.send_invitation is True
+
+    def test_invalid_email_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AddMemberRequest(email="not-an-email")
+
+    def test_role_valid_members(self) -> None:
+        for role in ("manager", "reviewer", "viewer", "consensus"):
+            assert AddMemberRequest(email="a@b.com", role=role).role == role
+
+    def test_role_invalid_member_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AddMemberRequest(email="a@b.com", role="admin")
+
+    def test_send_invitation_populate_by_alias(self) -> None:
+        m = AddMemberRequest(email="a@b.com", sendInvitation=False)
+        assert m.send_invitation is False
+
+    def test_send_invitation_populate_by_name(self) -> None:
+        m = AddMemberRequest(email="a@b.com", send_invitation=False)
+        assert m.send_invitation is False
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = AddMemberRequest(email="a@b.com").model_dump(by_alias=True)
+        assert "sendInvitation" in wire
+        assert wire["sendInvitation"] is True
+
+
+# =================== UpdateMemberRequest ===================
+
+
+class TestUpdateMemberRequest:
+    def test_empty_construction_defaults_none(self) -> None:
+        u = UpdateMemberRequest()
+        assert u.role is None
+        assert u.permissions is None
+
+    def test_role_valid_member(self) -> None:
+        assert UpdateMemberRequest(role="manager").role == "manager"
+
+    def test_role_invalid_member_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateMemberRequest(role="superuser")
+
+    def test_permissions_accepts_bool_dict(self) -> None:
+        u = UpdateMemberRequest(permissions={"can_export": True})
+        assert u.permissions == {"can_export": True}
+
+
+# =================== MemberResponse ===================
+
+
+def _member_response_attrs() -> types.SimpleNamespace:
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+    return types.SimpleNamespace(
+        id=uuid4(),
+        project_id=uuid4(),
+        user_id=uuid4(),
+        role="reviewer",
+        permissions={"can_export": False},
+        user_email="a@b.com",
+        user_name="Alice",
+        user_avatar=None,
+        invitation_email=None,
+        invitation_sent_at=None,
+        invitation_accepted_at=None,
+        created_at=now,
+    )
+
+
+class TestMemberResponse:
+    def test_from_attributes(self) -> None:
+        attrs = _member_response_attrs()
+        m = MemberResponse.model_validate(attrs)
+        assert m.project_id == attrs.project_id
+        assert m.user_id == attrs.user_id
+        assert m.role == "reviewer"
+        assert m.user_email == "a@b.com"
+        assert m.user_name == "Alice"
+
+    def test_optional_invitation_fields_default_none(self) -> None:
+        m = MemberResponse.model_validate(_member_response_attrs())
+        assert m.invitation_email is None
+        assert m.invitation_sent_at is None
+        assert m.invitation_accepted_at is None
+        assert m.user_avatar is None
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = MemberResponse.model_validate(_member_response_attrs()).model_dump(by_alias=True)
+        for key in (
+            "projectId",
+            "userId",
+            "userEmail",
+            "userName",
+            "userAvatar",
+            "invitationEmail",
+            "invitationSentAt",
+            "invitationAcceptedAt",
+            "createdAt",
+        ):
+            assert key in wire
+
+
+# =================== ProjectListItem ===================
+
+
+def _list_item_attrs() -> types.SimpleNamespace:
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+    return types.SimpleNamespace(
+        id=uuid4(),
+        name="Proj",
+        description=None,
+        is_active=True,
+        review_type="interventional",
+        articles_count=5,
+        members_count=2,
+        my_role="manager",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestProjectListItem:
+    def test_from_attributes(self) -> None:
+        item = ProjectListItem.model_validate(_list_item_attrs())
+        assert item.name == "Proj"
+        assert item.is_active is True
+        assert item.articles_count == 5
+        assert item.members_count == 2
+        assert item.my_role == "manager"
+
+    def test_count_defaults(self) -> None:
+        now = datetime(2026, 6, 13, tzinfo=UTC)
+        item = ProjectListItem(
+            id=uuid4(),
+            name="Proj",
+            is_active=True,
+            created_at=now,
+            updated_at=now,
+        )
+        assert item.articles_count == 0
+        assert item.members_count == 0
+        assert item.my_role is None
+        assert item.review_type == "interventional"
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ProjectListItem.model_validate(_list_item_attrs()).model_dump(by_alias=True)
+        for key in (
+            "isActive",
+            "reviewType",
+            "articlesCount",
+            "membersCount",
+            "myRole",
+            "createdAt",
+            "updatedAt",
+        ):
+            assert key in wire
+
+
+# =================== ProjectListResponse ===================
+
+
+class TestProjectListResponse:
+    def test_valid_construction_with_default_page(self) -> None:
+        resp = ProjectListResponse(
+            items=[],
+            total=0,
+            page_size=20,
+            has_more=False,
+        )
+        assert resp.items == []
+        assert resp.total == 0
+        assert resp.page == 1  # documented default
+        assert resp.page_size == 20
+        assert resp.has_more is False
+
+    def test_populate_by_camel_case_aliases(self) -> None:
+        resp = ProjectListResponse(
+            items=[],
+            total=10,
+            page=2,
+            pageSize=5,
+            hasMore=True,
+        )
+        assert resp.page == 2
+        assert resp.page_size == 5
+        assert resp.has_more is True
+
+    def test_nested_items_validated(self) -> None:
+        resp = ProjectListResponse(
+            items=[_list_item_attrs().__dict__],
+            total=1,
+            page_size=20,
+            has_more=False,
+        )
+        assert len(resp.items) == 1
+        assert isinstance(resp.items[0], ProjectListItem)
+
+    def test_dump_by_alias_emits_camel_case(self) -> None:
+        wire = ProjectListResponse(
+            items=[],
+            total=0,
+            page_size=20,
+            has_more=False,
+        ).model_dump(by_alias=True)
+        assert "pageSize" in wire
+        assert "hasMore" in wire

--- a/backend/tests/unit/test_user_api_key_schemas.py
+++ b/backend/tests/unit/test_user_api_key_schemas.py
@@ -1,0 +1,288 @@
+"""Pure validation tests for ``app.schemas.user_api_key``.
+
+Wire shapes for CreateAPIKeyResponse, KeyValidationResult and
+ListProvidersData are pinned in ``test_typed_envelope_schemas.py``; this
+file targets the untested surface: field constraints, aliases +
+populate_by_name round-trips, defaults, and the remaining response DTOs.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.user_api_key import SUPPORTED_PROVIDERS
+from app.schemas.user_api_key import (
+    APIKeyResponse,
+    CreateAPIKeyRequest,
+    CreateAPIKeyResponse,
+    DeleteAPIKeyResult,
+    KeyValidationResult,
+    ListAPIKeysData,
+    ListProvidersData,
+    ProviderInfo,
+    UpdateAPIKeyRequest,
+    UpdateAPIKeyResult,
+)
+
+
+class TestCreateAPIKeyRequest:
+    def test_minimal_valid_with_aliases(self) -> None:
+        req = CreateAPIKeyRequest.model_validate({"provider": "openai", "apiKey": "0123456789"})
+        assert req.provider == "openai"
+        assert req.api_key == "0123456789"
+
+    def test_populate_by_name_snake_case(self) -> None:
+        req = CreateAPIKeyRequest.model_validate({"provider": "anthropic", "api_key": "0123456789"})
+        assert req.api_key == "0123456789"
+
+    def test_dump_by_alias_is_camel_case(self) -> None:
+        req = CreateAPIKeyRequest.model_validate(
+            {"provider": "gemini", "apiKey": "0123456789", "keyName": "prod"}
+        )
+        wire = req.model_dump(by_alias=True)
+        assert wire["apiKey"] == "0123456789"
+        assert wire["keyName"] == "prod"
+        assert wire["isDefault"] is True
+        assert wire["validateKey"] is True
+        assert wire["metadata"] is None
+
+    def test_defaults(self) -> None:
+        req = CreateAPIKeyRequest.model_validate({"provider": "grok", "apiKey": "0123456789"})
+        assert req.is_default is True
+        assert req.validate_key is True
+        assert req.key_name is None
+        assert req.key_metadata is None
+
+    def test_api_key_min_length_boundary_accepted(self) -> None:
+        req = CreateAPIKeyRequest.model_validate(
+            {"provider": "openai", "apiKey": "1234567890"}  # exactly 10
+        )
+        assert len(req.api_key) == 10
+
+    def test_api_key_below_min_length_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateAPIKeyRequest.model_validate(
+                {"provider": "openai", "apiKey": "123456789"}  # 9 chars
+            )
+
+    def test_key_name_max_length_boundary_accepted(self) -> None:
+        req = CreateAPIKeyRequest.model_validate(
+            {"provider": "openai", "apiKey": "0123456789", "keyName": "x" * 100}
+        )
+        assert req.key_name is not None
+        assert len(req.key_name) == 100
+
+    def test_key_name_above_max_length_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateAPIKeyRequest.model_validate(
+                {"provider": "openai", "apiKey": "0123456789", "keyName": "x" * 101}
+            )
+
+    def test_provider_required(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateAPIKeyRequest.model_validate({"apiKey": "0123456789"})
+
+    @pytest.mark.parametrize("provider", list(SUPPORTED_PROVIDERS))
+    def test_supported_providers_accepted(self, provider: str) -> None:
+        req = CreateAPIKeyRequest.model_validate({"provider": provider, "apiKey": "0123456789"})
+        assert req.provider == provider
+
+    def test_unsupported_provider_is_not_rejected_by_schema(self) -> None:
+        """The schema does NOT validate provider against SUPPORTED_PROVIDERS.
+
+        ``provider`` is a plain ``str`` field; the allow-list is enforced
+        only by the DB CHECK constraint (see app.models.user_api_key).
+        Any string parses here.
+        """
+        req = CreateAPIKeyRequest.model_validate(
+            {"provider": "not-a-real-provider", "apiKey": "0123456789"}
+        )
+        assert req.provider == "not-a-real-provider"
+
+
+class TestUpdateAPIKeyRequest:
+    def test_all_fields_optional_empty_is_valid(self) -> None:
+        req = UpdateAPIKeyRequest.model_validate({})
+        assert req.is_default is None
+        assert req.is_active is None
+        assert req.key_name is None
+
+    def test_aliases_and_dump(self) -> None:
+        req = UpdateAPIKeyRequest.model_validate(
+            {"isDefault": True, "isActive": False, "keyName": "renamed"}
+        )
+        assert req.is_default is True
+        assert req.is_active is False
+        wire = req.model_dump(by_alias=True)
+        assert wire == {"isDefault": True, "isActive": False, "keyName": "renamed"}
+
+    def test_populate_by_name(self) -> None:
+        req = UpdateAPIKeyRequest.model_validate({"is_active": True})
+        assert req.is_active is True
+
+    def test_key_name_max_length_boundary_accepted(self) -> None:
+        req = UpdateAPIKeyRequest.model_validate({"keyName": "y" * 100})
+        assert req.key_name is not None
+        assert len(req.key_name) == 100
+
+    def test_key_name_above_max_length_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateAPIKeyRequest.model_validate({"keyName": "y" * 101})
+
+
+class TestAPIKeyResponse:
+    def _service_dict(self) -> dict[str, object]:
+        return {
+            "id": "k1",
+            "provider": "openai",
+            "key_name": "prod",
+            "is_active": True,
+            "is_default": False,
+            "validation_status": "valid",
+            "last_used_at": "2026-06-13T00:00:00Z",
+            "last_validated_at": None,
+            "created_at": "2026-06-01T00:00:00Z",
+        }
+
+    def test_validates_snake_case_and_dumps_camel(self) -> None:
+        resp = APIKeyResponse.model_validate(self._service_dict())
+        wire = resp.model_dump(by_alias=True)
+        assert wire["keyName"] == "prod"
+        assert wire["isActive"] is True
+        assert wire["isDefault"] is False
+        assert wire["validationStatus"] == "valid"
+        assert wire["lastUsedAt"] == "2026-06-13T00:00:00Z"
+        assert wire["lastValidatedAt"] is None
+        assert wire["createdAt"] == "2026-06-01T00:00:00Z"
+
+    def test_populate_by_camel_alias(self) -> None:
+        resp = APIKeyResponse.model_validate(
+            {
+                "id": "k2",
+                "provider": "grok",
+                "keyName": None,
+                "isActive": False,
+                "isDefault": True,
+                "validationStatus": None,
+                "lastUsedAt": None,
+                "lastValidatedAt": None,
+                "createdAt": "2026-06-02T00:00:00Z",
+            }
+        )
+        assert resp.key_name is None
+        assert resp.is_default is True
+
+    def test_missing_required_field_rejected(self) -> None:
+        bad = self._service_dict()
+        del bad["created_at"]
+        with pytest.raises(ValidationError):
+            APIKeyResponse.model_validate(bad)
+
+
+class TestCreateAPIKeyResponse:
+    def test_construction_and_alias_round_trip(self) -> None:
+        resp = CreateAPIKeyResponse.model_validate(
+            {
+                "id": "k1",
+                "provider": "openai",
+                "validation_status": "pending",
+                "validation_message": None,
+                "is_default": True,
+            }
+        )
+        wire = resp.model_dump(by_alias=True)
+        assert wire["validationStatus"] == "pending"
+        assert wire["validationMessage"] is None
+        assert wire["isDefault"] is True
+
+
+class TestListAPIKeysData:
+    def test_empty_list(self) -> None:
+        data = ListAPIKeysData.model_validate({"keys": []})
+        assert data.keys == []
+
+    def test_nested_response_round_trip(self) -> None:
+        data = ListAPIKeysData.model_validate(
+            {
+                "keys": [
+                    {
+                        "id": "k1",
+                        "provider": "openai",
+                        "keyName": "prod",
+                        "isActive": True,
+                        "isDefault": True,
+                        "validationStatus": "valid",
+                        "lastUsedAt": None,
+                        "lastValidatedAt": None,
+                        "createdAt": "2026-06-01T00:00:00Z",
+                    }
+                ]
+            }
+        )
+        assert len(data.keys) == 1
+        assert isinstance(data.keys[0], APIKeyResponse)
+        wire = data.model_dump(by_alias=True)
+        assert wire["keys"][0]["keyName"] == "prod"
+
+
+class TestUpdateAPIKeyResult:
+    def test_construction(self) -> None:
+        result = UpdateAPIKeyResult.model_validate({"id": "k1", "updated": True})
+        assert result.id == "k1"
+        assert result.updated is True
+
+    def test_missing_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateAPIKeyResult.model_validate({"id": "k1"})
+
+
+class TestDeleteAPIKeyResult:
+    def test_construction(self) -> None:
+        result = DeleteAPIKeyResult.model_validate({"id": "k1", "deleted": True})
+        assert result.id == "k1"
+        assert result.deleted is True
+
+
+class TestProviderInfo:
+    def test_validates_snake_and_dumps_camel(self) -> None:
+        info = ProviderInfo.model_validate(
+            {
+                "id": "openai",
+                "name": "OpenAI",
+                "description": "GPT models",
+                "docs_url": "https://example.com",
+            }
+        )
+        wire = info.model_dump(by_alias=True)
+        assert wire["docsUrl"] == "https://example.com"
+
+    def test_populate_by_camel_alias(self) -> None:
+        info = ProviderInfo.model_validate(
+            {
+                "id": "anthropic",
+                "name": "Anthropic",
+                "description": "Claude",
+                "docsUrl": "https://example.com/docs",
+            }
+        )
+        assert info.docs_url == "https://example.com/docs"
+
+
+class TestListProvidersData:
+    def test_empty_list(self) -> None:
+        data = ListProvidersData.model_validate({"providers": []})
+        assert data.providers == []
+
+
+class TestKeyValidationResult:
+    @pytest.mark.parametrize("status", ["valid", "invalid", "pending"])
+    def test_valid_literal_values(self, status: str) -> None:
+        result = KeyValidationResult.model_validate({"status": status, "message": "m"})
+        assert result.status == status
+
+    def test_invalid_literal_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            KeyValidationResult.model_validate({"status": "expired", "message": "m"})
+
+    def test_message_required(self) -> None:
+        with pytest.raises(ValidationError):
+            KeyValidationResult.model_validate({"status": "valid"})

--- a/backend/tests/unit/test_user_api_key_schemas.py
+++ b/backend/tests/unit/test_user_api_key_schemas.py
@@ -86,17 +86,19 @@ class TestCreateAPIKeyRequest:
         req = CreateAPIKeyRequest.model_validate({"provider": provider, "apiKey": "0123456789"})
         assert req.provider == provider
 
-    def test_unsupported_provider_is_not_rejected_by_schema(self) -> None:
-        """The schema does NOT validate provider against SUPPORTED_PROVIDERS.
+    def test_unsupported_provider_is_rejected_by_schema(self) -> None:
+        """The schema validates provider against SUPPORTED_PROVIDERS.
 
-        ``provider`` is a plain ``str`` field; the allow-list is enforced
-        only by the DB CHECK constraint (see app.models.user_api_key).
-        Any string parses here.
+        A ``field_validator`` enforces the allow-list at the boundary so an
+        unsupported value fails with a clean 422 ``ValidationError`` instead
+        of leaking out as a DB/500 at INSERT time. ``SUPPORTED_PROVIDERS``
+        (shared with the DB CHECK constraint) is the single source of truth.
         """
-        req = CreateAPIKeyRequest.model_validate(
-            {"provider": "not-a-real-provider", "apiKey": "0123456789"}
-        )
-        assert req.provider == "not-a-real-provider"
+        with pytest.raises(ValidationError) as exc_info:
+            CreateAPIKeyRequest.model_validate(
+                {"provider": "not-a-real-provider", "apiKey": "0123456789"}
+            )
+        assert any(error["loc"] == ("provider",) for error in exc_info.value.errors())
 
 
 class TestUpdateAPIKeyRequest:

--- a/backend/tests/unit/test_zotero_schemas.py
+++ b/backend/tests/unit/test_zotero_schemas.py
@@ -1,0 +1,557 @@
+"""Pure validation tests for ``app.schemas.zotero``.
+
+Wire shapes for SaveCredentialsResponse, TestConnectionResponse and
+DownloadAttachmentResponse are pinned in ``test_typed_envelope_schemas.py``;
+this file targets the untested surface: request-field constraints,
+Literal fields, aliases + populate_by_name round-trips, ``extra='allow'``
+preservation, and light construction of the remaining response DTOs.
+
+NOTE: ``TestConnection*`` classes carry a ``Test`` prefix, which makes
+pytest emit a harmless PytestCollectionWarning on import. That is
+expected (see test_typed_envelope_schemas.py) and not worked around.
+"""
+
+from datetime import datetime
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from app.schemas.zotero import (
+    DownloadAttachmentRequest,
+    FetchAttachmentsRequest,
+    FetchAttachmentsResponse,
+    FetchItemsRequest,
+    FetchItemsResponse,
+    ImportResult,
+    ImportToProjectRequest,
+    ImportToProjectResponse,
+    ListCollectionsResponse,
+    SaveCredentialsRequest,
+    SaveCredentialsResponse,
+    SyncCollectionRequest,
+    SyncCollectionResponse,
+    SyncCountsResponse,
+    SyncItemResultEntry,
+    SyncItemResultRequest,
+    SyncItemResultsResponse,
+    SyncRetryFailedRequest,
+    SyncRetryFailedResponse,
+    SyncStatusRequest,
+    SyncStatusResponse,
+    TestConnectionResponse,
+    ZoteroActionData,
+    ZoteroAttachment,
+    ZoteroCollection,
+    ZoteroCreator,
+    ZoteroItem,
+    ZoteroItemData,
+)
+
+# =================== REQUEST SCHEMAS ===================
+
+
+class TestSaveCredentialsRequest:
+    def test_valid_with_aliases(self) -> None:
+        req = SaveCredentialsRequest.model_validate(
+            {"zoteroUserId": "12345", "apiKey": "secret", "libraryType": "user"}
+        )
+        assert req.zotero_user_id == "12345"
+        assert req.api_key == "secret"
+        assert req.library_type == "user"
+
+    def test_populate_by_name(self) -> None:
+        req = SaveCredentialsRequest.model_validate(
+            {"zotero_user_id": "1", "api_key": "k", "library_type": "group"}
+        )
+        assert req.library_type == "group"
+
+    def test_dump_by_alias(self) -> None:
+        req = SaveCredentialsRequest.model_validate(
+            {"zoteroUserId": "1", "apiKey": "k", "libraryType": "user"}
+        )
+        wire = req.model_dump(by_alias=True)
+        assert wire == {"zoteroUserId": "1", "apiKey": "k", "libraryType": "user"}
+
+    def test_empty_zotero_user_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SaveCredentialsRequest.model_validate(
+                {"zoteroUserId": "", "apiKey": "k", "libraryType": "user"}
+            )
+
+    def test_empty_api_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SaveCredentialsRequest.model_validate(
+                {"zoteroUserId": "1", "apiKey": "", "libraryType": "user"}
+            )
+
+    @pytest.mark.parametrize("library_type", ["user", "group"])
+    def test_valid_library_types(self, library_type: str) -> None:
+        req = SaveCredentialsRequest.model_validate(
+            {"zoteroUserId": "1", "apiKey": "k", "libraryType": library_type}
+        )
+        assert req.library_type == library_type
+
+    def test_bad_library_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SaveCredentialsRequest.model_validate(
+                {"zoteroUserId": "1", "apiKey": "k", "libraryType": "shared"}
+            )
+
+
+class TestFetchItemsRequest:
+    def test_defaults(self) -> None:
+        req = FetchItemsRequest.model_validate({"collectionKey": "C1"})
+        assert req.limit == 100
+        assert req.start == 0
+
+    def test_populate_by_name(self) -> None:
+        req = FetchItemsRequest.model_validate({"collection_key": "C1"})
+        assert req.collection_key == "C1"
+
+    def test_empty_collection_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FetchItemsRequest.model_validate({"collectionKey": ""})
+
+    def test_limit_lower_boundary_accepted(self) -> None:
+        assert FetchItemsRequest.model_validate({"collectionKey": "C", "limit": 1}).limit == 1
+
+    def test_limit_upper_boundary_accepted(self) -> None:
+        assert FetchItemsRequest.model_validate({"collectionKey": "C", "limit": 100}).limit == 100
+
+    def test_limit_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FetchItemsRequest.model_validate({"collectionKey": "C", "limit": 0})
+
+    def test_limit_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FetchItemsRequest.model_validate({"collectionKey": "C", "limit": 101})
+
+    def test_start_lower_boundary_accepted(self) -> None:
+        assert FetchItemsRequest.model_validate({"collectionKey": "C", "start": 0}).start == 0
+
+    def test_start_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FetchItemsRequest.model_validate({"collectionKey": "C", "start": -1})
+
+
+class TestFetchAttachmentsRequest:
+    def test_valid_with_alias(self) -> None:
+        req = FetchAttachmentsRequest.model_validate({"itemKey": "I1"})
+        assert req.item_key == "I1"
+
+    def test_populate_by_name(self) -> None:
+        assert FetchAttachmentsRequest.model_validate({"item_key": "I1"}).item_key == "I1"
+
+    def test_empty_item_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FetchAttachmentsRequest.model_validate({"itemKey": ""})
+
+
+class TestDownloadAttachmentRequest:
+    def test_valid_with_alias(self) -> None:
+        req = DownloadAttachmentRequest.model_validate({"attachmentKey": "A1"})
+        assert req.attachment_key == "A1"
+
+    def test_empty_attachment_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            DownloadAttachmentRequest.model_validate({"attachmentKey": ""})
+
+
+class TestImportToProjectRequest:
+    def test_defaults(self) -> None:
+        req = ImportToProjectRequest.model_validate({"projectId": "p1", "collectionKey": "C1"})
+        assert req.item_keys == []
+        assert req.import_pdfs is True
+
+    def test_full_with_aliases_round_trip(self) -> None:
+        req = ImportToProjectRequest.model_validate(
+            {
+                "projectId": "p1",
+                "collectionKey": "C1",
+                "itemKeys": ["a", "b"],
+                "importPdfs": False,
+            }
+        )
+        assert req.item_keys == ["a", "b"]
+        wire = req.model_dump(by_alias=True)
+        assert wire["itemKeys"] == ["a", "b"]
+        assert wire["importPdfs"] is False
+
+
+class TestSyncCollectionRequest:
+    def test_defaults(self) -> None:
+        req = SyncCollectionRequest.model_validate({"projectId": "p1", "collectionKey": "C1"})
+        assert req.max_items == 1000
+        assert req.include_attachments is True
+        assert req.update_existing is True
+
+    def test_empty_collection_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncCollectionRequest.model_validate({"projectId": "p1", "collectionKey": ""})
+
+    def test_max_items_lower_boundary_accepted(self) -> None:
+        req = SyncCollectionRequest.model_validate(
+            {"projectId": "p1", "collectionKey": "C", "maxItems": 1}
+        )
+        assert req.max_items == 1
+
+    def test_max_items_upper_boundary_accepted(self) -> None:
+        req = SyncCollectionRequest.model_validate(
+            {"projectId": "p1", "collectionKey": "C", "maxItems": 10000}
+        )
+        assert req.max_items == 10000
+
+    def test_max_items_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncCollectionRequest.model_validate(
+                {"projectId": "p1", "collectionKey": "C", "maxItems": 0}
+            )
+
+    def test_max_items_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncCollectionRequest.model_validate(
+                {"projectId": "p1", "collectionKey": "C", "maxItems": 10001}
+            )
+
+
+class TestSyncStatusRequest:
+    def test_construction(self) -> None:
+        req = SyncStatusRequest.model_validate({"syncRunId": "s1"})
+        assert req.sync_run_id == "s1"
+
+
+class TestSyncRetryFailedRequest:
+    def test_default_limit(self) -> None:
+        req = SyncRetryFailedRequest.model_validate({"syncRunId": "s1"})
+        assert req.limit == 100
+
+    def test_limit_lower_boundary_accepted(self) -> None:
+        assert SyncRetryFailedRequest.model_validate({"syncRunId": "s", "limit": 1}).limit == 1
+
+    def test_limit_upper_boundary_accepted(self) -> None:
+        assert (
+            SyncRetryFailedRequest.model_validate({"syncRunId": "s", "limit": 1000}).limit == 1000
+        )
+
+    def test_limit_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncRetryFailedRequest.model_validate({"syncRunId": "s", "limit": 0})
+
+    def test_limit_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncRetryFailedRequest.model_validate({"syncRunId": "s", "limit": 1001})
+
+
+class TestSyncItemResultRequest:
+    def test_defaults(self) -> None:
+        req = SyncItemResultRequest.model_validate({"syncRunId": "s1"})
+        assert req.offset == 0
+        assert req.limit == 50
+        assert req.status_filter is None
+
+    def test_offset_lower_boundary_accepted(self) -> None:
+        assert SyncItemResultRequest.model_validate({"syncRunId": "s", "offset": 0}).offset == 0
+
+    def test_offset_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncItemResultRequest.model_validate({"syncRunId": "s", "offset": -1})
+
+    def test_limit_lower_boundary_accepted(self) -> None:
+        assert SyncItemResultRequest.model_validate({"syncRunId": "s", "limit": 1}).limit == 1
+
+    def test_limit_upper_boundary_accepted(self) -> None:
+        assert SyncItemResultRequest.model_validate({"syncRunId": "s", "limit": 200}).limit == 200
+
+    def test_limit_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncItemResultRequest.model_validate({"syncRunId": "s", "limit": 0})
+
+    def test_limit_above_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SyncItemResultRequest.model_validate({"syncRunId": "s", "limit": 201})
+
+
+# =================== RESPONSE / DATA SCHEMAS ===================
+
+
+class TestZoteroCreator:
+    def test_valid_with_aliases(self) -> None:
+        creator = ZoteroCreator.model_validate(
+            {"creatorType": "author", "firstName": "Ada", "lastName": "Lovelace"}
+        )
+        assert creator.creator_type == "author"
+        assert creator.first_name == "Ada"
+        wire = creator.model_dump(by_alias=True)
+        assert wire["creatorType"] == "author"
+        assert wire["firstName"] == "Ada"
+
+    def test_corporate_author_name_only(self) -> None:
+        creator = ZoteroCreator.model_validate({"creatorType": "author", "name": "ACME Corp"})
+        assert creator.name == "ACME Corp"
+        assert creator.first_name is None
+
+
+class TestZoteroItemData:
+    def test_valid_with_aliases(self) -> None:
+        data = ZoteroItemData.model_validate(
+            {"key": "K", "version": 1, "itemType": "journalArticle", "DOI": "10.1/x"}
+        )
+        assert data.item_type == "journalArticle"
+        assert data.doi == "10.1/x"
+
+    def test_populate_by_name(self) -> None:
+        data = ZoteroItemData.model_validate(
+            {"key": "K", "version": 1, "item_type": "journalArticle"}
+        )
+        assert data.item_type == "journalArticle"
+
+    def test_dump_by_alias(self) -> None:
+        data = ZoteroItemData.model_validate(
+            {
+                "key": "K",
+                "version": 1,
+                "itemType": "journalArticle",
+                "abstractNote": "abs",
+                "publicationTitle": "Nature",
+                "ISSN": "1234-5678",
+            }
+        )
+        wire = data.model_dump(by_alias=True)
+        assert wire["itemType"] == "journalArticle"
+        assert wire["abstractNote"] == "abs"
+        assert wire["publicationTitle"] == "Nature"
+        assert wire["ISSN"] == "1234-5678"
+
+    def test_extra_field_preserved(self) -> None:
+        data = ZoteroItemData.model_validate(
+            {"key": "K", "version": 1, "itemType": "book", "extraField": "kept"}
+        )
+        dumped = data.model_dump()
+        assert dumped["extraField"] == "kept"
+
+    def test_nested_creators(self) -> None:
+        data = ZoteroItemData.model_validate(
+            {
+                "key": "K",
+                "version": 1,
+                "itemType": "journalArticle",
+                "creators": [{"creatorType": "author", "lastName": "Turing"}],
+            }
+        )
+        assert data.creators[0].last_name == "Turing"
+
+
+class TestZoteroItem:
+    def test_valid_construction(self) -> None:
+        item = ZoteroItem.model_validate(
+            {
+                "key": "K",
+                "version": 1,
+                "library": {"id": 1},
+                "data": {"key": "K", "version": 1, "itemType": "book"},
+            }
+        )
+        assert item.links == {}
+        assert item.meta == {}
+        assert item.data.item_type == "book"
+
+    def test_extra_field_preserved(self) -> None:
+        item = ZoteroItem.model_validate(
+            {
+                "key": "K",
+                "version": 1,
+                "library": {"id": 1},
+                "data": {"key": "K", "version": 1, "itemType": "book"},
+                "topLevel": "kept",
+            }
+        )
+        assert item.model_dump()["topLevel"] == "kept"
+
+
+class TestZoteroCollection:
+    def test_valid_with_aliases(self) -> None:
+        col = ZoteroCollection.model_validate(
+            {
+                "key": "C",
+                "version": 1,
+                "name": "Refs",
+                "parentCollection": "P",
+                "numItems": 5,
+                "numCollections": 2,
+            }
+        )
+        assert col.parent_collection == "P"
+        assert col.num_items == 5
+        wire = col.model_dump(by_alias=True)
+        assert wire["parentCollection"] == "P"
+        assert wire["numItems"] == 5
+        assert wire["numCollections"] == 2
+
+    def test_populate_by_name(self) -> None:
+        col = ZoteroCollection.model_validate(
+            {"key": "C", "version": 1, "name": "Refs", "num_items": 3}
+        )
+        assert col.num_items == 3
+
+    def test_extra_field_preserved(self) -> None:
+        col = ZoteroCollection.model_validate(
+            {"key": "C", "version": 1, "name": "Refs", "extraField": "kept"}
+        )
+        assert col.model_dump()["extraField"] == "kept"
+
+
+class TestZoteroAttachment:
+    def test_valid_with_aliases(self) -> None:
+        att = ZoteroAttachment.model_validate(
+            {
+                "key": "A",
+                "version": 1,
+                "linkMode": "imported_file",
+                "contentType": "application/pdf",
+            }
+        )
+        assert att.link_mode == "imported_file"
+        assert att.content_type == "application/pdf"
+        wire = att.model_dump(by_alias=True)
+        assert wire["linkMode"] == "imported_file"
+        assert wire["contentType"] == "application/pdf"
+
+    def test_populate_by_name(self) -> None:
+        att = ZoteroAttachment.model_validate({"key": "A", "version": 1, "link_mode": "linked_url"})
+        assert att.link_mode == "linked_url"
+
+    def test_extra_field_preserved(self) -> None:
+        att = ZoteroAttachment.model_validate(
+            {"key": "A", "version": 1, "linkMode": "imported_file", "extraField": "kept"}
+        )
+        assert att.model_dump()["extraField"] == "kept"
+
+
+class TestResponseDTOs:
+    def test_save_credentials_response(self) -> None:
+        assert (
+            SaveCredentialsResponse.model_validate({"integration_id": "i1"}).integration_id == "i1"
+        )
+
+    def test_test_connection_response_defaults(self) -> None:
+        resp = TestConnectionResponse.model_validate({"success": True})
+        assert resp.access == {}
+        assert resp.user_name is None
+        assert resp.error is None
+
+    def test_list_collections_response(self) -> None:
+        resp = ListCollectionsResponse.model_validate({"collections": [{"key": "C"}]})
+        assert resp.collections[0]["key"] == "C"
+
+    def test_fetch_items_response_defaults(self) -> None:
+        resp = FetchItemsResponse.model_validate({"items": []})
+        assert resp.total_results is None
+        assert resp.has_more is False
+
+    def test_fetch_attachments_response(self) -> None:
+        resp = FetchAttachmentsResponse.model_validate({"attachments": []})
+        assert resp.attachments == []
+
+    def test_import_result_defaults(self) -> None:
+        result = ImportResult.model_validate({"zotero_key": "Z", "success": True})
+        assert result.article_id is None
+        assert result.pdf_imported is False
+
+    def test_import_to_project_response(self) -> None:
+        resp = ImportToProjectResponse.model_validate(
+            {
+                "total_items": 1,
+                "imported": 1,
+                "failed": 0,
+                "results": [{"zotero_key": "Z", "success": True}],
+            }
+        )
+        assert isinstance(resp.results[0], ImportResult)
+
+    def test_sync_collection_response_alias(self) -> None:
+        resp = SyncCollectionResponse.model_validate(
+            {"syncRunId": "s1", "status": "queued", "message": "ok"}
+        )
+        assert resp.sync_run_id == "s1"
+        assert resp.model_dump(by_alias=True)["syncRunId"] == "s1"
+
+    def test_sync_counts_response_aliases(self) -> None:
+        counts = SyncCountsResponse.model_validate(
+            {
+                "totalReceived": 10,
+                "persisted": 5,
+                "updated": 2,
+                "skipped": 1,
+                "failed": 1,
+                "removedAtSource": 1,
+                "reactivated": 0,
+            }
+        )
+        assert counts.total_received == 10
+        assert counts.removed_at_source == 1
+        wire = counts.model_dump(by_alias=True)
+        assert wire["totalReceived"] == 10
+        assert wire["removedAtSource"] == 1
+
+    def test_sync_status_response_with_datetimes(self) -> None:
+        resp = SyncStatusResponse.model_validate(
+            {
+                "syncRunId": "s1",
+                "status": "completed",
+                "counts": {
+                    "totalReceived": 0,
+                    "persisted": 0,
+                    "updated": 0,
+                    "skipped": 0,
+                    "failed": 0,
+                    "removedAtSource": 0,
+                    "reactivated": 0,
+                },
+                "startedAt": "2026-06-13T00:00:00Z",
+                "traceId": "t1",
+            }
+        )
+        assert isinstance(resp.started_at, datetime)
+        assert resp.completed_at is None
+        assert isinstance(resp.counts, SyncCountsResponse)
+
+    def test_sync_retry_failed_response_aliases(self) -> None:
+        resp = SyncRetryFailedResponse.model_validate(
+            {"syncRunId": "s2", "retryOfSyncRunId": "s1", "queuedItems": 3}
+        )
+        assert resp.retry_of_sync_run_id == "s1"
+        assert resp.queued_items == 3
+
+    def test_sync_item_result_entry_aliases(self) -> None:
+        entry = SyncItemResultEntry.model_validate(
+            {
+                "zoteroItemKey": "Z",
+                "articleId": "a1",
+                "status": "persisted",
+                "errorCode": None,
+                "errorMessage": None,
+                "authorityRuleApplied": None,
+                "processedAt": "2026-06-13T00:00:00Z",
+            }
+        )
+        assert entry.zotero_item_key == "Z"
+        assert isinstance(entry.processed_at, datetime)
+
+    def test_sync_item_results_response(self) -> None:
+        resp = SyncItemResultsResponse.model_validate(
+            {"items": [], "total": 0, "offset": 0, "limit": 50}
+        )
+        assert resp.items == []
+        assert resp.limit == 50
+
+
+class TestZoteroActionDataUnion:
+    def test_union_narrows_to_save_credentials(self) -> None:
+        adapter = TypeAdapter(ZoteroActionData)
+        parsed = adapter.validate_python({"integration_id": "i1"})
+        assert isinstance(parsed, SaveCredentialsResponse)
+
+    def test_union_narrows_to_fetch_items(self) -> None:
+        adapter = TypeAdapter(ZoteroActionData)
+        parsed = adapter.validate_python({"items": [], "total_results": 0, "has_more": False})
+        assert isinstance(parsed, FetchItemsResponse)

--- a/frontend/components/extraction/ArticleExtractionTable.test.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Regression test for the "extraction view stuck on the loading skeleton"
+ * outage.
+ *
+ * Root cause: the initial-load effect depended on the `loadArticles`
+ * function identity:
+ *
+ *     useEffect(() => {
+ *       if (projectId && templateId && currentUserId) loadArticles();
+ *     }, [projectId, templateId, currentUserId, loadArticles]);
+ *
+ * `loadArticles` calls `setArticles(newArray)` + `setLoading`, which forces a
+ * re-render every time it runs. After #270 removed its `useCallback`, the
+ * React Compiler did not stabilise the plain async function for the purposes
+ * of this dependency array, so each render produced a new identity → the
+ * effect re-fired → `loadArticles` ran again → ... an unbounded fetch loop
+ * that kept `loading === true` forever (the skeleton never cleared).
+ * Production fired the same `articles` request 383× in a few seconds.
+ *
+ * This test pins the contract: mounting the table triggers the article load
+ * exactly once, not in a loop. It keeps the component in its skeleton branch
+ * (entity-types still loading) so the loop logic is exercised without
+ * rendering the full table.
+ */
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { loadSpy, getUserSpy } = vi.hoisted(() => ({
+  loadSpy: vi.fn(),
+  getUserSpy: vi.fn(),
+}));
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+vi.mock('@/services/articlesService', () => ({
+  loadExtractionTableArticles: (...args: unknown[]) => loadSpy(...args),
+}));
+
+vi.mock('@/services/authService', () => ({
+  getCurrentUserId: (...args: unknown[]) => getUserSpy(...args),
+}));
+
+// Keep entity-types "loading" so the component stays in its skeleton branch:
+// the load effect still runs, we just avoid rendering the full table.
+vi.mock('@/hooks/extraction/useTemplateEntityTypes', () => ({
+  useTemplateEntityTypes: () => ({ entityTypes: [], isLoading: true }),
+}));
+
+vi.mock('@/hooks/extraction/useArticleExtractionValues', () => ({
+  useArticleExtractionValues: () => ({
+    valuesByArticle: new Map(),
+    isLoading: false,
+  }),
+  articleExtractionValuesKeys: { all: ['article-extraction-values'] },
+}));
+
+vi.mock('@/hooks/extraction/useFullAIExtraction', () => ({
+  useFullAIExtraction: () => ({ extractFullAI: vi.fn(), loading: false }),
+}));
+
+import { ArticleExtractionTable } from '@/components/extraction/ArticleExtractionTable';
+
+function renderTable() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ArticleExtractionTable projectId="p1" templateId="t1" />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUserSpy.mockResolvedValue({ ok: true, data: 'user-1' });
+  loadSpy.mockResolvedValue({
+    ok: true,
+    data: [
+      {
+        id: 'a1',
+        title: 'Article One',
+        authors: ['Doe'],
+        publication_year: 2020,
+        created_at: '2020-01-01T00:00:00Z',
+      },
+    ],
+  });
+});
+
+describe('ArticleExtractionTable → initial load', () => {
+  it('loads articles once and does not loop the fetch', async () => {
+    renderTable();
+
+    // Give the mount → auth → load chain time to settle, and give any
+    // runaway effect loop ample room to fire repeatedly.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // With the bug this is dozens/hundreds of calls; fixed it is exactly one.
+    expect(loadSpy.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(loadSpy).toHaveBeenCalledWith('p1');
+  });
+});

--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -286,13 +286,19 @@ export function ArticleExtractionTable({ projectId, templateId }: ArticleExtract
     queueMicrotask(() => void loadCurrentUser());
   }, [loadCurrentUser]);
 
-    // Load project articles
+    // Load project articles. Depend ONLY on the primitive identifiers — never
+    // on `loadArticles`. Its identity changes on every render (it is a plain
+    // async function the React Compiler does not stabilise for dependency
+    // arrays), and it calls setArticles/setLoading, so listing it here re-fired
+    // the effect every render and looped the fetch forever, pinning
+    // `loading === true` so the skeleton never cleared. Call through the ref,
+    // which the effect above refreshes before this one runs in the same commit
+    // (same pattern as the auto-refresh effect below).
   useEffect(() => {
     if (projectId && templateId && currentUserId) {
-        // Use loadArticles directly to avoid timing issues with ref
-      loadArticles();
+      void loadArticlesRef.current?.();
     }
-  }, [projectId, templateId, currentUserId, loadArticles]);
+  }, [projectId, templateId, currentUserId]);
 
     // Auto-refresh when returning to page (after finishing extraction)
     // Ensures data is updated after changes made on other pages


### PR DESCRIPTION
Promotes the current `dev` to `main` (production release).

## Payload
- **#289** fix(extraction): stop infinite fetch loop pinning the extraction skeleton — the production outage fix (Data-extraction tab stuck on its loading skeleton; `articles` query looped 383× in seconds). Frontend-only; ships to Vercel production (prumoai.vercel.app).
- **#288** fix(backend): validate API-key provider at the schema layer
- **#287** test(backend): add extensive unit tests for Pydantic schemas

All three already merged to `dev` with full green CI. This promotion triggers the Railway (backend) and Vercel (frontend) production deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)