### PR TITLE
fix(backend): surface QA reviewers in the export picker

### DIFF
--- a/backend/app/services/extraction_export_service.py
+++ b/backend/app/services/extraction_export_service.py
@@ -1219,13 +1219,28 @@ class ExtractionExportService(LoggerMixin):
         enforced here so the endpoint stays free of role-resolution
         plumbing (constitution §I: API layer is thin).
         """
-        all_reviewers = await self.list_reviewers_with_decisions(
-            project_id=project_id, template_id=template_id
-        )
+        # Resolve the caller first so a malformed subject short-circuits
+        # before any DB IO.
         try:
             caller_id = UUID(self.user_id)
         except (TypeError, ValueError):
             return []
+        # Key the run filter on the exported template's own kind so a
+        # quality_assessment template surfaces its reviewers; scoped by
+        # project_id (defense-in-depth, like the reviewer query) and
+        # falling back to ``extraction`` when absent (mirrors the
+        # ``run_kind`` default on ``_resolve_articles_for_consensus``).
+        run_kind = (
+            await self.db.execute(
+                select(ProjectExtractionTemplate.kind).where(
+                    ProjectExtractionTemplate.id == template_id,
+                    ProjectExtractionTemplate.project_id == project_id,
+                )
+            )
+        ).scalar_one_or_none() or "extraction"
+        all_reviewers = await self.list_reviewers_with_decisions(
+            project_id=project_id, template_id=template_id, run_kind=run_kind
+        )
         is_manager = await self._project_members_repo().has_role(
             project_id, caller_id, ProjectMemberRole.MANAGER
         )
@@ -1238,6 +1253,7 @@ class ExtractionExportService(LoggerMixin):
         *,
         project_id: UUID,
         template_id: UUID,
+        run_kind: str = "extraction",
     ) -> list[dict[str, str]]:
         """Reviewers with ≥ 1 non-reject decision on this project template.
 
@@ -1245,6 +1261,12 @@ class ExtractionExportService(LoggerMixin):
         alphabetically by display name. Primitive used by
         ``list_eligible_reviewers_for_picker``; not called directly from
         the API layer.
+
+        ``run_kind`` is the exported template's kind (``extraction`` or
+        ``quality_assessment``): a run's kind is copied from its template
+        at creation, so filtering on the template's own kind surfaces the
+        QA picker's reviewers (see ``_resolve_articles_for_consensus``)
+        instead of a hard-coded ``extraction`` that hides them.
         """
         from app.models.extraction_workflow import (
             ExtractionReviewerDecision,
@@ -1271,7 +1293,7 @@ class ExtractionExportService(LoggerMixin):
                 .where(
                     ExtractionRun.project_id == project_id,
                     ExtractionRun.template_id == template_id,
-                    ExtractionRun.kind == "extraction",
+                    ExtractionRun.kind == run_kind,
                     ExtractionReviewerDecision.decision != "reject",
                 )
                 .distinct()

--- a/backend/tests/integration/test_extraction_export_reviewer_picker.py
+++ b/backend/tests/integration/test_extraction_export_reviewer_picker.py
@@ -1,0 +1,55 @@
+"""Integration coverage for the export reviewer picker on a QA template.
+
+The single-/all-users export dialog populates its reviewer dropdown from
+``ExtractionExportService.list_eligible_reviewers_for_picker`` (FR-028),
+which delegates to ``list_reviewers_with_decisions``. That primitive must
+surface reviewers for a ``quality_assessment`` template the same way it
+does for ``extraction``: a run's ``kind`` is copied from its template at
+creation, so the picker keys on the exported template's own kind, not a
+hard-coded ``"extraction"``. Otherwise a QA template's reviewer dropdown
+comes back empty even though the finalized run and its decisions exist.
+
+Reuses the finalized two-domain QA fixture from
+``test_extraction_export_appraisal_summary`` (a QA run driven to FINALIZED
+with primary + second-reviewer non-reject decisions). The ``db_session``
+fixture is SAVEPOINT-isolated, so every write rolls back at teardown.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.integration.test_extraction_export_appraisal_summary import (
+    _seed_finalized_qa_run,
+    _service,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_qa_template_picker_surfaces_reviewers_with_decisions(
+    db_session: AsyncSession,
+) -> None:
+    """Manager picker lists QA-run reviewers with non-reject decisions.
+
+    The bug: ``list_reviewers_with_decisions`` hard-filtered
+    ``ExtractionRun.kind == "extraction"``, so a ``quality_assessment``
+    template surfaced ZERO reviewers even though its finalized run carries
+    real reviewer decisions. The manager (primary profile) must see both
+    the primary reviewer and the second reviewer.
+    """
+    fx = await _seed_finalized_qa_run(db_session, with_second_reviewer=True)
+    if fx is None:
+        pytest.skip("Missing fixtures.")
+
+    reviewers = await _service(db_session, fx).list_eligible_reviewers_for_picker(
+        project_id=fx.project_id,
+        template_id=fx.qa_template_id,
+    )
+
+    surfaced_ids = {r["id"] for r in reviewers}
+    assert str(fx.user_id) in surfaced_ids, "primary reviewer must surface for a QA template"
+    assert str(fx.reviewer_id) in surfaced_ids, "second reviewer must surface for a QA template"
+
+    await db_session.rollback()

--- a/backend/tests/unit/test_extraction_export_service.py
+++ b/backend/tests/unit/test_extraction_export_service.py
@@ -75,6 +75,13 @@ def _rows_result(rows: list) -> MagicMock:
     return result
 
 
+def _scalar_result(value) -> MagicMock:
+    """Return a fake Result whose .scalar_one_or_none() yields *value*."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
 def _make_run(
     *,
     article_id: UUID | None = None,
@@ -1479,6 +1486,7 @@ class TestListEligibleReviewersForPicker:
         """Manager → all reviewers from list_reviewers_with_decisions."""
         user_id = uuid4()
         svc = _make_service(user_id=str(user_id))
+        svc.db.execute = AsyncMock(return_value=_scalar_result("extraction"))
 
         all_reviewers = [
             {"id": str(uuid4()), "name": "Alice"},
@@ -1505,6 +1513,7 @@ class TestListEligibleReviewersForPicker:
         """Non-manager → only their own entry."""
         user_id = uuid4()
         svc = _make_service(user_id=str(user_id))
+        svc.db.execute = AsyncMock(return_value=_scalar_result("extraction"))
 
         self_entry = {"id": str(user_id), "name": "Self"}
         other_entry = {"id": str(uuid4()), "name": "Other"}
@@ -1527,7 +1536,7 @@ class TestListEligibleReviewersForPicker:
 
     @pytest.mark.asyncio
     async def test_invalid_user_id_returns_empty_list(self, monkeypatch):
-        """Non-UUID user_id → returns [] without raising."""
+        """Non-UUID user_id → returns [] before any DB IO."""
         svc = _make_service(user_id="not-a-uuid")
 
         member_repo = AsyncMock()
@@ -1542,7 +1551,11 @@ class TestListEligibleReviewersForPicker:
         )
 
         assert result == []
-        # has_role should not have been called since UUID() raised
+        # Malformed subject short-circuits before any DB IO: neither the
+        # template-kind lookup nor the reviewer query runs, and the manager
+        # check is never reached.
+        svc.db.execute.assert_not_called()
+        svc.list_reviewers_with_decisions.assert_not_called()
         member_repo.has_role.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1550,6 +1563,7 @@ class TestListEligibleReviewersForPicker:
         """Non-manager when no reviewers exist → returns []."""
         user_id = uuid4()
         svc = _make_service(user_id=str(user_id))
+        svc.db.execute = AsyncMock(return_value=_scalar_result("extraction"))
 
         member_repo = AsyncMock()
         member_repo.has_role = AsyncMock(return_value=False)


### PR DESCRIPTION
## What

The single-/all-users extraction-export **reviewer dropdown** came back **empty for `quality_assessment` templates**, even when the finalized run and its reviewer decisions existed. The picker
(`list_eligible_reviewers_for_picker` → `list_reviewers_with_decisions`) hard-filtered
`ExtractionRun.kind == "extraction"`.

## Why

A run's `kind` is copied from its template at creation. The publication-ready xlsx export (#292) already
keyed the three `_resolve_articles_for_*` resolution queries on the exported template's own kind
(threading `run_kind`, default `"extraction"`), but the reviewer picker was left on the literal
`"extraction"` — so a QA-template export surfaced **zero** reviewers in the picker.

## Fix

`list_reviewers_with_decisions` now takes `run_kind: str = "extraction"` and filters
`ExtractionRun.kind == run_kind`; the caller `list_eligible_reviewers_for_picker` loads the exported
template's own `kind` and threads it through — mirroring the Task-62 `run_kind` style. Two small
hardenings the review surfaced:

- the caller-id parse runs **first**, so a malformed JWT subject short-circuits before any DB IO;
- the `template.kind` lookup is **scoped by `project_id`** (defense-in-depth, matching the double-scoped
  downstream reviewer query).

## Tests

- New integration test drives a real QA run to FINALIZED with primary + second-reviewer decisions and
  asserts both surface in the manager picker (proven RED before the fix, GREEN after).
- Picker unit tests wire the new template-kind read and assert the invalid-subject path does **no** DB IO.

## Verification

- Rebased directly onto `dev` (squash of #292); `git range-diff` confirms the fix is preserved byte-for-byte.
- 203 export tests pass · ruff check + format clean · no new migrations · working tree clean.
- Adversarial agent review (diff-integrity / merge-safety / fix-validity): **0 confirmed defects, 0 conflicts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
