### PR TITLE
test(e2e): accept empty-state in single-user reviewer control + de-flake

### DIFF
--- a/frontend/e2e/flows/extraction-export.e2e.ts
+++ b/frontend/e2e/flows/extraction-export.e2e.ts
@@ -325,7 +325,7 @@ test.describe("Extraction export — UI flow", () => {
     ).toBeVisible();
   });
 
-  test("Single-user mode reveals the reviewer picker", async ({ page }) => {
+  test("Single-user mode reveals the reviewer control", async ({ page }) => {
     const env = loadE2EEnv();
     await loginViaUi(page);
     await page.goto(
@@ -335,14 +335,18 @@ test.describe("Extraction export — UI flow", () => {
     await page.getByTestId("extraction-export-button").click();
     await page.getByLabel(/Single user/i).check();
 
-    const picker = page.getByTestId("extraction-export-reviewer-picker");
-    const locked = page.getByTestId("extraction-export-reviewer-locked");
-    // Either the picker (manager) or the locked label (reviewer) is shown.
-    const visible = await Promise.race([
-      picker.isVisible().then((v) => (v ? "picker" : null)),
-      locked.isVisible().then((v) => (v ? "locked" : null)),
-    ]);
-    expect(["picker", "locked"]).toContain(visible);
+    // Single-user mode resolves to exactly one of three mutually exclusive
+    // states: a manager's reviewer picker, a reviewer's locked-to-self label,
+    // or the empty state when no reviewer has eligible data yet (the ephemeral
+    // seed has none — empty state added in #302). `.or()` auto-retries and
+    // never races on a non-retrying isVisible() (the old Promise.race resolved
+    // to whichever check settled first, flaking to null when the rendered
+    // element's check lost the race).
+    const reviewerControl = page
+      .getByTestId("extraction-export-reviewer-picker")
+      .or(page.getByTestId("extraction-export-reviewer-locked"))
+      .or(page.getByTestId("extraction-export-reviewer-empty"));
+    await expect(reviewerControl).toBeVisible();
   });
 
   test("All-users mode reveals the anonymize-reviewer toggle for managers", async ({ page }) => {


### PR DESCRIPTION
## Root cause (systematic-debugging)

`Frontend E2E (ephemeral stack)` hard-failed on `extraction-export.e2e.ts › Single-user mode reveals the reviewer picker` (failed initial + retry):

```
expect(received).toContain(expected)
Expected value: null
Received array: ["picker", "locked"]
> expect(["picker", "locked"]).toContain(visible);
```

`ExtractionExportDialog` renders **three** mutually exclusive controls in single-user mode — `extraction-export-reviewer-picker` (manager), `-locked` (reviewer), and **`-empty`** (no eligible reviewers). The `-empty` branch was added by #302 ("clear empty-state for the export reviewer picker") and the **unit** test was updated, but the **E2E** test was not — it still asserted only picker-or-locked. In the ephemeral stack the export article has no eligible reviewers (`useEligibleReviewers` → `[]`), so the component correctly shows `-empty` and the assertion fails.

Compounding flake: the test used `Promise.race` over two non-retrying `isVisible()` checks, so it resolved to whichever settled first — returning `null` even when an element was visible.

Unrelated to the finalize-gate fix (#304/#305) — that change touches only the completion metric and appears nowhere in this spec; #304 carried the identical E2E result and merged (non-required check).

## Fix

Assert an auto-retrying `.or()` locator over all three testids. The test now verifies the real invariant (single-user mode reveals *a* reviewer control) and no longer depends on seed reviewer data or check timing.

## Verification

- `npm run typecheck` (CI `tsconfig.app.json`, includes `frontend/e2e`) — clean
- `eslint` on the file — clean
- `playwright test --list` — test collected under the new title
- Full ephemeral E2E runs in CI on this PR (cannot spin the stack locally)

Note: tests 276/300 (`extraction-export-button` visibility) flaked separately and passed on retry #1 — a softer timing flake, left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
