### PR TITLE
Promote to main: notification bell reactivity fix (#307)

### DIFF
--- a/frontend/components/navigation/NotificationCenter.tsx
+++ b/frontend/components/navigation/NotificationCenter.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import {ScrollArea} from '@/components/ui/scroll-area';
 import {Progress} from '@/components/ui/progress';
-import {useBackgroundJobs} from '@/stores/useBackgroundJobs';
+import {selectRecentJobs, useBackgroundJobs} from '@/stores/useBackgroundJobs';
 import {useBackgroundJobPolling} from '@/hooks/useBackgroundJobPolling';
 import {cn} from '@/lib/utils';
 import {toast} from 'sonner';
@@ -54,11 +54,13 @@ function countRecentlyFinished(jobs: BackgroundJob[]): number {
 export function NotificationCenter() {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
-    const {jobs, removeJob, clearCompletedJobs, getRecentJobs, updateJob} = useBackgroundJobs();
-  
-  // kept: extra dep (jobs) forces recompute on any job-list change, even when
-  // getRecentJobs identity is stable — removing it would miss new job additions (zero-bailouts spec).
-  const recentJobs = useMemo(() => getRecentJobs(20), [jobs, getRecentJobs]);
+    const {jobs, removeJob, clearCompletedJobs, updateJob} = useBackgroundJobs();
+
+  // Derive from the reactive `jobs` (not the store getter): the React
+  // Compiler tracks deps from the callback body, so the callback MUST
+  // reference `jobs` or the memo is treated as stale and the bell misses
+  // jobs added in-session (the async-export "never downloads" incident).
+  const recentJobs = useMemo(() => selectRecentJobs(jobs, 20), [jobs]);
 
     useEffect(() => {
         let isInFlight = false;

--- a/frontend/components/navigation/__tests__/NotificationCenter.test.tsx
+++ b/frontend/components/navigation/__tests__/NotificationCenter.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Regression coverage for NotificationCenter reactivity.
+ *
+ * Root-cause guard for the async-export "never downloads" incident: a
+ * background job added AFTER the component mounted (e.g. the user submits
+ * an export) must appear in the bell without a page reload. The original
+ * `recentJobs = useMemo(() => getRecentJobs(20), [jobs, getRecentJobs])`
+ * never referenced `jobs` inside the callback, so the React Compiler
+ * (which derives deps from the body, not the manual array) memoized it on
+ * the stable `getRecentJobs` action and never recomputed on new jobs —
+ * the bell stayed stale until a reload rehydrated it.
+ */
+
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {render, screen, act} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {MemoryRouter} from "react-router-dom";
+
+vi.mock("sonner", () => ({
+    toast: {success: vi.fn(), info: vi.fn(), error: vi.fn()},
+}));
+vi.mock("@/services/extractionExportService", () => ({
+    getExportStatus: vi.fn().mockResolvedValue({job_id: "x", status: "completed"}),
+}));
+vi.mock("@/services/articlesExportService", () => ({
+    getExportStatus: vi.fn().mockResolvedValue({job_id: "x", status: "completed"}),
+}));
+
+import {NotificationCenter} from "../NotificationCenter";
+import {useBackgroundJobs} from "@/stores/useBackgroundJobs";
+import {createExtractionExportJob} from "@/types/background-jobs";
+
+function completedExportJob(id: string) {
+    return {
+        ...createExtractionExportJob("11111111-1111-1111-1111-111111111111", `backend-${id}`, {
+            templateId: "22222222-2222-2222-2222-222222222222",
+            mode: "all_users" as const,
+            articleCount: 5,
+            includeAiMetadata: false,
+            anonymizeReviewerNames: false,
+            downloadUrl: "https://example.test/export.xlsx",
+        }),
+        id,
+        status: "completed" as const,
+        completedAt: Date.now(),
+    };
+}
+
+beforeEach(() => {
+    act(() => {
+        useBackgroundJobs.setState({jobs: []});
+    });
+});
+
+describe("NotificationCenter", () => {
+    it("shows a job added after mount without a reload", async () => {
+        const user = userEvent.setup();
+        render(
+            <MemoryRouter>
+                <NotificationCenter />
+            </MemoryRouter>,
+        );
+
+        await user.click(screen.getByRole("button", {name: /notifications/i}));
+        expect(screen.getByText(/No notifications/i)).toBeInTheDocument();
+
+        // Simulate the export dialog enqueuing a completed job in-session.
+        act(() => {
+            useBackgroundJobs.getState().addJob(completedExportJob("job-1"));
+        });
+
+        // The bell must reflect it immediately (not only after a reload).
+        expect(await screen.findByText("Export extraction data")).toBeInTheDocument();
+        expect(screen.queryByText(/No notifications/i)).not.toBeInTheDocument();
+    });
+});

--- a/frontend/e2e/flows/extraction-export.e2e.ts
+++ b/frontend/e2e/flows/extraction-export.e2e.ts
@@ -325,7 +325,7 @@ test.describe("Extraction export — UI flow", () => {
     ).toBeVisible();
   });
 
-  test("Single-user mode reveals the reviewer picker", async ({ page }) => {
+  test("Single-user mode reveals the reviewer control", async ({ page }) => {
     const env = loadE2EEnv();
     await loginViaUi(page);
     await page.goto(
@@ -335,14 +335,18 @@ test.describe("Extraction export — UI flow", () => {
     await page.getByTestId("extraction-export-button").click();
     await page.getByLabel(/Single user/i).check();
 
-    const picker = page.getByTestId("extraction-export-reviewer-picker");
-    const locked = page.getByTestId("extraction-export-reviewer-locked");
-    // Either the picker (manager) or the locked label (reviewer) is shown.
-    const visible = await Promise.race([
-      picker.isVisible().then((v) => (v ? "picker" : null)),
-      locked.isVisible().then((v) => (v ? "locked" : null)),
-    ]);
-    expect(["picker", "locked"]).toContain(visible);
+    // Single-user mode resolves to exactly one of three mutually exclusive
+    // states: a manager's reviewer picker, a reviewer's locked-to-self label,
+    // or the empty state when no reviewer has eligible data yet (the ephemeral
+    // seed has none — empty state added in #302). `.or()` auto-retries and
+    // never races on a non-retrying isVisible() (the old Promise.race resolved
+    // to whichever check settled first, flaking to null when the rendered
+    // element's check lost the race).
+    const reviewerControl = page
+      .getByTestId("extraction-export-reviewer-picker")
+      .or(page.getByTestId("extraction-export-reviewer-locked"))
+      .or(page.getByTestId("extraction-export-reviewer-empty"));
+    await expect(reviewerControl).toBeVisible();
   });
 
   test("All-users mode reveals the anonymize-reviewer toggle for managers", async ({ page }) => {

--- a/frontend/stores/useBackgroundJobs.ts
+++ b/frontend/stores/useBackgroundJobs.ts
@@ -26,6 +26,34 @@ interface BackgroundJobsState {
 
 const MAX_COMPLETED_JOBS = 10; // Keep only last 10 completed jobs
 
+/**
+ * Pure selector for the notification list: active jobs first, then the most
+ * recently finished ones. Exported so components can derive it from a
+ * reactive `jobs` value — the React Compiler tracks dependencies from the
+ * callback body, so a `useMemo(() => getRecentJobs(20), [jobs])` whose
+ * callback never references `jobs` is memoized as stale and misses
+ * in-session additions. Passing `jobs` in keeps the dependency real.
+ */
+export function selectRecentJobs(
+  jobs: BackgroundJob[],
+  limit = 10,
+): BackgroundJob[] {
+  const activeJobs = jobs.filter(
+    (job) => job.status === 'running' || job.status === 'pending',
+  );
+  const finishedJobs = jobs
+    .filter(
+      (job) =>
+        job.status === 'completed' ||
+        job.status === 'failed' ||
+        job.status === 'cancelled',
+    )
+    .sort((a, b) => (b.completedAt || b.createdAt) - (a.completedAt || a.createdAt))
+    .slice(0, Math.max(limit - activeJobs.length, MAX_COMPLETED_JOBS));
+
+  return [...activeJobs, ...finishedJobs];
+}
+
 export const useBackgroundJobs = create<BackgroundJobsState>()(
   persist(
     (set, get) => ({
@@ -77,25 +105,7 @@ export const useBackgroundJobs = create<BackgroundJobsState>()(
         );
       },
 
-      getRecentJobs: (limit = 10) => {
-        const allJobs = get().jobs;
-
-          // Keep active jobs + last N completed/failed/cancelled
-        const activeJobs = allJobs.filter(
-          (job) => job.status === 'running' || job.status === 'pending'
-        );
-        
-        const finishedJobs = allJobs
-          .filter((job) => 
-            job.status === 'completed' || 
-            job.status === 'failed' || 
-            job.status === 'cancelled'
-          )
-          .sort((a, b) => (b.completedAt || b.createdAt) - (a.completedAt || a.createdAt))
-          .slice(0, Math.max(limit - activeJobs.length, MAX_COMPLETED_JOBS));
-
-        return [...activeJobs, ...finishedJobs];
-      },
+      getRecentJobs: (limit = 10) => selectRecentJobs(get().jobs, limit),
     }),
     {
       name: 'review-hub-background-jobs',


### PR DESCRIPTION
Promotes the real "never downloads" fix from `dev` to `main` (production).

- **#307** fix(frontend): notification bell reflects in-session jobs. `recentJobs` was memoized stale under the React Compiler (manual `[jobs]` dep not honored because the callback never referenced `jobs`), so async export jobs only appeared in the bell after a reload. Now derived from the reactive `jobs` via a pure `selectRecentJobs`.

Verified: NotificationCenter RED→GREEN test under the compiler; full suite 521 green; typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)