### PR TITLE
feat(parsing): structured-PDF ingest backbone — DocumentParser port + block repository + parsing service

### DIFF
--- a/backend/app/infrastructure/parsing/__init__.py
+++ b/backend/app/infrastructure/parsing/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure layer: document-parsing port."""

--- a/backend/app/infrastructure/parsing/base.py
+++ b/backend/app/infrastructure/parsing/base.py
@@ -100,6 +100,27 @@ class ParsedBlock:
 # ---------------------------------------------------------------------------
 
 
+def _blocks_by_page_sorted(
+    blocks: list[ParsedBlock],
+) -> dict[int, list[ParsedBlock]]:
+    """Group *blocks* by page number and sort each group by ``block_index``.
+
+    This is the single source of truth for per-page grouping and ordering used
+    by both ``concat_page_text`` and ``assign_char_offsets_to_blocks``.
+
+    Args:
+        blocks: Parsed blocks from one or more pages.  May be in any order.
+
+    Returns:
+        ``{page_number: [blocks sorted by block_index]}`` for every page that
+        appears in *blocks*.
+    """
+    pages: dict[int, list[ParsedBlock]] = {}
+    for block in blocks:
+        pages.setdefault(block.page_number, []).append(block)
+    return {pn: sorted(pb, key=lambda b: b.block_index) for pn, pb in pages.items()}
+
+
 def concat_page_text(blocks: list[ParsedBlock]) -> dict[int, str]:
     """Return a mapping of ``page_number → page_text`` for all pages in *blocks*.
 
@@ -123,17 +144,10 @@ def concat_page_text(blocks: list[ParsedBlock]) -> dict[int, str]:
         appears in *blocks*.  Pages not present in *blocks* are absent from
         the result.
     """
-    # Group blocks by page, sorted by block_index within each page.
-    pages: dict[int, list[ParsedBlock]] = {}
-    for block in blocks:
-        pages.setdefault(block.page_number, []).append(block)
-
-    result: dict[int, str] = {}
-    for page_number, page_blocks in pages.items():
-        sorted_blocks = sorted(page_blocks, key=lambda b: b.block_index)
-        result[page_number] = _BLOCK_SEPARATOR.join(b.text for b in sorted_blocks)
-
-    return result
+    return {
+        page_number: _BLOCK_SEPARATOR.join(b.text for b in page_blocks)
+        for page_number, page_blocks in _blocks_by_page_sorted(blocks).items()
+    }
 
 
 def assign_char_offsets_to_blocks(blocks: list[ParsedBlock]) -> list[ParsedBlock]:
@@ -154,15 +168,9 @@ def assign_char_offsets_to_blocks(blocks: list[ParsedBlock]) -> list[ParsedBlock
     Returns:
         The same list, mutated in place.
     """
-    # Group by page
-    pages: dict[int, list[ParsedBlock]] = {}
-    for block in blocks:
-        pages.setdefault(block.page_number, []).append(block)
-
-    for page_blocks in pages.values():
-        sorted_blocks = sorted(page_blocks, key=lambda b: b.block_index)
+    for page_blocks in _blocks_by_page_sorted(blocks).values():
         cursor = 0
-        for i, block in enumerate(sorted_blocks):
+        for i, block in enumerate(page_blocks):
             if i > 0:
                 # Account for the separator that precedes this block.
                 cursor += len(_BLOCK_SEPARATOR)

--- a/backend/app/infrastructure/parsing/base.py
+++ b/backend/app/infrastructure/parsing/base.py
@@ -1,0 +1,210 @@
+"""
+Document Parser Port.
+
+Defines the abstract DocumentParser interface and the ParsedBlock value
+type.  All concrete parsers (Docling, MinerU, …) implement DocumentParser;
+the rest of the codebase imports only from this module.
+
+Separator contract
+------------------
+``concat_page_text`` joins blocks with a single newline (``"\\n"``).  A
+newline is chosen rather than an empty string so that words at the end of
+one block and the start of the next do not merge into a single token (e.g.
+"method" + "s" → "methods"), which would break substring quote matching.
+The newline occupies exactly one character in the page string; char offsets
+account for it, so the invariant ::
+
+    block.text == page_text[block.char_start : block.char_end]
+
+holds for every block.
+
+Usage (read-only contract for downstream consumers)
+----------------------------------------------------
+The prompt-assembler and the evidence-anchorer in the extraction pipeline
+MUST import ``concat_page_text`` from this module and MUST NOT re-implement
+the concatenation or offset logic.  The function is the single source of
+truth.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Closed block-type vocabulary
+# ---------------------------------------------------------------------------
+
+#: The seven block types that the DB CHECK constraint accepts.
+#: Any value not in this set is normalised to ``"paragraph"`` before storage.
+BLOCK_TYPES: frozenset[str] = frozenset(
+    {
+        "paragraph",
+        "heading",
+        "list_item",
+        "table_cell",
+        "figure_caption",
+        "header",
+        "footer",
+    }
+)
+
+_FALLBACK_BLOCK_TYPE = "paragraph"
+
+#: Single newline separator inserted between consecutive blocks on the same
+#: page.  Must be one character so offset arithmetic stays simple.
+_BLOCK_SEPARATOR = "\n"
+
+
+def normalize_block_type(raw: str) -> str:
+    """Return *raw* if it is in the closed vocabulary, else ``"paragraph"``."""
+    return raw if raw in BLOCK_TYPES else _FALLBACK_BLOCK_TYPE
+
+
+# ---------------------------------------------------------------------------
+# ParsedBlock value type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParsedBlock:
+    """Immutable representation of one text block extracted from a PDF page.
+
+    Field semantics mirror ``ArticleTextBlock`` (the SQLAlchemy model in
+    ``backend/app/models/article.py``) exactly.
+
+    Attributes:
+        page_number: 1-indexed page number within the source PDF.
+        block_index: 0-indexed reading-order position within the page.
+        text: Raw text content of the block.
+        char_start: Start offset (inclusive) of *text* inside the page
+            string produced by ``concat_page_text``.
+        char_end: End offset (exclusive) of *text* inside the page string
+            produced by ``concat_page_text``.  Invariant:
+            ``page_text[char_start:char_end] == text``.
+        bbox: Bounding box in PDF user space (origin bottom-left, points)
+            with keys ``x``, ``y``, ``width``, ``height``.
+        block_type: One of the seven values in ``BLOCK_TYPES``.  Must be
+            normalised before construction (use ``normalize_block_type``).
+    """
+
+    page_number: int
+    block_index: int
+    text: str
+    char_start: int
+    char_end: int
+    bbox: dict[str, float]
+    block_type: str
+
+
+# ---------------------------------------------------------------------------
+# concat_page_text — single source of truth for char offsets
+# ---------------------------------------------------------------------------
+
+
+def concat_page_text(blocks: list[ParsedBlock]) -> dict[int, str]:
+    """Return a mapping of ``page_number → page_text`` for all pages in *blocks*.
+
+    Blocks on each page are joined in ascending ``block_index`` order with a
+    single newline (``"\\n"``) as separator (see module-level docstring for the
+    rationale).
+
+    The ``char_start`` / ``char_end`` fields stored on every ``ParsedBlock``
+    **must** be computed by this function (or by
+    ``assign_char_offsets_to_blocks``) so that the invariant ::
+
+        block.text == page_text[block.char_start : block.char_end]
+
+    holds for every block.
+
+    Args:
+        blocks: Parsed blocks from one or more pages.  May be in any order.
+
+    Returns:
+        ``{page_number: concatenated_page_string}`` for every page that
+        appears in *blocks*.  Pages not present in *blocks* are absent from
+        the result.
+    """
+    # Group blocks by page, sorted by block_index within each page.
+    pages: dict[int, list[ParsedBlock]] = {}
+    for block in blocks:
+        pages.setdefault(block.page_number, []).append(block)
+
+    result: dict[int, str] = {}
+    for page_number, page_blocks in pages.items():
+        sorted_blocks = sorted(page_blocks, key=lambda b: b.block_index)
+        result[page_number] = _BLOCK_SEPARATOR.join(b.text for b in sorted_blocks)
+
+    return result
+
+
+def assign_char_offsets_to_blocks(blocks: list[ParsedBlock]) -> list[ParsedBlock]:
+    """Compute and set ``char_start`` / ``char_end`` on each block in *blocks*.
+
+    This is the *write* side of the same single mechanism that
+    ``concat_page_text`` uses.  Concrete parsers should call this after
+    populating the other fields so that offsets are always consistent with
+    the concatenated page text.
+
+    The blocks are mutated in-place **and** returned for convenience.
+
+    Args:
+        blocks: Parsed blocks whose offsets should be set.  May span multiple
+            pages.  Within each page, blocks are processed in ascending
+            ``block_index`` order.
+
+    Returns:
+        The same list, mutated in place.
+    """
+    # Group by page
+    pages: dict[int, list[ParsedBlock]] = {}
+    for block in blocks:
+        pages.setdefault(block.page_number, []).append(block)
+
+    for page_blocks in pages.values():
+        sorted_blocks = sorted(page_blocks, key=lambda b: b.block_index)
+        cursor = 0
+        for i, block in enumerate(sorted_blocks):
+            if i > 0:
+                # Account for the separator that precedes this block.
+                cursor += len(_BLOCK_SEPARATOR)
+            block.char_start = cursor
+            block.char_end = cursor + len(block.text)
+            cursor = block.char_end
+
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# DocumentParser ABC
+# ---------------------------------------------------------------------------
+
+
+class DocumentParser(ABC):
+    """Abstract base class for PDF document parsers.
+
+    All concrete parser implementations (Docling, MinerU, etc.) must
+    subclass ``DocumentParser`` and implement ``parse``.
+
+    The returned ``ParsedBlock`` list must satisfy:
+    - ``block_type`` is one of ``BLOCK_TYPES`` (use ``normalize_block_type``).
+    - ``char_start`` / ``char_end`` are consistent with ``concat_page_text``;
+      the easiest way to guarantee this is to call
+      ``assign_char_offsets_to_blocks`` before returning.
+
+    No database, IO, or HTTP is permitted in this layer.
+    """
+
+    @abstractmethod
+    def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:
+        """Parse *pdf_bytes* and return a list of ``ParsedBlock`` objects.
+
+        Args:
+            pdf_bytes: Raw PDF file content.
+
+        Returns:
+            A flat list of ``ParsedBlock`` objects across all pages.  Order
+            within the list is not specified; use ``block_index`` and
+            ``page_number`` for sorting.
+
+        Raises:
+            ValueError: If *pdf_bytes* cannot be parsed as a PDF.
+        """

--- a/backend/app/repositories/article_text_block_repository.py
+++ b/backend/app/repositories/article_text_block_repository.py
@@ -1,0 +1,104 @@
+"""Repository for ArticleTextBlock — bulk writer and ordered reader.
+
+This is the *single ordered-read owner* for article_text_blocks.
+The read service (``app.services.article_text_block_read_service``) delegates
+its query here and only retains the dict/camelCase mapping layer.
+
+Design notes
+------------
+- ``replace_for_file`` is for **re-parse** of the same file. Re-upload
+  is handled upstream by the ``ON DELETE CASCADE`` on ``article_files``.
+- Uses ``flush()`` only, never ``commit()``.  The caller (service or
+  UnitOfWork) owns transaction boundaries.
+- Bulk-insert via ``db.add_all`` + single ``flush`` — avoids N round-trips.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.parsing.base import ParsedBlock
+from app.models.article import ArticleTextBlock
+from app.repositories.base import BaseRepository
+
+
+class ArticleTextBlockRepository(BaseRepository[ArticleTextBlock]):
+    """Persistence layer for ``ArticleTextBlock`` rows."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        super().__init__(db, ArticleTextBlock)
+
+    async def replace_for_file(
+        self,
+        article_file_id: UUID,
+        blocks: list[ParsedBlock],
+    ) -> list[ArticleTextBlock]:
+        """Delete all existing blocks for *article_file_id*, then bulk-insert *blocks*.
+
+        Intended for re-parse of the same file. Re-upload is handled by the
+        ``ON DELETE CASCADE`` on ``article_files``; do not call this from the
+        re-upload path.
+
+        Uses ``flush()`` — the caller must ``commit()`` to persist.
+
+        Args:
+            article_file_id: PK of the ``ArticleFile`` whose blocks to replace.
+            blocks: Flat list of ``ParsedBlock`` values from the parser.
+
+        Returns:
+            The newly inserted ``ArticleTextBlock`` ORM instances (unflushed
+            refresh not performed — caller must ``await session.refresh(row)``
+            individually if they need server-generated fields beyond ``id``).
+        """
+        # Delete existing rows for this file in a single statement.
+        await self.db.execute(
+            delete(ArticleTextBlock).where(ArticleTextBlock.article_file_id == article_file_id)
+        )
+
+        # Build ORM instances 1-to-1 from ParsedBlock.
+        orm_rows = [
+            ArticleTextBlock(
+                article_file_id=article_file_id,
+                page_number=block.page_number,
+                block_index=block.block_index,
+                text=block.text,
+                char_start=block.char_start,
+                char_end=block.char_end,
+                bbox=block.bbox,
+                block_type=block.block_type,
+            )
+            for block in blocks
+        ]
+
+        self.db.add_all(orm_rows)
+        await self.db.flush()
+        return orm_rows
+
+    async def list_ordered_for_file(
+        self,
+        article_file_id: UUID,
+    ) -> list[ArticleTextBlock]:
+        """Return all blocks for *article_file_id* in reading order.
+
+        Ordering: ``page_number ASC``, ``block_index ASC``.  This is the
+        single source of truth for ordering — the read service delegates here
+        rather than duplicating the ``ORDER BY`` clause.
+
+        Args:
+            article_file_id: PK of the target ``ArticleFile``.
+
+        Returns:
+            Ordered list of ``ArticleTextBlock`` ORM instances (may be empty).
+        """
+        result = await self.db.execute(
+            select(ArticleTextBlock)
+            .where(ArticleTextBlock.article_file_id == article_file_id)
+            .order_by(
+                ArticleTextBlock.page_number.asc(),
+                ArticleTextBlock.block_index.asc(),
+            )
+        )
+        return list(result.scalars().all())

--- a/backend/app/repositories/article_text_block_repository.py
+++ b/backend/app/repositories/article_text_block_repository.py
@@ -20,7 +20,7 @@ from uuid import UUID
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.parsing.base import ParsedBlock
+from app.infrastructure.parsing.base import ParsedBlock, normalize_block_type
 from app.models.article import ArticleTextBlock
 from app.repositories.base import BaseRepository
 
@@ -49,9 +49,10 @@ class ArticleTextBlockRepository(BaseRepository[ArticleTextBlock]):
             blocks: Flat list of ``ParsedBlock`` values from the parser.
 
         Returns:
-            The newly inserted ``ArticleTextBlock`` ORM instances (unflushed
-            refresh not performed — caller must ``await session.refresh(row)``
-            individually if they need server-generated fields beyond ``id``).
+            The newly inserted ``ArticleTextBlock`` ORM instances.
+            ``flush()`` populates ``id`` and other server defaults; call
+            ``await session.refresh(row)`` individually if you need additional
+            server-generated fields.
         """
         # Delete existing rows for this file in a single statement.
         await self.db.execute(
@@ -59,6 +60,8 @@ class ArticleTextBlockRepository(BaseRepository[ArticleTextBlock]):
         )
 
         # Build ORM instances 1-to-1 from ParsedBlock.
+        # normalize_block_type enforces the closed-set contract: unknown values
+        # degrade to "paragraph" rather than hitting the DB CHECK constraint.
         orm_rows = [
             ArticleTextBlock(
                 article_file_id=article_file_id,
@@ -68,7 +71,7 @@ class ArticleTextBlockRepository(BaseRepository[ArticleTextBlock]):
                 char_start=block.char_start,
                 char_end=block.char_end,
                 bbox=block.bbox,
-                block_type=block.block_type,
+                block_type=normalize_block_type(block.block_type),
             )
             for block in blocks
         ]

--- a/backend/app/services/article_text_block_read_service.py
+++ b/backend/app/services/article_text_block_read_service.py
@@ -1,7 +1,8 @@
 """Read-side service for ArticleTextBlock rows (typography reader view).
 
-Owns the inline SQL that `article_text_blocks.py` used to do directly,
-so the endpoint module stops importing from `app.models.*`.
+Owns the camelCase dict mapping that the pdf-viewer endpoint expects.
+The ordered query is delegated to ``ArticleTextBlockRepository`` — the
+single ordered-read owner.
 """
 
 from __future__ import annotations
@@ -12,7 +13,8 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.article import ArticleFile, ArticleTextBlock
+from app.models.article import ArticleFile
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
 
 
 class ArticleFileNotFoundError(Exception):
@@ -36,21 +38,13 @@ async def get_article_file_project_id(db: AsyncSession, article_file_id: UUID) -
 async def list_text_blocks(db: AsyncSession, article_file_id: UUID) -> list[dict[str, Any]]:
     """Return all text blocks for the given article_file in reading order
     (page_number asc, block_index asc), as the camelCase dicts the
-    pdf-viewer expects."""
-    rows = (
-        (
-            await db.execute(
-                select(ArticleTextBlock)
-                .where(ArticleTextBlock.article_file_id == article_file_id)
-                .order_by(
-                    ArticleTextBlock.page_number.asc(),
-                    ArticleTextBlock.block_index.asc(),
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
+    pdf-viewer expects.
+
+    Ordering is owned by ``ArticleTextBlockRepository.list_ordered_for_file``;
+    this function only applies the presentation mapping.
+    """
+    repo = ArticleTextBlockRepository(db)
+    rows = await repo.list_ordered_for_file(article_file_id)
     return [
         {
             "id": str(row.id),

--- a/backend/app/services/document_parsing_service.py
+++ b/backend/app/services/document_parsing_service.py
@@ -1,0 +1,155 @@
+"""Document Parsing Service.
+
+Orchestrates the PDF-only parsing pipeline:
+
+1. Load ArticleFile by ID.
+2. Download PDF bytes via the injected StorageAdapter.
+3. Parse bytes via the injected DocumentParser.
+4. Normalise char offsets via assign_char_offsets_to_blocks (single source of
+   truth from the parsing.base module).
+5. Persist blocks via ArticleTextBlockRepository.replace_for_file (flush only).
+6. Update ArticleFile.extraction_status and flush.
+7. Return a typed DocumentParsingResult.
+
+Transaction boundary
+--------------------
+This service NEVER commits.  All mutations are flushed inside the session so
+the caller (Celery worker task, Task 1.5) can commit or roll back as a unit.
+On parser error: the service sets ``extraction_status = "parse_failed"``,
+flushes, logs, and re-raises so the future worker can handle retries.
+
+NOTE: the ``parse_failed`` flush is best-effort in the context of a worker
+retry — if the worker's ``worker_session()`` rolls back the outer transaction
+the status update will not survive.  Durable ``parse_failed`` persistence is
+finalised by Task 1.5 (the Celery task that owns commit semantics).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logging import get_logger
+from app.infrastructure.parsing.base import DocumentParser, assign_char_offsets_to_blocks
+from app.infrastructure.storage.base import StorageAdapter
+from app.models.article import ArticleFile
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+
+_logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class DocumentParsingResult:
+    """Typed result returned by DocumentParsingService.parse_article_file.
+
+    Attributes:
+        block_count: Total number of ParsedBlock objects persisted.
+        page_count: Number of distinct page numbers across the persisted blocks.
+        status: Final extraction_status value set on the ArticleFile.
+            Either ``"parsed"`` (success) or ``"parse_failed"`` (error).
+    """
+
+    block_count: int
+    page_count: int
+    status: str
+
+
+class DocumentParsingService:
+    """Orchestrates PDF parsing for a single ArticleFile.
+
+    Receives its concrete ``parser`` and ``storage`` by injection so callers
+    (Celery task, unit tests) can choose the implementation without coupling
+    the service to a specific adapter.
+
+    Args:
+        db: Async SQLAlchemy session.  The service flushes but never commits.
+        user_id: Authenticated user ID (string form).
+        storage: Storage adapter used to download the PDF bytes.
+        parser: DocumentParser implementation to invoke.
+        trace_id: Trace / request ID threaded into structured log events.
+    """
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        user_id: str,
+        storage: StorageAdapter,
+        parser: DocumentParser,
+        trace_id: str,
+    ) -> None:
+        self.db = db
+        self.user_id = user_id
+        self.storage = storage
+        self.parser = parser
+        self.trace_id = trace_id
+        self._repo = ArticleTextBlockRepository(db)
+
+    async def parse_article_file(self, article_file_id: UUID) -> DocumentParsingResult:
+        """Parse the PDF associated with *article_file_id* and persist the blocks.
+
+        Args:
+            article_file_id: PK of the ``ArticleFile`` to process.
+
+        Returns:
+            A :class:`DocumentParsingResult` with block_count, page_count, and
+            status (``"parsed"``).
+
+        Raises:
+            FileNotFoundError: If the ArticleFile row does not exist.
+            Any exception raised by ``self.parser.parse``: re-raised after
+            setting ``extraction_status = "parse_failed"`` and flushing.
+        """
+        log = _logger.bind(
+            trace_id=self.trace_id,
+            article_file_id=str(article_file_id),
+            user_id=self.user_id,
+        )
+
+        # 1. Load ArticleFile.
+        article_file = (
+            await self.db.execute(select(ArticleFile).where(ArticleFile.id == article_file_id))
+        ).scalar_one_or_none()
+
+        if article_file is None:
+            raise FileNotFoundError(f"ArticleFile not found: {article_file_id}")
+
+        # 2. Download PDF bytes.
+        pdf_bytes = await self.storage.download("articles", article_file.storage_key)
+
+        # 3. Parse — isolate so we can catch and handle parser errors.
+        try:
+            blocks = self.parser.parse(pdf_bytes)
+        except Exception:
+            log.exception("document_parsing_failed")
+            article_file.extraction_status = "parse_failed"
+            await self.db.flush()
+            raise
+
+        # 4. Normalise char offsets via the canonical helper (single source of
+        #    truth for offset arithmetic — do NOT recompute inline).
+        assign_char_offsets_to_blocks(blocks)
+
+        # 5. Persist blocks (delete-then-bulk-insert, flush only).
+        await self._repo.replace_for_file(article_file_id, blocks)
+
+        # 6. Update status.
+        article_file.extraction_status = "parsed"
+        await self.db.flush()
+
+        page_count = len({b.page_number for b in blocks})
+
+        log.info(
+            "document_parsing_succeeded",
+            block_count=len(blocks),
+            page_count=page_count,
+        )
+
+        # 7. Return typed result.
+        return DocumentParsingResult(
+            block_count=len(blocks),
+            page_count=page_count,
+            status="parsed",
+        )

--- a/backend/tests/integration/test_article_text_block_repository.py
+++ b/backend/tests/integration/test_article_text_block_repository.py
@@ -1,0 +1,268 @@
+"""Integration tests for ArticleTextBlockRepository.
+
+Tests:
+- replace_for_file deletes existing rows and bulk-inserts new ones
+- field round-trip is exact (including bbox dict and block_type)
+- calling replace_for_file twice is idempotent (second call replaces, not appends)
+- list_ordered_for_file returns rows ordered by (page_number asc, block_index asc)
+- RLS: a non-member session cannot read the inserted rows
+
+Uses db_session_real because we need to test cross-session RLS visibility.
+"""
+
+from __future__ import annotations
+
+import uuid
+from uuid import UUID
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.parsing.base import ParsedBlock
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+from tests.integration.conftest import SEED
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+async def _insert_article_file(db: AsyncSession, *, project_id: UUID, article_id: UUID) -> UUID:
+    file_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": str(file_id),
+            "pid": str(project_id),
+            "aid": str(article_id),
+            "key": f"test/{file_id}.pdf",
+        },
+    )
+    await db.commit()
+    return file_id
+
+
+async def _cleanup(db: AsyncSession, *, file_id: UUID) -> None:
+    await db.execute(
+        text("DELETE FROM public.article_files WHERE id = :id"),
+        {"id": str(file_id)},
+    )
+    await db.commit()
+
+
+def _make_block(
+    page: int,
+    idx: int,
+    text_val: str,
+    char_start: int = 0,
+    char_end: int | None = None,
+    block_type: str = "paragraph",
+) -> ParsedBlock:
+    if char_end is None:
+        char_end = char_start + len(text_val)
+    return ParsedBlock(
+        page_number=page,
+        block_index=idx,
+        text=text_val,
+        char_start=char_start,
+        char_end=char_end,
+        bbox={"x": 10.0, "y": 20.0, "width": 400.0, "height": 12.5},
+        block_type=block_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replace_for_file_inserts_blocks_and_round_trips_fields(
+    db_session_real: AsyncSession,
+) -> None:
+    """replace_for_file inserts blocks; all fields round-trip exactly."""
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        blocks = [
+            _make_block(1, 0, "First paragraph", char_start=0, char_end=15),
+            _make_block(1, 1, "Second paragraph", char_start=16, char_end=32, block_type="heading"),
+        ]
+        repo = ArticleTextBlockRepository(db_session_real)
+        result = await repo.replace_for_file(file_id, blocks)
+        await db_session_real.commit()
+
+        assert len(result) == 2
+
+        ordered = await repo.list_ordered_for_file(file_id)
+        assert len(ordered) == 2
+
+        b0 = ordered[0]
+        assert b0.page_number == 1
+        assert b0.block_index == 0
+        assert b0.text == "First paragraph"
+        assert b0.char_start == 0
+        assert b0.char_end == 15
+        assert b0.bbox == {"x": 10.0, "y": 20.0, "width": 400.0, "height": 12.5}
+        assert b0.block_type == "paragraph"
+        assert b0.article_file_id == file_id
+
+        b1 = ordered[1]
+        assert b1.block_type == "heading"
+        assert b1.block_index == 1
+    finally:
+        await _cleanup(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_replace_for_file_deletes_existing_rows(
+    db_session_real: AsyncSession,
+) -> None:
+    """replace_for_file deletes old blocks before inserting new ones (not appending)."""
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        repo = ArticleTextBlockRepository(db_session_real)
+
+        # First call: 3 blocks
+        first_blocks = [_make_block(1, i, f"old block {i}") for i in range(3)]
+        await repo.replace_for_file(file_id, first_blocks)
+        await db_session_real.commit()
+
+        rows_after_first = await repo.list_ordered_for_file(file_id)
+        assert len(rows_after_first) == 3
+
+        # Second call: 2 different blocks (replaces, does not append)
+        second_blocks = [_make_block(2, i, f"new block {i}") for i in range(2)]
+        await repo.replace_for_file(file_id, second_blocks)
+        await db_session_real.commit()
+
+        rows_after_second = await repo.list_ordered_for_file(file_id)
+        assert len(rows_after_second) == 2
+        assert all(b.text.startswith("new block") for b in rows_after_second)
+        assert all(b.page_number == 2 for b in rows_after_second)
+    finally:
+        await _cleanup(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_replace_for_file_idempotent_on_same_content(
+    db_session_real: AsyncSession,
+) -> None:
+    """Calling replace_for_file twice with identical blocks yields the same result."""
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        repo = ArticleTextBlockRepository(db_session_real)
+        blocks = [_make_block(1, 0, "idempotent block")]
+
+        await repo.replace_for_file(file_id, blocks)
+        await db_session_real.commit()
+
+        await repo.replace_for_file(file_id, blocks)
+        await db_session_real.commit()
+
+        ordered = await repo.list_ordered_for_file(file_id)
+        assert len(ordered) == 1
+        assert ordered[0].text == "idempotent block"
+    finally:
+        await _cleanup(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_list_ordered_for_file_returns_reading_order(
+    db_session_real: AsyncSession,
+) -> None:
+    """list_ordered_for_file returns (page_number asc, block_index asc) regardless of insertion order."""
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        repo = ArticleTextBlockRepository(db_session_real)
+        # Insert in scrambled order
+        blocks = [
+            _make_block(2, 1, "p2b1"),
+            _make_block(1, 1, "p1b1"),
+            _make_block(2, 0, "p2b0"),
+            _make_block(1, 0, "p1b0"),
+        ]
+        await repo.replace_for_file(file_id, blocks)
+        await db_session_real.commit()
+
+        ordered = await repo.list_ordered_for_file(file_id)
+        assert [b.text for b in ordered] == ["p1b0", "p1b1", "p2b0", "p2b1"]
+    finally:
+        await _cleanup(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_replace_for_file_rls_non_member_cannot_read(
+    db_session_real: AsyncSession,
+) -> None:
+    """A non-member cannot read article_text_blocks via Supabase RLS.
+
+    Uses the established pattern from test_blind_review_isolation.py:
+    set_config('request.jwt.claims', ...) + SET LOCAL ROLE authenticated,
+    then RESET ROLE to restore the session.
+    """
+    import json
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        repo = ArticleTextBlockRepository(db_session_real)
+        blocks = [_make_block(1, 0, "rls test block")]
+        await repo.replace_for_file(file_id, blocks)
+        await db_session_real.commit()
+
+        # Verify the block exists as superuser before activating RLS.
+        superuser_rows = (
+            await db_session_real.execute(
+                text("SELECT id FROM public.article_text_blocks WHERE article_file_id = :fid"),
+                {"fid": str(file_id)},
+            )
+        ).fetchall()
+        assert len(superuser_rows) == 1, "Block must exist before RLS test"
+
+        # Activate RLS as the outsider (non-member of primary_project).
+        outsider_id = SEED.outsider_profile
+        try:
+            await db_session_real.execute(
+                text("SELECT set_config('request.jwt.claims', :claims, true)"),
+                {"claims": json.dumps({"sub": str(outsider_id), "role": "authenticated"})},
+            )
+            await db_session_real.execute(text("SET LOCAL ROLE authenticated"))
+
+            visible_rows = (
+                await db_session_real.execute(
+                    text("SELECT id FROM public.article_text_blocks WHERE article_file_id = :fid"),
+                    {"fid": str(file_id)},
+                )
+            ).fetchall()
+        finally:
+            await db_session_real.execute(text("RESET ROLE"))
+
+        assert visible_rows == [], (
+            f"RLS violation: non-member can see {len(visible_rows)} rows in article_text_blocks"
+        )
+    finally:
+        await _cleanup(db_session_real, file_id=file_id)

--- a/backend/tests/integration/test_article_text_block_repository.py
+++ b/backend/tests/integration/test_article_text_block_repository.py
@@ -212,6 +212,29 @@ async def test_list_ordered_for_file_returns_reading_order(
 
 
 @pytest.mark.asyncio
+async def test_replace_for_file_normalizes_unknown_block_type(
+    db_session_real: AsyncSession,
+) -> None:
+    """replace_for_file with an out-of-set block_type persists 'paragraph' (not the raw value)."""
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        repo = ArticleTextBlockRepository(db_session_real)
+        block = _make_block(1, 0, "sidebar content", block_type="sidebar")
+        await repo.replace_for_file(file_id, [block])
+        await db_session_real.commit()
+
+        ordered = await repo.list_ordered_for_file(file_id)
+        assert len(ordered) == 1
+        assert ordered[0].block_type == "paragraph"
+    finally:
+        await _cleanup(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
 async def test_replace_for_file_rls_non_member_cannot_read(
     db_session_real: AsyncSession,
 ) -> None:

--- a/backend/tests/integration/test_document_parsing_service.py
+++ b/backend/tests/integration/test_document_parsing_service.py
@@ -1,0 +1,265 @@
+"""Integration tests for DocumentParsingService.
+
+Tests:
+- Success path: downloads bytes, runs parser, persists blocks (exact fields),
+  sets extraction_status to 'parsed', returns correct DocumentParsingResult.
+- Failure path: parser raises -> extraction_status becomes 'parse_failed',
+  exception propagates.
+
+Uses db_session_real (deferred triggers). Fakes a StorageAdapter and a
+DocumentParser — the storage fake returns dummy bytes; the parser fake
+returns a fixed list of ParsedBlock spanning >=2 pages.
+"""
+
+from __future__ import annotations
+
+import uuid
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.parsing.base import DocumentParser, ParsedBlock
+from app.infrastructure.storage.base import StorageAdapter
+from app.models.article import ArticleFile
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+from app.services.document_parsing_service import DocumentParsingResult, DocumentParsingService
+from tests.integration.conftest import SEED
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeStorageAdapter(StorageAdapter):
+    """Minimal StorageAdapter that returns a fixed bytes payload."""
+
+    def __init__(self, payload: bytes = b"%PDF-1.4 fake") -> None:
+        self._payload = payload
+        self.downloaded: list[tuple[str, str]] = []
+
+    async def download(self, bucket: str, path: str) -> bytes:
+        self.downloaded.append((bucket, path))
+        return self._payload
+
+    # --- unused abstract methods ---
+    async def upload(
+        self, bucket: str, path: str, data: bytes, content_type: str = "application/octet-stream"
+    ) -> str:
+        raise NotImplementedError
+
+    async def delete(self, bucket: str, path: str) -> bool:
+        raise NotImplementedError
+
+    async def exists(self, bucket: str, path: str) -> bool:
+        raise NotImplementedError
+
+    async def get_public_url(self, bucket: str, path: str) -> str:
+        raise NotImplementedError
+
+    async def get_signed_url(self, bucket: str, path: str, expires_in: int = 3600) -> str:
+        raise NotImplementedError
+
+    async def list_files(self, bucket: str, prefix: str = "", limit: int = 100) -> list[dict]:
+        raise NotImplementedError
+
+
+class FakeParser(DocumentParser):
+    """Returns a fixed list of 3 ParsedBlock objects spanning 2 pages.
+
+    Offsets are intentionally left as 0 so the service's
+    assign_char_offsets_to_blocks call is what sets correct values.
+    """
+
+    FIXED_BLOCKS: list[ParsedBlock] = [
+        ParsedBlock(
+            page_number=1,
+            block_index=0,
+            text="Hello world",
+            char_start=0,
+            char_end=0,  # service must normalise
+            bbox={"x": 0.0, "y": 0.0, "width": 100.0, "height": 12.0},
+            block_type="paragraph",
+        ),
+        ParsedBlock(
+            page_number=1,
+            block_index=1,
+            text="Second block",
+            char_start=0,
+            char_end=0,
+            bbox={"x": 0.0, "y": 20.0, "width": 100.0, "height": 12.0},
+            block_type="heading",
+        ),
+        ParsedBlock(
+            page_number=2,
+            block_index=0,
+            text="Page two content",
+            char_start=0,
+            char_end=0,
+            bbox={"x": 0.0, "y": 0.0, "width": 100.0, "height": 12.0},
+            block_type="paragraph",
+        ),
+    ]
+
+    def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:  # noqa: ARG002
+        # Return fresh copies so tests don't mutate the class-level defaults.
+        import copy
+
+        return copy.deepcopy(self.FIXED_BLOCKS)
+
+
+class BrokenParser(DocumentParser):
+    """Always raises ValueError to test the failure path."""
+
+    def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:  # noqa: ARG002
+        raise ValueError("Simulated parser failure")
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+async def _insert_article_file(db: AsyncSession, *, project_id: UUID, article_id: UUID) -> UUID:
+    file_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": str(file_id),
+            "pid": str(project_id),
+            "aid": str(article_id),
+            "key": f"articles/{file_id}.pdf",
+        },
+    )
+    await db.commit()
+    return file_id
+
+
+async def _cleanup(db: AsyncSession, *, file_id: UUID) -> None:
+    await db.execute(
+        text("DELETE FROM public.article_files WHERE id = :id"),
+        {"id": str(file_id)},
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parse_article_file_success(
+    db_session_real: AsyncSession,
+) -> None:
+    """Service downloads bytes, persists blocks, sets status='parsed', returns correct result."""
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        storage = FakeStorageAdapter()
+        parser = FakeParser()
+        service = DocumentParsingService(
+            db=db_session_real,
+            user_id=str(SEED.primary_profile),
+            storage=storage,
+            parser=parser,
+            trace_id="test-trace-1",
+        )
+
+        result = await service.parse_article_file(file_id)
+        await db_session_real.commit()
+
+        # --- storage was called with the right bucket + key ---
+        assert len(storage.downloaded) == 1
+        bucket, path = storage.downloaded[0]
+        assert bucket == "articles"
+        assert path.endswith(".pdf")
+
+        # --- result shape ---
+        assert isinstance(result, DocumentParsingResult)
+        assert result.block_count == 3
+        assert result.page_count == 2  # pages 1 and 2
+        assert result.status == "parsed"
+
+        # --- blocks persisted in reading order ---
+        repo = ArticleTextBlockRepository(db_session_real)
+        blocks = await repo.list_ordered_for_file(file_id)
+        assert len(blocks) == 3
+
+        b0 = blocks[0]
+        assert b0.page_number == 1
+        assert b0.block_index == 0
+        assert b0.text == "Hello world"
+        # char offsets must be normalised by assign_char_offsets_to_blocks
+        assert b0.char_start == 0
+        assert b0.char_end == len("Hello world")
+
+        b1 = blocks[1]
+        assert b1.page_number == 1
+        assert b1.block_index == 1
+        assert b1.text == "Second block"
+        # offset: len("Hello world") + 1 separator
+        assert b1.char_start == len("Hello world") + 1
+        assert b1.char_end == len("Hello world") + 1 + len("Second block")
+
+        b2 = blocks[2]
+        assert b2.page_number == 2
+        assert b2.block_index == 0
+        assert b2.text == "Page two content"
+        # page 2 starts its own cursor at 0
+        assert b2.char_start == 0
+        assert b2.char_end == len("Page two content")
+
+        # --- extraction_status flipped ---
+        article_file = (
+            await db_session_real.execute(select(ArticleFile).where(ArticleFile.id == file_id))
+        ).scalar_one()
+        assert article_file.extraction_status == "parsed"
+
+    finally:
+        await _cleanup(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_parse_article_file_parser_error_sets_parse_failed_and_reraises(
+    db_session_real: AsyncSession,
+) -> None:
+    """When the parser raises, extraction_status becomes 'parse_failed' and the exception propagates."""
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        storage = FakeStorageAdapter()
+        parser = BrokenParser()
+        service = DocumentParsingService(
+            db=db_session_real,
+            user_id=str(SEED.primary_profile),
+            storage=storage,
+            parser=parser,
+            trace_id="test-trace-2",
+        )
+
+        with pytest.raises(ValueError, match="Simulated parser failure"):
+            await service.parse_article_file(file_id)
+
+        # Flush happened inside the service; check the status in the same session.
+        # (No commit; we are checking the in-flight flushed state.)
+        article_file = (
+            await db_session_real.execute(select(ArticleFile).where(ArticleFile.id == file_id))
+        ).scalar_one()
+        assert article_file.extraction_status == "parse_failed"
+
+        # Commit what the service flushed so cleanup can see it.
+        await db_session_real.commit()
+    finally:
+        await _cleanup(db_session_real, file_id=file_id)

--- a/backend/tests/unit/test_parsing_base.py
+++ b/backend/tests/unit/test_parsing_base.py
@@ -1,0 +1,305 @@
+"""
+Unit tests for the DocumentParser port + ParsedBlock value type.
+
+Tests cover:
+- ``concat_page_text``: produces correct per-page strings in block_index order
+  across multiple pages and multiple blocks per page.
+- Offset invariant: ``block.text == page_text[block.char_start:block.char_end]``
+  for every block.
+- ``block_type`` normalisation: known values pass through unchanged; unknown
+  values are mapped to ``"paragraph"``.
+- ``assign_char_offsets_to_blocks``: helper sets consistent offsets.
+- ``BLOCK_TYPES`` constant: contains exactly the seven expected values.
+"""
+
+import pytest
+
+from app.infrastructure.parsing.base import (
+    BLOCK_TYPES,
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+    normalize_block_type,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_block(
+    page_number: int,
+    block_index: int,
+    text: str,
+    block_type: str = "paragraph",
+    char_start: int = 0,
+    char_end: int = 0,
+) -> ParsedBlock:
+    return ParsedBlock(
+        page_number=page_number,
+        block_index=block_index,
+        text=text,
+        char_start=char_start,
+        char_end=char_end,
+        bbox={"x": 0.0, "y": 0.0, "width": 100.0, "height": 20.0},
+        block_type=block_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BLOCK_TYPES constant
+# ---------------------------------------------------------------------------
+
+
+class TestBlockTypes:
+    def test_contains_all_seven_values(self) -> None:
+        expected = {
+            "paragraph",
+            "heading",
+            "list_item",
+            "table_cell",
+            "figure_caption",
+            "header",
+            "footer",
+        }
+        assert expected == BLOCK_TYPES
+
+    def test_is_frozenset(self) -> None:
+        assert isinstance(BLOCK_TYPES, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# normalize_block_type
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeBlockType:
+    @pytest.mark.parametrize(
+        "known_type",
+        [
+            "paragraph",
+            "heading",
+            "list_item",
+            "table_cell",
+            "figure_caption",
+            "header",
+            "footer",
+        ],
+    )
+    def test_known_type_passes_through_unchanged(self, known_type: str) -> None:
+        assert normalize_block_type(known_type) == known_type
+
+    def test_unknown_type_maps_to_paragraph(self) -> None:
+        assert normalize_block_type("sidebar") == "paragraph"
+
+    def test_empty_string_maps_to_paragraph(self) -> None:
+        assert normalize_block_type("") == "paragraph"
+
+    def test_uppercase_known_type_maps_to_paragraph(self) -> None:
+        # vocabulary is case-sensitive
+        assert normalize_block_type("Paragraph") == "paragraph"
+
+    def test_arbitrary_unknown_type_maps_to_paragraph(self) -> None:
+        assert normalize_block_type("figure") == "paragraph"
+
+
+# ---------------------------------------------------------------------------
+# concat_page_text — basic shape
+# ---------------------------------------------------------------------------
+
+
+class TestConcatPageTextBasic:
+    def test_empty_blocks_returns_empty_dict(self) -> None:
+        result = concat_page_text([])
+        assert result == {}
+
+    def test_single_block_single_page(self) -> None:
+        block = make_block(page_number=1, block_index=0, text="Hello world")
+        result = concat_page_text([block])
+        assert result == {1: "Hello world"}
+
+    def test_two_blocks_same_page_joined_with_newline(self) -> None:
+        b0 = make_block(page_number=1, block_index=0, text="First block")
+        b1 = make_block(page_number=1, block_index=1, text="Second block")
+        result = concat_page_text([b0, b1])
+        assert result == {1: "First block\nSecond block"}
+
+    def test_blocks_on_two_separate_pages(self) -> None:
+        b1 = make_block(page_number=1, block_index=0, text="Page one text")
+        b2 = make_block(page_number=2, block_index=0, text="Page two text")
+        result = concat_page_text([b1, b2])
+        assert result == {1: "Page one text", 2: "Page two text"}
+
+    def test_blocks_sorted_by_block_index_not_list_order(self) -> None:
+        # Intentionally supply blocks in reverse order.
+        b1 = make_block(page_number=1, block_index=1, text="B")
+        b0 = make_block(page_number=1, block_index=0, text="A")
+        result = concat_page_text([b1, b0])
+        # Should be "A\nB", not "B\nA"
+        assert result == {1: "A\nB"}
+
+
+# ---------------------------------------------------------------------------
+# concat_page_text — multi-page, multi-block
+# ---------------------------------------------------------------------------
+
+
+class TestConcatPageTextMultiPageMultiBlock:
+    def test_three_blocks_two_pages(self) -> None:
+        blocks = [
+            make_block(page_number=1, block_index=0, text="Intro"),
+            make_block(page_number=1, block_index=1, text="Body"),
+            make_block(page_number=2, block_index=0, text="Conclusion"),
+        ]
+        result = concat_page_text(blocks)
+        assert result[1] == "Intro\nBody"
+        assert result[2] == "Conclusion"
+
+    def test_four_blocks_two_pages_interleaved_in_list(self) -> None:
+        # Blocks provided in arbitrary (interleaved) order.
+        blocks = [
+            make_block(page_number=2, block_index=1, text="D"),
+            make_block(page_number=1, block_index=0, text="A"),
+            make_block(page_number=2, block_index=0, text="C"),
+            make_block(page_number=1, block_index=1, text="B"),
+        ]
+        result = concat_page_text(blocks)
+        assert result[1] == "A\nB"
+        assert result[2] == "C\nD"
+
+    def test_page_keys_match_blocks_present(self) -> None:
+        blocks = [
+            make_block(page_number=3, block_index=0, text="Last page"),
+            make_block(page_number=1, block_index=0, text="First page"),
+        ]
+        result = concat_page_text(blocks)
+        assert set(result.keys()) == {1, 3}
+        # Page 2 is absent — not padded.
+        assert 2 not in result
+
+
+# ---------------------------------------------------------------------------
+# Offset invariant via assign_char_offsets_to_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestCharOffsetInvariant:
+    def _check_invariant(self, blocks: list[ParsedBlock]) -> None:
+        """Assert the offset invariant for every block in *blocks*."""
+        page_texts = concat_page_text(blocks)
+        for block in blocks:
+            page_text = page_texts[block.page_number]
+            extracted = page_text[block.char_start : block.char_end]
+            assert extracted == block.text, (
+                f"Invariant violated for block (page={block.page_number}, "
+                f"index={block.block_index}): "
+                f"expected {block.text!r}, got {extracted!r}"
+            )
+
+    def test_single_block_single_page(self) -> None:
+        blocks = [make_block(page_number=1, block_index=0, text="Hello")]
+        assign_char_offsets_to_blocks(blocks)
+        assert blocks[0].char_start == 0
+        assert blocks[0].char_end == 5
+        self._check_invariant(blocks)
+
+    def test_two_blocks_same_page(self) -> None:
+        blocks = [
+            make_block(page_number=1, block_index=0, text="Foo"),
+            make_block(page_number=1, block_index=1, text="Bar"),
+        ]
+        assign_char_offsets_to_blocks(blocks)
+        # "Foo\nBar": Foo at [0,3), separator at 3, Bar at [4,7)
+        assert blocks[0].char_start == 0
+        assert blocks[0].char_end == 3
+        assert blocks[1].char_start == 4
+        assert blocks[1].char_end == 7
+        self._check_invariant(blocks)
+
+    def test_three_blocks_same_page(self) -> None:
+        blocks = [
+            make_block(page_number=1, block_index=0, text="Alpha"),
+            make_block(page_number=1, block_index=1, text="Beta"),
+            make_block(page_number=1, block_index=2, text="Gamma"),
+        ]
+        assign_char_offsets_to_blocks(blocks)
+        # "Alpha\nBeta\nGamma"
+        assert blocks[0].char_start == 0
+        assert blocks[0].char_end == 5
+        assert blocks[1].char_start == 6
+        assert blocks[1].char_end == 10
+        assert blocks[2].char_start == 11
+        assert blocks[2].char_end == 16
+        self._check_invariant(blocks)
+
+    def test_multi_page_invariant_holds_independently(self) -> None:
+        blocks = [
+            make_block(page_number=1, block_index=0, text="Page one A"),
+            make_block(page_number=1, block_index=1, text="Page one B"),
+            make_block(page_number=2, block_index=0, text="Page two"),
+        ]
+        assign_char_offsets_to_blocks(blocks)
+        self._check_invariant(blocks)
+
+    def test_offsets_reset_per_page(self) -> None:
+        blocks = [
+            make_block(page_number=1, block_index=0, text="Long text on page one"),
+            make_block(page_number=2, block_index=0, text="Short"),
+        ]
+        assign_char_offsets_to_blocks(blocks)
+        # Page 2's first block always starts at 0.
+        page2_block = next(b for b in blocks if b.page_number == 2)
+        assert page2_block.char_start == 0
+        self._check_invariant(blocks)
+
+    def test_blocks_supplied_out_of_order_still_correct(self) -> None:
+        # Supply blocks in reversed order; assign should still sort by block_index.
+        blocks = [
+            make_block(page_number=1, block_index=1, text="Second"),
+            make_block(page_number=1, block_index=0, text="First"),
+        ]
+        assign_char_offsets_to_blocks(blocks)
+        first = next(b for b in blocks if b.block_index == 0)
+        second = next(b for b in blocks if b.block_index == 1)
+        assert first.char_start == 0
+        assert first.char_end == 5
+        assert second.char_start == 6
+        assert second.char_end == 12
+        self._check_invariant(blocks)
+
+    def test_invariant_with_multiword_texts(self) -> None:
+        blocks = [
+            make_block(page_number=1, block_index=0, text="The quick brown fox"),
+            make_block(page_number=1, block_index=1, text="jumps over the lazy dog"),
+        ]
+        assign_char_offsets_to_blocks(blocks)
+        self._check_invariant(blocks)
+
+    def test_assign_returns_same_list(self) -> None:
+        blocks = [make_block(page_number=1, block_index=0, text="x")]
+        returned = assign_char_offsets_to_blocks(blocks)
+        assert returned is blocks
+
+
+# ---------------------------------------------------------------------------
+# DocumentParser ABC
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentParserABC:
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        from app.infrastructure.parsing.base import DocumentParser
+
+        with pytest.raises(TypeError):
+            DocumentParser()  # type: ignore[abstract]
+
+    def test_concrete_subclass_must_implement_parse(self) -> None:
+        from app.infrastructure.parsing.base import DocumentParser
+
+        class ConcreteParser(DocumentParser):
+            def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:  # noqa: ARG002
+                return []
+
+        parser = ConcreteParser()
+        result = parser.parse(b"")
+        assert result == []


### PR DESCRIPTION
## What

The **bake-off-independent backbone** of structured-PDF-parsing-at-ingest (ADR-0011, plan `2026-06-19-structured-pdf-parsing-at-ingest.md`, Phase 1 Tasks 1.1/1.3/1.4). Three layers that let a parser populate the already-migrated `article_text_blocks`, with the concrete parser swapped in later:

- **Port** — `app/infrastructure/parsing/base.py`: the `ParsedBlock` value type (mirrors the `ArticleTextBlock` model field-for-field), the `DocumentParser` ABC (`parse(pdf_bytes) -> list[ParsedBlock]`, mirroring `StorageAdapter`), and the pure `concat_page_text` / `assign_char_offsets_to_blocks` helpers — the single source of truth for per-page char offsets (invariant `block.text == page_text[char_start:char_end]`), plus `normalize_block_type` (unknown → `paragraph`).
- **Writer** — `app/repositories/article_text_block_repository.py`: `ArticleTextBlockRepository.replace_for_file` (delete-then-bulk-insert, `flush()` not `commit()`, normalizes `block_type` at the boundary) + the single ordered-read owner; the existing `article_text_block_read_service` now **delegates** to it (output byte-for-byte unchanged).
- **Orchestrator skeleton** — `app/services/document_parsing_service.py`: `DocumentParsingService` with an **injected** `DocumentParser` + `StorageAdapter` (download → parse → normalize offsets → persist → set `extraction_status`; `parse_failed` + re-raise on error).

## Why

`article_text_blocks` + migration `0006` + `PositionV1` + `citation_read_service` already ship on `dev` for the *read* path, but nothing populates the table. This adds the missing **populating contract** without committing to a parser. It is a **runtime no-op**: nothing calls `DocumentParsingService` yet, and the only behavior change is the verified-equivalent read-service refactor.

## Scope / deferred

Deliberately **not** here (gated on the Phase 0 bake-off / heavy deps / paid APIs / PHII): the `create_document_parser` factory + concrete parser (Docling/MinerU/LlamaParse), the Celery ingest task + zotero wiring, JATS/OCR/supplementary routing, the table-vision pass, and the second LLM provider. No schema change (table + `0006` pre-exist).

## Verification

- 44 tests green (31 unit `concat`/offset/normalize invariants + 13 integration: repository round-trip / delete-replace / RLS non-member-denied / service success + parse_failed / endpoint regression).
- Backend collection clean (1860/1861, no import regressions); ruff clean.
- Per-task spec+quality reviews and an opus whole-branch review: **Ready to merge = Yes**, no Critical/Important.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
