### PR TITLE
fix(extraction): repair Frontend E2E regressions (export visibility + finalize gate)

### DIFF
--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -665,7 +665,10 @@ export function ArticleExtractionTable({ projectId, templateId, toolbarActions }
             <div className="flex flex-wrap items-center gap-2">
                 <Skeleton className="h-8 flex-1 min-w-[200px] rounded-md"/>
                 <Skeleton className="h-8 w-8 rounded-md"/>
-                <Skeleton className="h-4 w-24"/>
+                {/* Render the real toolbar actions (e.g. Export) during load so
+                    a view-level action is available immediately, not gated on the
+                    article fetch (avoids the e2e visibility flake). */}
+                {toolbarActions ?? <Skeleton className="h-4 w-24"/>}
             </div>
             <div className="rounded-md overflow-hidden border-b border-border/40">
                 <Table>
@@ -726,15 +729,24 @@ export function ArticleExtractionTable({ projectId, templateId, toolbarActions }
     );
   }
 
-    // Empty state — no articles in project (match ArticlesList pattern)
+    // Empty state — no articles in project (match ArticlesList pattern).
+    // Still render the toolbar actions (e.g. Export) so the action stays
+    // available whatever the table's own article load returns — its
+    // disabled state is owned by the caller. (Regression guard: moving
+    // Export into the toolbar previously hid it whenever this branch ran.)
   if (articles.length === 0) {
     return (
-        <div
-            className="flex flex-col items-center justify-center py-24 px-4 bg-muted/10 rounded-lg border border-dashed border-border/40">
-            <FileText className="h-10 w-10 text-muted-foreground/30 mb-4" strokeWidth={1.2}/>
-            <h3 className="text-base font-medium text-foreground mb-1.5 text-center">{t('extraction', 'listNoArticles')}</h3>
-            <p className="text-[13px] text-muted-foreground text-center max-w-xs mx-auto">{t('extraction', 'listNoArticlesDesc')}</p>
-      </div>
+        <div className="space-y-2">
+            {toolbarActions ? (
+                <div className="flex items-center justify-end">{toolbarActions}</div>
+            ) : null}
+            <div
+                className="flex flex-col items-center justify-center py-24 px-4 bg-muted/10 rounded-lg border border-dashed border-border/40">
+                <FileText className="h-10 w-10 text-muted-foreground/30 mb-4" strokeWidth={1.2}/>
+                <h3 className="text-base font-medium text-foreground mb-1.5 text-center">{t('extraction', 'listNoArticles')}</h3>
+                <p className="text-[13px] text-muted-foreground text-center max-w-xs mx-auto">{t('extraction', 'listNoArticlesDesc')}</p>
+            </div>
+        </div>
     );
   }
 

--- a/frontend/e2e/_fixtures/hitl-finalize.ts
+++ b/frontend/e2e/_fixtures/hitl-finalize.ts
@@ -1,0 +1,111 @@
+/**
+ * E2E helper: drive a run to FINALIZED under the completeness gate (ADR-0009).
+ *
+ * The backend now blocks `consensus -> finalized` for extraction runs unless
+ * every required field of every existing instance carries a resolved value.
+ * Flows that previously published a single field and finalized must now fill
+ * the rest. This helper publishes a placeholder `manual_override` consensus for
+ * every required (instance, field) that is NOT already published — so a value
+ * the test published deliberately (e.g. an AI-proposed one) is preserved — then
+ * advances to FINALIZED.
+ */
+
+import type { APIRequestContext } from "@playwright/test";
+
+import { authHeaders } from "./api";
+import { adminSelect } from "./supabase-admin";
+
+interface FinalizeOpts {
+  apiUrl: string;
+  token: string;
+  traceId: string;
+  runId: string;
+  /** project_extraction_templates.id the run was created against. */
+  templateId: string;
+  /** articles.id the run targets (instances are keyed by article + template). */
+  articleId: string;
+}
+
+/**
+ * Publishes every unpublished required (instance, field) coordinate, then
+ * advances the run to FINALIZED. Throws (with the response body) if any
+ * consensus publish or the final advance is rejected, so the calling test
+ * fails with an actionable message instead of a downstream stage assertion.
+ */
+export async function fillRequiredFieldsAndFinalize(
+  request: APIRequestContext,
+  { apiUrl, token, traceId, runId, templateId, articleId }: FinalizeOpts,
+): Promise<void> {
+  // Coords already published — don't overwrite a value the test set on purpose.
+  const detailRes = await request.get(`${apiUrl}/api/v1/runs/${runId}`, {
+    headers: authHeaders(token, traceId),
+    timeout: 15000,
+  });
+  const detailBody = (await detailRes.json()) as {
+    data?: { published_states?: Array<{ instance_id: string; field_id: string }> };
+  };
+  const published = new Set<string>(
+    (detailBody.data?.published_states ?? []).map(
+      (p) => `${p.instance_id}::${p.field_id}`,
+    ),
+  );
+
+  const instances = await adminSelect<{ id: string; entity_type_id: string }>(
+    "extraction_instances",
+    `select=id,entity_type_id&template_id=eq.${templateId}&article_id=eq.${articleId}&limit=500`,
+  );
+
+  // Required field ids per entity type (cached — many instances share a type).
+  const requiredByEntity = new Map<string, string[]>();
+
+  for (const inst of instances) {
+    let requiredFieldIds = requiredByEntity.get(inst.entity_type_id);
+    if (!requiredFieldIds) {
+      const fields = await adminSelect<{ id: string }>(
+        "extraction_fields",
+        `select=id&entity_type_id=eq.${inst.entity_type_id}&is_required=eq.true`,
+      );
+      requiredFieldIds = fields.map((f) => f.id);
+      requiredByEntity.set(inst.entity_type_id, requiredFieldIds);
+    }
+
+    for (const fieldId of requiredFieldIds) {
+      const coord = `${inst.id}::${fieldId}`;
+      if (published.has(coord)) continue;
+      const res = await request.post(
+        `${apiUrl}/api/v1/runs/${runId}/consensus`,
+        {
+          headers: authHeaders(token, traceId),
+          data: {
+            instance_id: inst.id,
+            field_id: fieldId,
+            mode: "manual_override",
+            value: { value: "e2e-required" },
+            rationale: "E2E: fill required field for the finalize completeness gate",
+          },
+          timeout: 15000,
+        },
+      );
+      if (!res.ok()) {
+        throw new Error(
+          `consensus publish failed for ${coord}: ${res.status()} ${await res.text()}`,
+        );
+      }
+      published.add(coord);
+    }
+  }
+
+  const advRes = await request.post(
+    `${apiUrl}/api/v1/runs/${runId}/advance`,
+    {
+      headers: authHeaders(token, traceId),
+      data: { target_stage: "finalized" },
+      timeout: 30000,
+    },
+  );
+  if (!advRes.ok()) {
+    throw new Error(
+      `finalize advance failed: ${advRes.status()} ${await advRes.text()}`,
+    );
+  }
+}

--- a/frontend/e2e/flows/extraction-reopen.ui.e2e.ts
+++ b/frontend/e2e/flows/extraction-reopen.ui.e2e.ts
@@ -19,6 +19,7 @@ import { expect, test } from "@playwright/test";
 import { authHeaders, parseEnvelope } from "../_fixtures/api";
 import { loginViaUi, resolveAuthToken } from "../_fixtures/auth";
 import { createTraceId, loadE2EEnv, missingEnvKeys } from "../_fixtures/env";
+import { fillRequiredFieldsAndFinalize } from "../_fixtures/hitl-finalize";
 import {
   adminDelete,
   adminSelect,
@@ -145,10 +146,15 @@ test.describe("Extraction reopen UI flow", () => {
     );
     expect(consensusRes.ok()).toBeTruthy();
 
-    await request.post(`${env.apiUrl}/api/v1/runs/${run.id}/advance`, {
-      headers: authHeaders(token, traceId),
-      data: { target_stage: "finalized" },
-      timeout: 15000,
+    // Completeness gate (ADR-0009): the seed coord above is published; fill the
+    // remaining required fields, then finalize so the parent reaches FINALIZED.
+    await fillRequiredFieldsAndFinalize(request, {
+      apiUrl: env.apiUrl,
+      token,
+      traceId,
+      runId: run.id,
+      templateId,
+      articleId: env.articleId!,
     });
 
     // Visit the extraction page. The HITL banner should render the

--- a/frontend/e2e/flows/hitl-ai-proposal.api.e2e.ts
+++ b/frontend/e2e/flows/hitl-ai-proposal.api.e2e.ts
@@ -24,6 +24,7 @@ import { expect, test } from "@playwright/test";
 import { authHeaders, parseEnvelope } from "../_fixtures/api";
 import { resolveAuthToken, loginViaUi } from "../_fixtures/auth";
 import { createTraceId, loadE2EEnv, missingEnvKeys } from "../_fixtures/env";
+import { fillRequiredFieldsAndFinalize } from "../_fixtures/hitl-finalize";
 import {
   adminSelect,
   resolveActiveExtractionTemplateId,
@@ -205,10 +206,15 @@ test.describe("HITL AI proposal pipeline", () => {
       },
     );
     expect(consensusRes.ok()).toBeTruthy();
-    await request.post(`${env.apiUrl}/api/v1/runs/${runBody.id}/advance`, {
-      headers: authHeaders(token, traceId),
-      data: { target_stage: "finalized" },
-      timeout: 15000,
+    // Completeness gate (ADR-0009): the AI-proposed coord above is published;
+    // fill the remaining required fields, then finalize.
+    await fillRequiredFieldsAndFinalize(request, {
+      apiUrl: env.apiUrl,
+      token,
+      traceId,
+      runId: runBody.id,
+      templateId,
+      articleId: env.articleId!,
     });
 
     // 6. The published value matches the AI proposal.


### PR DESCRIPTION
Repairs the Frontend E2E (ephemeral stack) failures introduced on dev by #311.

## Hard failures (were failing the job)
- `hitl-ai-proposal.api.e2e` + `extraction-reopen.ui.e2e`: the ADR-0009 completeness gate blocks finalizing a CHARMS run that published only one of ~28 required fields. New shared helper `_fixtures/hitl-finalize.ts` publishes every *unpublished* required (instance, field) — preserving the test's deliberate value — then finalizes.

## Flaky (export UI)
- The Export button, moved into the table toolbar in #311, was gated on the table's article-load lifecycle (absent in empty state, late during load → flaky visibility). Now rendered in the loading + empty + ready states so it's immediately available.

## Verification
- typecheck, build (React Compiler), eslint clean locally; e2e validated by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)