### PR TITLE
fix(extraction): stop optional entities blocking the finalize gate

### DIFF
--- a/frontend/hooks/extraction/useExtractionProgress.ts
+++ b/frontend/hooks/extraction/useExtractionProgress.ts
@@ -19,9 +19,33 @@ import {
 
 export type UseExtractionProgressReturn = RequiredFieldProgress;
 
+/** Minimal projection of a materialized instance the metric needs. */
+export interface ProgressInstanceProjection {
+  id: string;
+  entity_type_id: string;
+}
+
 export function useExtractionProgress(
   values: Record<string, any>,
   entityTypes: ProgressEntityProjection[],
+  instances?: ProgressInstanceProjection[],
 ): UseExtractionProgressReturn {
-  return computeRequiredFieldProgress(values, entityTypes);
+  // When the materialized instances are known, pass the TRUE instance set so the
+  // denominator reflects reality: an optional cardinality='many' entity (e.g.
+  // "Prediction Models" with zero models added) and its child sections add no
+  // required-field slots, so a fully-filled form is not stranded below 100%.
+  // Without instances (e.g. mid-load) we fall back to the value-key heuristic.
+  let instanceIdsByEntityType: Map<string, Set<string>> | undefined;
+  if (instances && instances.length > 0) {
+    instanceIdsByEntityType = new Map<string, Set<string>>();
+    for (const inst of instances) {
+      let set = instanceIdsByEntityType.get(inst.entity_type_id);
+      if (!set) {
+        set = new Set();
+        instanceIdsByEntityType.set(inst.entity_type_id, set);
+      }
+      set.add(inst.id);
+    }
+  }
+  return computeRequiredFieldProgress(values, entityTypes, instanceIdsByEntityType);
 }

--- a/frontend/lib/extraction/progress.test.ts
+++ b/frontend/lib/extraction/progress.test.ts
@@ -13,8 +13,12 @@ function field(id: string, is_required: boolean): ExtractionField {
   return { id, is_required } as ExtractionField;
 }
 
-function et(id: string, fields: ExtractionField[]): ProgressEntityProjection {
-  return { id, fields };
+function et(
+  id: string,
+  fields: ExtractionField[],
+  is_required = false,
+): ProgressEntityProjection {
+  return { id, fields, is_required };
 }
 
 describe('computeRequiredFieldProgress', () => {
@@ -83,6 +87,45 @@ describe('computeRequiredFieldProgress', () => {
     expect(r.completedFields).toBe(2);
     expect(r.completionPercentage).toBe(100);
   });
+
+  it('authoritative set + template marks the entity REQUIRED: zero instances keeps a phantom slot (form stays below 100% until one is added)', () => {
+    const entityTypes = [
+      et('study', [field('s1', true)]), // materialized singleton, filled
+      // A required cardinality='many' entity with no instances added: the
+      // template demands at least one, so it must keep the form incomplete.
+      et('required_models', [field('m1', true), field('m2', true)], true),
+    ];
+    const instanceIds = new Map([['study', new Set(['study-inst'])]]);
+    const r = computeRequiredFieldProgress(
+      { 'study-inst_s1': 'a' },
+      entityTypes,
+      instanceIds,
+    );
+    // denom = 1 (study) + 2 (required_models phantom) = 3; filled = 1.
+    expect(r.totalFields).toBe(3);
+    expect(r.completedFields).toBe(1);
+    expect(r.isComplete).toBe(false);
+  });
+
+  it('authoritative set: an entity type with zero instances contributes nothing — an optional cardinality=many entity (and its child sections) with no instances does not block 100%', () => {
+    const entityTypes = [
+      et('study', [field('s1', true), field('s2', true)]), // materialized singleton
+      et('prediction_models', [field('m1', true), field('m2', true)]), // optional many, no models added
+      et('model_performance', [field('p1', true)]), // child of models, no instances
+    ];
+    // Only the study singleton is materialized; both its required fields filled.
+    const instanceIds = new Map([['study', new Set(['study-inst'])]]);
+    const r = computeRequiredFieldProgress(
+      { 'study-inst_s1': 'a', 'study-inst_s2': 'b' },
+      entityTypes,
+      instanceIds,
+    );
+    // denom = 2 (study only); the absent model entities add no phantom slots.
+    expect(r.totalFields).toBe(2);
+    expect(r.completedFields).toBe(2);
+    expect(r.completionPercentage).toBe(100);
+    expect(r.isComplete).toBe(true);
+  });
 });
 
 describe('computeRowProgress (article/row level — shared by both list tables)', () => {
@@ -146,5 +189,21 @@ describe('computeRowProgress (article/row level — shared by both list tables)'
 
   it('no instances => 0%', () => {
     expect(computeRowProgress([], [], entityTypes)).toBe(0);
+  });
+
+  it('no-model article: optional model entities with no instances do not block 100% (the 40% bug)', () => {
+    const ets = [
+      et('participants', [field('a', true), field('b', true)]),
+      et('prediction_models', [field('m1', true), field('m2', true)]), // optional many, none added
+      et('model_performance', [field('p1', true)]), // child section, no instances
+    ];
+    const pct = computeRowProgress(
+      [inst('p-inst', 'participants')], // only the singleton is materialized
+      [val('p-inst', 'a', { value: 'x' }), val('p-inst', 'b', { value: 'y' })],
+      ets,
+    );
+    // Every materialized required field is filled and no models exist, so the
+    // article is complete — the unadded model sections must not drag this to 40%.
+    expect(pct).toBe(100);
   });
 });

--- a/frontend/lib/extraction/progress.ts
+++ b/frontend/lib/extraction/progress.ts
@@ -2,10 +2,16 @@ import type { ExtractionField } from '@/types/extraction';
 
 /**
  * Minimal projection of an entity type needed for progress computation.
+ *
+ * `is_required` is the template's own signal (it varies per template / per
+ * user): a `cardinality='many'` entity with zero instances only blocks
+ * completion when the template marks it required. Defaults to optional when
+ * omitted, so a caller that doesn't thread it never over-counts.
  */
 export interface ProgressEntityProjection {
   id: string;
   fields: ExtractionField[];
+  is_required?: boolean;
 }
 
 export interface RequiredFieldProgress {
@@ -35,6 +41,17 @@ export interface RequiredFieldProgress {
  * derived from the value keys — the header's historical behaviour, preserved
  * unchanged because the form holds every instance's keys already.
  *
+ * When the authoritative set IS supplied, an entity type with **no instances**
+ * contributes to the denominator only if the template marks it `is_required`:
+ * an optional `cardinality='many'` entity (e.g. "Prediction Models" with
+ * `is_required=false` and zero models added) — and its child sections — reach
+ * 100% instead of stranding the form below the finalize gate (the "40%, can't
+ * submit" bug); a required entity keeps a phantom slot so the form stays below
+ * 100% until at least one instance is added. This is template-driven, so the
+ * behaviour adapts to each user's template, not just CHARMS. The value-key
+ * fallback keeps the historical phantom-1 so a not-yet-typed singleton is still
+ * represented when no explicit set is available.
+ *
  * `values` is keyed `${instanceId}_${fieldId}` → value (the shape the form and
  * both tables build).
  */
@@ -57,6 +74,13 @@ export function computeRequiredFieldProgress(
   // Observed instances per entity type: prefer the explicit set (true count,
   // so empty cardinality='many' instances still count in the denominator);
   // else derive from filled value keys.
+  //
+  // The set is "authoritative" only when the caller passed it: then an entity
+  // type absent from it genuinely has zero instances and contributes no
+  // required-field slots. When derived from value keys we cannot tell "no
+  // instance" from "instance with no values typed yet", so we keep the
+  // phantom-1 fallback for that path.
+  const authoritative = instanceIdsByEntityType !== undefined;
   let observedInstances: Map<string, Set<string>>;
   if (instanceIdsByEntityType) {
     observedInstances = instanceIdsByEntityType;
@@ -82,9 +106,19 @@ export function computeRequiredFieldProgress(
   for (const et of entityTypes) {
     const reqCount = requiredFieldIdsByEntityType.get(et.id)?.size ?? 0;
     if (reqCount === 0) continue;
-    // An entity type with no observed instances contributes one "phantom"
-    // instance so the entity is still represented in the denominator.
-    const instanceCount = observedInstances.get(et.id)?.size ?? 1;
+    const observed = observedInstances.get(et.id)?.size;
+    let instanceCount: number;
+    if (observed !== undefined) {
+      instanceCount = observed;
+    } else if (authoritative) {
+      // No instances: honor the template. A required entity keeps a phantom-1
+      // (form stays below 100% until one is added); an optional entity (e.g.
+      // CHARMS prediction models, is_required=false) contributes nothing.
+      instanceCount = et.is_required ? 1 : 0;
+    } else {
+      // Value-key fallback: represent a not-yet-typed singleton.
+      instanceCount = 1;
+    }
     totalRequired += reqCount * instanceCount;
   }
 

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -287,9 +287,12 @@ export default function ExtractionFullScreen() {
     setReopening(false);
   };
 
-  // Hook para calcular progresso
+  // Hook para calcular progresso. Pass the materialized instances so optional
+  // cardinality='many' entities with no instances (e.g. no prediction models
+  // added) and their child sections don't strand the form below the finalize
+  // gate — the "40%, can't submit" bug.
   const { completedFields, totalFields, completionPercentage, isComplete } =
-    useExtractionProgress(values, entityTypes);
+    useExtractionProgress(values, entityTypes, instances);
 
   // Captures the scroll position of the form + PDF panels around async
   // refreshes so the user does not get bounced back to the top after an AI

--- a/frontend/test/hooks/useExtractionProgress.test.tsx
+++ b/frontend/test/hooks/useExtractionProgress.test.tsx
@@ -77,6 +77,39 @@ describe('useExtractionProgress', () => {
     expect(result.current.completionPercentage).toBe(0);
   });
 
+  it('reaches 100% when all materialized singletons are filled and no models are added (optional cardinality=many)', () => {
+    const entityTypes = [
+      et('participants', [
+        { id: 'p-age', is_required: true },
+        { id: 'p-n', is_required: true },
+      ]),
+      // Optional prediction-models entity + a child section with many required
+      // fields. No model instance exists ("No models added").
+      et('prediction_models', [
+        { id: 'm-type', is_required: true },
+        { id: 'm-auc', is_required: true },
+      ]),
+      et('model_performance', [{ id: 'perf', is_required: true }]),
+    ];
+    const values: Record<string, unknown> = {
+      'participants-inst_p-age': '45',
+      'participants-inst_p-n': '1200',
+    };
+    // The materialized instances: only the participants singleton.
+    const instances = [
+      { id: 'participants-inst', entity_type_id: 'participants' },
+    ];
+
+    const { result } = renderHook(() =>
+      useExtractionProgress(values, entityTypes, instances),
+    );
+
+    expect(result.current.totalFields).toBe(2);
+    expect(result.current.completedFields).toBe(2);
+    expect(result.current.completionPercentage).toBe(100);
+    expect(result.current.isComplete).toBe(true);
+  });
+
   it('ignores optional fields in the denominator', () => {
     const entityTypes = [
       et('et-1', [


### PR DESCRIPTION
## Problem

The extraction completion percentage gates the "Submit for review" button (`isComplete` = 100%). It injected a mandatory **phantom instance** for *every* entity type with required fields but zero instances — ignoring the template's own `is_required` flag.

For the CHARMS template, `prediction_models` is **optional** (`is_required=false`, `cardinality=many`) with 6 child sections (Model Performance alone has 35 required fields). An article with all **33** study-level required fields filled but **no models added** read **33 / 82 = 40%** and could never reach 100%, so the button stayed disabled with no explanation.

The backend has **no** completeness gate for `advance_stage` PROPOSAL→REVIEW ([run_lifecycle_service.py](backend/app/services/run_lifecycle_service.py)), so this was a purely frontend block, stricter than the actual contract. The same wrong number also showed in the HITL article list, extraction table and dashboard (shared `computeRowProgress`).

## Fix (template-driven — not CHARMS-specific)

When the authoritative instance set is supplied, a zero-instance entity type contributes to the denominator **only if the template marks it `is_required`**:

- optional entity (and its child sections) with no instances → contributes nothing → zero models = complete;
- required entity with no instances → keeps a phantom slot → form stays below 100% until one is added.

No entity names are hardcoded — it keys off `cardinality` / `is_required` / instance existence, so it adapts to each user's template. The header path now passes the materialized `instances` so it gets the same authoritative behaviour as the tables. The value-key fallback keeps the historical phantom-1 for callers that omit instances (regression #55 preserved).

## Files

- `frontend/lib/extraction/progress.ts` — `is_required`-aware denominator
- `frontend/hooks/extraction/useExtractionProgress.ts` — accepts + forwards `instances`
- `frontend/pages/ExtractionFullScreen.tsx` — passes `instances` into the hook

## Verification

- **Live prod run** (`263f4b75…`, the reported one): post-fix math = **33 / 33 = 100%** → button enables. No data change needed; resolves on deploy.
- **TDD:** added tests that fail red then pass green — the exact `40 → 100` for a no-model article, the required-entity-stays-gated case, and the header path; regression #55 still passes.
- 365 extraction-area tests pass; `tsc --noEmit` clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
