### PR TITLE
Promote to main: async-export completion download fix (#300)

### DIFF
--- a/frontend/components/navigation/NotificationCenter.tsx
+++ b/frontend/components/navigation/NotificationCenter.tsx
@@ -142,9 +142,8 @@ export function NotificationCenter() {
         };
     }, [updateJob]);
 
-    // Polling to update jobs
+    // Observe job status transitions to surface completion/failure toasts.
   useBackgroundJobPolling({
-    interval: 2000,
     onJobComplete: (job) => {
       toast.success(getCompletionMessage(job), {
         duration: 5000,

--- a/frontend/hooks/useBackgroundJobPolling.test.tsx
+++ b/frontend/hooks/useBackgroundJobPolling.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Regression coverage for useBackgroundJobPolling.
+ *
+ * Root-cause guard for the async-export "never downloads" incident
+ * (extraction + articles export): the completion observer must fire
+ * `onJobComplete` / `onJobFailed` when a background job transitions
+ * INTO a terminal state. The original implementation only inspected
+ * `getActiveJobs()` (running|pending), so a job became invisible the
+ * instant it completed and the completion toast (+ download action)
+ * never appeared — the worker built and signed the file, but the user
+ * never saw a download.
+ */
+
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {act, renderHook} from "@testing-library/react";
+import {useBackgroundJobPolling} from "@/hooks/useBackgroundJobPolling";
+import {useBackgroundJobs} from "@/stores/useBackgroundJobs";
+import {createExtractionExportJob} from "@/types/background-jobs";
+
+function addRunningExportJob(id: string) {
+    const job = {
+        ...createExtractionExportJob("proj-1", "backend-1", {
+            templateId: "tpl-1",
+            mode: "all_users" as const,
+            articleCount: 19,
+            includeAiMetadata: true,
+            anonymizeReviewerNames: false,
+        }),
+        id,
+        status: "running" as const,
+    };
+    act(() => {
+        useBackgroundJobs.getState().addJob(job);
+    });
+    return job;
+}
+
+beforeEach(() => {
+    act(() => {
+        useBackgroundJobs.setState({jobs: []});
+    });
+});
+
+describe("useBackgroundJobPolling", () => {
+    it("fires onJobComplete when a job transitions to completed", () => {
+        const onJobComplete = vi.fn();
+        renderHook(() => useBackgroundJobPolling({onJobComplete}));
+
+        addRunningExportJob("job-1");
+        expect(onJobComplete).not.toHaveBeenCalled();
+
+        act(() => {
+            useBackgroundJobs.getState().updateJob("job-1", {
+                status: "completed",
+                completedAt: Date.now(),
+            });
+        });
+
+        expect(onJobComplete).toHaveBeenCalledTimes(1);
+        const completed = onJobComplete.mock.calls[0][0];
+        expect(completed.id).toBe("job-1");
+        expect(completed.status).toBe("completed");
+    });
+
+    it("fires onJobFailed when a job transitions to failed", () => {
+        const onJobFailed = vi.fn();
+        renderHook(() => useBackgroundJobPolling({onJobFailed}));
+
+        addRunningExportJob("job-2");
+
+        act(() => {
+            useBackgroundJobs.getState().updateJob("job-2", {
+                status: "failed",
+                completedAt: Date.now(),
+                error: "boom",
+            });
+        });
+
+        expect(onJobFailed).toHaveBeenCalledTimes(1);
+        expect(onJobFailed.mock.calls[0][0].status).toBe("failed");
+    });
+
+    it("does not re-fire onJobComplete for a job that was already completed on mount", () => {
+        const onJobComplete = vi.fn();
+        // Seed an already-completed job before the hook mounts.
+        act(() => {
+            useBackgroundJobs.getState().addJob({
+                ...createExtractionExportJob("proj-1", "backend-3", {
+                    templateId: "tpl-1",
+                    mode: "consensus" as const,
+                    articleCount: 1,
+                    includeAiMetadata: false,
+                    anonymizeReviewerNames: false,
+                }),
+                id: "job-3",
+                status: "completed",
+                completedAt: Date.now(),
+            });
+        });
+
+        renderHook(() => useBackgroundJobPolling({onJobComplete}));
+
+        expect(onJobComplete).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/hooks/useBackgroundJobPolling.ts
+++ b/frontend/hooks/useBackgroundJobPolling.ts
@@ -1,86 +1,73 @@
 /**
- * Hook para polling de Background Jobs
- * 
- * Monitora jobs ativos e atualiza seu status automaticamente.
- * Syncs with running services to reflect progress in real time.
+ * Observes background-job status transitions and fires terminal-state
+ * callbacks (completion / failure).
+ *
+ * Why this is subscription-driven, not interval-driven: the store's
+ * `getActiveJobs()` only returns non-terminal jobs (running|pending),
+ * so a job is invisible the instant it completes. Polling that set
+ * could never witness a running→completed transition, which silently
+ * killed the async-export completion toast + download action — the
+ * worker built and signed the file, but the user never saw a download.
+ *
+ * We instead subscribe to the full `jobs` list and diff the previous
+ * status of every job. `updateJob` always produces a new array, so a
+ * completion is guaranteed to schedule a render and re-run the effect,
+ * letting us observe the transition exactly once.
  */
 
-import { useEffect, useRef } from 'react';
-import { useBackgroundJobs } from '@/stores/useBackgroundJobs';
-import type { BackgroundJob } from '@/types/background-jobs';
+import {useEffect, useRef} from 'react';
+import {useBackgroundJobs} from '@/stores/useBackgroundJobs';
+import type {BackgroundJob} from '@/types/background-jobs';
 
 interface UseBackgroundJobPollingOptions {
-    interval?: number; // Polling interval in ms (default: 2000)
   onJobComplete?: (job: BackgroundJob) => void;
   onJobFailed?: (job: BackgroundJob) => void;
 }
 
 /**
- * Hook that polls active jobs and updates notifications
+ * Hook that watches every background job and notifies on terminal
+ * transitions.
  */
 export function useBackgroundJobPolling(options: UseBackgroundJobPollingOptions = {}) {
-  const { interval = 2000, onJobComplete, onJobFailed } = options;
-  
-  const { getActiveJobs } = useBackgroundJobs();
-  const previousJobStatesRef = useRef<Map<string, string>>(new Map());
+  const {onJobComplete, onJobFailed} = options;
 
-  const checkJobStatus = () => {
-    const activeJobs = getActiveJobs();
-
-      // Check for state changes
-    activeJobs.forEach((job) => {
-      const previousStatus = previousJobStatesRef.current.get(job.id);
-
-      // Job completado
-        if (
-            previousStatus !== undefined &&
-            previousStatus !== 'completed' &&
-            job.status === 'completed'
-        ) {
-        onJobComplete?.(job);
-      }
-
-      // Job falhou
-        if (
-            previousStatus !== undefined &&
-            previousStatus !== 'failed' &&
-            job.status === 'failed'
-        ) {
-        onJobFailed?.(job);
-      }
-
-        // Update previous state
-      previousJobStatesRef.current.set(job.id, job.status);
-    });
-
-      // Clear jobs that no longer exist
-    const activeJobIds = new Set(activeJobs.map(j => j.id));
-    for (const [jobId] of previousJobStatesRef.current) {
-      if (!activeJobIds.has(jobId)) {
-        previousJobStatesRef.current.delete(jobId);
-      }
-    }
-  };
+  const jobs = useBackgroundJobs((state) => state.jobs);
+  const previousStatusRef = useRef<Map<string, BackgroundJob['status']>>(new Map());
 
   useEffect(() => {
-    const activeJobs = getActiveJobs();
+    const seen = previousStatusRef.current;
 
-      // If no active jobs, do not poll
-    if (activeJobs.length === 0) {
-      return;
+    for (const job of jobs) {
+      const previous = seen.get(job.id);
+      // Fire only on a genuine transition INTO a terminal state.
+      // `previous === undefined` means the job first appeared already
+      // terminal (e.g. rehydrated from localStorage on reload) — that is
+      // not a transition we caused, so we never re-toast it.
+      if (previous !== undefined && previous !== job.status) {
+        if (job.status === 'completed') {
+          onJobComplete?.(job);
+        } else if (job.status === 'failed') {
+          onJobFailed?.(job);
+        }
+      }
+      seen.set(job.id, job.status);
     }
 
-    // Polling interval
-    const intervalId = setInterval(checkJobStatus, interval);
+    // Drop bookkeeping for jobs that no longer exist so the map cannot
+    // grow unbounded and a recycled id cannot inherit a stale status.
+    const liveIds = new Set(jobs.map((job) => job.id));
+    for (const id of seen.keys()) {
+      if (!liveIds.has(id)) {
+        seen.delete(id);
+      }
+    }
+  }, [jobs, onJobComplete, onJobFailed]);
 
-    // Cleanup
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [getActiveJobs, checkJobStatus, interval]);
+  const activeJobsCount = jobs.filter(
+    (job) => job.status === 'running' || job.status === 'pending',
+  ).length;
 
   return {
-    activeJobsCount: getActiveJobs().length,
+    activeJobsCount,
   };
 }
-


### PR DESCRIPTION
Promotes the verified fix from `dev` to `main` (production deploy via Railway + Vercel).

### Included
- **#300** fix(frontend): surface async-export completion so the file actually downloads.
  `useBackgroundJobPolling` only iterated `getActiveJobs()` (running|pending), so the `running→completed` transition was never observed and `onJobComplete`/`onJobFailed` were dead code — async extraction/articles exports built + signed the file on the worker but no completion toast/download ever appeared. Now subscribes to the full job list and diffs each job's previous status.

### Verification
- New `useBackgroundJobPolling.test.tsx` (RED→GREEN), full frontend suite **515 tests green**, typecheck + eslint clean.
- Root cause corroborated by Railway worker logs (worker `task_completed`, 25,961-byte `.xlsx` signed) + status endpoint returning `completed` while the UI never surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)