### PR TITLE
fix(frontend): clear empty-state for the export reviewer picker

### DIFF
--- a/frontend/components/extraction/ExtractionExportDialog.test.tsx
+++ b/frontend/components/extraction/ExtractionExportDialog.test.tsx
@@ -264,6 +264,25 @@ describe("ExtractionExportDialog", () => {
         );
     });
 
+    it("blocks Single-user export with an empty-state when no reviewer has decisions", async () => {
+        useEligibleReviewersMock.mockReturnValue({data: [], isLoading: false});
+        const user = userEvent.setup();
+        renderDialog();
+        await user.click(screen.getByLabelText(/Single user/i));
+
+        // Empty-state message replaces the picker — there is nobody to pick.
+        await waitFor(() =>
+            expect(
+                screen.getByTestId("extraction-export-reviewer-empty"),
+            ).toBeInTheDocument(),
+        );
+        expect(
+            screen.queryByTestId("extraction-export-reviewer-picker"),
+        ).not.toBeInTheDocument();
+        // Export is blocked so the user cannot submit a doomed request.
+        expect(screen.getByTestId("extraction-export-submit")).toBeDisabled();
+    });
+
     it("renders the anonymize-reviewers toggle only when All-users mode + manager (US3 / FR-028)", async () => {
         const user = userEvent.setup();
         renderDialog();

--- a/frontend/components/extraction/ExtractionExportDialog.tsx
+++ b/frontend/components/extraction/ExtractionExportDialog.tsx
@@ -146,10 +146,26 @@ export function ExtractionExportDialog({
     });
     const reviewers = reviewersQuery.data ?? [];
 
-    // Default reviewer to "me" when entering single_user mode.
-    // Render-phase invariant — the guard guarantees termination.
-    if (mode === "single_user" && !reviewerId && userId) {
-        setReviewerId(userId);
+    const reviewersLoading = reviewersQuery.isLoading;
+    // True once the picker has loaded and nobody is eligible — the project has
+    // no non-reject reviewer decisions on this template yet, so single-user
+    // export is impossible and we surface an empty-state instead of a blank
+    // dropdown the user cannot resolve.
+    const noEligibleReviewers =
+        mode === "single_user" && !reviewersLoading && reviewers.length === 0;
+
+    // Reconcile the reviewer selection against the eligible list (render-phase
+    // invariant — each branch makes the guard false next render, so it
+    // terminates). Default to "me" when I'm eligible; clear a selection that
+    // isn't in the list so Export stays blocked until a real reviewer is
+    // chosen — we never silently export a reviewer who has no data.
+    if (mode === "single_user" && !reviewersLoading && reviewers.length > 0) {
+        const selectedIsEligible =
+            reviewerId !== null && reviewers.some((r) => r.id === reviewerId);
+        if (!selectedIsEligible) {
+            const self = reviewers.find((r) => r.id === userId);
+            setReviewerId(self ? self.id : null);
+        }
     }
 
     // Abort any in-flight request if the dialog closes while submitting.
@@ -163,7 +179,9 @@ export function ExtractionExportDialog({
     const articleIds =
         articleScope === "selected_only" ? selectedIds : currentListIds;
     const articleCount = articleIds.length;
-    const modeReady = mode !== "single_user" || Boolean(reviewerId);
+    const modeReady =
+        mode !== "single_user" ||
+        (reviewerId !== null && reviewers.some((r) => r.id === reviewerId));
     const canSubmit = articleCount > 0 && modeReady && !submitting;
 
     const expectedSync =
@@ -323,7 +341,14 @@ export function ExtractionExportDialog({
                             <Label htmlFor="reviewer-picker">
                                 {t("extraction", "exportReviewerLabel")}
                             </Label>
-                            {isManager ? (
+                            {noEligibleReviewers ? (
+                                <p
+                                    className="text-sm text-muted-foreground"
+                                    data-testid="extraction-export-reviewer-empty"
+                                >
+                                    {t("extraction", "exportReviewerEmptyState")}
+                                </p>
+                            ) : isManager ? (
                                 <Select
                                     value={reviewerId ?? undefined}
                                     onValueChange={(v) => setReviewerId(v)}
@@ -443,7 +468,7 @@ export function ExtractionExportDialog({
                     </div>
 
                     {/* Live preview line (FR-027) */}
-                    {articleCount > 0 && (
+                    {articleCount > 0 && !noEligibleReviewers && (
                         <p
                             className="text-xs text-muted-foreground"
                             aria-live="polite"

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -706,6 +706,7 @@ export const extraction = {
     exportSourceAllUsersDisabledTooltip: 'Only project managers can export all reviewers side-by-side.',
     exportReviewerLabel: 'Reviewer',
     exportReviewerSelfFallback: 'Only your own decisions are available — your role does not allow exporting other reviewers.',
+    exportReviewerEmptyState: 'No reviewer has recorded decisions on this template yet, so there is nothing to export for a single user. Run extraction and review first, or pick another source.',
     exportScopeLabel: 'Articles to export',
     exportScopeCurrentList: 'Current list',
     exportScopeSelectedOnly: 'Selected only',


### PR DESCRIPTION
## Problem

On a project with no reviewer decisions yet (e.g. a freshly-imported project), the export dialog's **Single user** reviewer dropdown is empty, but the dialog still defaulted the selection to the current user (not in the list) and kept **Export** enabled. Result: a blank dropdown the user can't resolve, and submitting only returns `422 EMPTY_ELIGIBLE_ARTICLES`. Reported from a real project ("sfa") that has 19 articles but 0 instances / runs / reviewer decisions.

The picker query itself is correct — it returns reviewers-with-decisions and works on projects that have data (verified against another project where it correctly lists the reviewer).

## Fix

- Reconcile the reviewer selection against the eligible list: default to "me" only when I'm eligible; clear a selection that isn't in the list so Export stays blocked until a real reviewer is chosen.
- When **no** reviewer is eligible, show a clear empty-state message in place of the dropdown and disable Export (and hide the misleading "Will export N articles" preview).
- `modeReady` now requires an eligible selection in single-user mode.

Picker behaves normally on projects that have reviewer decisions.

## Tests

- New `ExtractionExportDialog.test.tsx` case: empty reviewers → empty-state shown, picker hidden, Export disabled (RED→GREEN).
- Full suite green: **516 tests / 80 files**, typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)