### PR TITLE
chore(claude): add design-review visual feedback loop skill + command

### DIFF
--- a/.claude/commands/design-review.md
+++ b/.claude/commands/design-review.md
@@ -1,0 +1,134 @@
+---
+description: Run prumo's visual feedback loop on a screen — render it, screenshot it, compare to the Plane/Linear target, list prioritised diffs, and (with --fix) apply + re-verify.
+argument-hint: "<route or screen> [--fix] [--dark] [--mobile] [--baseline]"
+allowed-tools:
+  - Read
+  - Edit
+  - Glob
+  - Grep
+  - Bash(npm run dev*)
+  - mcp__Claude_Preview__preview_start
+  - mcp__Claude_Preview__preview_screenshot
+  - mcp__Claude_Preview__preview_snapshot
+  - mcp__Claude_Preview__preview_inspect
+  - mcp__Claude_Preview__preview_resize
+  - mcp__Claude_Preview__preview_eval
+  - mcp__Claude_Preview__preview_console_logs
+  - mcp__Claude_Preview__preview_click
+  - mcp__Claude_Preview__preview_fill
+---
+
+# /design-review — visual feedback loop
+
+User-supplied arguments: `$ARGUMENTS`
+
+You are running prumo's **design-review loop** against the live frontend. The
+governing process is the `design-review` skill — invoke it and follow it. The
+target language is the `frontend-ux` skill; class mechanics come from
+`ui-styling`. Reproduce the **Plane/Linear** language; do not invent a new one
+(`frontend-ux` outranks the `frontend-design` plugin on core product UI).
+
+> Iron law (from `verification-before-completion`): no "looks good" without a
+> fresh screenshot you actually captured and compared. A described screen is not
+> a verified screen.
+
+---
+
+## Phase 1 — Parse arguments
+
+From `$ARGUMENTS`, extract:
+
+- **target** — the first non-flag token(s): either a route path (`/projects/:id/extraction`)
+  or a screen description ("extraction list empty state"). Required. If absent,
+  ask the user which screen, then stop.
+- `--fix` — apply P0/P1 fixes and re-verify (default: report only, no edits).
+- `--dark` — also capture and review dark mode.
+- `--mobile` — also capture and review at ≈390px width.
+- `--baseline` — after the screen matches, print the Playwright `toHaveScreenshot`
+  line + the command for the user to run (recording is `web-testing` §7, and this
+  command has no Playwright grant — it reports, it doesn't write baselines).
+
+## Phase 2 — Resolve the route
+
+If **target** is a description, find the route: `Grep`/`Glob` under
+`frontend/pages/` and the router for the matching screen, and state the resolved
+path. If you cannot resolve it confidently, ask rather than guess.
+
+## Phase 3 — Render
+
+Start the preview with `preview_start` at `http://127.0.0.1:8080<route>` (Vite,
+`npm run dev`). It reuses a server already on :8080; if nothing is listening, start
+one first (`npm run dev`) and wait for it, then `preview_start`.
+
+**Auth.** Most product routes sit behind `ProtectedRoute` and redirect an
+unauthenticated session to `/auth` — so a deep route renders the login form, not
+your screen. If you land on `/auth`, sign in with the browser test account:
+`preview_fill` email + password (`teste@prumo.local` / `Senha123`), `preview_click`
+submit, then go to the target. Confirm via `preview_snapshot` that you're on the
+app shell (not `/auth`) before capturing. If sign-in is rejected (`Invalid login
+credentials` in the console), the dev build's Supabase has no such account — bring
+up the full local stack (`make start` / `make db-seed`) or use known-good creds.
+
+If the screen needs a specific state (empty / loading / a particular run or
+reviewer), drive to it with `preview_click` / `preview_eval` and say which state
+you captured. Check `preview_console_logs` for errors that would distort the render.
+
+## Phase 4 — Capture
+
+- Desktop light: `preview_screenshot` (always).
+- `--dark`: theme is `next-themes` (`storageKey="prumo:theme"`), so force it
+  durably — `preview_eval("localStorage.setItem('prumo:theme','dark'); location.reload()")`,
+  then `preview_screenshot`; restore with `'system'`/`'light'` + reload.
+- `--mobile`: `preview_resize` to ≈390 wide, `preview_screenshot`, restore.
+- `preview_snapshot` for structure, and `preview_inspect` on any node whose token
+  you doubt (confirm the header is really 48px, the border really `/0.4`, the
+  shadow not `none`).
+
+## Phase 5 — Compare against the two anchors
+
+Load both targets and judge the capture against the `design-review` rubric:
+
+1. **Objective** — the `frontend-ux` checklist: `h-12` header, `text-[13px]` body,
+   `border-border/40`, `h-4 w-4` `strokeWidth={1.5}` icons, instant
+   `hover:bg-muted/50`, soft `elev-*`/`shadow-[…0.04]` shadows, breadcrumb-first.
+2. **Vocabulary** — `Read` the reference images
+   `docs/design-references/linear_ux.png` and
+   `docs/design-references/linear_project_configuration.png` and compare *feel*:
+   density, contrast, chrome, spacing rhythm.
+
+Also sweep the **anti-slop tells** in the skill (oversized centered titles, hard
+shadow slabs, gradients, full-opacity borders, `rounded-2xl` everywhere, emoji
+icons, missing hover/focus).
+
+## Phase 6 — Report prioritised diffs
+
+Print one Markdown table. Severity: **P0** = breaks the look / off-language, **P1**
+= clearly wrong vs the checklist, **P2** = cosmetic polish.
+
+```
+| PRI | WHAT'S OFF | frontend-ux RULE | FIX (exact class/token change) | FILE:LINE |
+|-----|-----------|------------------|--------------------------------|-----------|
+```
+
+Each fix must be a concrete `ui-styling`-correct change (semantic token, `cn()`
+order, `border-border/40`, …) — never a raw hex/HSL, never a hardcoded string.
+
+## Phase 7 — Fix + re-verify (only with `--fix`)
+
+If `--fix` was passed, apply the **P0 and P1** rows with `Edit` (smallest change
+each; leave P2 as noted follow-ups). Then **re-capture the same screen and state**
+(repeat Phases 3–4) and confirm each diff actually closed. Loop Phases 5–7 until no
+P0/P1 remain. Respect the React Compiler rule: no `try/finally`/`throw` in
+component bodies; all copy through `frontend/lib/copy/`.
+
+Without `--fix`: stop after Phase 6 and let the user decide.
+
+## Phase 8 — Verdict
+
+End with:
+
+- The before screenshot path, and (if `--fix`) the after path.
+- One line: `## RESULT: MATCHES TARGET` (no P0/P1 left) or
+  `## RESULT: N P0 / M P1 diffs remain` with the table above.
+- If `--baseline` and the screen matches: state the exact `toHaveScreenshot` line
+  and the file it would live in, and ask before recording it.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -31,6 +31,12 @@ mechanics in `ui-styling`. This file is the always-true core.
   i18n) — never hardcode strings in components.
 - shadcn/Radix primitives; `cn()` merge order matters; every
   interactive element keeps a visible focus state.
+- Visual language is authoritative in `frontend-ux` (it outranks the
+  `frontend-design` plugin on core product UI — that plugin is for
+  greenfield only). After a non-trivial UI change, verify with your
+  eyes, not the diff: run the `design-review` loop
+  (`/design-review <route>`) — render, screenshot, compare to the
+  Plane/Linear target, fix, re-screenshot.
 
 ## Tests
 

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: design-review
+description: prumo's visual feedback loop — render the screen, screenshot it, compare to the Plane/Linear target, list the diffs, fix, re-screenshot, confirm. Use BEFORE claiming any frontend screen or component "done", and whenever the ask is "does this look right", "match Linear/Plane", "tighten this screen", "iterate on the UI", "why does this look off / generic / AI-made", or after any non-trivial layout, density, spacing, or theme change. The `/design-review` command runs this loop on a route. Siblings: `frontend-ux` sets the visual language (what it should look like), `ui-styling` is the Tailwind/shadcn mechanics (how to wire the classes); this skill is the *did it actually end up that way* layer that closes the loop with your eyes, not the diff.
+---
+
+# Design Review — the visual feedback loop
+
+The single load-bearing frontend practice: **never judge a UI from the code diff
+alone — render it, look at it, and correct against a target.** A class string that
+reads correct still ships the wrong screen (a stale token, a missed `min-w-0`, a
+shadow that resolved to `none`, a dark-mode foreground that vanished). The check
+that closes the loop is visual.
+
+- `frontend-ux` → *what it should look like* (the Plane/Linear/WorkOS language).
+- `ui-styling` → *how to wire it* (Tailwind v3 + shadcn + Radix mechanics).
+- **this skill** → *what you actually rendered, and how to walk it to the target.*
+
+Read `frontend-ux` first to know the target; run this loop to verify you hit it.
+
+## When to run
+
+- Before claiming **any** frontend screen/component done (this is the UI analogue
+  of `verification-before-completion` — a screenshot is your fresh evidence).
+- "Does this look right?", "match Linear/Plane", "tighten / polish this screen",
+  "this feels generic / AI-made", "iterate on the UI".
+- After a non-trivial change to layout, density, spacing, borders, shadows,
+  empty/loading states, dark mode, or responsive behaviour.
+- Via the `/design-review <route> [--fix] [--dark] [--mobile] [--baseline]`
+  command.
+
+## The loop (do not skip a step)
+
+```
+1. RENDER     dev server up, log in if the screen is gated, open the exact state
+2. CAPTURE    screenshot it (desktop light; add dark + mobile if you touched them)
+3. COMPARE    hold it against TWO anchors (rubric below): the frontend-ux
+              checklist (objective) and the Linear reference images (vocabulary)
+4. DIFF       write a prioritised list — P0 (breaks the look) → P2 (nice-to-have)
+5. FIX        apply the smallest class/token change per diff (ui-styling mechanics)
+6. RE-CAPTURE screenshot the same screen + state again
+7. CONFIRM    diff closed? loop back to 4 until no P0/P1 remain, then stop
+```
+
+Stop when there are no P0/P1 diffs left, or the user calls it. Don't loop on P2
+cosmetics forever — note them and move on.
+
+## Tooling — what to capture with
+
+| Goal | Tool | Why |
+| --- | --- | --- |
+| Interactive iteration (the loop above) | **Claude_Preview MCP** — `preview_start`, `preview_screenshot`, `preview_snapshot`, `preview_inspect`, `preview_resize`, `preview_eval`, `preview_fill`, `preview_click` | First-party harness preview; the harness's preview-tools guidance prefers `preview_*` over Bash/Chrome for running the dev server + verifying. |
+| A scripted capture or a committed regression baseline | **Playwright** `toHaveScreenshot` | Deterministic, lives in CI. Owned by the `web-testing` skill §7 — read it before adding baselines. |
+
+Mechanics:
+
+- Dev server is `npm run dev` → Vite on **:8080** (`http://127.0.0.1:8080`).
+  `preview_start` reuses a server already on :8080; if nothing is listening,
+  start it first (`npm run dev`) and wait for it before `preview_start`.
+- **Auth.** Most product screens (extraction, HITL, runs, settings) sit behind
+  `ProtectedRoute`, which redirects an unauthenticated session to `/auth` — so
+  `preview_start` at a deep route lands on the **login form**, not your screen.
+  Sign in first: open `/auth`, `preview_fill` the email + password with the
+  browser test account (`teste@prumo.local` / `Senha123`), `preview_click` submit,
+  then go to the target. Confirm with `preview_snapshot` that you're on the app
+  shell (not `/auth`) before you screenshot. If sign-in is rejected (`Invalid login
+  credentials` in `preview_console_logs`), the dev build points at a Supabase where
+  that account isn't seeded — bring up the full local stack (`make start` /
+  `make db-seed`) or use known-good creds before retrying.
+- Navigate within the app with `preview_eval` (`window.location.assign('/...')`)
+  or by starting the preview at the target URL. There is no `preview_navigate`.
+- `preview_screenshot` = the visual; `preview_snapshot` = the DOM/structure;
+  `preview_inspect` = computed CSS for a node (use it to confirm a token actually
+  resolved, e.g. the header is really `48px`, the border is really
+  `hsl(var(--border) / 0.4)`).
+- **Dark mode** is driven by `next-themes` (`attribute="class"`,
+  `storageKey="prumo:theme"`), so a bare `classList.toggle("dark")` gets re-synced
+  out from under you. Force it durably with
+  `preview_eval("localStorage.setItem('prumo:theme','dark'); location.reload()")`,
+  screenshot, then restore (`'system'` or `'light'`) and reload.
+- Responsive: `preview_resize` to a narrow width (≈390) before re-capturing.
+
+## Targets — what "correct" means (two anchors)
+
+**1. The objective rubric — the `frontend-ux` checklist.** Always available,
+unambiguous, and the thing to enforce first:
+
+- Header height is exactly `h-12` (48px), `bg-background/80 backdrop-blur-md`,
+  `border-b border-border/40`.
+- Body/UI font is `text-[13px]`; titles `text-foreground`, everything else
+  `text-muted-foreground`.
+- Borders use `border-border/40` for chrome/dividers (`border-border/50` for
+  menus & dropdowns, per frontend-ux §3) — never full-opacity 1px slabs.
+- Icons are `h-4 w-4` with `strokeWidth={1.5}`, consistent across the screen.
+- List hover is instant (`duration-0`/`duration-75`) and `hover:bg-muted/50`.
+- Shadows are soft and large (`shadow-[0_8px_30px_rgb(0,0,0,0.04)]` / the
+  `shadow-elev-*` tokens), never a hard `shadow-md` slab.
+- Navigation is breadcrumb-first, not a 24px page title.
+
+**2. The vocabulary anchor — the Linear reference images.** Open them and compare
+*feel* (density, contrast, chrome, spacing rhythm):
+
+- `docs/design-references/linear_ux.png` — list density, hover affordances,
+  command-palette feel.
+- `docs/design-references/linear_project_configuration.png` — configuration /
+  settings surfaces.
+
+These are references, not pixel specs (see `docs/design-references/README.md`).
+Use them to answer "does this *feel* like the same family of tool?"
+
+## The rubric — what to actually look at in the screenshot
+
+- **Density & rhythm** — too much vertical padding? rows taller than `h-9`? Is the
+  information-per-screen close to the Linear reference, or sparse and "webpage-y"?
+- **Hierarchy & contrast** — is exactly one thing the title (`text-foreground`)
+  and the rest muted? Or is everything competing at full contrast? Borderline
+  contrast → don't eyeball it, run the `web-testing` §6 axe `color-contrast` check.
+- **Chrome & borders** — borders subtle (`/40` chrome, `/50` menus) and used to
+  separate, not decorate? Any double borders (use `gap-px bg-border`)? Header thin?
+- **Hover & interaction** — every interactive row/button has a hover state? Focus
+  ring visible on keyboard (`focus-visible:ring-2 focus-visible:ring-ring
+  focus-visible:ring-offset-2`)? Hover is instant?
+- **Empty & loading** — skeletons match real line-height/width (no layout shift)?
+  Empty states intentional, not a bare "No data"?
+- **Dark mode** — any text that vanished (raw color instead of a token)? Do the
+  `reviewer-1..5` dots/avatars and status/severity colors still read on the dark
+  surface and come from tokens (`text-reviewer-N`), not hardcoded hex/HSL? Shadows
+  still read on the dark surface?
+- **Responsive** — overflow on flex/grid (missing `min-w-0`)? Does it degrade
+  cleanly at ≈390px?
+- **Reduced motion** — with `prefers-reduced-motion` forced, do the
+  field-just-updated flash and any transitions degrade to no-motion (not animate)?
+  Hover stays instant per `frontend-ux` either way.
+
+## Anti-slop tells (catch generic-AI output before the user does)
+
+| Slop tell | prumo-correct |
+| --- | --- |
+| 24–32px centered page title | breadcrumb + `text-[13px]` context, content starts high |
+| Hard `shadow-md`/`shadow-lg` slabs | soft `shadow-[0_8px_30px_rgb(0,0,0,0.04)]` / `elev-*` |
+| Purple/indigo gradient, glassy hero | flat semantic surfaces (`bg-background`, `bg-muted`) |
+| Full-opacity borders everywhere | `border-border/40`, dividers via `gap-px bg-border` |
+| Generous `p-6`/`p-8`, `space-y-6` | dense `py-1`–`py-2`, `text-[13px]`, `h-9` rows |
+| `rounded-2xl` on everything | `rounded-md` (8px) per the menu/dropdown spec |
+| Emoji as icons, mismatched icon sizes | `lucide` `h-4 w-4` `strokeWidth={1.5}` |
+| No hover affordance on rows/actions | `group-hover` reveal + `hover:bg-muted/50` |
+
+## Precedence: `frontend-ux` wins; `frontend-design` is greenfield-only
+
+The enabled `frontend-design@claude-plugins-official` plugin optimises for
+*distinctive novelty* — it pushes bold, one-of-a-kind directions and bans common
+defaults (e.g. Inter / system fonts). That is **the wrong objective for a fixed
+Plane/Linear benchmark**: it pulls core product UI *away* from the consistent
+language we are matching. So:
+
+- **Core product UI** (extraction, HITL, runs, settings, layout) → this loop +
+  `frontend-ux` + `ui-styling` govern. Reproduce the existing language; do not
+  invent a new one.
+- **Greenfield / marketing / illustrative** surfaces with no existing pattern to
+  match → `frontend-design` is fair game for exploration.
+
+When the two conflict on a core screen, `frontend-ux` is authoritative.
+
+## Recording a regression baseline (optional)
+
+Once a screen matches the target and is stable, you can lock it with a Playwright
+snapshot so cosmetic regressions get caught in CI:
+
+```ts
+await expect(page).toHaveScreenshot('extraction-list.png', { maxDiffPixels: 200 });
+```
+
+Baselines live alongside the test; diffs land in `test-results/`. Use **sparingly**
+— snapshots are heavy and break on legit refactors. This is `web-testing` §7
+territory; read it before adding one, and `mask:` volatile regions (timestamps,
+avatars, reviewer colors).
+
+## Checklist (make these TodoWrite items)
+
+- [ ] Rendered the exact screen **and state** I changed (not just the happy path).
+- [ ] Captured desktop-light; added dark + mobile if I touched them.
+- [ ] Compared against the `frontend-ux` checklist (objective) and the Linear
+      reference images (vocabulary).
+- [ ] Wrote a prioritised diff list (P0 → P2).
+- [ ] Fixed every P0/P1 with the smallest token/class change.
+- [ ] Re-captured and confirmed each diff actually closed.
+- [ ] No raw colors, no full-opacity border slabs, no AI-slop tells remain.

--- a/.claude/skills/frontend-ux/SKILL.md
+++ b/.claude/skills/frontend-ux/SKILL.md
@@ -5,6 +5,19 @@ description: prumo's visual language — the *what it should look like* layer (P
 
 # Frontend UX & UI Design System (Plane/Linear/WorkOS Style)
 
+> **Precedence.** On core product UI this skill is authoritative — reproduce the
+> existing Plane/Linear language, do not invent a new one. The enabled
+> `frontend-design@claude-plugins-official` plugin optimises for *distinctive
+> novelty* (it bans common defaults like Inter/system fonts and pushes bold,
+> one-off directions); that fights a fixed benchmark, so reserve it for
+> greenfield / marketing / illustrative surfaces only. When they conflict on a
+> core screen, `frontend-ux` wins.
+>
+> **Verify with your eyes, not the diff.** After applying these rules, close the
+> loop with the `design-review` skill (`/design-review <route>`): render →
+> screenshot → compare to target → fix → re-screenshot. A class string that reads
+> correct still ships the wrong screen.
+
 ## Role
 
 You are a senior UX Engineer focused on **Productivity Software**. Your goal is to create an interface that feels like a

--- a/.claude/skills/ui-styling/SKILL.md
+++ b/.claude/skills/ui-styling/SKILL.md
@@ -53,9 +53,12 @@ Files you will touch most:
 4. **Always extend the base via the `className` prop**, never override base
    styles in the consuming file by re-declaring layout primitives. Pass a thin
    delta. `cn()` will merge correctly.
-5. **Dark mode is `class`-based**, toggled by adding/removing `dark` on `<html>`
-   (see `frontend/contexts` / `ThemeProvider`). No `next-themes` — we are on Vite.
-   Test every new component in both modes; do not assume `dark:` variants.
+5. **Dark mode is `class`-based**, driven by `next-themes` via `ThemeProvider`
+   (`frontend/contexts/ThemeContext.tsx`: `attribute="class"`,
+   `defaultTheme="system"`, `storageKey="prumo:theme"`). Switch through it (the
+   `useTheme().cycle` helper or `setTheme`), not by hand-poking the `dark` class —
+   it re-syncs from storage + system preference. Test every new component in both
+   modes; do not assume `dark:` variants.
 6. **Focus is never invisible.** Keep `focus-visible:ring-2
    focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none`
    on any interactive element. Radix gives you keyboard nav for free; do not

--- a/.claude/skills/web-testing/SKILL.md
+++ b/.claude/skills/web-testing/SKILL.md
@@ -253,6 +253,8 @@ Deeper patterns: [`references/playwright.md`](references/playwright.md) and [`re
 
 Playwright snapshots are stored alongside tests; diffs land in `test-results/`. Use sparingly — visual tests are heavy and easy to break with cosmetic refactors.
 
+This is the *regression-locking* half of visual work — it catches drift on an already-correct screen. The *getting-it-correct* half (render → screenshot → compare to the Plane/Linear target → fix → re-screenshot) is the `design-review` skill / `/design-review`; reach for that first when iterating, and only drop a `toHaveScreenshot` baseline once the screen matches and is stable.
+
 ```ts
 await expect(page).toHaveScreenshot('extraction-empty-state.png', {
   maxDiffPixels: 100,

--- a/llms.txt
+++ b/llms.txt
@@ -19,6 +19,9 @@ Hosting: Railway (backend + worker + Redis) + Vercel (frontend) + Supabase
 - Extraction or quality-assessment → [docs/reference/extraction-hitl-architecture.md](docs/reference/extraction-hitl-architecture.md)
 - Deployment → [docs/reference/deployment.md](docs/reference/deployment.md)
 - Tests → [docs/reference/test-strategy.md](docs/reference/test-strategy.md)
+- Frontend UI / visual changes → the `frontend-ux` + `ui-styling` skills; close
+  the loop with `design-review` (`/design-review <route>`) — render, screenshot,
+  compare to the Plane/Linear target, fix, re-screenshot — before calling a screen done
 - An architectural decision → [docs/adr/](docs/adr/)
 
 ## Do not read these (archived / generated)


### PR DESCRIPTION
## What

Adds a screenshot-driven **visual feedback loop** to the repo's Claude Code config so the agent verifies frontend UI *with its eyes*, not just the diff — and reproduces the Plane/Linear visual language consistently.

- **NEW** `.claude/skills/design-review/SKILL.md` — the loop (render → screenshot → compare to target → diff → fix → re-screenshot), an objective rubric tied to `frontend-ux`, anti-slop tells, and two comparison anchors (the `frontend-ux` checklist + `docs/design-references/linear_*.png`).
- **NEW** `.claude/commands/design-review.md` — `/design-review <route> [--fix] [--dark] [--mobile] [--baseline]`, drives the loop via the Claude_Preview MCP.
- `.claude/skills/frontend-ux/SKILL.md` + `.claude/rules/frontend.md` — **precedence note**: `frontend-ux` outranks the enabled `frontend-design` plugin on core product UI (the plugin optimizes for *distinctive novelty*, which fights a fixed benchmark; it's greenfield-only).
- `.claude/skills/web-testing/SKILL.md` §7 — bidirectional cross-link (loop = get-it-correct; `toHaveScreenshot` = lock-the-regression).
- `.claude/skills/ui-styling/SKILL.md` — corrects a stale "no next-themes" claim (the app *does* use `next-themes`, `attribute="class"`, `storageKey="prumo:theme"`).
- `llms.txt` — discoverability pointer.

## Why

Anthropic's best-practices guidance identifies the closed visual loop as the load-bearing SOTA frontend practice, and it was the one thing the repo's otherwise-strong frontend tooling lacked. Everything else here is refinement, not a rebuild.

## How it was validated

- **5-lens adversarial audit** of the new files (tool/API correctness, convention match, executability, precedence accuracy, completeness). It caught a factual P0 — a wrong "no next-themes" claim — plus the auth gap and an allow-list/body mismatch; all fixed.
- **Dogfooded live** against the `/auth` screen: the loop ran end-to-end (dev server → auth-gate detection → form drive → console-error capture → objective measurement → light + dark screenshots). The `next-themes` dark-mode recipe was validated on the running app.

## Reviewer notes

- Docs/config only — no app code changes, no runtime impact.
- The `/design-review` auth step uses the browser test account; if a dev build points at a Supabase where it isn't seeded, the skill now says to run `make start` / `make db-seed` first (surfaced during dogfooding).
- Intentionally **not** in this PR (research flagged them unverified): Playwright `toHaveScreenshot` CI baselines, and a PR-time design-review subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
