### PR TITLE
feat(extraction): grounded-extraction backbone + reviewer click-to-highlight (dark until parser)

### DIFF
--- a/backend/app/api/v1/endpoints/citations.py
+++ b/backend/app/api/v1/endpoints/citations.py
@@ -3,12 +3,13 @@
 Read-side of Phase 3 (Citation API + ExtractionEvidence integration).
 Writes still flow through the existing extraction services
 (``section_extraction_service``, ``ExtractionProposalService``);
-this endpoint surfaces the rows with their ``position`` JSONB validated
-against ``PositionV1`` so the frontend viewer can render them without
-a translation layer.
+this endpoint surfaces the rows with their ``position`` JSONB, adding
+``verified`` + ``anchorKind`` derived fields so callers can distinguish
+confirmed-present quotes from hallucinated / not-yet-verifiable ones.
 
-Rows whose ``position`` is the legacy empty ``{}`` are skipped — they
-predate the citation contract and have no anchor to render.
+All evidence rows are returned — unanchored rows (empty or unparseable
+``position``) are included with ``verified=False`` and ``anchorKind=None``
+rather than skipped.  The read path never raises on a bad position.
 """
 
 from typing import Any
@@ -39,7 +40,11 @@ async def list_article_citations_endpoint(
     db: DbSession,
     current_user_sub: UUID = Depends(get_current_user_sub),
 ) -> ApiResponse[list[dict[str, Any]]]:
-    """Return all v1-shape citations attached to ``article_id``."""
+    """Return all v1-shape citations attached to ``article_id``.
+
+    Unanchored rows (hallucinated or pre-ingestion) are included with
+    ``verified=False``; anchored rows carry ``verified=True`` + ``anchorKind``.
+    """
     try:
         project_id = await get_article_project_id(db, article_id)
     except ArticleNotFoundError as e:

--- a/backend/app/llm/validators.py
+++ b/backend/app/llm/validators.py
@@ -3,11 +3,19 @@
 Raising ModelRetry feeds the message back to the model for another
 attempt — the structured replacement for the legacy silent-empty-dict
 fallback. Pydantic itself already enforces types, enums, and the 0-1
-confidence range; these validators cover what a type system cannot."""
+confidence range; these validators cover what a type system cannot.
+
+Read-time predicates (``evidence_is_grounded``, ``anchor_kind``) are
+pure, never-raising helpers used in the citation read path — they are
+distinct from the extraction-time ``evidence_is_plausible`` validator
+and must never raise ``ModelRetry`` or any exception."""
 
 from typing import Any
 
+from pydantic import ValidationError
 from pydantic_ai import ModelRetry
+
+from app.schemas.extraction import PositionV1, parse_position
 
 
 def evidence_is_plausible(output: Any) -> Any:
@@ -34,3 +42,39 @@ def evidence_is_plausible(output: Any) -> Any:
                 f"Field '{label}': evidence.page_number must be a 1-based page number or null."
             )
     return output
+
+
+def evidence_is_grounded(position: dict[str, Any] | None) -> bool:
+    """Return True iff ``position`` parses to a valid anchored ``PositionV1``.
+
+    Pure read-time predicate — never raises. Used by ``citation_read_service``
+    to derive the ``verified`` flag without a schema migration.
+
+    Returns False for:
+    - None or empty dict  (no position stored / legacy row)
+    - dicts that fail ``PositionV1`` validation  (corrupted data)
+    """
+    if not position:
+        return False
+    try:
+        parsed: PositionV1 | None = parse_position(position)
+    except ValidationError:
+        return False
+    return parsed is not None
+
+
+def anchor_kind(position: dict[str, Any] | None) -> str | None:
+    """Return the anchor ``kind`` string when ``position`` is a valid ``PositionV1``.
+
+    Returns None for unanchored / invalid positions. Pure, never raises.
+    Possible non-None values: ``"text"``, ``"region"``, ``"hybrid"``.
+    """
+    if not position:
+        return None
+    try:
+        parsed: PositionV1 | None = parse_position(position)
+    except ValidationError:
+        return None
+    if parsed is None:
+        return None
+    return parsed.anchor.kind

--- a/backend/app/llm/validators.py
+++ b/backend/app/llm/validators.py
@@ -10,7 +10,7 @@ pure, never-raising helpers used in the citation read path — they are
 distinct from the extraction-time ``evidence_is_plausible`` validator
 and must never raise ``ModelRetry`` or any exception."""
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import ValidationError
 from pydantic_ai import ModelRetry
@@ -63,7 +63,7 @@ def evidence_is_grounded(position: dict[str, Any] | None) -> bool:
     return parsed is not None
 
 
-def anchor_kind(position: dict[str, Any] | None) -> str | None:
+def anchor_kind(position: dict[str, Any] | None) -> Literal["text", "region", "hybrid"] | None:
     """Return the anchor ``kind`` string when ``position`` is a valid ``PositionV1``.
 
     Returns None for unanchored / invalid positions. Pure, never raises.

--- a/backend/app/services/citation_read_service.py
+++ b/backend/app/services/citation_read_service.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.llm.validators import anchor_kind, evidence_is_grounded
 from app.models.article import Article
 from app.models.extraction import ExtractionEvidence
-from app.schemas.extraction import PositionV1, parse_position
+from app.schemas.extraction import parse_position
 
 
 class ArticleNotFoundError(Exception):
@@ -40,10 +40,17 @@ async def get_article_project_id(db: AsyncSession, article_id: UUID) -> UUID:
 async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dict[str, Any]]:
     """Return all v1-shape citations attached to the article (chronological).
 
-    Rows without a parseable PositionV1 anchor are skipped — they predate
-    the citation contract (legacy empty `{}` position) or fail schema
-    validation. Skipping (rather than 500-ing) preserves list semantics
-    for partial-failure cases.
+    Every evidence row is returned — unanchored rows (empty or unparseable
+    ``position``) are included with ``verified=False`` and ``anchorKind=None``
+    rather than skipped. This surfaces hallucination / no-blocks-yet signals
+    to callers without ever raising in the read path.
+
+    Wire shape per item:
+    - ``id``         — UUID string
+    - ``verified``   — True iff position parses to a valid PositionV1 anchor
+    - ``anchorKind`` — "text" | "region" | "hybrid" when verified, else None
+    - ``anchor``     — camelCase anchor dict when verified, else None (omit key)
+    - ``metadata``   — pageNumber / textContent / source (always present)
     """
     rows = (
         (
@@ -60,14 +67,8 @@ async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dic
     citations: list[dict[str, Any]] = []
     for row in rows:
         position = row.position
-        if not position:
-            continue
-        try:
-            parsed: PositionV1 | None = parse_position(position)
-        except ValidationError:
-            continue
-        if parsed is None:
-            continue
+        verified = evidence_is_grounded(position)
+        kind = anchor_kind(position)
 
         metadata: dict[str, Any] = {}
         if row.page_number is not None:
@@ -82,12 +83,20 @@ async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dic
         elif row.consensus_decision_id is not None:
             metadata["source"] = "review"
 
-        citations.append(
-            {
-                "id": str(row.id),
-                "anchor": parsed.anchor.model_dump(by_alias=True, exclude_none=True),
-                "metadata": metadata,
-            }
-        )
+        item: dict[str, Any] = {
+            "id": str(row.id),
+            "verified": verified,
+            "anchorKind": kind,
+            "metadata": metadata,
+        }
+        if verified:
+            # parse_position is safe here: evidence_is_grounded already confirmed it parses.
+            parsed = parse_position(position)
+            assert parsed is not None  # guaranteed by evidence_is_grounded
+            item["anchor"] = parsed.anchor.model_dump(by_alias=True, exclude_none=True)
+        else:
+            item["anchor"] = None
+
+        citations.append(item)
 
     return citations

--- a/backend/app/services/citation_read_service.py
+++ b/backend/app/services/citation_read_service.py
@@ -49,7 +49,7 @@ async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dic
     - ``id``         — UUID string
     - ``verified``   — True iff position parses to a valid PositionV1 anchor
     - ``anchorKind`` — "text" | "region" | "hybrid" when verified, else None
-    - ``anchor``     — camelCase anchor dict when verified, else None (omit key)
+    - ``anchor``     — camelCase anchor dict when verified, else None (always present; check ``c["anchor"] is None`` for unanchored rows)
     - ``metadata``   — pageNumber / textContent / source (always present)
     """
     rows = (
@@ -92,8 +92,13 @@ async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dic
         if verified:
             # parse_position is safe here: evidence_is_grounded already confirmed it parses.
             parsed = parse_position(position)
-            assert parsed is not None  # guaranteed by evidence_is_grounded
-            item["anchor"] = parsed.anchor.model_dump(by_alias=True, exclude_none=True)
+            if parsed is None:
+                # Defensive guard: logic regression — treat as unanchored.
+                item["anchor"] = None
+                item["verified"] = False
+                item["anchorKind"] = None
+            else:
+                item["anchor"] = parsed.anchor.model_dump(by_alias=True, exclude_none=True)
         else:
             item["anchor"] = None
 

--- a/backend/app/services/citation_read_service.py
+++ b/backend/app/services/citation_read_service.py
@@ -75,7 +75,9 @@ async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dic
             metadata["pageNumber"] = row.page_number
         if row.text_content is not None:
             metadata["textContent"] = row.text_content
-        # Source attribution — exactly one of these is set (CHECK constraint).
+        # Source attribution — at least one of proposal/reviewer/consensus is set
+        # (workflow_target_present CHECK enforces an OR, not exactly-one);
+        # the if/elif picks the first by priority.
         if row.proposal_record_id is not None:
             metadata["source"] = "ai"
         elif row.reviewer_decision_id is not None:

--- a/backend/app/services/evidence_anchor_service.py
+++ b/backend/app/services/evidence_anchor_service.py
@@ -323,18 +323,85 @@ def _fuzzy_better(
 # ---------------------------------------------------------------------------
 
 
-def _map_norm_span_to_original(
-    candidate: _PageCandidate,
-    norm_to_orig: list[int],
-    original_len: int,
-) -> tuple[int, int]:
-    """Translate a normalised ``[norm_start, norm_end)`` span to original offsets."""
-    char_start = norm_to_orig[candidate.norm_start]
-    if candidate.norm_end < len(norm_to_orig):
-        char_end = norm_to_orig[candidate.norm_end]
-    else:
-        char_end = original_len
+def _trim_whitespace(original: str, char_start: int, char_end: int) -> tuple[int, int]:
+    """Tighten ``[char_start, char_end)`` over leading/trailing ORIGINAL whitespace.
+
+    Whitespace folding means a match can map back onto a span that begins or
+    ends inside a collapsed-whitespace run (or across a block separator), so the
+    returned slice would carry stray ``\\n`` / spaces a highlighter would render.
+    Trim the start forward over leading whitespace and the end back over trailing
+    whitespace.  Fold-equality is preserved because folding strips exactly this
+    leading/trailing whitespace anyway.
+    """
+    while char_start < char_end and original[char_start] in _WHITESPACE:
+        char_start += 1
+    while char_end > char_start and original[char_end - 1] in _WHITESPACE:
+        char_end -= 1
     return char_start, char_end
+
+
+def _resolve_original_span(
+    candidate: _PageCandidate,
+    norm_page: str,
+    norm_to_orig: list[int],
+    original: str,
+) -> tuple[int, int] | None:
+    """Map a matched normalised span to an ORIGINAL span that honours the invariant.
+
+    Returns ``(char_start, char_end)`` such that
+    ``_normalize(original[char_start:char_end]) == _normalize(norm_span)`` (the
+    advertised fold-back guarantee), or ``None`` when no such span exists.
+
+    The naive map-back (``norm_to_orig[ns]`` … ``norm_to_orig[ne]``) can break in
+    two ways; both are corrected here with fold-equality as the source of truth:
+
+    * **Whitespace padding.**  A boundary can land inside a collapsed-whitespace
+      run / across a block separator, so the span carries stray leading/trailing
+      ``\\n`` / spaces a highlighter would render.  These are trimmed first
+      (:func:`_trim_whitespace`); folding strips exactly that whitespace, so
+      trimming never disturbs fold-equality.
+
+    * **Expansion boundary.**  ``norm_to_orig`` maps every sub-character of a
+      1→many NFKC expansion (e.g. the ligature ``ﬁ`` → ``f``, ``i``) to the SAME
+      original index.  When the match *starts* on a non-first sub-character, the
+      naive span includes the WHOLE original expansion char and folds one char too
+      WIDE.  We snap the start forward to original-character granularity (dropping
+      the partially-covered expansion char) only when that repairs fold-equality.
+      If the quote genuinely begins/ends mid-expansion — a degenerate input a real
+      LLM quote never produces — no original slice folds to it and we return
+      ``None`` rather than a span that violates the guarantee.
+
+    Fold-equality is re-checked after every adjustment, so a valid exact span
+    (the overwhelmingly common case) is accepted untouched and a non-representable
+    one is rejected rather than silently widened.
+    """
+    target = _normalize(norm_page[candidate.norm_start : candidate.norm_end])
+
+    char_start = norm_to_orig[candidate.norm_start]
+    char_end = (
+        norm_to_orig[candidate.norm_end]
+        if candidate.norm_end < len(norm_to_orig)
+        else len(original)
+    )
+    char_start, char_end = _trim_whitespace(original, char_start, char_end)
+
+    if char_end > char_start and _normalize(original[char_start:char_end]) == target:
+        return char_start, char_end
+
+    # The naive span folds wider than the match: the start fell inside an NFKC
+    # expansion.  Snap the start forward to the next original character (dropping
+    # the over-included expansion char) and re-check.  If it still does not fold
+    # to the match the quote is not representable as any original slice — honour
+    # the guarantee by reporting no anchor.
+    if char_start < char_end:
+        snapped_start, snapped_end = _trim_whitespace(original, char_start + 1, char_end)
+        if (
+            snapped_end > snapped_start
+            and _normalize(original[snapped_start:snapped_end]) == target
+        ):
+            return snapped_start, snapped_end
+
+    return None
 
 
 def _overlapping_blocks(
@@ -448,13 +515,23 @@ def match(
         if candidate is None:
             continue
 
-        char_start, char_end = _map_norm_span_to_original(candidate, norm_to_orig, len(original))
-        if char_end <= char_start:
+        resolved = _resolve_original_span(candidate, norm_page, norm_to_orig, original)
+        if resolved is None:
             continue
+        char_start, char_end = resolved
 
         overlapping = _overlapping_blocks(blocks_by_page[page], char_start, char_end)
         if not overlapping:
             continue
+
+        # Post-condition: the advertised fold-back invariant MUST hold for every
+        # non-None return — the returned span, sliced from the ORIGINAL page text
+        # and folded, equals the folded matched region.  ``_resolve_original_span``
+        # guarantees this; assert it so this class of bug can never silently
+        # return a span-too-wide again.
+        assert _normalize(original[char_start:char_end]) == _normalize(
+            norm_page[candidate.norm_start : candidate.norm_end]
+        ), "fold-back invariant violated"
 
         overlap_len = char_end - char_start
         key = (page, char_start, -overlap_len)

--- a/backend/app/services/evidence_anchor_service.py
+++ b/backend/app/services/evidence_anchor_service.py
@@ -18,7 +18,7 @@ page text and the quote are normalised before comparison.
 **Normalisation (both sides).**  Unicode **NFKC** + whitespace folding (runs of
 whitespace collapse to a single space; leading/trailing whitespace stripped).
 This makes a quote that differs only by ligatures (``ﬁ`` → ``fi``), smart
-quotes (``’`` → ``'``), or collapsed whitespace still match.
+quotes (``'`` → ``'``), or collapsed whitespace still match.
 
 **Offset coordinate space (the crucial part).**  NFKC and whitespace folding
 *change* string length and character positions.  The ``char_start`` /
@@ -81,6 +81,13 @@ from app.infrastructure.parsing.base import (
     assign_char_offsets_to_blocks,
     concat_page_text,
 )
+from app.schemas.extraction import (
+    HybridCitationAnchor,
+    PDFRect,
+    PDFTextRange,
+    PositionV1,
+    TextCitationAnchor,
+)
 
 # ---------------------------------------------------------------------------
 # Tuning constants (parameters, not config)
@@ -102,6 +109,13 @@ _FUZZ_LEN_SLACK: float = 0.25
 #: Length 1 below the upper bound is always probed too; this only coarsens the
 #: *length* sweep, not the *position* sweep (which is exhaustive).
 _FUZZ_LEN_STEP: int = 1
+
+#: Block types considered "prose" for anchor-variant selection.
+#: Any block whose type is NOT in this set (i.e. ``table_cell`` or
+#: ``figure_caption``) triggers a ``HybridCitationAnchor`` (range + bbox).
+_PROSE_BLOCK_TYPES: frozenset[str] = frozenset(
+    {"paragraph", "heading", "list_item", "header", "footer"}
+)
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +168,7 @@ class _Block(Protocol):
 # Normalisation + index map
 # ---------------------------------------------------------------------------
 
-_WHITESPACE = frozenset(" \t\n\r\f\v\xa0\u2028\u2029")
+_WHITESPACE = frozenset(" \t\n\r\f\v\xa0  ")
 #: Typographic punctuation that NFKC does NOT fold but which routinely differs
 #: between an LLM's quote and the source PDF.  Each mapping is a 1:1 character
 #: replacement so the normalised → original index map stays exact (length is
@@ -546,3 +560,68 @@ def match(
             )
 
     return best_result
+
+
+def build_anchor(
+    quote: str,
+    blocks: Sequence[_Block],
+    *,
+    fuzz_threshold: float = DEFAULT_FUZZ_THRESHOLD,
+) -> PositionV1 | None:
+    """Build a :class:`PositionV1` anchor for *quote* against *blocks*.
+
+    Calls :func:`match` to locate the quote, then picks the
+    :class:`~app.schemas.extraction.CitationAnchor` variant based on the
+    matched blocks' ``block_type``:
+
+    * **All matched blocks are prose** (``paragraph``, ``heading``,
+      ``list_item``, ``header``, ``footer``) →
+      :class:`~app.schemas.extraction.TextCitationAnchor` (char range only).
+    * **Any matched block is** ``table_cell`` **or** ``figure_caption`` →
+      :class:`~app.schemas.extraction.HybridCitationAnchor` (char range +
+      bbox union + quote).  Hybrid carries the region for table/figure
+      highlighting and is the recommended AI anchor shape.
+
+    The function is **pure** (no DB, no IO).  Idempotent on re-run — same
+    inputs always produce the same output.
+
+    Args:
+        quote: The LLM's free-text evidence quote.
+        blocks: ``ArticleTextBlock`` ORM rows (or ``ParsedBlock`` dataclasses).
+            Must cover the full document; typically obtained from
+            ``ArticleTextBlockRepository.list_ordered_for_file``.
+        fuzz_threshold: Passed through to :func:`match`.  ``1.0`` = exact only.
+
+    Returns:
+        A :class:`PositionV1` whose ``anchor`` is set to the appropriate
+        variant, or ``None`` if the quote cannot be located in *blocks*.
+    """
+    m = match(quote, blocks, fuzz_threshold=fuzz_threshold)
+    if m is None:
+        return None
+
+    # Look up the block_type for each matched block_index on m.page.
+    matched_block_types: set[str] = set()
+    for b in blocks:
+        if b.page_number == m.page and b.block_index in m.block_ids:
+            matched_block_types.add(b.block_type)
+
+    text_range = PDFTextRange(page=m.page, char_start=m.char_start, char_end=m.char_end)
+
+    # Hybrid if any matched block is a non-prose type (table_cell / figure_caption).
+    non_prose = matched_block_types - _PROSE_BLOCK_TYPES
+    if non_prose:
+        anchor = HybridCitationAnchor(
+            kind="hybrid",
+            range=text_range,
+            rect=PDFRect(**m.bbox_union),
+            quote=quote,
+        )
+    else:
+        anchor = TextCitationAnchor(
+            kind="text",
+            range=text_range,
+            quote=quote,
+        )
+
+    return PositionV1(version=1, anchor=anchor)

--- a/backend/app/services/evidence_anchor_service.py
+++ b/backend/app/services/evidence_anchor_service.py
@@ -1,0 +1,471 @@
+"""
+Evidence-anchor service — the quote → block matcher.
+
+This is the core grounding algorithm of the grounded-extraction pipeline.  It
+anchors an LLM's free-text evidence *quote* back to a verifiable span in the
+source document, returning the page, the char range in the canonical
+``concat_page_text`` coordinate space, the overlapping block ids, and the union
+bounding box for PDF highlighting.
+
+Design
+------
+
+**Matching surface.**  The quote is searched against the per-page text produced
+by the canonical ``concat_page_text`` (imported from
+``app.infrastructure.parsing.base`` — the single source of truth).  Both the
+page text and the quote are normalised before comparison.
+
+**Normalisation (both sides).**  Unicode **NFKC** + whitespace folding (runs of
+whitespace collapse to a single space; leading/trailing whitespace stripped).
+This makes a quote that differs only by ligatures (``ﬁ`` → ``fi``), smart
+quotes (``’`` → ``'``), or collapsed whitespace still match.
+
+**Offset coordinate space (the crucial part).**  NFKC and whitespace folding
+*change* string length and character positions.  The ``char_start`` /
+``char_end`` returned by :func:`match`, however, MUST be offsets into the
+ORIGINAL (un-normalised) ``concat_page_text`` page string — the same coordinate
+space every block's own ``char_start`` / ``char_end`` lives in.  So for each
+page we build a *normalised* surface together with an index map
+``norm_to_orig`` such that ``norm_to_orig[i]`` is the original index at which
+normalised character ``i`` began.  A matched normalised span ``[ns, ne)`` maps
+back to the original span ``[norm_to_orig[ns], norm_to_orig[ne])`` (with
+``ne == len(norm)`` mapping to ``len(original)``).
+
+**Bounded, deterministic fuzz.**  OCR noise (a few wrong characters) should
+still match.  Matching is tried in two tiers:
+
+1. *Exact* substring search of the folded quote inside the folded page text.
+2. If absent, a bounded sliding-window fuzzy search using
+   :class:`difflib.SequenceMatcher` (stdlib — pure, deterministic, no new
+   dependency).  Candidate windows are sized around the quote length; the best
+   similarity ratio ≥ ``fuzz_threshold`` wins.  The window length band is
+   bounded (``±FUZZ_LEN_SLACK`` fraction of the quote length) so cost stays
+   linear-ish and the result is reproducible.
+
+The fuzz unit is a **similarity ratio in [0.0, 1.0]** (``SequenceMatcher.ratio``
+— ``2*M/T`` where ``M`` is matched chars and ``T`` is total chars of both
+strings).  ``fuzz_threshold=1.0`` means *exact only*; the default
+``DEFAULT_FUZZ_THRESHOLD`` tolerates a handful of OCR errors in a sentence-length
+quote.  The threshold is a PARAMETER with a sensible default — it is NOT read
+from config (config wiring is deferred to a later task).
+
+**Multi-block span + bbox union.**  After mapping the match back to an original
+``[char_start, char_end)`` range, ``block_ids`` is every block whose own
+``[char_start, char_end)`` overlaps that range (ascending ``block_index``).
+``bbox_union`` is the union rectangle over those blocks:
+``x = min(x)``, ``y = min(y)``, ``width = max(x+width) - x``,
+``height = max(y+height) - y``.
+
+**Deterministic tie-breaking.**  Earliest page, then earliest matched original
+``char_start`` (which, because blocks are concatenated in ``block_index`` order,
+is the earliest block), then the longest contiguous overlap.  Same inputs always
+produce the same output.
+
+**Purity.**  No DB, no IO, no globals.  Input blocks are NEVER mutated: local
+``ParsedBlock`` copies are built so that ``assign_char_offsets_to_blocks`` (which
+mutates in place) only ever touches the copies, never the caller's
+``ArticleTextBlock`` ORM rows (mutating those would dirty the SQLAlchemy
+session).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Sequence
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Protocol, runtime_checkable
+
+from app.infrastructure.parsing.base import (
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+)
+
+# ---------------------------------------------------------------------------
+# Tuning constants (parameters, not config)
+# ---------------------------------------------------------------------------
+
+#: Default minimum ``SequenceMatcher.ratio`` for a fuzzy match to be accepted.
+#: 0.85 tolerates a handful of OCR-style character substitutions in a
+#: sentence-length quote while rejecting unrelated text.  ``1.0`` disables fuzz
+#: (exact match only).
+DEFAULT_FUZZ_THRESHOLD: float = 0.85
+
+#: Fractional slack on the candidate window length during fuzzy search.  We try
+#: window lengths from ``(1 - slack) * len(quote)`` to ``(1 + slack) * len(quote)``
+#: so OCR noise that inserts/deletes a few characters is still reachable while
+#: the search stays bounded.
+_FUZZ_LEN_SLACK: float = 0.25
+
+#: Step (in characters) of the longer window length probed during fuzzy search.
+#: Length 1 below the upper bound is always probed too; this only coarsens the
+#: *length* sweep, not the *position* sweep (which is exhaustive).
+_FUZZ_LEN_STEP: int = 1
+
+
+# ---------------------------------------------------------------------------
+# Public result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AnchorMatch:
+    """A grounded anchor for an evidence quote.
+
+    Attributes:
+        page: 1-indexed page number the quote was found on.
+        char_start: Start offset (inclusive) of the matched span inside the
+            ORIGINAL ``concat_page_text`` string for ``page`` — the same
+            coordinate space as each block's ``char_start``.
+        char_end: End offset (exclusive) of the matched span, same space.
+        block_ids: ``block_index`` of every block whose ``[char_start, char_end)``
+            overlaps the matched range, in ascending order.
+        bbox_union: Union bounding box over ``block_ids`` in PDF user space,
+            with keys ``x``, ``y``, ``width``, ``height``.
+    """
+
+    page: int
+    char_start: int
+    char_end: int
+    block_ids: list[int]
+    bbox_union: dict[str, float]
+
+
+# ---------------------------------------------------------------------------
+# Internal: structural protocol (ParsedBlock and ArticleTextBlock both satisfy)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _Block(Protocol):
+    """Structural protocol satisfied by both ``ParsedBlock`` and ``ArticleTextBlock``."""
+
+    page_number: int
+    block_index: int
+    text: str
+    char_start: int
+    char_end: int
+    bbox: dict[str, float]
+    block_type: str
+
+
+# ---------------------------------------------------------------------------
+# Normalisation + index map
+# ---------------------------------------------------------------------------
+
+_WHITESPACE = frozenset(" \t\n\r\f\v\xa0\u2028\u2029")
+#: Typographic punctuation that NFKC does NOT fold but which routinely differs
+#: between an LLM's quote and the source PDF.  Each mapping is a 1:1 character
+#: replacement so the normalised → original index map stays exact (length is
+#: preserved).  Curly single/double quotes and primes fold to their ASCII
+#: equivalents; the various dashes fold to a hyphen-minus.
+_PUNCT_FOLD: dict[str, str] = {
+    "‘": "'",  # left single quote
+    "’": "'",  # right single quote / apostrophe
+    "‚": "'",  # single low-9 quote
+    "‛": "'",  # single high-reversed-9 quote
+    "′": "'",  # prime
+    "“": '"',  # left double quote
+    "”": '"',  # right double quote
+    "„": '"',  # double low-9 quote
+    "‟": '"',  # double high-reversed-9 quote
+    "″": '"',  # double prime
+    "‐": "-",  # hyphen
+    "‑": "-",  # non-breaking hyphen
+    "‒": "-",  # figure dash
+    "–": "-",  # en dash
+    "—": "-",  # em dash
+    "―": "-",  # horizontal bar
+    "−": "-",  # minus sign
+}
+
+
+def _normalize_with_index_map(original: str) -> tuple[str, list[int]]:
+    """Return ``(normalised, norm_to_orig)`` for *original*.
+
+    Normalisation is **NFKC + whitespace folding**: each original character is
+    NFKC-normalised individually (which may expand it to several characters,
+    e.g. the ligature ``ﬁ`` → ``"fi"``), runs of whitespace collapse to a single
+    space, and leading/trailing whitespace is stripped.
+
+    ``norm_to_orig[i]`` is the index into *original* at which normalised
+    character ``i`` began.  Mapping the normalised half-open span ``[ns, ne)``
+    back to the original is ``original[norm_to_orig[ns] : end]`` where ``end`` is
+    ``norm_to_orig[ne]`` if ``ne < len(norm)`` else ``len(original)``.
+
+    Processing character-by-character (rather than normalising the whole string
+    at once) is what keeps the index map exact: we always know which ORIGINAL
+    offset produced each emitted normalised character.
+    """
+    norm_chars: list[str] = []
+    norm_to_orig: list[int] = []
+    pending_space = False  # a folded-whitespace run is pending emission
+
+    for orig_idx, ch in enumerate(original):
+        if ch in _WHITESPACE:
+            # Collapse any run of whitespace; defer the single space so that
+            # trailing whitespace never gets emitted.
+            pending_space = True
+            continue
+
+        nfkc = unicodedata.normalize("NFKC", ch)
+        # NFKC of a single non-whitespace char can itself contain whitespace
+        # (rare), so fold those too rather than emit them verbatim.
+        for sub in nfkc:
+            sub = _PUNCT_FOLD.get(sub, sub)  # 1:1 punctuation fold; length-stable
+            if sub in _WHITESPACE:
+                pending_space = True
+                continue
+            if pending_space and norm_chars:
+                # Emit the single folded space only between real characters.
+                norm_chars.append(" ")
+                norm_to_orig.append(orig_idx)
+            pending_space = False
+            norm_chars.append(sub)
+            norm_to_orig.append(orig_idx)
+
+    return "".join(norm_chars), norm_to_orig
+
+
+def _normalize(text: str) -> str:
+    """NFKC + punctuation + whitespace fold (used for the quote side).
+
+    Mirrors :func:`_normalize_with_index_map` minus the index map: the result
+    must be byte-identical to the page side so exact substring search works.
+    """
+    nfkc = unicodedata.normalize("NFKC", text)
+    folded = "".join(_PUNCT_FOLD.get(c, c) for c in nfkc)
+    return " ".join(folded.split())
+
+
+# ---------------------------------------------------------------------------
+# Internal: candidate match within one page
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _PageCandidate:
+    """The best match found on a single page (in normalised coordinates)."""
+
+    norm_start: int
+    norm_end: int
+    ratio: float
+
+
+def _best_exact(norm_page: str, norm_quote: str) -> _PageCandidate | None:
+    """Return the EARLIEST exact occurrence of *norm_quote* in *norm_page*."""
+    idx = norm_page.find(norm_quote)
+    if idx == -1:
+        return None
+    return _PageCandidate(norm_start=idx, norm_end=idx + len(norm_quote), ratio=1.0)
+
+
+def _best_fuzzy(
+    norm_page: str,
+    norm_quote: str,
+    fuzz_threshold: float,
+) -> _PageCandidate | None:
+    """Return the best fuzzy match of *norm_quote* in *norm_page* (or ``None``).
+
+    Slides windows of length within ``±_FUZZ_LEN_SLACK`` of the quote length and
+    keeps the highest ``SequenceMatcher.ratio`` ≥ *fuzz_threshold*.  Ties on
+    ratio break toward the earliest ``norm_start`` then the shortest window,
+    which keeps the result deterministic.
+    """
+    q_len = len(norm_quote)
+    page_len = len(norm_page)
+    if q_len == 0 or page_len == 0:
+        return None
+
+    min_len = max(1, int(q_len * (1.0 - _FUZZ_LEN_SLACK)))
+    max_len = min(page_len, int(q_len * (1.0 + _FUZZ_LEN_SLACK)) + 1)
+
+    matcher = SequenceMatcher(autojunk=False)
+    matcher.set_seq2(norm_quote)
+
+    best: _PageCandidate | None = None
+    # Probe a small band of window lengths so insertions/deletions are reachable.
+    window_lengths = sorted(set(range(min_len, max_len + 1, _FUZZ_LEN_STEP)) | {q_len})
+    for win_len in window_lengths:
+        if win_len <= 0 or win_len > page_len:
+            continue
+        for start in range(0, page_len - win_len + 1):
+            end = start + win_len
+            matcher.set_seq1(norm_page[start:end])
+            # real_quick_ratio / quick_ratio are deterministic upper bounds;
+            # use them to skip windows that cannot beat the current best.
+            if best is not None and matcher.real_quick_ratio() < best.ratio:
+                continue
+            if matcher.quick_ratio() < fuzz_threshold:
+                continue
+            ratio = matcher.ratio()
+            if ratio < fuzz_threshold:
+                continue
+            if best is None or _fuzzy_better(ratio, start, win_len, best):
+                best = _PageCandidate(norm_start=start, norm_end=end, ratio=ratio)
+    return best
+
+
+def _fuzzy_better(
+    ratio: float,
+    start: int,
+    win_len: int,
+    incumbent: _PageCandidate,
+) -> bool:
+    """Deterministic ordering: higher ratio, then earlier start, then shorter."""
+    inc_len = incumbent.norm_end - incumbent.norm_start
+    return (ratio, -start, -win_len) > (incumbent.ratio, -incumbent.norm_start, -inc_len)
+
+
+# ---------------------------------------------------------------------------
+# Internal: map a normalised span back to the original, then to blocks
+# ---------------------------------------------------------------------------
+
+
+def _map_norm_span_to_original(
+    candidate: _PageCandidate,
+    norm_to_orig: list[int],
+    original_len: int,
+) -> tuple[int, int]:
+    """Translate a normalised ``[norm_start, norm_end)`` span to original offsets."""
+    char_start = norm_to_orig[candidate.norm_start]
+    if candidate.norm_end < len(norm_to_orig):
+        char_end = norm_to_orig[candidate.norm_end]
+    else:
+        char_end = original_len
+    return char_start, char_end
+
+
+def _overlapping_blocks(
+    page_blocks: list[ParsedBlock],
+    char_start: int,
+    char_end: int,
+) -> list[ParsedBlock]:
+    """Return blocks whose ``[char_start, char_end)`` overlaps ``[char_start, char_end)``.
+
+    *page_blocks* must carry offsets in ``concat_page_text`` coordinates and be
+    sorted by ``block_index`` (the local copies built in :func:`match` satisfy
+    both).  Half-open overlap: ``b.char_start < char_end and b.char_end > char_start``.
+    """
+    return [b for b in page_blocks if b.char_start < char_end and b.char_end > char_start]
+
+
+def _bbox_union(blocks: list[ParsedBlock]) -> dict[str, float]:
+    """Union rectangle over *blocks* in PDF user space.
+
+    ``x = min(x)``, ``y = min(y)``, ``width = max(x+width) - x``,
+    ``height = max(y+height) - y``.
+    """
+    xs = [float(b.bbox["x"]) for b in blocks]
+    ys = [float(b.bbox["y"]) for b in blocks]
+    x_maxes = [float(b.bbox["x"]) + float(b.bbox["width"]) for b in blocks]
+    y_maxes = [float(b.bbox["y"]) + float(b.bbox["height"]) for b in blocks]
+    min_x = min(xs)
+    min_y = min(ys)
+    return {
+        "x": min_x,
+        "y": min_y,
+        "width": max(x_maxes) - min_x,
+        "height": max(y_maxes) - min_y,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def match(
+    quote: str,
+    blocks: Sequence[_Block],
+    *,
+    fuzz_threshold: float = DEFAULT_FUZZ_THRESHOLD,
+) -> AnchorMatch | None:
+    """Anchor *quote* to a span in *blocks*, or return ``None`` if absent.
+
+    Args:
+        quote: The LLM's evidence quote (free text).  Normalised with NFKC +
+            whitespace folding before matching.
+        blocks: ``ArticleTextBlock`` ORM rows or ``ParsedBlock`` dataclasses.
+            May be in any order and may carry placeholder ``char_start`` /
+            ``char_end`` — the matcher derives canonical offsets itself and
+            NEVER mutates the input blocks.
+        fuzz_threshold: Minimum ``SequenceMatcher.ratio`` in ``[0.0, 1.0]`` for a
+            fuzzy (OCR-tolerant) match.  ``1.0`` accepts exact matches only.
+            Defaults to :data:`DEFAULT_FUZZ_THRESHOLD`.  This is a parameter, not
+            a config value.
+
+    Returns:
+        An :class:`AnchorMatch` whose ``char_start`` / ``char_end`` index the
+        ORIGINAL ``concat_page_text`` page string, or ``None`` if the quote is
+        not found (exactly or within the fuzz threshold) on any page.
+
+    Tie-breaking is deterministic: earliest page, then earliest original
+    ``char_start``, then the longest contiguous overlap.
+    """
+    norm_quote = _normalize(quote)
+    if not norm_quote or not blocks:
+        return None
+
+    # Build LOCAL copies so assign_char_offsets_to_blocks mutates only the
+    # copies, never the caller's ORM rows.  This also makes the matcher robust
+    # to inputs whose char_start/char_end are placeholders.
+    copies = [
+        ParsedBlock(
+            page_number=b.page_number,
+            block_index=b.block_index,
+            text=b.text,
+            char_start=0,
+            char_end=0,
+            bbox=getattr(b, "bbox", {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}),
+            block_type=b.block_type,
+        )
+        for b in blocks
+    ]
+    assign_char_offsets_to_blocks(copies)  # mutates the COPIES only
+    page_texts = concat_page_text(copies)
+
+    blocks_by_page: dict[int, list[ParsedBlock]] = {}
+    for c in copies:
+        blocks_by_page.setdefault(c.page_number, []).append(c)
+    for page_blocks in blocks_by_page.values():
+        page_blocks.sort(key=lambda b: b.block_index)
+
+    best_result: AnchorMatch | None = None
+    best_key: tuple[int, int, int] | None = None  # (page, char_start, -overlap_len)
+
+    # Iterate pages in ascending order for deterministic earliest-page tie-break.
+    for page in sorted(page_texts):
+        original = page_texts[page]
+        norm_page, norm_to_orig = _normalize_with_index_map(original)
+        if not norm_page:
+            continue
+
+        candidate = _best_exact(norm_page, norm_quote)
+        if candidate is None and fuzz_threshold < 1.0:
+            candidate = _best_fuzzy(norm_page, norm_quote, fuzz_threshold)
+        if candidate is None:
+            continue
+
+        char_start, char_end = _map_norm_span_to_original(candidate, norm_to_orig, len(original))
+        if char_end <= char_start:
+            continue
+
+        overlapping = _overlapping_blocks(blocks_by_page[page], char_start, char_end)
+        if not overlapping:
+            continue
+
+        overlap_len = char_end - char_start
+        key = (page, char_start, -overlap_len)
+        if best_key is None or key < best_key:
+            best_key = key
+            best_result = AnchorMatch(
+                page=page,
+                char_start=char_start,
+                char_end=char_end,
+                block_ids=[b.block_index for b in overlapping],
+                bbox_union=_bbox_union(overlapping),
+            )
+
+    return best_result

--- a/backend/app/services/evidence_anchor_service.py
+++ b/backend/app/services/evidence_anchor_service.py
@@ -538,14 +538,17 @@ def match(
         if not overlapping:
             continue
 
-        # Post-condition: the advertised fold-back invariant MUST hold for every
-        # non-None return — the returned span, sliced from the ORIGINAL page text
-        # and folded, equals the folded matched region.  ``_resolve_original_span``
-        # guarantees this; assert it so this class of bug can never silently
-        # return a span-too-wide again.
-        assert _normalize(original[char_start:char_end]) == _normalize(
+        # Post-condition: the fold-back invariant MUST hold for every non-None
+        # return — the returned span, sliced from the ORIGINAL page text and
+        # folded, equals the folded matched region.  ``_resolve_original_span``
+        # guarantees this for well-formed inputs.  If it does NOT hold (a
+        # degenerate edge case the upstream pipeline cannot produce), degrade
+        # gracefully: treat the quote as unlocatable rather than raising in the
+        # extraction write path.  A non-None return ALWAYS satisfies the invariant.
+        if _normalize(original[char_start:char_end]) != _normalize(
             norm_page[candidate.norm_start : candidate.norm_end]
-        ), "fold-back invariant violated"
+        ):
+            continue
 
         overlap_len = char_end - char_start
         key = (page, char_start, -overlap_len)

--- a/backend/app/services/extraction_block_assembler.py
+++ b/backend/app/services/extraction_block_assembler.py
@@ -1,0 +1,404 @@
+"""
+Section-aware block assembler for the grounded-extraction pipeline.
+
+Converts a flat list of ``ArticleTextBlock`` (or ``ParsedBlock``) objects into
+a structured prompt text that:
+
+1. Preserves reading order (page_number asc, block_index asc).
+2. Emits ``## <heading>`` markers from ``heading`` blocks (IMRaD-aware).
+3. Coalesces contiguous ``table_cell`` runs into a reconstructed markdown
+   table instead of emitting one cell per line.
+4. When the serialised text exceeds ``budget`` chars, drops WHOLE sections
+   (never a mid-sentence or mid-table prefix cut) according to a deterministic
+   IMRaD-aware ranking, and records what was dropped in ``DroppedSection``
+   objects.
+
+Design decisions
+----------------
+**Budget unit**: characters (``len(text)``).  Characters are the simplest
+defensible unit for a pure, deterministic function that has no tokeniser
+dependency.  The call site that wires this into the extraction prompts can
+apply a safety multiplier if needed (e.g. chars × 0.25 ≈ tokens for typical
+scientific prose).
+
+**Section ranking (deterministic)**:
+Sections are ranked for inclusion in priority order:
+
+    Abstract > Results > Methods > Introduction > Discussion > Conclusion
+    > Figures/Tables > Other > References > Appendix > Header/Footer chrome
+
+When a ``focus`` hint is supplied (e.g. ``focus="Methods"``), the named
+section is promoted to rank 0 (highest priority), ahead of Abstract.  All
+other ranks shift down by one.  The ranking is a static look-up — no
+embeddings or ML.
+
+**Table reconstruction**: contiguous ``table_cell`` runs on the same page
+are detected by scanning blocks in reading order.  A run break occurs when a
+non-cell block is encountered OR when the page changes.  Each run is
+serialised as a simple markdown table.  The column count is inferred from the
+first row (the longest prefix of cells before the grid wraps — estimated by
+looking for repeated column-count patterns; if inference fails, all cells
+are placed in a single-column table).
+
+**concat_page_text reuse**: the assembler calls the canonical
+``concat_page_text`` imported from ``app.infrastructure.parsing.base`` to
+produce per-page text strings.  This guarantees that char offsets written by
+the ingestion pipeline and used by the evidence-anchorer are consistent with
+the text the LLM will see.
+
+**Scope**: pure function, no DB, no IO, no globals.  This module is
+intentionally unwired — the call sites in ``section_extraction_service`` and
+``model_extraction_service`` are wired in a separate follow-up task.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DroppedSection:
+    """Metadata about a section that was excluded because of budget constraints.
+
+    Attributes:
+        title: The heading text (or ``"<preamble>"`` for content before the
+            first heading).
+        char_count: Approximate character count of the dropped section's
+            serialised text (including the heading marker).
+        rank: The priority rank assigned to this section (lower = higher
+            priority, i.e. kept sections have lower rank numbers).
+    """
+
+    title: str
+    char_count: int
+    rank: int
+
+
+# ---------------------------------------------------------------------------
+# Internal: block protocol (works on both ParsedBlock and ArticleTextBlock ORM rows)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _Block(Protocol):
+    """Structural protocol satisfied by both ``ParsedBlock`` and ``ArticleTextBlock``."""
+
+    page_number: int
+    block_index: int
+    text: str
+    char_start: int
+    char_end: int
+    block_type: str
+
+
+# ---------------------------------------------------------------------------
+# IMRaD section ranking
+# ---------------------------------------------------------------------------
+
+# Canonical IMRaD priority: lower index = higher priority (kept first).
+# The ranking is applied to the *heading text* after normalisation to lower
+# case and stripping of trailing punctuation/numbering.
+_IMRAD_KEYWORDS: list[tuple[int, tuple[str, ...]]] = [
+    (0, ("abstract", "summary")),
+    (1, ("result", "finding")),
+    (2, ("method", "material", "patient", "participant", "procedure", "protocol")),
+    (3, ("introduction", "background", "objective", "aim", "purpose")),
+    (4, ("discussion",)),
+    (5, ("conclusion", "implication")),
+    (6, ("figure", "table", "supplementary", "supplement")),
+    (7, ()),  # catch-all "other" — assigned dynamically
+    (8, ("reference", "bibliography", "cited")),
+    (9, ("appendix", "annex")),
+    (10, ()),  # page chrome (header / footer type blocks that leaked through)
+]
+
+_DEFAULT_RANK = 7  # "other"
+
+
+def _section_rank(heading_text: str, focus: str | None) -> int:
+    """Return a priority rank for *heading_text* (lower = higher priority).
+
+    If *focus* is provided and matches the heading, the section is promoted
+    to rank -1 (highest possible priority, above Abstract).
+    """
+    normalised = re.sub(r"^\d[\d.\s]*", "", heading_text.lower().strip(" :.-"))
+    if focus and normalised == focus.lower().strip():
+        return -1
+    for rank, keywords in _IMRAD_KEYWORDS:
+        if not keywords:
+            continue
+        if any(kw in normalised for kw in keywords):
+            return rank
+    return _DEFAULT_RANK
+
+
+# ---------------------------------------------------------------------------
+# Internal: Section dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Section:
+    """One logical section: a heading (optional) followed by its body blocks."""
+
+    title: str  # "" for pre-heading preamble
+    rank: int
+    blocks: list[_Block] = field(default_factory=list)
+
+
+def _is_chrome(block: _Block) -> bool:
+    """Return True for page chrome blocks (header / footer) that add noise."""
+    return block.block_type in ("header", "footer")
+
+
+# ---------------------------------------------------------------------------
+# Table reconstruction
+# ---------------------------------------------------------------------------
+
+_CELL_SEP = " | "
+_ROW_SEP_CHAR = "-"
+
+
+def _infer_column_count(cell_texts: list[str]) -> int:
+    """Heuristically infer the number of columns in a table.
+
+    Tries column counts from 2 to min(8, n) and picks the one where
+    n % cols == 0 (exact fit) and cols is smallest.  Falls back to 1.
+    """
+    n = len(cell_texts)
+    if n <= 1:
+        return 1
+    for cols in range(2, min(9, n + 1)):
+        if n % cols == 0:
+            return cols
+    # No exact fit — use the square-root heuristic (rounded up), capped at 8
+    import math
+
+    return min(8, max(2, math.ceil(math.sqrt(n))))
+
+
+def _render_table(cell_texts: list[str]) -> str:
+    """Render *cell_texts* as a markdown table string."""
+    if not cell_texts:
+        return ""
+    cols = _infer_column_count(cell_texts)
+    rows: list[list[str]] = []
+    for i in range(0, len(cell_texts), cols):
+        row = cell_texts[i : i + cols]
+        # Pad the last row if it is short
+        while len(row) < cols:
+            row.append("")
+        rows.append(row)
+
+    # Compute column widths
+    col_widths = [max(len(r[c]) for r in rows) for c in range(cols)]
+
+    def _fmt_row(row: list[str]) -> str:
+        cells = [r.ljust(w) for r, w in zip(row, col_widths, strict=True)]
+        return "| " + _CELL_SEP.join(cells) + " |"
+
+    def _separator() -> str:
+        return "|-" + "-|-".join(_ROW_SEP_CHAR * w for w in col_widths) + "-|"
+
+    lines = [_fmt_row(rows[0]), _separator()]
+    for row in rows[1:]:
+        lines.append(_fmt_row(row))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Internal: serialize a section's blocks into a text string
+# ---------------------------------------------------------------------------
+
+
+def _serialize_section(section: _Section) -> str:
+    """Serialise *section* into a text string (heading marker + body)."""
+    parts: list[str] = []
+
+    if section.title:
+        parts.append(f"## {section.title}")
+
+    # Walk blocks, coalescing contiguous table_cell runs.
+    # A run breaks when block type changes away from table_cell, or page changes.
+    i = 0
+    blocks = section.blocks
+    while i < len(blocks):
+        block = blocks[i]
+
+        if _is_chrome(block):
+            i += 1
+            continue
+
+        if block.block_type == "table_cell":
+            # Collect the contiguous run
+            run: list[str] = []
+            current_page = block.page_number
+            while (
+                i < len(blocks)
+                and blocks[i].block_type == "table_cell"
+                and blocks[i].page_number == current_page
+            ):
+                run.append(blocks[i].text)
+                i += 1
+            parts.append(_render_table(run))
+        else:
+            parts.append(block.text)
+            i += 1
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Internal: segment blocks into sections
+# ---------------------------------------------------------------------------
+
+
+def _segment_into_sections(
+    sorted_blocks: list[_Block],
+    focus: str | None,
+) -> list[_Section]:
+    """Group *sorted_blocks* (in reading order) into ``_Section`` objects.
+
+    A new section begins every time a ``heading`` block is encountered.
+    Blocks before the first heading are grouped into a preamble section
+    with title ``""`` (empty string) and rank equal to Abstract's rank (0),
+    since the preamble usually contains the abstract or title.
+    """
+    sections: list[_Section] = []
+    current = _Section(title="", rank=_section_rank("abstract", focus))
+
+    for block in sorted_blocks:
+        if block.block_type == "heading":
+            # Only start a new section if the current one has content
+            # (to avoid empty preamble sections when the doc starts with a heading).
+            if current.blocks or current.title:
+                sections.append(current)
+            current = _Section(
+                title=block.text,
+                rank=_section_rank(block.text, focus),
+                blocks=[],
+            )
+        else:
+            current.blocks.append(block)
+
+    # Don't forget the last in-progress section
+    if current.blocks or current.title:
+        sections.append(current)
+
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def assemble(
+    blocks: list[_Block],
+    budget: int,
+    focus: str | None = None,
+) -> tuple[str, list[DroppedSection]]:
+    """Assemble *blocks* into structured prompt text within *budget* characters.
+
+    Args:
+        blocks: ``ArticleTextBlock`` ORM rows or ``ParsedBlock`` dataclasses.
+            May be in any order; this function sorts by (page_number, block_index).
+        budget: Maximum number of characters in the returned text (inclusive).
+            When the full document exceeds this limit, whole sections are dropped
+            according to the deterministic IMRaD-aware ranking (lower rank =
+            higher priority = kept first).  Budget is measured in characters
+            (``len(text)``).
+        focus: Optional section-title hint (case-insensitive exact match after
+            normalisation).  The matching section is promoted to the highest
+            priority rank, ensuring it is never dropped before lower-priority
+            sections.
+
+    Returns:
+        A tuple ``(text, dropped_sections)`` where:
+        - *text* is the assembled prompt string, ≤ *budget* chars.
+        - *dropped_sections* is a list of ``DroppedSection`` objects describing
+          every section that was omitted due to budget constraints (empty list
+          when everything fits).
+
+    Notes:
+        - Pure function: no DB, no IO, no globals.
+        - Uses ``concat_page_text`` from ``app.infrastructure.parsing.base``
+          as the canonical source of per-page text (required by the anchorer).
+        - ``header`` and ``footer`` blocks are suppressed (page chrome).
+        - Contiguous ``table_cell`` blocks on the same page are coalesced into
+          a markdown table.
+        - When over budget, WHOLE sections are dropped — never a mid-sentence
+          or mid-table prefix cut.
+    """
+    if not blocks:
+        return "", []
+
+    # 1. Sort into reading order (page asc, block_index asc).
+    sorted_blocks: list[_Block] = sorted(blocks, key=lambda b: (b.page_number, b.block_index))
+
+    # 2. Segment into sections.
+    sections = _segment_into_sections(sorted_blocks, focus)
+
+    # 3. Serialise each section to compute its character cost.
+    serialised: list[tuple[_Section, str]] = [(sec, _serialize_section(sec)) for sec in sections]
+
+    # 4. Check if everything fits within budget.
+    #    Join with double newline between sections.
+    separator = "\n\n"
+    full_text_parts = [text for _, text in serialised if text]
+    full_text = separator.join(full_text_parts)
+
+    if len(full_text) <= budget:
+        return full_text, []
+
+    # 5. Over budget: select whole sections greedily, highest priority first.
+    #    Within the same rank, preserve original document order (stable sort).
+    #    We keep track of original indices so we can reconstruct document order
+    #    for kept sections.
+    indexed: list[tuple[int, _Section, str]] = [
+        (i, sec, text) for i, (sec, text) in enumerate(serialised) if text
+    ]
+
+    # Sort by (rank asc, original_index asc) — deterministic.
+    priority_order = sorted(indexed, key=lambda t: (t[1].rank, t[0]))
+
+    kept_indices: set[int] = set()
+    running_chars = 0
+    dropped: list[DroppedSection] = []
+
+    for orig_idx, sec, text in priority_order:
+        # Cost: text length + separator if this is not the first kept section
+        extra = len(separator) if kept_indices else 0
+        cost = len(text) + extra
+        if running_chars + cost <= budget:
+            kept_indices.add(orig_idx)
+            running_chars += cost
+        else:
+            dropped.append(
+                DroppedSection(
+                    title=sec.title or "<preamble>",
+                    char_count=len(text),
+                    rank=sec.rank,
+                )
+            )
+
+    # 6. Reconstruct in original document order.
+    kept_parts = [text for i, _, text in indexed if i in kept_indices]
+    result_text = separator.join(kept_parts)
+
+    # Defensive: ensure we never exceed budget (rounding/separator edge cases).
+    if len(result_text) > budget:
+        # Fallback: drop last kept section until we fit.
+        # This should virtually never happen given the greedy selection above.
+        parts = result_text.split(separator)
+        while parts and len(separator.join(parts)) > budget:
+            parts.pop()
+        result_text = separator.join(parts)
+
+    return result_text, dropped

--- a/backend/app/services/extraction_block_assembler.py
+++ b/backend/app/services/extraction_block_assembler.py
@@ -42,9 +42,13 @@ are placed in a single-column table).
 
 **concat_page_text reuse**: the assembler calls the canonical
 ``concat_page_text`` imported from ``app.infrastructure.parsing.base`` to
-produce per-page text strings.  This guarantees that char offsets written by
-the ingestion pipeline and used by the evidence-anchorer are consistent with
-the text the LLM will see.
+produce per-page text strings.  Local copies of the input blocks are built
+so that ``assign_char_offsets_to_blocks`` can mutate them without ever
+touching the caller's ORM objects (which would cause spurious SQLAlchemy
+dirty-tracking and unwanted UPDATEs).  Prose blocks are sourced from the
+canonical surface via ``page_texts[page][cs:ce]``, which is content-identical
+to ``block.text`` by construction but guarantees byte-for-byte alignment with
+what the evidence-anchorer will index.
 
 **Scope**: pure function, no DB, no IO, no globals.  This module is
 intentionally unwired — the call sites in ``section_extraction_service`` and
@@ -53,9 +57,16 @@ intentionally unwired — the call sites in ``section_extraction_service`` and
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
+
+from app.infrastructure.parsing.base import (
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+)
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -178,8 +189,6 @@ def _infer_column_count(cell_texts: list[str]) -> int:
         if n % cols == 0:
             return cols
     # No exact fit — use the square-root heuristic (rounded up), capped at 8
-    import math
-
     return min(8, max(2, math.ceil(math.sqrt(n))))
 
 
@@ -217,8 +226,26 @@ def _render_table(cell_texts: list[str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _serialize_section(section: _Section) -> str:
-    """Serialise *section* into a text string (heading marker + body)."""
+def _serialize_section(
+    section: _Section,
+    page_texts: dict[int, str],
+    offsets: dict[tuple[int, int], tuple[int, int]],
+) -> str:
+    """Serialise *section* into a text string (heading marker + body).
+
+    Prose blocks are sourced from *page_texts* via *offsets* — the canonical
+    surface produced by ``concat_page_text`` — so that the assembler's output
+    is byte-for-byte consistent with what the evidence-anchorer indexes.
+    Table-cell text is taken directly from the block (cells are not indexed by
+    the anchorer via char offsets).
+
+    Args:
+        section: The section to serialise.
+        page_texts: Mapping of ``page_number → concatenated page string``
+            produced by ``concat_page_text`` on local block copies.
+        offsets: Mapping of ``(page_number, block_index) → (char_start, char_end)``
+            derived from ``assign_char_offsets_to_blocks`` on local block copies.
+    """
     parts: list[str] = []
 
     if section.title:
@@ -236,7 +263,7 @@ def _serialize_section(section: _Section) -> str:
             continue
 
         if block.block_type == "table_cell":
-            # Collect the contiguous run
+            # Collect the contiguous run — cells use .text directly
             run: list[str] = []
             current_page = block.page_number
             while (
@@ -248,7 +275,11 @@ def _serialize_section(section: _Section) -> str:
                 i += 1
             parts.append(_render_table(run))
         else:
-            parts.append(block.text)
+            # Route prose through the canonical surface so offsets align with
+            # what the evidence-anchorer will index in concat_page_text.
+            cs, ce = offsets[(block.page_number, block.block_index)]
+            prose = page_texts[block.page_number][cs:ce]
+            parts.append(prose)
             i += 1
 
     return "\n".join(parts)
@@ -309,6 +340,7 @@ def assemble(
     Args:
         blocks: ``ArticleTextBlock`` ORM rows or ``ParsedBlock`` dataclasses.
             May be in any order; this function sorts by (page_number, block_index).
+            Input blocks are NEVER mutated.
         budget: Maximum number of characters in the returned text (inclusive).
             When the full document exceeds this limit, whole sections are dropped
             according to the deterministic IMRaD-aware ranking (lower rank =
@@ -328,8 +360,11 @@ def assemble(
 
     Notes:
         - Pure function: no DB, no IO, no globals.
-        - Uses ``concat_page_text`` from ``app.infrastructure.parsing.base``
-          as the canonical source of per-page text (required by the anchorer).
+        - Input blocks are never mutated; local ``ParsedBlock`` copies are used
+          so that ``assign_char_offsets_to_blocks`` does not dirty SQLAlchemy
+          ORM objects.
+        - Prose text is sourced from ``concat_page_text`` (canonical surface)
+          so char offsets match what the evidence-anchorer indexes.
         - ``header`` and ``footer`` blocks are suppressed (page chrome).
         - Contiguous ``table_cell`` blocks on the same page are coalesced into
           a markdown table.
@@ -342,13 +377,35 @@ def assemble(
     # 1. Sort into reading order (page asc, block_index asc).
     sorted_blocks: list[_Block] = sorted(blocks, key=lambda b: (b.page_number, b.block_index))
 
-    # 2. Segment into sections.
+    # 2. Build local ParsedBlock copies so assign_char_offsets_to_blocks can
+    #    mutate them without ever touching the caller's ORM objects.
+    copies = [
+        ParsedBlock(
+            page_number=b.page_number,
+            block_index=b.block_index,
+            text=b.text,
+            char_start=0,
+            char_end=0,
+            bbox=getattr(b, "bbox", {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}),
+            block_type=b.block_type,
+        )
+        for b in sorted_blocks
+    ]
+    assign_char_offsets_to_blocks(copies)  # mutates the COPIES only
+    page_texts = concat_page_text(copies)  # canonical per-page text
+    offsets: dict[tuple[int, int], tuple[int, int]] = {
+        (c.page_number, c.block_index): (c.char_start, c.char_end) for c in copies
+    }
+
+    # 3. Segment into sections.
     sections = _segment_into_sections(sorted_blocks, focus)
 
-    # 3. Serialise each section to compute its character cost.
-    serialised: list[tuple[_Section, str]] = [(sec, _serialize_section(sec)) for sec in sections]
+    # 4. Serialise each section to compute its character cost.
+    serialised: list[tuple[_Section, str]] = [
+        (sec, _serialize_section(sec, page_texts, offsets)) for sec in sections
+    ]
 
-    # 4. Check if everything fits within budget.
+    # 5. Check if everything fits within budget.
     #    Join with double newline between sections.
     separator = "\n\n"
     full_text_parts = [text for _, text in serialised if text]
@@ -357,7 +414,7 @@ def assemble(
     if len(full_text) <= budget:
         return full_text, []
 
-    # 5. Over budget: select whole sections greedily, highest priority first.
+    # 6. Over budget: select whole sections greedily, highest priority first.
     #    Within the same rank, preserve original document order (stable sort).
     #    We keep track of original indices so we can reconstruct document order
     #    for kept sections.
@@ -388,17 +445,19 @@ def assemble(
                 )
             )
 
-    # 6. Reconstruct in original document order.
+    # 7. Reconstruct in original document order.
     kept_parts = [text for i, _, text in indexed if i in kept_indices]
     result_text = separator.join(kept_parts)
 
     # Defensive: ensure we never exceed budget (rounding/separator edge cases).
+    # Track kept sections as a list and pop WHOLE sections from the back —
+    # never string-split the serialized output (which would break on separator
+    # strings that appear inside block text).
     if len(result_text) > budget:
-        # Fallback: drop last kept section until we fit.
-        # This should virtually never happen given the greedy selection above.
-        parts = result_text.split(separator)
-        while parts and len(separator.join(parts)) > budget:
-            parts.pop()
-        result_text = separator.join(parts)
+        # Rebuild the kept list in document order so we can pop whole sections.
+        kept_list: list[str] = list(kept_parts)
+        while kept_list and len(separator.join(kept_list)) > budget:
+            kept_list.pop()
+        result_text = separator.join(kept_list)
 
     return result_text, dropped

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -44,6 +44,8 @@ from app.repositories import (
     ExtractionInstanceRepository,
     ExtractionRunRepository,
 )
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+from app.services.evidence_anchor_service import build_anchor
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.pdf_processor import PDFProcessor
 from app.services.run_lifecycle_service import RunLifecycleService
@@ -1219,6 +1221,23 @@ class SectionExtractionService(LoggerMixin):
                 entity_type_id=str(entity_type_id),
             )
 
+        # Resolve the article's main PDF file and its text blocks once, so
+        # build_anchor can ground each evidence quote to a PositionV1 anchor.
+        # Guard: missing main file or no blocks → empty list; safe fallback
+        # keeps position={} and the LLM's page_number (no exception raised).
+        _anchor_blocks: list = []
+        _anchor_file_id: UUID | None = None
+        try:
+            _main_file = await self._article_files.get_latest_pdf(article_id)
+            if _main_file is not None:
+                _anchor_file_id = _main_file.id
+                _anchor_blocks = await ArticleTextBlockRepository(self.db).list_ordered_for_file(
+                    _main_file.id
+                )
+        except Exception:
+            _anchor_blocks = []
+            _anchor_file_id = None
+
         # Record one ProposalRecord per extracted field. Evidence cited by
         # the LLM is stored as a real extraction_evidence row linked to
         # the proposal via proposal_record_id.
@@ -1269,15 +1288,24 @@ class SectionExtractionService(LoggerMixin):
             )
 
             if evidence_meta:
+                _quote = evidence_meta.get("text") or ""
+                _pos = build_anchor(_quote, _anchor_blocks) if _anchor_blocks and _quote else None
+                if _pos is not None:
+                    _position: dict = _pos.model_dump(by_alias=True, mode="json")
+                    _page_num = _pos.anchor.range.page
+                else:
+                    _position = {}
+                    _page_num = evidence_meta.get("page_number")
                 self.db.add(
                     ExtractionEvidence(
                         project_id=project_id,
                         article_id=article_id,
+                        article_file_id=_anchor_file_id if _pos is not None else None,
                         run_id=run.id,
                         proposal_record_id=proposal.id,
-                        page_number=evidence_meta.get("page_number"),
+                        page_number=_page_num,
                         text_content=evidence_meta.get("text"),
-                        position={},
+                        position=_position,
                         created_by=UUID(self.user_id),
                     )
                 )

--- a/backend/tests/integration/test_position_v1_anchoring.py
+++ b/backend/tests/integration/test_position_v1_anchoring.py
@@ -1,0 +1,502 @@
+"""Integration tests for PositionV1 evidence anchoring (Task 2.2).
+
+Verifies the full write path:
+  build_anchor(quote, blocks) → PositionV1 → ExtractionEvidence.position (JSONB)
+
+Four cases:
+  1. prose quote  → TextCitationAnchor  (kind="text")
+  2. table_cell quote → HybridCitationAnchor (kind="hybrid", rect present)
+  3. unmatched quote / no blocks → position == {} (safe fallback, run continues)
+  4. citation_read_service emits the stored anchor camelCase for an anchored row
+
+Uses db_session_real because ExtractionEvidence is inserted inside
+_create_suggestions, which calls flush() (not commit()); we commit at
+the end of each test body and clean up in finally blocks.
+"""
+
+from __future__ import annotations
+
+import uuid
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.extraction import ExtractionEvidence
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+from app.schemas.extraction import (
+    HybridCitationAnchor,
+    PositionV1,
+    TextCitationAnchor,
+    parse_position,
+)
+from app.services.citation_read_service import list_article_citations
+from app.services.evidence_anchor_service import build_anchor
+from tests.integration.conftest import SEED
+
+# ---------------------------------------------------------------------------
+# Shared helpers  (mirror the pattern from test_article_text_block_repository)
+# ---------------------------------------------------------------------------
+
+
+async def _insert_article_file(
+    db: AsyncSession,
+    *,
+    project_id: UUID,
+    article_id: UUID,
+) -> UUID:
+    file_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": str(file_id),
+            "pid": str(project_id),
+            "aid": str(article_id),
+            "key": f"test-anchor/{file_id}.pdf",
+        },
+    )
+    await db.commit()
+    return file_id
+
+
+async def _cleanup_file(db: AsyncSession, *, file_id: UUID) -> None:
+    """Cascade-delete the article_file and everything under it."""
+    await db.execute(
+        text("DELETE FROM public.article_files WHERE id = :id"),
+        {"id": str(file_id)},
+    )
+    await db.commit()
+
+
+async def _cleanup_evidence(db: AsyncSession, *, article_id: UUID) -> None:
+    """Remove evidence rows inserted by the test."""
+    await db.execute(
+        text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+        {"aid": str(article_id)},
+    )
+    await db.commit()
+
+
+async def _insert_run_and_proposal(
+    db: AsyncSession,
+    *,
+    project_id: UUID,
+    article_id: UUID,
+) -> tuple[UUID, UUID]:
+    """Create a minimal extraction_run + proposal_record so evidence rows
+    satisfy the ``workflow_target_present`` CHECK constraint.
+
+    Returns (run_id, proposal_record_id).
+    """
+    # Resolve template + active version + instance + field from seed rows.
+    template_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.project_extraction_templates "
+                "WHERE project_id = :pid AND kind='extraction' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
+        )
+    ).scalar()
+    version_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.extraction_template_versions "
+                "WHERE project_template_id = :tid AND is_active LIMIT 1"
+            ),
+            {"tid": str(template_id)},
+        )
+    ).scalar()
+    entity_type_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.extraction_entity_types "
+                "WHERE project_template_id = :tid LIMIT 1"
+            ),
+            {"tid": str(template_id)},
+        )
+    ).scalar()
+    field_id = (
+        await db.execute(
+            text("SELECT id FROM public.extraction_fields WHERE entity_type_id = :etid LIMIT 1"),
+            {"etid": str(entity_type_id)},
+        )
+    ).scalar()
+
+    # Auto-create an instance for this article if one doesn't exist yet.
+    instance_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.extraction_instances "
+                "WHERE article_id = :aid AND entity_type_id = :etid LIMIT 1"
+            ),
+            {"aid": str(article_id), "etid": str(entity_type_id)},
+        )
+    ).scalar()
+    if instance_id is None:
+        instance_id = uuid.uuid4()
+        await db.execute(
+            text(
+                "INSERT INTO public.extraction_instances "
+                "(id, project_id, template_id, entity_type_id, article_id, "
+                " label, status, created_by) "
+                "VALUES (:id, :pid, :tid, :etid, :aid, 'anchor-test', 'pending', :cb)"
+            ),
+            {
+                "id": str(instance_id),
+                "pid": str(project_id),
+                "tid": str(template_id),
+                "etid": str(entity_type_id),
+                "aid": str(article_id),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+
+    run_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.extraction_runs "
+            "(id, project_id, article_id, template_id, version_id, kind, stage, "
+            " status, created_by) "
+            "VALUES (:id, :pid, :aid, :tid, :vid, 'extraction', 'pending', "
+            " 'pending', :cb)"
+        ),
+        {
+            "id": str(run_id),
+            "pid": str(project_id),
+            "aid": str(article_id),
+            "tid": str(template_id),
+            "vid": str(version_id),
+            "cb": str(SEED.primary_profile),
+        },
+    )
+    proposal_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.extraction_proposal_records "
+            "(id, run_id, instance_id, field_id, source, proposed_value) "
+            "VALUES (:id, :rid, :inst, :fid, 'ai', '{}'::jsonb)"
+        ),
+        {
+            "id": str(proposal_id),
+            "rid": str(run_id),
+            "inst": str(instance_id),
+            "fid": str(field_id),
+        },
+    )
+    await db.commit()
+    return run_id, proposal_id
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_anchor_prose_block_returns_text_citation(
+    db_session_real: AsyncSession,
+) -> None:
+    """A quote from a prose block produces a TextCitationAnchor written to the DB."""
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        prose_text = "The sample consisted of one hundred adult participants."
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(
+                    page_number=1,
+                    block_index=0,
+                    text=prose_text,
+                    char_start=0,
+                    char_end=len(prose_text),
+                    bbox={"x": 10.0, "y": 100.0, "width": 400.0, "height": 12.0},
+                    block_type="paragraph",
+                )
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        pos = build_anchor(prose_text, blocks)
+        assert pos is not None, "Expected a PositionV1 for a prose quote"
+        assert isinstance(pos, PositionV1)
+        assert pos.version == 1
+        assert isinstance(pos.anchor, TextCitationAnchor)
+        assert pos.anchor.kind == "text"
+        assert pos.anchor.range.page == 1
+        assert pos.anchor.range.char_start == 0
+        assert pos.anchor.range.char_end == len(prose_text)
+        assert pos.anchor.quote == prose_text
+
+        # Round-trip: model_dump (camelCase) → parse_position
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        assert "charStart" in dumped["anchor"]["range"]
+        assert "charEnd" in dumped["anchor"]["range"]
+        reparsed = parse_position(dumped)
+        assert reparsed is not None
+        assert isinstance(reparsed.anchor, TextCitationAnchor)
+
+        # Create a run + proposal so the workflow_target_present CHECK passes.
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real,
+            project_id=SEED.primary_project,
+            article_id=SEED.primary_article,
+        )
+
+        # Write a real evidence row and verify the JSONB round-trip from the DB
+        evidence_id = uuid.uuid4()
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, "
+                " run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, :pg, :tc, CAST(:pos AS jsonb), :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(SEED.primary_article),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "pg": 1,
+                "tc": prose_text,
+                "pos": __import__("json").dumps(dumped),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        row = (
+            await db_session_real.execute(
+                select(ExtractionEvidence).where(ExtractionEvidence.id == evidence_id)
+            )
+        ).scalar_one()
+        db_pos = parse_position(row.position)
+        assert db_pos is not None
+        assert isinstance(db_pos.anchor, TextCitationAnchor)
+        assert db_pos.anchor.range.char_start == 0
+    finally:
+        # Clean up evidence, run (CASCADE handles evidence + proposal), and file.
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE id = :id"),
+            {"id": str(evidence_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :id"),
+            {"id": str(run_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_build_anchor_table_cell_block_returns_hybrid_citation(
+    db_session_real: AsyncSession,
+) -> None:
+    """A quote from a table_cell block produces a HybridCitationAnchor with rect."""
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        table_text = "RR 0.72 (95% CI 0.55-0.94)"
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(
+                    page_number=2,
+                    block_index=0,
+                    text=table_text,
+                    char_start=0,
+                    char_end=len(table_text),
+                    bbox={"x": 50.0, "y": 200.0, "width": 150.0, "height": 10.0},
+                    block_type="table_cell",
+                )
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        pos = build_anchor(table_text, blocks)
+        assert pos is not None, "Expected a PositionV1 for a table_cell quote"
+        assert isinstance(pos, PositionV1)
+        assert isinstance(pos.anchor, HybridCitationAnchor)
+        assert pos.anchor.kind == "hybrid"
+        assert pos.anchor.range.page == 2
+        assert pos.anchor.rect.x == 50.0
+        assert pos.anchor.rect.width == 150.0
+        assert pos.anchor.quote == table_text
+
+        # camelCase round-trip
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        assert "rect" in dumped["anchor"]
+        reparsed = parse_position(dumped)
+        assert reparsed is not None
+        assert isinstance(reparsed.anchor, HybridCitationAnchor)
+    finally:
+        await _cleanup_file(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_build_anchor_no_match_returns_none() -> None:
+    """build_anchor returns None when the quote is not found in the blocks."""
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    blocks = [
+        ParsedBlock(
+            page_number=1,
+            block_index=0,
+            text="Completely different text that shares nothing with the query.",
+            char_start=0,
+            char_end=59,
+            bbox={"x": 0.0, "y": 0.0, "width": 400.0, "height": 12.0},
+            block_type="paragraph",
+        )
+    ]
+    pos = build_anchor("The sky is green and pigs can fly over rainbows.", blocks)
+    assert pos is None
+
+
+@pytest.mark.asyncio
+async def test_build_anchor_empty_blocks_returns_none() -> None:
+    """build_anchor returns None when the block list is empty (no PDF ingested)."""
+    pos = build_anchor("Any quote at all", [])
+    assert pos is None
+
+
+@pytest.mark.asyncio
+async def test_citation_read_service_emits_anchored_evidence_camelcase(
+    db_session_real: AsyncSession,
+) -> None:
+    """citation_read_service returns the stored TextCitationAnchor camelCase for an anchored row."""
+    import json
+
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    # Use a fresh article so we don't collide with other test rows
+    fresh_article_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {
+            "id": str(fresh_article_id),
+            "pid": str(SEED.primary_project),
+            "title": "Anchor Read Service Test Article",
+        },
+    )
+    await db_session_real.commit()
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=fresh_article_id,
+    )
+
+    try:
+        quote = "Patients were randomized in a 1:1 ratio."
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(
+                    page_number=3,
+                    block_index=0,
+                    text=quote,
+                    char_start=0,
+                    char_end=len(quote),
+                    bbox={"x": 72.0, "y": 300.0, "width": 380.0, "height": 12.0},
+                    block_type="paragraph",
+                )
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        pos = build_anchor(quote, blocks)
+        assert pos is not None
+
+        # Create a run + proposal so the workflow_target_present CHECK passes.
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real,
+            project_id=SEED.primary_project,
+            article_id=fresh_article_id,
+        )
+
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        evidence_id = uuid.uuid4()
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, "
+                " run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, :pg, :tc, CAST(:pos AS jsonb), :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(fresh_article_id),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "pg": pos.anchor.range.page,
+                "tc": quote,
+                "pos": json.dumps(dumped),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        citations = await list_article_citations(db_session_real, fresh_article_id)
+        assert len(citations) == 1
+        c = citations[0]
+        assert c["id"] == str(evidence_id)
+        anchor = c["anchor"]
+        assert anchor["kind"] == "text"
+        assert "range" in anchor
+        assert "charStart" in anchor["range"]
+        assert "charEnd" in anchor["range"]
+        assert anchor["range"]["charStart"] == 0
+        assert anchor["range"]["charEnd"] == len(quote)
+        meta = c["metadata"]
+        assert meta["pageNumber"] == 3
+        assert meta["textContent"] == quote
+    finally:
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+            {"aid": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :id"),
+            {"id": str(run_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+        await db_session_real.execute(
+            text("DELETE FROM public.articles WHERE id = :id"),
+            {"id": str(fresh_article_id)},
+        )
+        await db_session_real.commit()

--- a/backend/tests/integration/test_position_v1_anchoring.py
+++ b/backend/tests/integration/test_position_v1_anchoring.py
@@ -385,6 +385,204 @@ async def test_build_anchor_empty_blocks_returns_none() -> None:
 
 
 @pytest.mark.asyncio
+async def test_citation_read_service_verified_true_for_anchored_row(
+    db_session_real: AsyncSession,
+) -> None:
+    """An evidence row with a valid PositionV1 is returned with verified=True, anchorKind='text'."""
+    import json
+
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    fresh_article_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {
+            "id": str(fresh_article_id),
+            "pid": str(SEED.primary_project),
+            "title": "Verified True Test Article",
+        },
+    )
+    await db_session_real.commit()
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=fresh_article_id,
+    )
+
+    try:
+        quote = "Beta-blocker therapy reduced all-cause mortality by 34%."
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(
+                    page_number=5,
+                    block_index=0,
+                    text=quote,
+                    char_start=0,
+                    char_end=len(quote),
+                    bbox={"x": 72.0, "y": 400.0, "width": 380.0, "height": 12.0},
+                    block_type="paragraph",
+                )
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        pos = build_anchor(quote, blocks)
+        assert pos is not None
+
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real,
+            project_id=SEED.primary_project,
+            article_id=fresh_article_id,
+        )
+
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        evidence_id = uuid.uuid4()
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, "
+                " run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, :pg, :tc, CAST(:pos AS jsonb), :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(fresh_article_id),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "pg": pos.anchor.range.page,
+                "tc": quote,
+                "pos": json.dumps(dumped),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        citations = await list_article_citations(db_session_real, fresh_article_id)
+        assert len(citations) == 1
+        c = citations[0]
+        assert c["id"] == str(evidence_id)
+        # verified / anchorKind presence (Task 2.3)
+        assert c["verified"] is True
+        assert c["anchorKind"] == "text"
+        assert "anchor" in c
+        assert c["anchor"]["kind"] == "text"
+    finally:
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+            {"aid": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :id"),
+            {"id": str(run_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+        await db_session_real.execute(
+            text("DELETE FROM public.articles WHERE id = :id"),
+            {"id": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+
+
+@pytest.mark.asyncio
+async def test_citation_read_service_verified_false_for_unanchored_row(
+    db_session_real: AsyncSession,
+) -> None:
+    """An evidence row with position={} is returned verified=False, anchorKind=None, not skipped."""
+    fresh_article_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {
+            "id": str(fresh_article_id),
+            "pid": str(SEED.primary_project),
+            "title": "Verified False Test Article",
+        },
+    )
+    await db_session_real.commit()
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=fresh_article_id,
+    )
+
+    try:
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real,
+            project_id=SEED.primary_project,
+            article_id=fresh_article_id,
+        )
+
+        evidence_id = uuid.uuid4()
+        # Insert with position={} — the hallucinated / no-blocks-yet case.
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, "
+                " run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, NULL, :tc, '{}'::jsonb, :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(fresh_article_id),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "tc": "This quote was hallucinated by the AI.",
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        citations = await list_article_citations(db_session_real, fresh_article_id)
+        # Must NOT be skipped — the row should be present
+        assert len(citations) == 1, f"Expected 1 citation (not skipped), got {len(citations)}"
+        c = citations[0]
+        assert c["id"] == str(evidence_id)
+        # verified=False, anchorKind=None (unanchored)
+        assert c["verified"] is False
+        assert c["anchorKind"] is None
+        # anchor is absent or None for unanchored rows
+        assert c.get("anchor") is None
+        # metadata still present
+        assert c["metadata"]["textContent"] == "This quote was hallucinated by the AI."
+        # nothing raised — we got here
+    finally:
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+            {"aid": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :id"),
+            {"id": str(run_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+        await db_session_real.execute(
+            text("DELETE FROM public.articles WHERE id = :id"),
+            {"id": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+
+
+@pytest.mark.asyncio
 async def test_citation_read_service_emits_anchored_evidence_camelcase(
     db_session_real: AsyncSession,
 ) -> None:

--- a/backend/tests/unit/test_block_assembler.py
+++ b/backend/tests/unit/test_block_assembler.py
@@ -1,0 +1,395 @@
+"""
+Unit tests for the section-aware block assembler.
+
+Tests cover:
+- Reading-order preservation across pages.
+- Heading → section markers (IMRaD-aware).
+- Contiguous ``table_cell`` blocks → reconstructed table (markdown).
+- Over-budget → whole-section selection with ``dropped_sections`` populated,
+  no mid-section/mid-table cut.
+- In-budget: nothing past a naive 15k char cut is silently lost.
+- Optional ``focus`` hint biases section priority deterministically.
+"""
+
+from app.infrastructure.parsing.base import ParsedBlock
+from app.services.extraction_block_assembler import DroppedSection, assemble
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BBOX = {"x": 0.0, "y": 0.0, "width": 100.0, "height": 20.0}
+
+
+def _b(
+    page: int,
+    idx: int,
+    text: str,
+    block_type: str = "paragraph",
+) -> ParsedBlock:
+    """Convenience factory for ParsedBlock with dummy offsets."""
+    return ParsedBlock(
+        page_number=page,
+        block_index=idx,
+        text=text,
+        char_start=0,
+        char_end=len(text),
+        bbox=_BBOX,
+        block_type=block_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Reading-order preservation across pages
+# ---------------------------------------------------------------------------
+
+
+class TestReadingOrder:
+    def test_single_page_order(self) -> None:
+        blocks = [
+            _b(1, 2, "Third"),
+            _b(1, 0, "First"),
+            _b(1, 1, "Second"),
+        ]
+        text, dropped = assemble(blocks, budget=10_000)
+        assert dropped == []
+        # Reading order: First, Second, Third
+        pos_first = text.index("First")
+        pos_second = text.index("Second")
+        pos_third = text.index("Third")
+        assert pos_first < pos_second < pos_third
+
+    def test_multi_page_order(self) -> None:
+        blocks = [
+            _b(2, 0, "Page two content"),
+            _b(1, 0, "Page one content"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        assert text.index("Page one content") < text.index("Page two content")
+
+    def test_multi_page_multi_block_order(self) -> None:
+        blocks = [
+            _b(2, 1, "P2B2"),
+            _b(1, 1, "P1B2"),
+            _b(2, 0, "P2B1"),
+            _b(1, 0, "P1B1"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        positions = [text.index(t) for t in ("P1B1", "P1B2", "P2B1", "P2B2")]
+        assert positions == sorted(positions)
+
+    def test_pages_not_necessarily_contiguous(self) -> None:
+        blocks = [
+            _b(5, 0, "Last"),
+            _b(1, 0, "First"),
+            _b(3, 0, "Middle"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        assert text.index("First") < text.index("Middle") < text.index("Last")
+
+
+# ---------------------------------------------------------------------------
+# 2. Heading → section markers
+# ---------------------------------------------------------------------------
+
+
+class TestSectionMarkers:
+    def test_heading_emits_section_marker(self) -> None:
+        blocks = [
+            _b(1, 0, "Introduction", "heading"),
+            _b(1, 1, "Some paragraph text.", "paragraph"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        # The heading text must appear as a marker (e.g. ## Introduction or === Introduction)
+        assert "Introduction" in text
+        # The section marker must appear before the paragraph text
+        assert text.index("Introduction") < text.index("Some paragraph text.")
+
+    def test_multiple_headings_in_order(self) -> None:
+        blocks = [
+            _b(1, 0, "Methods", "heading"),
+            _b(1, 1, "We did X.", "paragraph"),
+            _b(2, 0, "Results", "heading"),
+            _b(2, 1, "We found Y.", "paragraph"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        assert text.index("Methods") < text.index("We did X.")
+        assert text.index("Results") < text.index("We found Y.")
+        assert text.index("We did X.") < text.index("Results")
+
+    def test_header_footer_blocks_excluded_or_suppressed(self) -> None:
+        """header/footer blocks (page chrome) should not produce content markers."""
+        blocks = [
+            _b(1, 0, "Journal Name", "header"),
+            _b(1, 1, "Introduction", "heading"),
+            _b(1, 2, "Real content.", "paragraph"),
+            _b(1, 3, "Page 1 of 10", "footer"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        # Main content must appear
+        assert "Introduction" in text
+        assert "Real content." in text
+
+
+# ---------------------------------------------------------------------------
+# 3. Contiguous table_cell blocks → reconstructed table
+# ---------------------------------------------------------------------------
+
+
+class TestTableReconstruction:
+    def test_contiguous_cells_become_table_not_scattered_lines(self) -> None:
+        """Four cells (2 rows × 2 cols) must not appear as four separate lines."""
+        blocks = [
+            _b(1, 0, "Name", "table_cell"),
+            _b(1, 1, "Age", "table_cell"),
+            _b(1, 2, "Alice", "table_cell"),
+            _b(1, 3, "30", "table_cell"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        # All cell texts must be present
+        for cell_text in ("Name", "Age", "Alice", "30"):
+            assert cell_text in text
+        # The cells should NOT appear as four completely isolated lines separated by
+        # no table structure (a good proxy: they must appear close together, not with
+        # non-table content between them).
+        # More precisely: the reconstructed text for this run should form a
+        # recognisable table block (markdown | separators). Just assert that
+        # the content is not interleaved with non-table text in a raw line-per-cell
+        # manner by checking there is no non-table content between the first and
+        # last cell.
+        start = min(text.index(c) for c in ("Name", "Age", "Alice", "30"))
+        end = max(text.index(c) + len(c) for c in ("Name", "Age", "Alice", "30"))
+        table_span = text[start:end]
+        # The span must contain all four cells
+        for cell_text in ("Name", "Age", "Alice", "30"):
+            assert cell_text in table_span
+
+    def test_cells_not_interleaved_with_paragraphs(self) -> None:
+        """Paragraph text between two sets of cells must not appear inside
+        a reconstructed table."""
+        blocks = [
+            _b(1, 0, "Cell A1", "table_cell"),
+            _b(1, 1, "Cell A2", "table_cell"),
+            _b(1, 2, "Mid paragraph text.", "paragraph"),
+            _b(1, 3, "Cell B1", "table_cell"),
+            _b(1, 4, "Cell B2", "table_cell"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        # Both cell groups and paragraph must appear
+        for content in ("Cell A1", "Cell A2", "Mid paragraph text.", "Cell B1", "Cell B2"):
+            assert content in text
+        # The paragraph must separate the two table runs — it must appear
+        # between the end of the first pair and the start of the second pair.
+        end_of_first_table = max(
+            text.index("Cell A1") + len("Cell A1"), text.index("Cell A2") + len("Cell A2")
+        )
+        start_of_second_table = min(text.index("Cell B1"), text.index("Cell B2"))
+        mid_pos = text.index("Mid paragraph text.")
+        assert end_of_first_table < mid_pos < start_of_second_table
+
+    def test_single_cell_renders(self) -> None:
+        blocks = [_b(1, 0, "Only cell", "table_cell")]
+        text, _ = assemble(blocks, budget=10_000)
+        assert "Only cell" in text
+
+
+# ---------------------------------------------------------------------------
+# 4. Over-budget: whole-section selection, dropped_sections populated
+# ---------------------------------------------------------------------------
+
+
+TINY_BUDGET = 200  # chars — forces section dropping for most test docs
+
+
+class TestOverBudgetSectionSelection:
+    def _imrad_doc(self) -> list[ParsedBlock]:
+        """Return a small IMRaD document whose full text exceeds TINY_BUDGET."""
+        return [
+            _b(1, 0, "Abstract", "heading"),
+            _b(1, 1, "A" * 60, "paragraph"),
+            _b(2, 0, "Introduction", "heading"),
+            _b(2, 1, "B" * 60, "paragraph"),
+            _b(3, 0, "Methods", "heading"),
+            _b(3, 1, "C" * 60, "paragraph"),
+            _b(4, 0, "Results", "heading"),
+            _b(4, 1, "D" * 60, "paragraph"),
+            _b(5, 0, "Discussion", "heading"),
+            _b(5, 1, "E" * 60, "paragraph"),
+            _b(6, 0, "References", "heading"),
+            _b(6, 1, "F" * 60, "paragraph"),
+        ]
+
+    def test_dropped_sections_populated_when_over_budget(self) -> None:
+        blocks = self._imrad_doc()
+        text, dropped = assemble(blocks, budget=TINY_BUDGET)
+        assert len(dropped) > 0
+
+    def test_dropped_sections_are_DroppedSection_instances(self) -> None:
+        blocks = self._imrad_doc()
+        _, dropped = assemble(blocks, budget=TINY_BUDGET)
+        for d in dropped:
+            assert isinstance(d, DroppedSection)
+
+    def test_no_mid_section_cut(self) -> None:
+        """Every section that appears in the output must be FULLY included.
+
+        Strategy: for each kept section heading, assert its paragraph body
+        also appears.
+        """
+        section_map = {
+            "Abstract": "A" * 60,
+            "Introduction": "B" * 60,
+            "Methods": "C" * 60,
+            "Results": "D" * 60,
+            "Discussion": "E" * 60,
+            "References": "F" * 60,
+        }
+        blocks = self._imrad_doc()
+        text, dropped = assemble(blocks, budget=TINY_BUDGET)
+        dropped_names = {d.title for d in dropped}
+        for heading, body in section_map.items():
+            if heading in dropped_names:
+                # Dropped sections must not appear in text
+                assert body not in text, f"Dropped section '{heading}' body leaked into text"
+            else:
+                # Kept sections must be fully present
+                assert body in text, f"Kept section '{heading}' body missing from text"
+
+    def test_output_within_budget(self) -> None:
+        blocks = self._imrad_doc()
+        text, _ = assemble(blocks, budget=TINY_BUDGET)
+        assert len(text) <= TINY_BUDGET
+
+    def test_deterministic_output(self) -> None:
+        """Same input must always produce the same output."""
+        blocks = self._imrad_doc()
+        results = [assemble(blocks, budget=TINY_BUDGET) for _ in range(3)]
+        assert all(r[0] == results[0][0] for r in results)
+        assert all(r[1] == results[0][1] for r in results)
+
+    def test_references_dropped_before_results(self) -> None:
+        """IMRaD priority: Results/Methods rank higher than References/Discussion.
+
+        When the budget is tight, References should be dropped before Results.
+        """
+        blocks = self._imrad_doc()
+        # Budget big enough to keep Results but not everything
+        # Each section is ~heading(~10-15 chars) + body(60 chars) ~ 75 chars per section
+        # 3 sections fit in ~225 chars
+        text, dropped = assemble(blocks, budget=225)
+        dropped_names = {d.title for d in dropped}
+        # If any sections are dropped, Results should not be dropped before References
+        if dropped_names:
+            # References should appear in dropped before Results would be dropped
+            if "Results" not in dropped_names:
+                pass  # Results kept — good
+            else:
+                # If Results is dropped, References must also be dropped
+                assert "References" in dropped_names
+
+    def test_no_table_mid_cut(self) -> None:
+        """A table run must never be split across budget boundary."""
+        # Build a doc where a table plus surrounding sections exceed the budget.
+        # The table must appear in full or not at all.
+        table_blocks = [
+            _b(2, 0, "Results Table", "heading"),
+            _b(2, 1, "T" * 10, "table_cell"),
+            _b(2, 2, "U" * 10, "table_cell"),
+            _b(2, 3, "V" * 10, "table_cell"),
+            _b(2, 4, "W" * 10, "table_cell"),
+        ]
+        other_blocks = [
+            _b(1, 0, "Introduction", "heading"),
+            _b(1, 1, "I" * 60, "paragraph"),
+            _b(3, 0, "Discussion", "heading"),
+            _b(3, 1, "J" * 60, "paragraph"),
+        ]
+        blocks = other_blocks + table_blocks
+        text, dropped = assemble(blocks, budget=150)
+        table_cells = ["T" * 10, "U" * 10, "V" * 10, "W" * 10]
+        cells_present = [c in text for c in table_cells]
+        # Either all cells are present or none are (whole-table constraint)
+        assert all(cells_present) or not any(cells_present)
+
+
+# ---------------------------------------------------------------------------
+# 5. In-budget: nothing past naive 15k cut is silently lost
+# ---------------------------------------------------------------------------
+
+
+class TestInBudgetNoSilentLoss:
+    def test_content_beyond_15k_preserved_when_in_budget(self) -> None:
+        """For a doc whose total text > 15 000 chars but fits within budget,
+        assemble() must include ALL content — not silently drop what lies beyond
+        a hypothetical 15 000-char cut."""
+        # Build ~18 000 chars of content spread across pages.
+        blocks: list[ParsedBlock] = []
+        for page in range(1, 7):  # 6 pages
+            blocks.append(_b(page, 0, f"Section {page}", "heading"))
+            blocks.append(_b(page, 1, "X" * 2_900, "paragraph"))  # ~2 900 chars/page
+
+        # Total text ≈ 6 × (len("Section N") + 2900) ≈ 17 454 chars → > 15 000
+        full_text = "\n".join(
+            b.text for b in sorted(blocks, key=lambda b: (b.page_number, b.block_index))
+        )
+        assert len(full_text) > 15_000, "Pre-condition: doc must exceed 15k chars"
+
+        # Budget large enough to fit everything
+        large_budget = 20_000
+        text, dropped = assemble(blocks, budget=large_budget)
+
+        assert dropped == [], f"No sections should be dropped when in-budget; got {dropped}"
+        # Every section heading and every paragraph must appear
+        for page in range(1, 7):
+            assert f"Section {page}" in text, f"Section {page} heading missing"
+            assert "X" * 2_900 in text, f"Section {page} paragraph missing"
+
+    def test_last_section_fully_included_when_at_budget_boundary(self) -> None:
+        """If adding the last section would just fit, it must be fully included."""
+        # A small two-section doc that fits in budget
+        blocks = [
+            _b(1, 0, "First Section", "heading"),
+            _b(1, 1, "Content A", "paragraph"),
+            _b(2, 0, "Second Section", "heading"),
+            _b(2, 1, "Content B", "paragraph"),
+        ]
+        budget = 10_000  # Obviously fits
+        text, dropped = assemble(blocks, budget=budget)
+        assert "Content A" in text
+        assert "Content B" in text
+        assert dropped == []
+
+
+# ---------------------------------------------------------------------------
+# 6. focus hint biases section priority
+# ---------------------------------------------------------------------------
+
+
+class TestFocusHint:
+    def test_focus_keeps_matching_section(self) -> None:
+        """When focus='Methods', Methods should be kept even at tight budget."""
+        blocks = [
+            _b(1, 0, "Introduction", "heading"),
+            _b(1, 1, "A" * 80, "paragraph"),
+            _b(2, 0, "Methods", "heading"),
+            _b(2, 1, "B" * 80, "paragraph"),
+            _b(3, 0, "Results", "heading"),
+            _b(3, 1, "C" * 80, "paragraph"),
+        ]
+        # Budget fits 2 sections, not all 3
+        text, dropped = assemble(blocks, budget=200, focus="Methods")
+        assert "B" * 80 in text, "Focus section body must be present"
+        dropped_names = {d.title for d in dropped}
+        assert "Methods" not in dropped_names
+
+    def test_focus_is_deterministic(self) -> None:
+        blocks = [
+            _b(1, 0, "Introduction", "heading"),
+            _b(1, 1, "A" * 80, "paragraph"),
+            _b(2, 0, "Results", "heading"),
+            _b(2, 1, "B" * 80, "paragraph"),
+        ]
+        result1 = assemble(blocks, budget=150, focus="Results")
+        result2 = assemble(blocks, budget=150, focus="Results")
+        assert result1[0] == result2[0]
+        assert result1[1] == result2[1]

--- a/backend/tests/unit/test_block_assembler.py
+++ b/backend/tests/unit/test_block_assembler.py
@@ -9,9 +9,16 @@ Tests cover:
   no mid-section/mid-table cut.
 - In-budget: nothing past a naive 15k char cut is silently lost.
 - Optional ``focus`` hint biases section priority deterministically.
+- Prose routes through canonical concat_page_text surface.
+- Input blocks are never mutated by assemble().
+- Over-budget fallback pops WHOLE sections (never string-splits on separator).
 """
 
-from app.infrastructure.parsing.base import ParsedBlock
+from app.infrastructure.parsing.base import (
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+)
 from app.services.extraction_block_assembler import DroppedSection, assemble
 
 # ---------------------------------------------------------------------------
@@ -129,6 +136,9 @@ class TestSectionMarkers:
         # Main content must appear
         assert "Introduction" in text
         assert "Real content." in text
+        # Chrome text must NOT appear in the output
+        assert "Journal Name" not in text
+        assert "Page 1 of 10" not in text
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +321,43 @@ class TestOverBudgetSectionSelection:
         # Either all cells are present or none are (whole-table constraint)
         assert all(cells_present) or not any(cells_present)
 
+    def test_fallback_whole_section_drop_not_string_split(self) -> None:
+        """Defensive fallback drops WHOLE sections, never fragments on separator.
+
+        Build a block whose text contains the inter-section separator ("\\n\\n").
+        With a budget that forces a drop, the survivor must be intact and
+        dropped_sections must name the dropped section — no fragment leak.
+        """
+        # Section A: text that contains the separator string inside it.
+        # This would corrupt result if we did result_text.split(separator).pop().
+        separator_in_body = "first part\n\nsecond part"  # contains "\n\n"
+        blocks = [
+            _b(1, 0, "Alpha", "heading"),
+            _b(1, 1, separator_in_body, "paragraph"),
+            _b(2, 0, "Beta", "heading"),
+            _b(2, 1, "B" * 80, "paragraph"),
+        ]
+        # Alpha section text = "## Alpha\n" + separator_in_body  ≈ 41 chars
+        # Beta section text  = "## Beta\n"  + "B"*80             ≈ 89 chars
+        # Full text = ~41 + 2 (sep) + 89 = ~132 chars
+        # Budget just big enough for Beta but not both
+        text, dropped = assemble(blocks, budget=100)
+        # Exactly one section must be dropped
+        assert len(dropped) == 1
+        dropped_title = dropped[0].title
+        # The survivor must be fully intact — no partial content from dropped section
+        if dropped_title == "Alpha":
+            # Beta survives: must be whole
+            assert "B" * 80 in text
+            # Alpha body must not appear (even the fragment "first part")
+            assert "first part" not in text
+            assert "second part" not in text
+        else:
+            # Alpha survives: must be whole including the embedded separator
+            assert separator_in_body in text
+            # Beta body must not appear
+            assert "B" * 80 not in text
+
 
 # ---------------------------------------------------------------------------
 # 5. In-budget: nothing past naive 15k cut is silently lost
@@ -393,3 +440,72 @@ class TestFocusHint:
         result2 = assemble(blocks, budget=150, focus="Results")
         assert result1[0] == result2[0]
         assert result1[1] == result2[1]
+
+
+# ---------------------------------------------------------------------------
+# 7. Prose routes through canonical concat_page_text surface
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalSurface:
+    def test_prose_matches_concat_page_text_slice(self) -> None:
+        """For a multi-block page, prose in assemble() output equals
+        concat_page_text(copies)[page][cs:ce] for the block's offsets.
+
+        This verifies that assemble() genuinely routes prose through the
+        canonical surface rather than just copying block.text.
+        """
+        blocks = [
+            _b(1, 0, "First block", "paragraph"),
+            _b(1, 1, "Second block", "paragraph"),
+            _b(1, 2, "Third block", "paragraph"),
+        ]
+        # Build copies and compute canonical offsets the same way assemble() does.
+        copies = [
+            ParsedBlock(
+                page_number=b.page_number,
+                block_index=b.block_index,
+                text=b.text,
+                char_start=0,
+                char_end=0,
+                bbox=b.bbox,
+                block_type=b.block_type,
+            )
+            for b in blocks
+        ]
+        assign_char_offsets_to_blocks(copies)
+        page_texts = concat_page_text(copies)
+        offsets = {(c.page_number, c.block_index): (c.char_start, c.char_end) for c in copies}
+
+        text, dropped = assemble(blocks, budget=10_000)
+        assert dropped == []
+
+        # Each block's prose must equal the canonical slice.
+        for b in blocks:
+            cs, ce = offsets[(b.page_number, b.block_index)]
+            canonical_slice = page_texts[b.page_number][cs:ce]
+            assert canonical_slice == b.text  # by construction
+            assert canonical_slice in text, (
+                f"Block '{b.text}' canonical slice not found in assembled output"
+            )
+
+    def test_input_blocks_not_mutated_by_assemble(self) -> None:
+        """assemble() must not mutate char_start/char_end on input blocks."""
+        # Use dummy offsets that are intentionally wrong (0 / len) to detect mutation.
+        blocks = [
+            _b(1, 0, "Alpha paragraph"),
+            _b(1, 1, "Beta paragraph"),
+            _b(2, 0, "Gamma paragraph"),
+        ]
+        original_starts = [b.char_start for b in blocks]
+        original_ends = [b.char_end for b in blocks]
+
+        assemble(blocks, budget=10_000)
+
+        for i, b in enumerate(blocks):
+            assert b.char_start == original_starts[i], (
+                f"Block {i} char_start was mutated: {original_starts[i]} → {b.char_start}"
+            )
+            assert b.char_end == original_ends[i], (
+                f"Block {i} char_end was mutated: {original_ends[i]} → {b.char_end}"
+            )

--- a/backend/tests/unit/test_evidence_anchor_service.py
+++ b/backend/tests/unit/test_evidence_anchor_service.py
@@ -542,3 +542,76 @@ class TestFuzzyDeterminismAndCoverage:
         assert page_text[: first.char_start] == ""  # anchored at the very start
         sliced = page_text[first.char_start : first.char_end]
         assert sliced.startswith("alpha bravo")
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation — match() must never raise (Fix: graceful post-condition)
+# ---------------------------------------------------------------------------
+
+
+class TestMatchNeverRaises:
+    """The post-condition in ``match`` is now a guarded ``continue`` rather than
+    an ``assert``.  This class pins the contract: ``match(...)`` NEVER raises for
+    any combination of degenerate inputs; it always returns either a
+    fold-back-valid ``AnchorMatch`` or ``None``.
+
+    The defensive branch (invariant violated → skip candidate) cannot be triggered
+    through the public ``match`` API because ``_resolve_original_span`` already
+    returns ``None`` whenever no valid original span satisfies fold-equality.
+    We therefore exercise the contract via a broad sweep of degenerate inputs and
+    assert two properties:
+      1. No call raises any exception.
+      2. Every non-None result satisfies the fold-back invariant.
+    """
+
+    # Degenerate inputs: quotes that stress boundary conditions.
+    DEGENERATE_QUOTES = [
+        "",  # empty
+        "   ",  # whitespace only
+        "\n\t\r",  # only control whitespace
+        "inal result",  # begins mid-ligature-expansion in the fixture below
+        "ﬁ",  # the raw ligature itself (1 original char → 2 normalised)
+        "a" * 5000,  # much longer than any page — no match possible
+        "\x00\x01\xff",  # non-printable / high-byte characters
+        "αβγ",  # non-ASCII entirely absent from the ASCII pages
+        "  leading and trailing  ",  # extra whitespace around real content
+    ]
+
+    BLOCKS = [
+        make_block(1, 0, "aﬁnal result"),
+        make_block(1, 1, "The mitochondria is the powerhouse of the cell."),
+        make_block(2, 0, "Results were significant (p < 0.001)."),
+    ]
+
+    def test_degenerate_quotes_never_raise(self) -> None:
+        for quote in self.DEGENERATE_QUOTES:
+            # Must not raise — any exception (including AssertionError) is a bug.
+            result = match(quote, self.BLOCKS)
+            # Non-None results must satisfy the fold-back invariant.
+            if result is not None:
+                _assert_slice_folds_to_quote(result, self.BLOCKS, quote)
+
+    def test_empty_blocks_never_raise(self) -> None:
+        for quote in self.DEGENERATE_QUOTES:
+            result = match(quote, [])
+            assert result is None  # no blocks → always None
+
+    def test_single_empty_block_never_raise(self) -> None:
+        empty_text_block = [make_block(1, 0, "")]
+        for quote in self.DEGENERATE_QUOTES:
+            result = match(quote, empty_text_block)
+            assert result is None  # empty page text → always None
+
+    def test_real_quote_mid_ligature_returns_none_not_raises(self) -> None:
+        # The canonical degenerate case: a quote that begins on the SECOND
+        # sub-char of a ligature expansion.  The post-condition (now guarded)
+        # would fire here if ``_resolve_original_span`` ever returned a
+        # span that doesn't satisfy fold-equality.  It must return None, not raise.
+        blocks = [make_block(1, 0, "aﬁnal result")]
+        result = match("inal result", blocks)
+        assert result is None  # unrepresentable → unanchored, not an error
+
+    def test_quote_longer_than_page_returns_none_not_raises(self) -> None:
+        blocks = [make_block(1, 0, "Short text.")]
+        result = match("x" * 10_000, blocks)
+        assert result is None

--- a/backend/tests/unit/test_evidence_anchor_service.py
+++ b/backend/tests/unit/test_evidence_anchor_service.py
@@ -383,3 +383,162 @@ class TestAnchorMatchShape:
         assert result.char_start < result.char_end
         assert result.block_ids == [0]
         assert set(result.bbox_union.keys()) == {"x", "y", "width", "height"}
+
+
+# ---------------------------------------------------------------------------
+# Fold-back invariant at NFKC-expansion boundaries (Fix 1)
+# ---------------------------------------------------------------------------
+
+
+class TestExpansionBoundaryInvariant:
+    """A match boundary that lands inside a 1→many NFKC expansion must never
+    return a span that folds WIDER than the matched text.
+
+    ``norm_to_orig`` maps every sub-character of an expansion (e.g. the ligature
+    ``ﬁ`` → ``f``, ``i``) to the SAME original index, so the naive map-back of a
+    boundary on a non-first sub-char would include the whole original expansion
+    char.  The matcher must instead honour the advertised guarantee:
+    ``_fold(original[char_start:char_end]) == _fold(matched span)``.
+    """
+
+    def test_quote_starting_mid_ligature_is_unrepresentable_returns_none(self) -> None:
+        # NFKC-normalised "aﬁnal result" == "afinal result"; the quote "inal
+        # result" starts on the SECOND sub-char ('i') of the ligature 'ﬁ'.  No
+        # original slice folds to exactly "inal result" (the ligature is one
+        # indivisible original char), so the matcher must return None rather than
+        # the span-too-wide [1:12] -> "ﬁnal result" -> "final result".
+        blocks = [make_block(1, 0, "aﬁnal result")]
+        assert match("inal result", blocks) is None
+
+    def test_quote_covering_whole_ligature_matches_and_folds_exactly(self) -> None:
+        # "final result" starts BEFORE the ligature and covers the whole 'ﬁ'
+        # expansion, so it is representable: the original slice still contains the
+        # ligature and folds exactly to the quote.
+        blocks = [make_block(1, 0, "aﬁnal result")]
+        result = match("final result", blocks)
+        assert result is not None
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "ﬁ" in sliced
+        assert _fold(sliced) == _fold("final result")
+        _assert_slice_folds_to_quote(result, blocks, "final result")
+
+    def test_quote_starting_after_ligature_snaps_to_narrower_span(self) -> None:
+        # "nal result" starts AFTER the full ligature expansion ('fi'); the start
+        # boundary fell inside the expansion but the quote is representable as the
+        # narrower original slice beginning at 'n'.  The matcher must snap to that
+        # narrower span (dropping the ligature), not widen to include it.
+        blocks = [make_block(1, 0, "aﬁnal result")]
+        result = match("nal result", blocks)
+        assert result is not None
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "ﬁ" not in sliced  # ligature dropped by the snap
+        assert _fold(sliced) == _fold("nal result")
+        _assert_slice_folds_to_quote(result, blocks, "nal result")
+
+
+# ---------------------------------------------------------------------------
+# Whitespace-tight span (Fix 2)
+# ---------------------------------------------------------------------------
+
+
+class TestWhitespaceTrim:
+    """The returned span must not carry leading/trailing ORIGINAL whitespace.
+
+    When a match ends just before a collapsed-whitespace run or a block
+    separator, the naive map-back can include that trailing ``\\n`` / spaces.  A
+    downstream highlighter would render them, so the span is trimmed tight.
+    """
+
+    def test_match_adjacent_to_block_separator_has_no_trailing_newline(self) -> None:
+        # The quote ends exactly at the end of block 0; the naive map-back would
+        # carry the "\n" block separator into the slice.
+        blocks = [
+            make_block(1, 0, "the result was"),
+            make_block(1, 1, "clearly positive"),
+        ]
+        result = match("result was", blocks)
+        assert result is not None
+        assert result.block_ids == [0]
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert sliced == "result was"
+        assert sliced == sliced.strip()  # no leading/trailing whitespace
+        _assert_slice_folds_to_quote(result, blocks, "result was")
+
+    def test_match_adjacent_to_collapsed_whitespace_run_is_tight(self) -> None:
+        # In-block whitespace run after the matched word; the slice must stop at
+        # the word, not run into the spaces/newline.
+        blocks = [make_block(1, 0, "The   sample\n   was   incubated   overnight.")]
+        result = match("sample", blocks)
+        assert result is not None
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert sliced == "sample"
+        assert sliced == sliced.strip()
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy tier: determinism + multi-block coverage (Fix 3)
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzyDeterminismAndCoverage:
+    def test_fuzzy_quote_spanning_two_blocks_merges_range_and_bboxes(self) -> None:
+        # An OCR-noisy quote (within threshold) that crosses the block boundary
+        # must still return the merged char range, BOTH block_ids, and the bbox
+        # union over both blocks.
+        blocks = [
+            make_block(
+                1,
+                0,
+                "the treatment group showed",
+                bbox={"x": 10.0, "y": 100.0, "width": 200.0, "height": 20.0},
+            ),
+            make_block(
+                1,
+                1,
+                "a marked improvement in outcomes",
+                bbox={"x": 12.0, "y": 70.0, "width": 220.0, "height": 22.0},
+            ),
+        ]
+        # "treatment" -> "treatrnent" (rn for m), "improvement" -> "irnprovement".
+        quote = "treatrnent group showed a marked irnprovement"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.page == 1
+        assert result.block_ids == [0, 1]
+        # Merged range covers text from block 0 into block 1.
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "treatment group showed" in sliced
+        assert "marked improvement" in sliced
+        # bbox union over both blocks.
+        assert result.bbox_union["x"] == 10.0
+        assert result.bbox_union["y"] == 70.0
+        assert result.bbox_union["width"] == 232.0 - 10.0
+        assert result.bbox_union["height"] == 120.0 - 70.0
+
+    def test_fuzzy_equal_ratio_windows_resolve_to_earliest_start(self) -> None:
+        # Two windows match the noisy quote with the SAME ratio; the earliest
+        # start must win and repeated calls must agree (determinism).
+        blocks = [
+            make_block(
+                1,
+                0,
+                "alpha bravo charlie delta alpha bravo charlie delta",
+            )
+        ]
+        # OCR-noisy version of "alpha bravo charlie" — present twice in the source
+        # with identical surrounding context, so both windows score equally.
+        noisy = "alpha bravo charlle"
+        first = match(noisy, blocks)
+        second = match(noisy, blocks)
+        assert first is not None
+        assert first == second  # fully deterministic
+        # Earliest start wins: the matched slice is the FIRST occurrence.
+        page_text = _original_page_text(blocks)[1]
+        assert page_text[: first.char_start] == ""  # anchored at the very start
+        sliced = page_text[first.char_start : first.char_end]
+        assert sliced.startswith("alpha bravo")

--- a/backend/tests/unit/test_evidence_anchor_service.py
+++ b/backend/tests/unit/test_evidence_anchor_service.py
@@ -1,0 +1,385 @@
+"""
+Unit tests for the evidence-anchor service (quote → block matcher).
+
+The matcher anchors an LLM's evidence quote back to a verifiable span in the
+source document.  It is a PURE function: no DB, no IO, deterministic.
+
+Coverage:
+- exact quote → correct block + char range (offsets index the ORIGINAL page
+  string produced by ``concat_page_text``).
+- ligature / smart-quote / collapsed-whitespace quote still matches under
+  Unicode NFKC + whitespace folding, AND the returned offsets index the
+  ORIGINAL (un-normalised) page text.
+- a quote spanning two adjacent blocks → merged char range + both block_ids +
+  unioned bbox.
+- a genuinely absent quote → ``None``.
+- bounded fuzz: an OCR-noisy quote within threshold matches; beyond threshold
+  returns ``None``.
+- deterministic tie-break: when the quote appears twice, the earliest page /
+  block wins.
+
+The key invariant asserted throughout: slicing the returned
+``[char_start, char_end)`` out of the ORIGINAL ``concat_page_text`` page string
+and applying the SAME NFKC + whitespace fold yields the folded quote.
+"""
+
+from __future__ import annotations
+
+from app.infrastructure.parsing.base import (
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+)
+from app.services.evidence_anchor_service import (
+    AnchorMatch,
+    _normalize,
+    match,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_block(
+    page_number: int,
+    block_index: int,
+    text: str,
+    *,
+    block_type: str = "paragraph",
+    bbox: dict[str, float] | None = None,
+) -> ParsedBlock:
+    """Build a ParsedBlock with PLACEHOLDER char offsets (0/0).
+
+    The matcher must derive offsets itself from ``concat_page_text`` /
+    ``assign_char_offsets_to_blocks``, so the offsets passed in here are
+    intentionally wrong (0/0) to prove the matcher does not trust them.
+    """
+    return ParsedBlock(
+        page_number=page_number,
+        block_index=block_index,
+        text=text,
+        char_start=0,
+        char_end=0,
+        bbox=bbox if bbox is not None else {"x": 0.0, "y": 0.0, "width": 100.0, "height": 20.0},
+        block_type=block_type,
+    )
+
+
+def _fold(s: str) -> str:
+    """The canonical comparison surface (NFKC + punctuation + whitespace fold).
+
+    Delegates to the service's own ``_normalize`` so the test asserts against
+    the real folding surface rather than a reimplementation that could drift.
+    """
+    return _normalize(s)
+
+
+def _original_page_text(blocks: list[ParsedBlock]) -> dict[int, str]:
+    """Build the ORIGINAL per-page text the matcher's offsets must index.
+
+    Uses LOCAL copies so the test's input blocks are never mutated (mirrors
+    what the matcher does internally).
+    """
+    copies = [
+        ParsedBlock(
+            page_number=b.page_number,
+            block_index=b.block_index,
+            text=b.text,
+            char_start=0,
+            char_end=0,
+            bbox=b.bbox,
+            block_type=b.block_type,
+        )
+        for b in blocks
+    ]
+    assign_char_offsets_to_blocks(copies)
+    return concat_page_text(copies)
+
+
+def _assert_slice_folds_to_quote(
+    result: AnchorMatch,
+    blocks: list[ParsedBlock],
+    quote: str,
+) -> None:
+    """Core invariant: the returned span, sliced from the ORIGINAL page text
+    and folded, equals the folded quote."""
+    page_text = _original_page_text(blocks)[result.page]
+    sliced = page_text[result.char_start : result.char_end]
+    assert _fold(sliced) == _fold(quote), (
+        f"sliced original {sliced!r} folds to {_fold(sliced)!r}, "
+        f"expected folded quote {_fold(quote)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exact match
+# ---------------------------------------------------------------------------
+
+
+class TestExactMatch:
+    def test_exact_quote_anchors_to_correct_block_and_range(self) -> None:
+        blocks = [
+            make_block(1, 0, "The mitochondria is the powerhouse of the cell."),
+            make_block(1, 1, "Ribosomes synthesize proteins from amino acids."),
+        ]
+        quote = "powerhouse of the cell"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.page == 1
+        assert result.block_ids == [0]
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+        page_text = _original_page_text(blocks)[1]
+        assert page_text[result.char_start : result.char_end] == "powerhouse of the cell"
+
+    def test_exact_full_block_quote(self) -> None:
+        blocks = [
+            make_block(2, 0, "Alpha beta gamma."),
+            make_block(2, 1, "Delta epsilon zeta."),
+        ]
+        quote = "Delta epsilon zeta."
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.page == 2
+        assert result.block_ids == [1]
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+    def test_match_on_second_page(self) -> None:
+        blocks = [
+            make_block(1, 0, "First page content here."),
+            make_block(2, 0, "Second page has the target sentence."),
+        ]
+        result = match("the target sentence", blocks)
+        assert result is not None
+        assert result.page == 2
+        assert result.block_ids == [0]
+        _assert_slice_folds_to_quote(result, blocks, "the target sentence")
+
+
+# ---------------------------------------------------------------------------
+# Normalization: ligatures / smart quotes / collapsed whitespace
+# ---------------------------------------------------------------------------
+
+
+class TestNormalization:
+    def test_ligature_quote_matches_and_offsets_index_original(self) -> None:
+        # Block contains the ligature 'ﬁ' (U+FB01); quote uses ASCII "fi".
+        blocks = [make_block(1, 0, "The classiﬁcation of cells is complex.")]
+        quote = "classification of cells"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.block_ids == [0]
+        # Offsets index the ORIGINAL string, which still contains the ligature.
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "ﬁ" in sliced  # original ligature preserved in the slice
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+    def test_smart_quotes_match_straight_quotes(self) -> None:
+        # Block uses a curly apostrophe (U+2019); quote uses a straight one.
+        blocks = [make_block(1, 0, "The cell’s membrane is selectively permeable.")]
+        quote = "cell's membrane"
+        result = match(quote, blocks)
+        assert result is not None
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+    def test_collapsed_whitespace_matches(self) -> None:
+        # Block has a newline + multiple spaces; quote has single spaces.
+        blocks = [make_block(1, 0, "The   sample\n   was   incubated   overnight.")]
+        quote = "sample was incubated overnight"
+        result = match(quote, blocks)
+        assert result is not None
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+    def test_quote_with_extra_whitespace_matches(self) -> None:
+        blocks = [make_block(1, 0, "Results were significant.")]
+        quote = "  Results   were    significant.  "
+        result = match(quote, blocks)
+        assert result is not None
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+
+# ---------------------------------------------------------------------------
+# Multi-block span
+# ---------------------------------------------------------------------------
+
+
+class TestMultiBlockSpan:
+    def test_quote_spanning_two_adjacent_blocks(self) -> None:
+        blocks = [
+            make_block(
+                1,
+                0,
+                "the treatment group showed",
+                bbox={"x": 10.0, "y": 100.0, "width": 200.0, "height": 20.0},
+            ),
+            make_block(
+                1,
+                1,
+                "a marked improvement in outcomes",
+                bbox={"x": 12.0, "y": 70.0, "width": 220.0, "height": 22.0},
+            ),
+        ]
+        # The quote crosses the block boundary (the "\n" separator folds to " ").
+        quote = "treatment group showed a marked improvement"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.page == 1
+        assert result.block_ids == [0, 1]
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+        # bbox_union: min x, min y, max (x+width), max (y+height).
+        # block 0: x in [10, 210], y in [100, 120]
+        # block 1: x in [12, 232], y in [70, 92]
+        assert result.bbox_union["x"] == 10.0
+        assert result.bbox_union["y"] == 70.0
+        assert result.bbox_union["width"] == 232.0 - 10.0
+        assert result.bbox_union["height"] == 120.0 - 70.0
+
+    def test_single_block_bbox_union_is_that_block(self) -> None:
+        bbox = {"x": 5.0, "y": 50.0, "width": 80.0, "height": 12.0}
+        blocks = [make_block(1, 0, "A single isolated sentence here.", bbox=bbox)]
+        result = match("isolated sentence", blocks)
+        assert result is not None
+        assert result.block_ids == [0]
+        assert result.bbox_union == bbox
+
+
+# ---------------------------------------------------------------------------
+# Absent quote
+# ---------------------------------------------------------------------------
+
+
+class TestAbsentQuote:
+    def test_absent_quote_returns_none(self) -> None:
+        blocks = [
+            make_block(1, 0, "The mitochondria is the powerhouse of the cell."),
+        ]
+        assert match("quantum entanglement of photons", blocks) is None
+
+    def test_empty_quote_returns_none(self) -> None:
+        blocks = [make_block(1, 0, "Some text.")]
+        assert match("", blocks) is None
+
+    def test_empty_blocks_returns_none(self) -> None:
+        assert match("anything", []) is None
+
+    def test_whitespace_only_quote_returns_none(self) -> None:
+        blocks = [make_block(1, 0, "Some text.")]
+        assert match("   \n  ", blocks) is None
+
+
+# ---------------------------------------------------------------------------
+# Bounded fuzz
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedFuzz:
+    def test_ocr_noisy_quote_within_threshold_matches(self) -> None:
+        # Source is clean; quote has a couple of OCR-style character errors.
+        blocks = [
+            make_block(
+                1,
+                0,
+                "The patients received a daily dose of the experimental compound.",
+            )
+        ]
+        # "patients" -> "patlents", "experimental" -> "experirnental" (rn for m)
+        quote = "patlents received a daily dose of the experirnental compound"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.block_ids == [0]
+        # The matched original slice corresponds to the clean source span.
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "received a daily dose" in sliced
+
+    def test_quote_beyond_fuzz_threshold_returns_none(self) -> None:
+        blocks = [
+            make_block(
+                1,
+                0,
+                "The patients received a daily dose of the experimental compound.",
+            )
+        ]
+        # Garble most of the characters — far beyond any sane threshold.
+        quote = "Xhq zatuqxlk rqmqwxqg z xzuzk xqkq"
+        assert match(quote, blocks) is None
+
+    def test_tight_threshold_rejects_noisy_quote(self) -> None:
+        blocks = [make_block(1, 0, "The quick brown fox jumps over the lazy dog.")]
+        noisy = "The qulck brown fox jximps over the lazy dog"
+        # With fuzz disabled (threshold 1.0 = exact only) the noisy quote fails.
+        assert match(noisy, blocks, fuzz_threshold=1.0) is None
+        # With the default (looser) threshold it matches.
+        assert match(noisy, blocks) is not None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic tie-break
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicTieBreak:
+    def test_duplicate_quote_earliest_page_wins(self) -> None:
+        blocks = [
+            make_block(2, 0, "The repeated phrase appears here."),
+            make_block(1, 0, "The repeated phrase appears here."),
+        ]
+        result = match("repeated phrase", blocks)
+        assert result is not None
+        assert result.page == 1  # earliest page wins, not list order
+
+    def test_duplicate_quote_earliest_block_wins(self) -> None:
+        blocks = [
+            make_block(1, 0, "The repeated phrase appears here."),
+            make_block(1, 1, "The repeated phrase appears here too."),
+        ]
+        result = match("repeated phrase", blocks)
+        assert result is not None
+        assert result.page == 1
+        assert result.block_ids == [0]  # earliest block within the page
+
+    def test_same_inputs_same_output(self) -> None:
+        blocks = [
+            make_block(1, 0, "Alpha beta gamma delta."),
+            make_block(1, 1, "Epsilon zeta eta theta."),
+            make_block(2, 0, "Iota kappa lambda."),
+        ]
+        quote = "zeta eta"
+        first = match(quote, blocks)
+        second = match(quote, blocks)
+        assert first == second
+        assert first is not None
+        assert first.block_ids == [1]
+
+
+# ---------------------------------------------------------------------------
+# Input integrity
+# ---------------------------------------------------------------------------
+
+
+class TestInputIntegrity:
+    def test_input_blocks_are_not_mutated(self) -> None:
+        blocks = [
+            make_block(1, 0, "Alpha beta."),
+            make_block(1, 1, "Gamma delta."),
+        ]
+        # Offsets start as placeholders (0/0).
+        match("Gamma delta", blocks)
+        # Matcher must NOT have written real offsets onto the input blocks.
+        assert all(b.char_start == 0 and b.char_end == 0 for b in blocks)
+
+
+class TestAnchorMatchShape:
+    def test_anchor_match_fields(self) -> None:
+        blocks = [make_block(3, 0, "Find me in here please.")]
+        result = match("Find me", blocks)
+        assert result is not None
+        assert result.page == 3
+        assert isinstance(result.char_start, int)
+        assert isinstance(result.char_end, int)
+        assert result.char_start < result.char_end
+        assert result.block_ids == [0]
+        assert set(result.bbox_union.keys()) == {"x", "y", "width", "height"}

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -41,6 +41,9 @@ def service(mock_db, mock_storage):
         patch("app.services.section_extraction_service.PDFProcessor") as mock_pdf,
         patch("app.services.section_extraction_service.ArticleFileRepository") as mock_article_repo,
         patch(
+            "app.services.section_extraction_service.ArticleTextBlockRepository"
+        ) as mock_block_repo,
+        patch(
             "app.services.section_extraction_service.ExtractionEntityTypeRepository"
         ) as mock_entity_repo,
         patch(
@@ -57,7 +60,16 @@ def service(mock_db, mock_storage):
 
         # Mock repositories
         mock_article_repo_instance = MagicMock()
+        # get_latest_pdf is async; return None so _create_suggestions falls
+        # back to position={} (no blocks → safe fallback, no anchor attempt).
+        mock_article_repo_instance.get_latest_pdf = AsyncMock(return_value=None)
         mock_article_repo.return_value = mock_article_repo_instance
+
+        # ArticleTextBlockRepository is instantiated inside _create_suggestions;
+        # mock the class so the constructor returns a proper async mock.
+        mock_block_repo_instance = MagicMock()
+        mock_block_repo_instance.list_ordered_for_file = AsyncMock(return_value=[])
+        mock_block_repo.return_value = mock_block_repo_instance
 
         mock_entity_repo_instance = MagicMock()
         mock_entity_repo.return_value = mock_entity_repo_instance
@@ -270,13 +282,22 @@ class TestSectionExtractionFullFlow:
         )
 
         # Mock SQLAlchemy model class to avoid mapper issues
-        with patch(
-            "app.services.section_extraction_service.ExtractionInstance"
-        ) as mock_instance_class:
+        with (
+            patch(
+                "app.services.section_extraction_service.ExtractionInstance"
+            ) as mock_instance_class,
+            patch(
+                "app.services.section_extraction_service.ArticleTextBlockRepository"
+            ) as mock_blk_repo,
+        ):
             mock_created_instance = MagicMock()
             mock_created_instance.id = uuid4()
             mock_instance_class.return_value = mock_created_instance
             service._instances.create = AsyncMock(return_value=mock_created_instance)
+
+            mock_blk_repo_inst = MagicMock()
+            mock_blk_repo_inst.list_ordered_for_file = AsyncMock(return_value=[])
+            mock_blk_repo.return_value = mock_blk_repo_inst
 
             result = await service.extract_section(
                 project_id=project_id,
@@ -377,13 +398,22 @@ class TestExtractSectionWithExistingRun:
 
         self._wire_pipeline(service, mock_storage, existing_run, entity_type_id)
 
-        with patch(
-            "app.services.section_extraction_service.ExtractionInstance"
-        ) as mock_instance_class:
+        with (
+            patch(
+                "app.services.section_extraction_service.ExtractionInstance"
+            ) as mock_instance_class,
+            patch(
+                "app.services.section_extraction_service.ArticleTextBlockRepository"
+            ) as mock_blk_repo,
+        ):
             inst = MagicMock()
             inst.id = uuid4()
             mock_instance_class.return_value = inst
             service._instances.create = AsyncMock(return_value=inst)
+
+            mock_blk_repo_inst = MagicMock()
+            mock_blk_repo_inst.list_ordered_for_file = AsyncMock(return_value=[])
+            mock_blk_repo.return_value = mock_blk_repo_inst
 
             result = await service.extract_section(
                 project_id=project_id,

--- a/frontend/components/extraction/ExtractionPDFPanel.tsx
+++ b/frontend/components/extraction/ExtractionPDFPanel.tsx
@@ -7,18 +7,26 @@
  */
 
 import {memo} from 'react';
+import type {StoreApi} from 'zustand';
 import {ResizableHandle, ResizablePanel} from '@/components/ui/resizable';
 import {PrumoPdfViewer, articleFileSource} from '@prumo/pdf-viewer';
+import type {ViewerState} from '@prumo/pdf-viewer';
 
 export interface ExtractionPDFPanelProps {
   articleId: string;
   projectId: string;
   showPDF: boolean;
+  /** Shared viewer store. When provided, the PDF viewer joins the caller's
+   *  ViewerProvider instead of creating its own — required for the
+   *  click-evidence → highlight flow where the form panel must reach the
+   *  same store instance. */
+  store?: StoreApi<ViewerState>;
 }
 
 function ExtractionPDFPanelComponent({
   articleId,
   showPDF,
+  store,
 }: ExtractionPDFPanelProps) {
   const source = articleId ? articleFileSource(articleId) : null;
 
@@ -35,7 +43,7 @@ function ExtractionPDFPanelComponent({
         minSize={30}
         maxSize={70}
       >
-        <PrumoPdfViewer source={source} className="h-full" />
+        <PrumoPdfViewer source={source} store={store} className="h-full" />
       </ResizablePanel>
       <ResizableHandle withHandle />
     </>
@@ -48,7 +56,8 @@ export const ExtractionPDFPanel = memo(
   (prev, next) =>
     prev.articleId === next.articleId &&
     prev.projectId === next.projectId &&
-    prev.showPDF === next.showPDF,
+    prev.showPDF === next.showPDF &&
+    prev.store === next.store,
 );
 
 ExtractionPDFPanel.displayName = 'ExtractionPDFPanel';

--- a/frontend/components/extraction/FieldInput.tsx
+++ b/frontend/components/extraction/FieldInput.tsx
@@ -58,7 +58,7 @@ interface FieldInputProps {
 // =================== COMPONENT ===================
 
 export function FieldInput(props: FieldInputProps) {
-  const { field, instanceId, value, onChange, disabled, aiSuggestion, onAcceptAI, onRejectAI, getSuggestionsHistory, isActionLoading } = props;
+  const { field, instanceId, value, onChange, disabled, aiSuggestion, onAcceptAI, onRejectAI, getSuggestionsHistory, isActionLoading, articleId } = props;
   const [validationError, setValidationError] = useState<string | null>(null);
   // Briefly highlights this field when its value was just updated (e.g. by an
   // AI extraction refresh) so the user sees what changed without having to
@@ -457,6 +457,7 @@ export function FieldInput(props: FieldInputProps) {
             suggestion={aiSuggestion}
             instanceId={instanceId}
             fieldId={field.id}
+            articleId={articleId}
             onAccept={onAcceptAI}
             onReject={onRejectAI}
             loading={isActionLoading ? isActionLoading(instanceId, field.id) === 'accept' || isActionLoading(instanceId, field.id) === 'reject' : false}

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -20,6 +20,7 @@ interface AISuggestionDisplayProps {
   suggestion: AISuggestion;
   instanceId: string;
   fieldId: string;
+  articleId?: string;
   onAccept?: () => void;
   onReject?: () => void;
   loading?: boolean;
@@ -39,6 +40,7 @@ export function AISuggestionDisplay({
   suggestion,
   instanceId: _instanceId,
   fieldId: _fieldId,
+  articleId,
   onAccept,
   onReject,
   loading = false,
@@ -56,6 +58,7 @@ export function AISuggestionDisplay({
           {hasDetails ? (
             <AISuggestionDetailsPopover
               suggestion={suggestion}
+              articleId={articleId}
               trigger={
                 <div
                   className={triggerAreaClass}

--- a/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Tests for AISuggestionEvidence (presentational component).
+ *
+ * Three scenarios:
+ *  (a) citation verified + anchor + onHighlight spy → clicking calls onHighlight
+ *  (b) citation present but unverified / no anchor → "couldn't locate" affordance,
+ *      no onHighlight call, no dead jump
+ *  (c) no citation / no onHighlight → renders as before (quote + page badge),
+ *      no crash, no click handler
+ *
+ * The component is purely presentational: no hooks, safe outside ViewerProvider.
+ * (Tooltip still needs TooltipProvider — that is a Radix requirement, not
+ *  a viewer-store requirement; we wrap all renders with TooltipProvider.)
+ */
+
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, expect, it, vi} from 'vitest';
+import type {ReactNode} from 'react';
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+import {AISuggestionEvidence} from './AISuggestionEvidence';
+import {TooltipProvider} from '@/components/ui/tooltip';
+import type {ArticleCitationItem} from '@/services/citationsService';
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+
+function Wrapper({children}: {children: ReactNode}) {
+  return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+const anchor: CitationAnchor = {
+  kind: 'text',
+  range: {page: 3, charStart: 10, charEnd: 50},
+  quote: 'some evidence text',
+};
+
+const verifiedCitation: ArticleCitationItem = {
+  id: 'cit-1',
+  verified: true,
+  anchorKind: 'text',
+  anchor,
+  metadata: {pageNumber: 3, textContent: 'some evidence text', source: 'pdf'},
+};
+
+const unverifiedCitation: ArticleCitationItem = {
+  id: 'cit-2',
+  verified: false,
+  anchorKind: null,
+  anchor: null,
+  metadata: {pageNumber: null, textContent: null, source: 'pdf'},
+};
+
+const evidence = {text: 'some evidence text', pageNumber: 3};
+
+describe('AISuggestionEvidence', () => {
+  describe('(a) verified citation + anchor + onHighlight', () => {
+    it('renders a jump-to-source button', () => {
+      const onHighlight = vi.fn();
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={verifiedCitation}
+          onHighlight={onHighlight}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(
+        screen.getByRole('button', {name: 'evidenceJumpToSource'}),
+      ).toBeInTheDocument();
+    });
+
+    it('calls onHighlight with the anchor when the jump button is clicked', async () => {
+      const user = userEvent.setup();
+      const onHighlight = vi.fn();
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={verifiedCitation}
+          onHighlight={onHighlight}
+        />,
+        {wrapper: Wrapper},
+      );
+      await user.click(screen.getByRole('button', {name: 'evidenceJumpToSource'}));
+      expect(onHighlight).toHaveBeenCalledOnce();
+      expect(onHighlight).toHaveBeenCalledWith(anchor);
+    });
+
+    it('does NOT show the evidenceNotLocated affordance', () => {
+      const onHighlight = vi.fn();
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={verifiedCitation}
+          onHighlight={onHighlight}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('(b) citation present but unverified / no anchor', () => {
+    it('renders the evidenceNotLocated affordance', () => {
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={unverifiedCitation}
+          onHighlight={vi.fn()}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(screen.getByText('evidenceNotLocated')).toBeInTheDocument();
+    });
+
+    it('does NOT render a jump-to-source button', () => {
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={unverifiedCitation}
+          onHighlight={vi.fn()}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(
+        screen.queryByRole('button', {name: 'evidenceJumpToSource'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT call onHighlight even if provided', () => {
+      const onHighlight = vi.fn();
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={unverifiedCitation}
+          onHighlight={onHighlight}
+        />,
+        {wrapper: Wrapper},
+      );
+      // No jump button exists — onHighlight is never invoked on render
+      expect(onHighlight).not.toHaveBeenCalled();
+    });
+
+    it('also shows "not located" when citation has no anchor (verified=true but anchor=null)', () => {
+      const noAnchorCitation: ArticleCitationItem = {
+        ...verifiedCitation,
+        anchor: null,
+        anchorKind: null,
+      };
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={noAnchorCitation}
+          onHighlight={vi.fn()}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(screen.getByText('evidenceNotLocated')).toBeInTheDocument();
+    });
+  });
+
+  describe('(c) no citation / no onHighlight — backward compat', () => {
+    it('renders the quote text', () => {
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      expect(screen.getByText(/some evidence text/)).toBeInTheDocument();
+    });
+
+    it('renders the page badge', () => {
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      // t() mock returns key as-is; component replaces {{n}} → "pageLabel3" effectively
+      // The component does: t('extraction', 'pageLabel').replace('{{n}}', '3')
+      // Mock returns 'pageLabel', then .replace → 'pageLabel' (no {{n}} in key string itself)
+      // Actually the key is 'pageLabel', mock returns 'pageLabel', replace is no-op → 'pageLabel'
+      expect(screen.getByText('pageLabel')).toBeInTheDocument();
+    });
+
+    it('does NOT render a jump button', () => {
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      expect(
+        screen.queryByRole('button', {name: 'evidenceJumpToSource'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT render evidenceNotLocated', () => {
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
+    });
+
+    it('renders without crashing when no citation/onHighlight (no viewer state needed)', () => {
+      // Component must not access viewer store — purely presentational path
+      const {unmount} = render(
+        <AISuggestionEvidence evidence={{text: 'safe'}} />,
+        {wrapper: Wrapper},
+      );
+      expect(screen.getByText(/safe/)).toBeInTheDocument();
+      unmount();
+    });
+  });
+});

--- a/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
@@ -7,6 +7,7 @@
  *      no onHighlight call, no dead jump
  *  (c) no citation / no onHighlight → renders as before (quote + page badge),
  *      no crash, no click handler
+ *  (d) handleCopy fix — setCopied(true) only fires on clipboard success
  *
  * The component is purely presentational: no hooks, safe outside ViewerProvider.
  * (Tooltip still needs TooltipProvider — that is a Radix requirement, not
@@ -196,6 +197,40 @@ describe('AISuggestionEvidence', () => {
       );
       expect(screen.getByText(/safe/)).toBeInTheDocument();
       unmount();
+    });
+  });
+
+  describe('(d) handleCopy — only shows success on clipboard success', () => {
+    // jsdom provides navigator.clipboard but its writeText always rejects with
+    // a DOMException ("not implemented"). We spy on it per-test instead of
+    // trying to redefine the whole clipboard object, which is non-configurable
+    // in some jsdom versions.
+
+    it('sets copied=true when clipboard write succeeds', async () => {
+      const spy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      const copyBtn = screen.getByRole('button', {name: 'copySnippet'});
+
+      await user.click(copyBtn);
+      // After success the button label should change to "copyCopied"
+      expect(screen.getByRole('button', {name: 'copyCopied'})).toBeInTheDocument();
+      spy.mockRestore();
+    });
+
+    it('does NOT set copied=true when clipboard write rejects', async () => {
+      const spy = vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(
+        new Error('permission denied'),
+      );
+      const user = userEvent.setup();
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      const copyBtn = screen.getByRole('button', {name: 'copySnippet'});
+
+      await user.click(copyBtn);
+      // Button label must NOT switch to "copyCopied" on failure
+      expect(screen.queryByRole('button', {name: 'copyCopied'})).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'copySnippet'})).toBeInTheDocument();
+      spy.mockRestore();
     });
   });
 });

--- a/frontend/components/extraction/ai/AISuggestionEvidence.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.tsx
@@ -3,16 +3,26 @@
  *
  * Shows the text passage cited by the LLM as evidence for extraction,
  * including page number (if available).
- * 
+ *
+ * Optional citation highlight: when a matched `citation` and `onHighlight`
+ * are provided (by a parent inside a ViewerProvider), the evidence block
+ * becomes clickable to jump to the source in the PDF viewer.
+ * When `citation` is provided but unverified / anchor-less, renders a
+ * non-alarming "Couldn't locate in source" affordance instead.
+ * When neither prop is provided the component renders exactly as before —
+ * backward compatible, safe to use outside a ViewerProvider.
+ *
  * @component
  */
 
-import {Check, Copy, FileText} from 'lucide-react';
+import {Check, Copy, FileText, MapPin, MapPinOff} from 'lucide-react';
 import {Button} from '@/components/ui/button';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {useState} from 'react';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
+import type {ArticleCitationItem} from '@/services/citationsService';
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
 
 // =================== INTERFACES ===================
 
@@ -23,67 +33,119 @@ interface AISuggestionEvidenceProps {
   };
   className?: string;
   showCopyButton?: boolean;
+  /** The matched citation for this evidence, or null = no match. Optional. */
+  citation?: ArticleCitationItem | null;
+  /** Called with the anchor when the user clicks to jump. Provided by a parent
+   *  inside a ViewerProvider. Optional. */
+  onHighlight?: (anchor: CitationAnchor) => void;
 }
 
 // =================== COMPONENT ===================
 
 export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
-  const { evidence, className, showCopyButton = true } = props;
+  const {
+    evidence,
+    className,
+    showCopyButton = true,
+    citation,
+    onHighlight,
+  } = props;
   const [copied, setCopied] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(evidence.text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
+    await navigator.clipboard.writeText(evidence.text).catch((err: unknown) => {
       console.error('Failed to copy evidence text:', err);
-    }
+    });
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
+  // Determine citation-highlight state:
+  // - canHighlight: we have everything needed for a real jump
+  // - showNotLocated: citation provided but cannot jump (unverified or no anchor)
+  const canHighlight =
+    citation != null &&
+    citation.verified &&
+    citation.anchor != null &&
+    onHighlight != null;
+
+  const showNotLocated =
+    citation != null && !canHighlight;
+
   return (
-    <div className={cn("flex flex-col gap-4 p-4 bg-muted/50 rounded-lg border", className)}>
-        {/* Header with icon and page */}
+    <div className={cn('flex flex-col gap-4 p-4 bg-muted/50 rounded-lg border', className)}>
+      {/* Header with icon and page */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
         <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap">
           <FileText className="h-4 w-4 shrink-0" />
-            <span className="font-medium">{t('extraction', 'evidenceCited')}</span>
+          <span className="font-medium">{t('extraction', 'evidenceCited')}</span>
           {evidence.pageNumber !== null && evidence.pageNumber !== undefined && (
             <span className="px-2 py-1 bg-background rounded text-xs shrink-0">
               {t('extraction', 'pageLabel').replace('{{n}}', String(evidence.pageNumber))}
             </span>
           )}
+          {showNotLocated && (
+            <span className="flex items-center gap-1 text-muted-foreground/70">
+              <MapPinOff className="h-3 w-3 shrink-0" />
+              <span>{t('extraction', 'evidenceNotLocated')}</span>
+            </span>
+          )}
         </div>
-        
-        {showCopyButton && (
-          <Tooltip open={showTooltip && !copied} delayDuration={300}>
-            <TooltipTrigger asChild>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-8 w-8 p-0 shrink-0 hover:bg-muted"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleCopy();
-                  setShowTooltip(false);
-                }}
-                onMouseEnter={() => setShowTooltip(true)}
-                onMouseLeave={() => setShowTooltip(false)}
-                aria-label={copied ? t('extraction', 'copyCopied') : t('extraction', 'copySnippet')}
-              >
-                {copied ? (
-                  <Check className="h-4 w-4 text-success" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="top" onPointerDownOutside={() => setShowTooltip(false)}>
+
+        <div className="flex items-center gap-1 shrink-0">
+          {canHighlight && (
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 w-8 p-0 hover:bg-muted"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    // citation.anchor is guaranteed non-null by canHighlight
+                    onHighlight(citation.anchor!);
+                  }}
+                  aria-label={t('extraction', 'evidenceJumpToSource')}
+                >
+                  <MapPin className="h-4 w-4 text-primary" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                <p>{t('extraction', 'evidenceJumpToSource')}</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          {showCopyButton && (
+            <Tooltip open={showTooltip && !copied} delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 w-8 p-0 shrink-0 hover:bg-muted"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCopy();
+                    setShowTooltip(false);
+                  }}
+                  onMouseEnter={() => setShowTooltip(true)}
+                  onMouseLeave={() => setShowTooltip(false)}
+                  aria-label={copied ? t('extraction', 'copyCopied') : t('extraction', 'copySnippet')}
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4 text-success" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" onPointerDownOutside={() => setShowTooltip(false)}>
                 <p>{t('extraction', 'copySnippet')}</p>
-            </TooltipContent>
-          </Tooltip>
-        )}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       </div>
 
       {/* Trecho do texto */}
@@ -93,4 +155,3 @@ export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
     </div>
   );
 }
-

--- a/frontend/components/extraction/ai/AISuggestionEvidence.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.tsx
@@ -54,11 +54,14 @@ export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
   const [showTooltip, setShowTooltip] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(evidence.text).catch((err: unknown) => {
+    const ok = await navigator.clipboard.writeText(evidence.text).then(() => true).catch((err: unknown) => {
       console.error('Failed to copy evidence text:', err);
+      return false;
     });
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
   };
 
   // Determine citation-highlight state:

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
@@ -72,10 +72,12 @@ const verifiedCitation: ArticleCitationItem = {
 
 const suggestion = {
   id: 'sug-1',
+  runId: 'run-1',
   value: 'some value',
   status: 'pending' as const,
   confidence: 0.9,
   reasoning: 'Because of this evidence.',
+  timestamp: new Date('2024-01-01T00:00:00Z'),
   evidence: {text: 'test evidence', pageNumber: 2},
 };
 

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
@@ -5,9 +5,10 @@
  *  - A matched verified citation → AISuggestionEvidence receives the right
  *    citation and an onHighlight that calls the highlight controller.
  *  - No match → citation=null → evidenceNotLocated affordance path.
+ *  - isAvailable=false (no viewer) → onHighlight not passed → renders
+ *    non-clickable (no jump button) and does NOT crash.
  *
  * Mocks: useArticleCitations, matchEvidenceToCitation, useCitationHighlight.
- * Wraps in QueryClientProvider + ViewerProvider so useCitationHighlight resolves.
  */
 
 import {render, screen} from '@testing-library/react';
@@ -31,10 +32,18 @@ vi.mock('@/services/citationsService', () => ({
   matchEvidenceToCitation: vi.fn(),
 }));
 
-// Mock useCitationHighlight — expose a spy for the highlight fn
+// Mock useCitationHighlight — expose a spy for the highlight fn.
+// isAvailable defaults to true (simulates a component inside a ViewerProvider).
+// Individual tests can override via mockReturnValue.
 const highlightSpy = vi.fn();
+const useCitationHighlightMock = vi.fn(() => ({
+  highlight: highlightSpy,
+  clear: vi.fn(),
+  activeHighlight: null,
+  isAvailable: true,
+}));
 vi.mock('@/hooks/extraction/useCitationHighlight', () => ({
-  useCitationHighlight: () => ({highlight: highlightSpy, clear: vi.fn(), activeHighlight: null}),
+  useCitationHighlight: () => useCitationHighlightMock(),
 }));
 
 import {AISuggestionDetailsPopover} from './AISuggestionDetailsPopover';
@@ -83,6 +92,12 @@ function makeWrapper() {
 
 beforeEach(() => {
   highlightSpy.mockClear();
+  useCitationHighlightMock.mockReturnValue({
+    highlight: highlightSpy,
+    clear: vi.fn(),
+    activeHighlight: null,
+    isAvailable: true,
+  });
   // Default: citations loaded with one item
   useArticleCitationsMock.mockReturnValue({data: [verifiedCitation], isLoading: false});
 });
@@ -154,5 +169,35 @@ describe('AISuggestionDetailsPopover — citation wiring', () => {
     expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
     // Evidence text is still shown
     expect(screen.getByText(/test evidence/)).toBeInTheDocument();
+  });
+
+  it('isAvailable=false (no viewer) → no jump button rendered, does NOT crash', async () => {
+    const user = userEvent.setup();
+    // Simulate the QA-screen path: hook returns isAvailable=false
+    useCitationHighlightMock.mockReturnValue({
+      highlight: vi.fn(),
+      clear: vi.fn(),
+      activeHighlight: null,
+      isAvailable: false,
+    });
+    matchEvidenceMock.mockReturnValue(verifiedCitation);
+
+    render(
+      <AISuggestionDetailsPopover
+        suggestion={suggestion}
+        articleId="article-123"
+        trigger={<button>Open</button>}
+      />,
+      {wrapper: makeWrapper()},
+    );
+
+    // Must not throw when opening
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+
+    // Evidence text is shown
+    expect(await screen.findByText(/test evidence/)).toBeInTheDocument();
+
+    // No jump button — onHighlight was not passed because isAvailable=false
+    expect(screen.queryByRole('button', {name: 'evidenceJumpToSource'})).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Wiring tests for AISuggestionDetailsPopover.
+ *
+ * Verifies that:
+ *  - A matched verified citation → AISuggestionEvidence receives the right
+ *    citation and an onHighlight that calls the highlight controller.
+ *  - No match → citation=null → evidenceNotLocated affordance path.
+ *
+ * Mocks: useArticleCitations, matchEvidenceToCitation, useCitationHighlight.
+ * Wraps in QueryClientProvider + ViewerProvider so useCitationHighlight resolves.
+ */
+
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import type {ReactNode} from 'react';
+
+// Mock copy so all keys are returned as-is
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+// Mock useArticleCitations — returns controlled data
+vi.mock('@/hooks/articles/useArticleCitations', () => ({
+  useArticleCitations: vi.fn(),
+}));
+
+// Mock matchEvidenceToCitation — returns controlled result
+vi.mock('@/services/citationsService', () => ({
+  matchEvidenceToCitation: vi.fn(),
+}));
+
+// Mock useCitationHighlight — expose a spy for the highlight fn
+const highlightSpy = vi.fn();
+vi.mock('@/hooks/extraction/useCitationHighlight', () => ({
+  useCitationHighlight: () => ({highlight: highlightSpy, clear: vi.fn(), activeHighlight: null}),
+}));
+
+import {AISuggestionDetailsPopover} from './AISuggestionDetailsPopover';
+import {useArticleCitations} from '@/hooks/articles/useArticleCitations';
+import {matchEvidenceToCitation} from '@/services/citationsService';
+import type {ArticleCitationItem} from '@/services/citationsService';
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+import {TooltipProvider} from '@/components/ui/tooltip';
+
+const useArticleCitationsMock = useArticleCitations as ReturnType<typeof vi.fn>;
+const matchEvidenceMock = matchEvidenceToCitation as ReturnType<typeof vi.fn>;
+
+const anchor: CitationAnchor = {
+  kind: 'text',
+  range: {page: 2, charStart: 0, charEnd: 30},
+  quote: 'test evidence',
+};
+
+const verifiedCitation: ArticleCitationItem = {
+  id: 'cit-x',
+  verified: true,
+  anchorKind: 'text',
+  anchor,
+  metadata: {pageNumber: 2, textContent: 'test evidence', source: 'pdf'},
+};
+
+const suggestion = {
+  id: 'sug-1',
+  value: 'some value',
+  status: 'pending' as const,
+  confidence: 0.9,
+  reasoning: 'Because of this evidence.',
+  evidence: {text: 'test evidence', pageNumber: 2},
+};
+
+function makeWrapper() {
+  const qc = new QueryClient({defaultOptions: {queries: {retry: false}}});
+  return function Wrapper({children}: {children: ReactNode}) {
+    return (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  highlightSpy.mockClear();
+  // Default: citations loaded with one item
+  useArticleCitationsMock.mockReturnValue({data: [verifiedCitation], isLoading: false});
+});
+
+describe('AISuggestionDetailsPopover — citation wiring', () => {
+  it('matched verified citation → evidenceJumpToSource button present and calls highlight', async () => {
+    const user = userEvent.setup();
+    matchEvidenceMock.mockReturnValue(verifiedCitation);
+
+    render(
+      <AISuggestionDetailsPopover
+        suggestion={suggestion}
+        articleId="article-123"
+        trigger={<button>Open</button>}
+      />,
+      {wrapper: makeWrapper()},
+    );
+
+    // Open the dialog
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+
+    // Jump button should appear
+    const jumpBtn = await screen.findByRole('button', {name: 'evidenceJumpToSource'});
+    expect(jumpBtn).toBeInTheDocument();
+
+    // Clicking it calls highlight with the anchor
+    await user.click(jumpBtn);
+    expect(highlightSpy).toHaveBeenCalledOnce();
+    expect(highlightSpy).toHaveBeenCalledWith(anchor);
+  });
+
+  it('no match → citation=null → evidenceNotLocated affordance', async () => {
+    const user = userEvent.setup();
+    matchEvidenceMock.mockReturnValue(null);
+
+    render(
+      <AISuggestionDetailsPopover
+        suggestion={suggestion}
+        articleId="article-123"
+        trigger={<button>Open</button>}
+      />,
+      {wrapper: makeWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+
+    // No jump button
+    expect(screen.queryByRole('button', {name: 'evidenceJumpToSource'})).not.toBeInTheDocument();
+    // No "not located" affordance either — citation is null (not provided but unverified)
+    // (When citation=null, the component renders as before — no affordance)
+    expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
+  });
+
+  it('no articleId → no citation passed → renders as before (no jump, no not-located)', async () => {
+    const user = userEvent.setup();
+    matchEvidenceMock.mockReturnValue(null);
+
+    render(
+      <AISuggestionDetailsPopover
+        suggestion={suggestion}
+        trigger={<button>Open</button>}
+      />,
+      {wrapper: makeWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+
+    expect(screen.queryByRole('button', {name: 'evidenceJumpToSource'})).not.toBeInTheDocument();
+    expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
+    // Evidence text is still shown
+    expect(screen.getByText(/test evidence/)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
@@ -1,8 +1,12 @@
 /**
  * AI suggestion details modal (rationale + evidence) - Extraction
  *
- * Uses viewport-centered Dialog so content is never clipped
+ * Uses viewport-centered Dialog so content is never clipped.
  * Same strategy as Assessment. Responsive, with internal scroll.
+ *
+ * When `articleId` is provided (and the component is mounted inside the shared
+ * ViewerProvider at ExtractionFullScreen level), the evidence block gains a
+ * "jump to source" button via useCitationHighlight.
  */
 
 import {useState} from 'react';
@@ -12,6 +16,9 @@ import {Sparkles} from 'lucide-react';
 import {AISuggestionEvidence} from '../AISuggestionEvidence';
 import {t} from '@/lib/copy';
 import type {AISuggestion} from '@/hooks/extraction/ai/useAISuggestions';
+import {useArticleCitations} from '@/hooks/articles/useArticleCitations';
+import {matchEvidenceToCitation} from '@/services/citationsService';
+import {useCitationHighlight} from '@/hooks/extraction/useCitationHighlight';
 
 // -----------------------------------------------------------------------------
 // Constantes de layout (viewport-safe, alinhado ao Assessment)
@@ -34,21 +41,61 @@ function hasSuggestionDetails(suggestion: AISuggestion): boolean {
 }
 
 // -----------------------------------------------------------------------------
-// Tipos
+// Types
 // -----------------------------------------------------------------------------
 
 interface AISuggestionDetailsPopoverProps {
   suggestion: AISuggestion;
   trigger: React.ReactNode;
+  /** Article id. When provided (and inside a ViewerProvider) enables the
+   *  citation highlight on the evidence block. */
+  articleId?: string;
 }
 
 // -----------------------------------------------------------------------------
-// Componente
+// Inner component — holds the citation-highlight hooks.
+// Separated so the hooks only run when the modal is open.
+// -----------------------------------------------------------------------------
+
+interface EvidenceSectionProps {
+  evidence: {text: string; pageNumber?: number | null};
+  articleId: string | undefined;
+}
+
+function EvidenceSection({evidence, articleId}: EvidenceSectionProps) {
+  const citations = useArticleCitations(articleId);
+  const {highlight} = useCitationHighlight();
+
+  const matched =
+    articleId != null
+      ? matchEvidenceToCitation(
+          {text: evidence.text, pageNumber: evidence.pageNumber ?? undefined},
+          citations.data ?? [],
+        )
+      : null;
+
+  return (
+    <section className="space-y-2" aria-label={t('extraction', 'evidenceCitedAria')}>
+      <AISuggestionEvidence
+        evidence={{
+          text: evidence.text,
+          pageNumber: evidence.pageNumber ?? null,
+        }}
+        citation={matched}
+        onHighlight={articleId != null ? highlight : undefined}
+      />
+    </section>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Component
 // -----------------------------------------------------------------------------
 
 export function AISuggestionDetailsPopover({
   suggestion,
   trigger,
+  articleId,
 }: AISuggestionDetailsPopoverProps) {
   const [open, setOpen] = useState(false);
 
@@ -87,14 +134,13 @@ export function AISuggestionDetailsPopover({
             )}
 
             {evidence?.text?.trim() && (
-                <section className="space-y-2" aria-label={t('extraction', 'evidenceCitedAria')}>
-                <AISuggestionEvidence
-                  evidence={{
-                    text: evidence.text,
-                    pageNumber: evidence.pageNumber ?? null,
-                  }}
-                />
-              </section>
+              <EvidenceSection
+                evidence={{
+                  text: evidence.text,
+                  pageNumber: evidence.pageNumber ?? null,
+                }}
+                articleId={articleId}
+              />
             )}
           </div>
         </ScrollArea>

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
@@ -64,7 +64,7 @@ interface EvidenceSectionProps {
 
 function EvidenceSection({evidence, articleId}: EvidenceSectionProps) {
   const citations = useArticleCitations(articleId);
-  const {highlight} = useCitationHighlight();
+  const {highlight, isAvailable} = useCitationHighlight();
 
   const matched =
     articleId != null
@@ -82,7 +82,7 @@ function EvidenceSection({evidence, articleId}: EvidenceSectionProps) {
           pageNumber: evidence.pageNumber ?? null,
         }}
         citation={matched}
-        onHighlight={articleId != null ? highlight : undefined}
+        onHighlight={isAvailable && articleId != null ? highlight : undefined}
       />
     </section>
   );

--- a/frontend/hooks/articles/useArticleCitations.ts
+++ b/frontend/hooks/articles/useArticleCitations.ts
@@ -1,0 +1,28 @@
+/**
+ * Fetches the citation list for an article.
+ *
+ * Used by the PDF viewer's reviewer-highlight feature to resolve AI evidence
+ * quotes to backend-stored citation anchors. Returns an empty array when the
+ * article has no citations or when the query is disabled.
+ */
+import {useQuery} from '@tanstack/react-query';
+
+import {articleKeys} from '@/lib/query-keys';
+import {fetchArticleCitations, type ArticleCitationItem} from '@/services/citationsService';
+
+const STALE_MS = 5 * 60_000;
+
+export function useArticleCitations(articleId: string | null | undefined) {
+  return useQuery({
+    queryKey: articleKeys.citations(articleId ?? ''),
+    enabled: Boolean(articleId),
+    staleTime: STALE_MS,
+    queryFn: async (): Promise<ArticleCitationItem[]> => {
+      const result = await fetchArticleCitations(articleId!);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return result.data;
+    },
+  });
+}

--- a/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
+++ b/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
@@ -4,6 +4,11 @@
  * Uses a real ViewerProvider wrapping the hook, a stubbed document that
  * exposes numPages so goToPage clamping works, and a vi.mock for
  * usePageHandle (so no pdfjs / network required).
+ *
+ * Also covers the no-provider (graceful degradation) path:
+ *  - isAvailable === false
+ *  - highlight() is a safe no-op
+ *  - activeHighlight stays null
  */
 import {renderHook, act} from '@testing-library/react';
 import {createElement, type ReactNode} from 'react';
@@ -259,5 +264,48 @@ describe('useCitationHighlight', () => {
     expect(state.currentPage).toBe(3);
     // In reader mode the overlay rect is null (no canvas surface)
     expect(result.current.activeHighlight).toBeNull();
+  });
+
+  it('with a ViewerProvider: isAvailable === true', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+    expect(result.current.isAvailable).toBe(true);
+  });
+
+  describe('no ViewerProvider — graceful degradation', () => {
+    it('isAvailable === false when rendered without a provider', () => {
+      const {result} = renderHook(() => useCitationHighlight());
+      expect(result.current.isAvailable).toBe(false);
+    });
+
+    it('activeHighlight is null when rendered without a provider', () => {
+      const {result} = renderHook(() => useCitationHighlight());
+      expect(result.current.activeHighlight).toBeNull();
+    });
+
+    it('highlight() does NOT throw and is a no-op when no provider is present', () => {
+      const {result} = renderHook(() => useCitationHighlight());
+      expect(() => {
+        act(() => {
+          result.current.highlight({
+            kind: 'text',
+            range: {page: 1, charStart: 0, charEnd: 10},
+            quote: 'test',
+          });
+        });
+      }).not.toThrow();
+      // State is unchanged — no store to mutate
+      expect(result.current.activeHighlight).toBeNull();
+      expect(result.current.isAvailable).toBe(false);
+    });
+
+    it('clear() does NOT throw when no provider is present', () => {
+      const {result} = renderHook(() => useCitationHighlight());
+      expect(() => {
+        act(() => {
+          result.current.clear();
+        });
+      }).not.toThrow();
+    });
   });
 });

--- a/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
+++ b/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
@@ -308,4 +308,102 @@ describe('useCitationHighlight', () => {
       }).not.toThrow();
     });
   });
+
+  describe('shared store — anchor put into citations map', () => {
+    it('highlight(regionAnchor) puts the anchor into the store as an active citation', () => {
+      const wrapper = makeWrapper(storeRef);
+      const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+      const anchor = {
+        kind: 'region' as const,
+        page: 4,
+        rect: {x: 10, y: 20, width: 80, height: 30},
+      };
+
+      act(() => {
+        result.current.highlight(anchor);
+      });
+
+      const state = storeRef.current!.getState();
+      // activeCitationId must be set
+      expect(state.activeCitationId).not.toBeNull();
+      // The citations map must contain the citation with that id
+      const id = state.activeCitationId!;
+      const citation = state.citations.get(id);
+      expect(citation).not.toBeUndefined();
+      expect(citation!.anchor).toEqual(anchor);
+    });
+
+    it('highlight(hybridAnchor) puts the anchor into the store as an active citation', () => {
+      const wrapper = makeWrapper(storeRef);
+      const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+      const anchor = {
+        kind: 'hybrid' as const,
+        range: {page: 2, charStart: 0, charEnd: 10},
+        rect: {x: 0, y: 0, width: 50, height: 20},
+        quote: 'test quote',
+      };
+
+      act(() => {
+        result.current.highlight(anchor);
+      });
+
+      const state = storeRef.current!.getState();
+      expect(state.activeCitationId).not.toBeNull();
+      const id = state.activeCitationId!;
+      const citation = state.citations.get(id);
+      expect(citation).not.toBeUndefined();
+      expect(citation!.anchor).toEqual(anchor);
+    });
+
+    it('clear() removes the citation from the store (citations map is empty)', () => {
+      const wrapper = makeWrapper(storeRef);
+      const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+      act(() => {
+        result.current.highlight({
+          kind: 'region' as const,
+          page: 1,
+          rect: {x: 0, y: 0, width: 100, height: 50},
+        });
+      });
+
+      act(() => {
+        result.current.clear();
+      });
+
+      const state = storeRef.current!.getState();
+      expect(state.activeCitationId).toBeNull();
+      expect(state.citations.size).toBe(0);
+    });
+
+    it('second highlight() call clears the previous citation before adding the new one', () => {
+      const wrapper = makeWrapper(storeRef);
+      const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+      act(() => {
+        result.current.highlight({
+          kind: 'region' as const,
+          page: 1,
+          rect: {x: 0, y: 0, width: 100, height: 50},
+        });
+      });
+
+      const firstId = storeRef.current!.getState().activeCitationId;
+
+      act(() => {
+        result.current.highlight({
+          kind: 'region' as const,
+          page: 2,
+          rect: {x: 10, y: 10, width: 50, height: 20},
+        });
+      });
+
+      const state = storeRef.current!.getState();
+      // Old id gone, only 1 citation in the map
+      expect(state.citations.size).toBe(1);
+      expect(state.activeCitationId).not.toBe(firstId);
+    });
+  });
 });

--- a/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
+++ b/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
@@ -47,7 +47,7 @@ function makeWrapper(storeRef: {current: ReturnType<typeof createViewerStore> | 
         destroy: () => {},
       });
     }
-    return createElement(ViewerProvider, {store: storeRef.current}, children);
+    return createElement(ViewerProvider, {store: storeRef.current, children});
   };
 }
 
@@ -117,7 +117,6 @@ describe('useCitationHighlight', () => {
 
   it('RegionCitationAnchor: projected rect scales with store.scale', () => {
     const storeRef2: {current: ReturnType<typeof createViewerStore> | null} = {current: null};
-    const wrapper = makeWrapper(storeRef2);
     // Set scale to 1.5 before render
     storeRef2.current = createViewerStore({scale: 1.5});
     storeRef2.current.getState().actions.setDocument({
@@ -131,7 +130,7 @@ describe('useCitationHighlight', () => {
 
     const {result} = renderHook(() => useCitationHighlight(), {
       wrapper: function W({children}: {children: ReactNode}) {
-        return createElement(ViewerProvider, {store: storeRef2.current!}, children);
+        return createElement(ViewerProvider, {store: storeRef2.current!, children});
       },
     });
 
@@ -248,7 +247,7 @@ describe('useCitationHighlight', () => {
 
     const {result} = renderHook(() => useCitationHighlight(), {
       wrapper: function W({children}: {children: ReactNode}) {
-        return createElement(ViewerProvider, {store: storeRef3.current!}, children);
+        return createElement(ViewerProvider, {store: storeRef3.current!, children});
       },
     });
 

--- a/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
+++ b/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for useCitationHighlight hook.
+ *
+ * Uses a real ViewerProvider wrapping the hook, a stubbed document that
+ * exposes numPages so goToPage clamping works, and a vi.mock for
+ * usePageHandle (so no pdfjs / network required).
+ */
+import {renderHook, act} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+
+import {ViewerProvider} from '@/pdf-viewer/core/context';
+import {createViewerStore} from '@/pdf-viewer/core/store';
+
+// --- stub usePageHandle to return a known page size ---
+vi.mock('@/pdf-viewer/hooks/usePageHandle', () => ({
+  usePageHandle: (_page: number) => ({
+    pageNumber: _page,
+    size: {width: 612, height: 792},
+    render: vi.fn(),
+    getTextContent: vi.fn(),
+    renderTextLayer: vi.fn(),
+    cleanup: vi.fn(),
+  }),
+}));
+
+import {useCitationHighlight} from '../useCitationHighlight';
+
+// Helper: render the hook inside a ViewerProvider backed by a store that
+// has numPages set so goToPage clamping resolves to the right page.
+function makeWrapper(storeRef: {current: ReturnType<typeof createViewerStore> | null}) {
+  return function Wrapper({children}: {children: ReactNode}) {
+    if (!storeRef.current) {
+      storeRef.current = createViewerStore();
+      // Simulate a loaded doc with 20 pages so goToPage doesn't clamp to 1.
+      storeRef.current.getState().actions.setDocument({
+        numPages: 20,
+        fingerprint: 'test',
+        metadata: async () => ({}),
+        outline: async () => [],
+        getPage: async () => {throw new Error('stub');},
+        destroy: () => {},
+      });
+    }
+    return createElement(ViewerProvider, {store: storeRef.current}, children);
+  };
+}
+
+describe('useCitationHighlight', () => {
+  const storeRef: {current: ReturnType<typeof createViewerStore> | null} = {current: null};
+
+  beforeEach(() => {
+    storeRef.current = null;
+  });
+
+  it('TextCitationAnchor: goToPage(range.page) and setSearchMatches with correct charStart/charEnd', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    act(() => {
+      result.current.highlight({
+        kind: 'text',
+        range: {page: 3, charStart: 10, charEnd: 42},
+        quote: 'hello world',
+      });
+    });
+
+    const state = storeRef.current!.getState();
+    // Page navigation
+    expect(state.currentPage).toBe(3);
+    // Search match wired up
+    expect(state.search.matches).toHaveLength(1);
+    expect(state.search.matches[0]).toMatchObject({
+      pageNumber: 3,
+      charStart: 10,
+      charEnd: 42,
+      context: 'hello world',
+    });
+    // No projected rect for text-only
+    expect(result.current.activeHighlight).toBeNull();
+  });
+
+  it('RegionCitationAnchor: goToPage(anchor.page), no search match, projected rect with Y-flip', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    // scale=1 (default), pageHeight=792
+    // rect = {x:100, y:200, width:150, height:50}
+    // expected: left=100*1=100, top=(792-200-50)*1=542, width=150, height=50
+    act(() => {
+      result.current.highlight({
+        kind: 'region',
+        page: 5,
+        rect: {x: 100, y: 200, width: 150, height: 50},
+      });
+    });
+
+    const state = storeRef.current!.getState();
+    expect(state.currentPage).toBe(5);
+    // No text search
+    expect(state.search.matches).toHaveLength(0);
+    // Projected overlay rect
+    expect(result.current.activeHighlight).not.toBeNull();
+    expect(result.current.activeHighlight).toMatchObject({
+      page: 5,
+      left: 100,
+      top: 542,
+      width: 150,
+      height: 50,
+    });
+  });
+
+  it('RegionCitationAnchor: projected rect scales with store.scale', () => {
+    const storeRef2: {current: ReturnType<typeof createViewerStore> | null} = {current: null};
+    const wrapper = makeWrapper(storeRef2);
+    // Set scale to 1.5 before render
+    storeRef2.current = createViewerStore({scale: 1.5});
+    storeRef2.current.getState().actions.setDocument({
+      numPages: 20,
+      fingerprint: 'test2',
+      metadata: async () => ({}),
+      outline: async () => [],
+      getPage: async () => {throw new Error('stub');},
+      destroy: () => {},
+    });
+
+    const {result} = renderHook(() => useCitationHighlight(), {
+      wrapper: function W({children}: {children: ReactNode}) {
+        return createElement(ViewerProvider, {store: storeRef2.current!}, children);
+      },
+    });
+
+    act(() => {
+      result.current.highlight({
+        kind: 'region',
+        page: 2,
+        rect: {x: 100, y: 200, width: 150, height: 50},
+      });
+    });
+
+    // scale=1.5: left=150, top=(792-200-50)*1.5=813, width=225, height=75
+    expect(result.current.activeHighlight).toMatchObject({
+      page: 2,
+      left: 150,
+      top: 813,
+      width: 225,
+      height: 75,
+    });
+  });
+
+  it('HybridCitationAnchor: both text match AND projected rect', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    act(() => {
+      result.current.highlight({
+        kind: 'hybrid',
+        range: {page: 7, charStart: 5, charEnd: 20},
+        rect: {x: 50, y: 100, width: 200, height: 30},
+        quote: 'some text',
+      });
+    });
+
+    const state = storeRef.current!.getState();
+    expect(state.currentPage).toBe(7);
+    // Text match
+    expect(state.search.matches).toHaveLength(1);
+    expect(state.search.matches[0]).toMatchObject({
+      pageNumber: 7,
+      charStart: 5,
+      charEnd: 20,
+      context: 'some text',
+    });
+    // Overlay rect: left=50, top=(792-100-30)*1=662, width=200, height=30
+    expect(result.current.activeHighlight).toMatchObject({
+      page: 7,
+      left: 50,
+      top: 662,
+      width: 200,
+      height: 30,
+    });
+  });
+
+  it('clear() resets search, activeCitationId, and activeHighlight', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    act(() => {
+      result.current.highlight({
+        kind: 'hybrid',
+        range: {page: 2, charStart: 0, charEnd: 5},
+        rect: {x: 10, y: 10, width: 50, height: 20},
+        quote: 'test',
+      });
+    });
+
+    act(() => {
+      result.current.clear();
+    });
+
+    const state = storeRef.current!.getState();
+    expect(state.search.matches).toHaveLength(0);
+    expect(state.activeCitationId).toBeNull();
+    expect(result.current.activeHighlight).toBeNull();
+  });
+
+  it('a second highlight() call replaces the previous (clears first)', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    act(() => {
+      result.current.highlight({
+        kind: 'text',
+        range: {page: 1, charStart: 0, charEnd: 5},
+      });
+    });
+
+    act(() => {
+      result.current.highlight({
+        kind: 'text',
+        range: {page: 2, charStart: 10, charEnd: 15},
+      });
+    });
+
+    const state = storeRef.current!.getState();
+    // Only the second highlight is active
+    expect(state.search.matches).toHaveLength(1);
+    expect(state.search.matches[0].pageNumber).toBe(2);
+    expect(state.currentPage).toBe(2);
+  });
+
+  it('reader mode: still calls goToPage and setSearchMatches (no crash)', () => {
+    const storeRef3: {current: ReturnType<typeof createViewerStore> | null} = {current: null};
+    storeRef3.current = createViewerStore({mode: 'reader'});
+    storeRef3.current.getState().actions.setDocument({
+      numPages: 20,
+      fingerprint: 'reader-test',
+      metadata: async () => ({}),
+      outline: async () => [],
+      getPage: async () => {throw new Error('stub');},
+      destroy: () => {},
+    });
+
+    const {result} = renderHook(() => useCitationHighlight(), {
+      wrapper: function W({children}: {children: ReactNode}) {
+        return createElement(ViewerProvider, {store: storeRef3.current!}, children);
+      },
+    });
+
+    act(() => {
+      result.current.highlight({
+        kind: 'region',
+        page: 3,
+        rect: {x: 0, y: 0, width: 100, height: 50},
+      });
+    });
+
+    const state = storeRef3.current.getState();
+    expect(state.currentPage).toBe(3);
+    // In reader mode the overlay rect is null (no canvas surface)
+    expect(result.current.activeHighlight).toBeNull();
+  });
+});

--- a/frontend/hooks/extraction/useCitationHighlight.ts
+++ b/frontend/hooks/extraction/useCitationHighlight.ts
@@ -92,7 +92,7 @@ function useCitationHighlightInner(
   if (anchor.kind === 'text') return null;
 
   const pageHeightPts = pageHandle.size.height;
-  const rect = anchor.kind === 'region' ? anchor.rect : anchor.rect;
+  const rect = anchor.rect;
 
   return {
     page,

--- a/frontend/hooks/extraction/useCitationHighlight.ts
+++ b/frontend/hooks/extraction/useCitationHighlight.ts
@@ -1,0 +1,156 @@
+/**
+ * useCitationHighlight — orchestrates the PDF viewer state to highlight a
+ * single CitationAnchor (text, region, or hybrid).
+ *
+ * Text / hybrid anchors reuse the viewer's existing search-highlight system
+ * (`setSearchMatches`): the TextLayer already renders `.highlight.selected`
+ * spans for matching char ranges and scrolls them into view — no new DOM
+ * selection logic needed.
+ *
+ * Region / hybrid anchors expose a `activeHighlight` projected rect
+ * (`{page, top, left, width, height}` in CSS pixels) so a consumer can
+ * render a `position:absolute` overlay inside the page canvas area.
+ *
+ * Projection formula (PDF user space → CSS pixels, Y-flip origin):
+ *   left   = rect.x * scale
+ *   top    = (pageHeightPts - rect.y - rect.height) * scale
+ *   width  = rect.width  * scale
+ *   height = rect.height * scale
+ *
+ * In `reader` mode there is no canvas surface; the overlay rect is set to
+ * null while navigation and text-highlight still work normally.
+ *
+ * React Compiler constraint: no try/finally, no throw inside try.
+ */
+import {useState, useCallback} from 'react';
+
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+import {useViewerStoreApi} from '@/pdf-viewer/core/context';
+import {usePageHandle} from '@/pdf-viewer/hooks/usePageHandle';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A projected rect in CSS pixels, relative to the page canvas element.
+ * `top`/`left` are the CSS-space coordinates of the PDF bbox top-left corner.
+ */
+export interface CitationOverlayRect {
+  page: number;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export interface UseCitationHighlightReturn {
+  /**
+   * Activate a citation anchor in the viewer.
+   * Navigates to the correct page, drives text highlighting (text/hybrid),
+   * and computes an overlay rect (region/hybrid, canvas mode only).
+   * Replaces any previously active highlight.
+   */
+  highlight(anchor: CitationAnchor): void;
+  /** Clear the active highlight: search, activeCitation, and overlay rect. */
+  clear(): void;
+  /** The projected overlay rect for the current anchor, or null. */
+  activeHighlight: CitationOverlayRect | null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper: compute the target page number from any anchor kind.
+// ---------------------------------------------------------------------------
+function anchorPage(anchor: CitationAnchor): number {
+  if (anchor.kind === 'region') return anchor.page;
+  return anchor.range.page;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Inner hook that runs AFTER we know which page to load.
+ * Separated so that `usePageHandle` receives a stable page number —
+ * the outer hook shell drives which page that is.
+ */
+function useCitationHighlightInner(
+  anchor: CitationAnchor | null,
+): CitationOverlayRect | null {
+  const storeApi = useViewerStoreApi();
+  const page = anchor != null ? anchorPage(anchor) : 1;
+  const pageHandle = usePageHandle(page);
+
+  if (anchor == null || pageHandle == null) return null;
+
+  const {mode, scale} = storeApi.getState();
+
+  // Overlay rect only applies in canvas mode (canvas surface exists).
+  if (mode !== 'canvas') return null;
+
+  if (anchor.kind === 'text') return null;
+
+  const pageHeightPts = pageHandle.size.height;
+  const rect = anchor.kind === 'region' ? anchor.rect : anchor.rect;
+
+  return {
+    page,
+    left: rect.x * scale,
+    top: (pageHeightPts - rect.y - rect.height) * scale,
+    width: rect.width * scale,
+    height: rect.height * scale,
+  };
+}
+
+export function useCitationHighlight(): UseCitationHighlightReturn {
+  const storeApi = useViewerStoreApi();
+
+  // The anchor we are currently highlighting — drives usePageHandle.
+  const [activeAnchor, setActiveAnchor] = useState<CitationAnchor | null>(null);
+
+  // Overlay rect computed reactively from the active anchor + page handle.
+  const overlayRect = useCitationHighlightInner(activeAnchor);
+
+  const clear = useCallback((): void => {
+    const {actions} = storeApi.getState();
+    actions.clearSearch();
+    actions.setActiveCitation(null);
+    setActiveAnchor(null);
+  }, [storeApi]);
+
+  const highlight = useCallback(
+    (anchor: CitationAnchor): void => {
+      const {actions} = storeApi.getState();
+
+      // Replace previous highlight.
+      actions.clearSearch();
+      actions.setActiveCitation(null);
+
+      const page = anchorPage(anchor);
+      actions.goToPage(page);
+
+      // Text range → drive the TextLayer search-highlight system.
+      if (anchor.kind === 'text' || anchor.kind === 'hybrid') {
+        const quote = anchor.kind === 'text' ? (anchor.quote ?? '') : anchor.quote;
+        actions.setSearchMatches([
+          {
+            pageNumber: anchor.range.page,
+            charStart: anchor.range.charStart,
+            charEnd: anchor.range.charEnd,
+            context: quote,
+          },
+        ]);
+      }
+
+      // Mark an active citation so overlay consumers know something is active.
+      // Use a stable synthetic id derived from anchor coords.
+      actions.setActiveCitation(`citation-highlight-${page}`);
+
+      setActiveAnchor(anchor);
+    },
+    [storeApi],
+  );
+
+  return {highlight, clear, activeHighlight: overlayRect};
+}

--- a/frontend/hooks/extraction/useCitationHighlight.ts
+++ b/frontend/hooks/extraction/useCitationHighlight.ts
@@ -23,9 +23,11 @@
  * React Compiler constraint: no try/finally, no throw inside try.
  */
 import {useState, useCallback} from 'react';
+import type {StoreApi} from 'zustand';
 
 import type {CitationAnchor} from '@/pdf-viewer/core/citation';
-import {useViewerStoreApi} from '@/pdf-viewer/core/context';
+import {useViewerStoreApiOptional} from '@/pdf-viewer/core/context';
+import type {ViewerState} from '@/pdf-viewer/core/state';
 import {usePageHandle} from '@/pdf-viewer/hooks/usePageHandle';
 
 // ---------------------------------------------------------------------------
@@ -50,12 +52,20 @@ export interface UseCitationHighlightReturn {
    * Navigates to the correct page, drives text highlighting (text/hybrid),
    * and computes an overlay rect (region/hybrid, canvas mode only).
    * Replaces any previously active highlight.
+   * Safe no-op when `isAvailable` is false (no ViewerProvider present).
    */
   highlight(anchor: CitationAnchor): void;
-  /** Clear the active highlight: search, activeCitation, and overlay rect. */
+  /** Clear the active highlight: search, activeCitation, and overlay rect.
+   * Safe no-op when `isAvailable` is false. */
   clear(): void;
   /** The projected overlay rect for the current anchor, or null. */
   activeHighlight: CitationOverlayRect | null;
+  /**
+   * `true` when the hook is mounted inside a ViewerProvider and can drive
+   * the PDF viewer. `false` when outside a provider — highlight/clear are
+   * safe no-ops and activeHighlight stays null.
+   */
+  isAvailable: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -74,15 +84,17 @@ function anchorPage(anchor: CitationAnchor): number {
  * Inner hook that runs AFTER we know which page to load.
  * Separated so that `usePageHandle` receives a stable page number —
  * the outer hook shell drives which page that is.
+ *
+ * Returns null immediately when `storeApi` is null (no provider present).
  */
 function useCitationHighlightInner(
   anchor: CitationAnchor | null,
+  storeApi: StoreApi<ViewerState> | null,
 ): CitationOverlayRect | null {
-  const storeApi = useViewerStoreApi();
   const page = anchor != null ? anchorPage(anchor) : 1;
   const pageHandle = usePageHandle(page);
 
-  if (anchor == null || pageHandle == null) return null;
+  if (storeApi == null || anchor == null || pageHandle == null) return null;
 
   const {mode, scale} = storeApi.getState();
 
@@ -104,15 +116,16 @@ function useCitationHighlightInner(
 }
 
 export function useCitationHighlight(): UseCitationHighlightReturn {
-  const storeApi = useViewerStoreApi();
+  const storeApi = useViewerStoreApiOptional();
 
   // The anchor we are currently highlighting — drives usePageHandle.
   const [activeAnchor, setActiveAnchor] = useState<CitationAnchor | null>(null);
 
   // Overlay rect computed reactively from the active anchor + page handle.
-  const overlayRect = useCitationHighlightInner(activeAnchor);
+  const overlayRect = useCitationHighlightInner(activeAnchor, storeApi);
 
   const clear = useCallback((): void => {
+    if (storeApi == null) return;
     const {actions} = storeApi.getState();
     actions.clearSearch();
     actions.setActiveCitation(null);
@@ -121,6 +134,7 @@ export function useCitationHighlight(): UseCitationHighlightReturn {
 
   const highlight = useCallback(
     (anchor: CitationAnchor): void => {
+      if (storeApi == null) return;
       const {actions} = storeApi.getState();
 
       // Replace previous highlight.
@@ -152,5 +166,5 @@ export function useCitationHighlight(): UseCitationHighlightReturn {
     [storeApi],
   );
 
-  return {highlight, clear, activeHighlight: overlayRect};
+  return {highlight, clear, activeHighlight: overlayRect, isAvailable: storeApi != null};
 }

--- a/frontend/hooks/extraction/useCitationHighlight.ts
+++ b/frontend/hooks/extraction/useCitationHighlight.ts
@@ -26,6 +26,7 @@ import {useState, useCallback} from 'react';
 import type {StoreApi} from 'zustand';
 
 import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+import {projectPdfRectToCss} from '@/pdf-viewer/core/coordinates';
 import {useViewerStoreApiOptional} from '@/pdf-viewer/core/context';
 import type {ViewerState} from '@/pdf-viewer/core/state';
 import {usePageHandle} from '@/pdf-viewer/hooks/usePageHandle';
@@ -104,14 +105,11 @@ function useCitationHighlightInner(
   if (anchor.kind === 'text') return null;
 
   const pageHeightPts = pageHandle.size.height;
-  const rect = anchor.rect;
+  const cssRect = projectPdfRectToCss(anchor.rect, pageHeightPts, scale);
 
   return {
     page,
-    left: rect.x * scale,
-    top: (pageHeightPts - rect.y - rect.height) * scale,
-    width: rect.width * scale,
-    height: rect.height * scale,
+    ...cssRect,
   };
 }
 
@@ -128,7 +126,7 @@ export function useCitationHighlight(): UseCitationHighlightReturn {
     if (storeApi == null) return;
     const {actions} = storeApi.getState();
     actions.clearSearch();
-    actions.setActiveCitation(null);
+    actions.clearCitations();
     setActiveAnchor(null);
   }, [storeApi]);
 
@@ -137,9 +135,9 @@ export function useCitationHighlight(): UseCitationHighlightReturn {
       if (storeApi == null) return;
       const {actions} = storeApi.getState();
 
-      // Replace previous highlight.
+      // Replace previous highlight — single active citation at a time.
       actions.clearSearch();
-      actions.setActiveCitation(null);
+      actions.clearCitations();
 
       const page = anchorPage(anchor);
       actions.goToPage(page);
@@ -157,9 +155,11 @@ export function useCitationHighlight(): UseCitationHighlightReturn {
         ]);
       }
 
-      // Mark an active citation so overlay consumers know something is active.
+      // Put the anchor in the shared store so CitationOverlay can render it.
       // Use a stable synthetic id derived from anchor coords.
-      actions.setActiveCitation(`citation-highlight-${page}`);
+      const id = `citation-highlight-${page}`;
+      actions.addCitation({id, anchor});
+      actions.setActiveCitation(id);
 
       setActiveAnchor(anchor);
     },

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -822,6 +822,10 @@ export const extraction = {
     // AISuggestionEvidence – citation highlight
     evidenceNotLocated: "Couldn't locate in source",
     evidenceJumpToSource: 'Jump to source in PDF',
+    // CitationLiveRegion – aria-live jump announcement
+    citationJumpAnnouncement: 'Jumped to cited source on page {{n}}',
+    // CitationOverlay – focusable active highlight box
+    citationHighlightLabel: 'Cited source highlight',
 } as const;
 
 export type ExtractionCopy = typeof extraction;

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -819,6 +819,9 @@ export const extraction = {
     aiEvidenceClickTitle: 'Click to view evidence',
     aiEvidenceClickAria: 'View evidence for this suggestion',
     evidenceCitedAria: 'Cited evidence',
+    // AISuggestionEvidence – citation highlight
+    evidenceNotLocated: "Couldn't locate in source",
+    evidenceJumpToSource: 'Jump to source in PDF',
 } as const;
 
 export type ExtractionCopy = typeof extraction;

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -64,6 +64,7 @@ import {FullAIExtractionProgress} from '@/components/extraction/FullAIExtraction
 import {useModelManagement} from '@/hooks/extraction/useModelManagement';
 import {usePreserveScroll} from '@/hooks/usePreserveScroll';
 import {t} from '@/lib/copy';
+import {ViewerProvider, createViewerStore} from '@prumo/pdf-viewer';
 
 const SCROLL_CONTAINERS_TO_PRESERVE = [
   // Form panel — actual scroll happens on radix' inner viewport node.
@@ -77,6 +78,15 @@ const SCROLL_CONTAINERS_TO_PRESERVE = [
 export default function ExtractionFullScreen() {
   const { projectId, articleId } = useParams();
   const navigate = useNavigate();
+
+  // ONE stable viewer store shared between the PDF panel and the form panel.
+  // useState lazy initializer creates the store exactly once per mount —
+  // the React-Compiler-approved pattern (mirrors ViewerProvider's own
+  // internal creation). Both <ExtractionPDFPanel store={viewerStore}> and
+  // <ViewerProvider store={viewerStore}> below point at this instance —
+  // that is the prerequisite for the click-evidence → highlight feature
+  // (Task 4B follow-up).
+  const [viewerStore] = useState(createViewerStore);
 
     // Load data using dedicated hook (SRP: separation of concerns)
   const {
@@ -1123,14 +1133,21 @@ export default function ExtractionFullScreen() {
         </div>
       ) : null}
 
-      {/* Main content */}
+      {/* Main content — wrapped in ViewerProvider so both the PDF viewer and
+          the form panel resolve useViewerStore/useViewerStoreApi to the same
+          store instance. The viewer also receives store={viewerStore} so
+          Viewer.Root forwards it rather than creating a second store.
+          QA-screen shared-store lift is deferred (AssessmentShell passes the
+          viewer as a ReactNode prop; out of scope here). */}
       <div className="flex-1 overflow-hidden">
+        <ViewerProvider store={viewerStore}>
         <ResizablePanelGroup direction="horizontal">
             {/* PDF Viewer (optional) - Extracted to isolated component */}
-          <ExtractionPDFPanel 
-            articleId={articleId || ''} 
-            projectId={projectId || ''} 
+          <ExtractionPDFPanel
+            articleId={articleId || ''}
+            projectId={projectId || ''}
             showPDF={showPDF}
+            store={viewerStore}
           />
 
             {/* Extraction form - Extracted to isolated component */}
@@ -1183,6 +1200,7 @@ export default function ExtractionFullScreen() {
             />
           </ResizablePanel>
         </ResizablePanelGroup>
+        </ViewerProvider>
       </div>
 
       {/* Dialogs */}

--- a/frontend/pdf-viewer/PrumoPdfViewer.tsx
+++ b/frontend/pdf-viewer/PrumoPdfViewer.tsx
@@ -4,6 +4,7 @@ import {Viewer} from './primitives/Viewer';
 import {CanvasLayer} from './primitives/CanvasLayer';
 import {TextLayer} from './primitives/TextLayer';
 import {Reader, type ReaderTextBlock} from './primitives/Reader';
+import {CitationLiveRegion} from './primitives/CitationLiveRegion';
 import {Toolbar} from './ui/Toolbar';
 import {SearchBar} from './ui/SearchBar';
 import {LoadingState} from './ui/LoadingState';
@@ -76,6 +77,8 @@ export function PrumoPdfViewer({
       <Viewer.Root source={source} store={store} className="flex flex-col flex-1 min-h-0">
         {toolbar && <Toolbar onSearchToggle={() => setSearchOpen((v) => !v)} />}
         <SearchBar open={searchOpen} onClose={() => setSearchOpen(false)} />
+        {/* aria-live region: announces citation jumps to screen readers (canvas + reader mode) */}
+        <CitationLiveRegion />
         <ViewerContent
           readerBlocks={readerBlocks}
           readerLoading={readerLoading}

--- a/frontend/pdf-viewer/PrumoPdfViewer.tsx
+++ b/frontend/pdf-viewer/PrumoPdfViewer.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useRef, useState} from 'react';
+import type {StoreApi} from 'zustand';
 import {Viewer} from './primitives/Viewer';
 import {CanvasLayer} from './primitives/CanvasLayer';
 import {TextLayer} from './primitives/TextLayer';
@@ -9,6 +10,7 @@ import {LoadingState} from './ui/LoadingState';
 import {ErrorState} from './ui/ErrorState';
 import {useViewerStore} from './core/context';
 import type {PDFSource} from './core/source';
+import type {ViewerState} from './core/state';
 
 export interface PrumoPdfViewerProps {
   source: PDFSource | null;
@@ -23,6 +25,14 @@ export interface PrumoPdfViewerProps {
    */
   readerBlocks?: readonly ReaderTextBlock[];
   readerLoading?: boolean;
+  /**
+   * Optional pre-built store. When provided, the viewer uses this store
+   * instead of creating its own — enabling a parent to share ONE store
+   * between the viewer and a sibling panel (e.g. the AI-suggestion form).
+   * When omitted, the default behaviour (internal store creation) is
+   * unchanged.
+   */
+  store?: StoreApi<ViewerState>;
 }
 
 /**
@@ -39,6 +49,7 @@ export function PrumoPdfViewer({
   toolbar = true,
   readerBlocks,
   readerLoading,
+  store,
 }: PrumoPdfViewerProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -62,7 +73,7 @@ export function PrumoPdfViewer({
 
   return (
     <div ref={rootRef} className={`flex flex-col h-full ${className ?? ''}`} tabIndex={-1}>
-      <Viewer.Root source={source} className="flex flex-col flex-1 min-h-0">
+      <Viewer.Root source={source} store={store} className="flex flex-col flex-1 min-h-0">
         {toolbar && <Toolbar onSearchToggle={() => setSearchOpen((v) => !v)} />}
         <SearchBar open={searchOpen} onClose={() => setSearchOpen(false)} />
         <ViewerContent

--- a/frontend/pdf-viewer/__tests__/CitationLiveRegion.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationLiveRegion.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for CitationLiveRegion — the aria-live jump announcement component.
+ *
+ * TDD: these tests are written before the implementation.
+ * Expected behaviors:
+ *   - No active citation → live region is empty.
+ *   - Active region/hybrid citation on page N → announces
+ *     "Jumped to cited source on page N".
+ *   - Active text citation on page N → also announces (mode-independent).
+ *   - Changing active citation updates the announcement.
+ *   - The region has aria-live="polite" and is visually hidden (sr-only).
+ */
+import {render, act} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
+import {describe, expect, it, beforeEach} from 'vitest';
+
+import {ViewerProvider} from '../core/context';
+import {createViewerStore} from '../core/store';
+import type {Citation} from '../core/citation';
+
+// Import after store is available
+const {CitationLiveRegion} = await import('../primitives/CitationLiveRegion');
+
+function renderWithStore(
+  store: ReturnType<typeof createViewerStore>,
+) {
+  const wrapper = ({children}: {children: ReactNode}) =>
+    createElement(ViewerProvider, {store}, children);
+  return render(createElement(CitationLiveRegion, {}), {wrapper});
+}
+
+describe('<CitationLiveRegion>', () => {
+  let store: ReturnType<typeof createViewerStore>;
+
+  beforeEach(() => {
+    store = createViewerStore();
+  });
+
+  it('renders a polite aria-live region', () => {
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region).not.toBeNull();
+  });
+
+  it('is empty when there is no active citation', () => {
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toBe('');
+  });
+
+  it('announces the page when a REGION citation becomes active', () => {
+    const citation: Citation = {
+      id: 'live1',
+      anchor: {kind: 'region', page: 4, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('live1');
+
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toContain('4');
+    // Should contain a "Jumped to" / "page" style announcement
+    expect(region.textContent).toMatch(/jump|cited|source|page/i);
+  });
+
+  it('announces for a HYBRID citation', () => {
+    const citation: Citation = {
+      id: 'live2',
+      anchor: {
+        kind: 'hybrid',
+        range: {page: 7, charStart: 0, charEnd: 10},
+        rect: {x: 0, y: 0, width: 100, height: 50},
+        quote: 'test',
+      },
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('live2');
+
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toContain('7');
+  });
+
+  it('announces for a TEXT citation (mode-independent)', () => {
+    const citation: Citation = {
+      id: 'live3',
+      anchor: {kind: 'text', range: {page: 2, charStart: 0, charEnd: 5}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('live3');
+
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toContain('2');
+  });
+
+  it('clears the announcement when citation is cleared', async () => {
+    const citation: Citation = {
+      id: 'live4',
+      anchor: {kind: 'region', page: 5, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('live4');
+
+    const {container} = renderWithStore(store);
+
+    // Wrap the store mutation in act so React flushes the re-render.
+    await act(async () => {
+      store.getState().actions.clearCitations();
+    });
+
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toBe('');
+  });
+
+  it('is visually hidden (has sr-only class or equivalent style)', () => {
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    // Should have sr-only class or position:absolute style for screen-reader-only
+    const hasSrOnly = region.className.includes('sr-only');
+    const hasAbsolutePosition =
+      region.style.position === 'absolute' ||
+      getComputedStyle(region).position === 'absolute';
+    expect(hasSrOnly || hasAbsolutePosition).toBe(true);
+  });
+});

--- a/frontend/pdf-viewer/__tests__/CitationLiveRegion.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationLiveRegion.test.tsx
@@ -25,7 +25,7 @@ function renderWithStore(
   store: ReturnType<typeof createViewerStore>,
 ) {
   const wrapper = ({children}: {children: ReactNode}) =>
-    createElement(ViewerProvider, {store}, children);
+    createElement(ViewerProvider, {store, children});
   return render(createElement(CitationLiveRegion, {}), {wrapper});
 }
 

--- a/frontend/pdf-viewer/__tests__/CitationOverlay.a11y.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationOverlay.a11y.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Accessibility tests for CitationOverlay.
+ *
+ * NOTE: The repo has no axe-core / jest-axe / vitest-axe harness installed.
+ * These tests use focused role/aria assertions instead of a full automated
+ * axe pass.  A future task should add `@axe-core/react` or `jest-axe` to the
+ * devDependencies and convert these to `toHaveNoViolations()` sweeps.
+ *
+ * TDD: written before implementation changes to CitationOverlay.
+ *
+ * Covered behaviors:
+ *   - Active overlay box is NOT aria-hidden (an aria-hidden focusable element
+ *     is an a11y violation per WCAG 4.1.2).
+ *   - Active overlay box has tabIndex=-1 (programmatically focusable).
+ *   - Active overlay box has an aria-label (non-empty).
+ *   - Active overlay box has pointer-events:none (visual-only, accessible).
+ *   - Inactive / non-matching-page overlay renders nothing.
+ */
+import {render, act} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+
+import {ViewerProvider} from '../core/context';
+import {createViewerStore} from '../core/store';
+import type {Citation} from '../core/citation';
+
+vi.mock('../hooks/usePageHandle', () => ({
+  usePageHandle: (_page: number) => ({
+    pageNumber: _page,
+    size: {width: 612, height: 792},
+    render: vi.fn(),
+    getTextContent: vi.fn(),
+    renderTextLayer: vi.fn(),
+    cleanup: vi.fn(),
+  }),
+}));
+
+const {CitationOverlay} = await import('../primitives/CitationOverlay');
+
+function renderWithStore(
+  store: ReturnType<typeof createViewerStore>,
+  pageNumber: number,
+) {
+  const wrapper = ({children}: {children: ReactNode}) =>
+    createElement(ViewerProvider, {store}, children);
+  return render(createElement(CitationOverlay, {pageNumber}), {wrapper});
+}
+
+function getBox(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('[tabindex="-1"]') as HTMLElement | null;
+}
+
+describe('<CitationOverlay> — a11y (role/aria assertions)', () => {
+  let store: ReturnType<typeof createViewerStore>;
+
+  beforeEach(() => {
+    store = createViewerStore();
+    vi.clearAllMocks();
+  });
+
+  it('active box is NOT aria-hidden (focusable elements must not be aria-hidden)', () => {
+    const citation: Citation = {
+      id: 'a1',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a1');
+
+    const {container} = renderWithStore(store, 1);
+
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    // Must NOT be aria-hidden when it is the focusable active box.
+    expect(box!.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('active box has tabIndex=-1', () => {
+    const citation: Citation = {
+      id: 'a2',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a2');
+
+    const {container} = renderWithStore(store, 1);
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.tabIndex).toBe(-1);
+  });
+
+  it('active box has a non-empty aria-label', () => {
+    const citation: Citation = {
+      id: 'a3',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a3');
+
+    const {container} = renderWithStore(store, 1);
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.getAttribute('aria-label')).toBeTruthy();
+    expect(box!.getAttribute('aria-label')!.length).toBeGreaterThan(0);
+  });
+
+  it('active box keeps pointer-events:none (visual only)', () => {
+    const citation: Citation = {
+      id: 'a4',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a4');
+
+    const {container} = renderWithStore(store, 1);
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.style.pointerEvents).toBe('none');
+  });
+
+  it('active box for HYBRID citation has aria-label and tabIndex=-1', () => {
+    const citation: Citation = {
+      id: 'a5',
+      anchor: {
+        kind: 'hybrid',
+        range: {page: 2, charStart: 0, charEnd: 5},
+        rect: {x: 10, y: 20, width: 100, height: 50},
+        quote: 'test',
+      },
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a5');
+
+    const {container} = renderWithStore(store, 2);
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.tabIndex).toBe(-1);
+    expect(box!.getAttribute('aria-label')).toBeTruthy();
+    expect(box!.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('receives focus on activation (useEffect calls .focus())', async () => {
+    const citation: Citation = {
+      id: 'a6',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+
+    await act(async () => {
+      store.getState().actions.addCitation(citation);
+      store.getState().actions.setActiveCitation('a6');
+    });
+
+    const {container} = renderWithStore(store, 1);
+
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    // jsdom supports programmatic focus; after mount with an active citation
+    // the useEffect fires and the box should be document.activeElement.
+    expect(document.activeElement).toBe(box);
+  });
+
+  it('renders nothing when citation is on a different page', () => {
+    const citation: Citation = {
+      id: 'a7',
+      anchor: {kind: 'region', page: 3, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a7');
+
+    const {container} = renderWithStore(store, 1);
+    expect(getBox(container)).toBeNull();
+  });
+});

--- a/frontend/pdf-viewer/__tests__/CitationOverlay.a11y.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationOverlay.a11y.test.tsx
@@ -42,7 +42,7 @@ function renderWithStore(
   pageNumber: number,
 ) {
   const wrapper = ({children}: {children: ReactNode}) =>
-    createElement(ViewerProvider, {store}, children);
+    createElement(ViewerProvider, {store, children});
   return render(createElement(CitationOverlay, {pageNumber}), {wrapper});
 }
 

--- a/frontend/pdf-viewer/__tests__/CitationOverlay.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationOverlay.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Tests for CitationOverlay component.
+ *
+ * Strategy: wrap in ViewerProvider backed by a real createViewerStore, mock
+ * usePageHandle to return a known page size (height=792), and assert rendered
+ * box geometry or null render based on mode / anchor kind / page.
+ */
+import {render} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+
+import {ViewerProvider} from '../core/context';
+import {createViewerStore} from '../core/store';
+import type {Citation} from '../core/citation';
+
+// Stub usePageHandle — returns a fixed 612×792 page handle.
+vi.mock('../hooks/usePageHandle', () => ({
+  usePageHandle: (_page: number) => ({
+    pageNumber: _page,
+    size: {width: 612, height: 792},
+    render: vi.fn(),
+    getTextContent: vi.fn(),
+    renderTextLayer: vi.fn(),
+    cleanup: vi.fn(),
+  }),
+}));
+
+// Import component AFTER mock is registered.
+const {CitationOverlay} = await import('../primitives/CitationOverlay');
+
+// Helper to render CitationOverlay inside a ViewerProvider.
+function renderWithStore(
+  store: ReturnType<typeof createViewerStore>,
+  pageNumber: number,
+) {
+  const wrapper = ({children}: {children: ReactNode}) =>
+    createElement(ViewerProvider, {store}, children);
+  return render(createElement(CitationOverlay, {pageNumber}), {wrapper});
+}
+
+describe('<CitationOverlay>', () => {
+  let store: ReturnType<typeof createViewerStore>;
+
+  beforeEach(() => {
+    store = createViewerStore();
+  });
+
+  it('renders a box with correct projected geometry for a REGION citation on the matching page', () => {
+    // rect={x:100, y:200, width:150, height:50}, pageHeight=792, scale=1
+    // expected: left=100, top=(792-200-50)*1=542, width=150, height=50
+    const citation: Citation = {
+      id: 'c1',
+      anchor: {kind: 'region', page: 3, rect: {x: 100, y: 200, width: 150, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('c1');
+
+    const {container} = renderWithStore(store, 3);
+
+    const box = container.querySelector('[aria-hidden="true"]') as HTMLElement | null;
+    expect(box).not.toBeNull();
+    expect(box!.style.left).toBe('100px');
+    expect(box!.style.top).toBe('542px');
+    expect(box!.style.width).toBe('150px');
+    expect(box!.style.height).toBe('50px');
+    expect(box!.style.position).toBe('absolute');
+    expect(box!.style.pointerEvents).toBe('none');
+  });
+
+  it('renders a box for a HYBRID citation on the matching page', () => {
+    // rect={x:50, y:100, width:200, height:30}, pageHeight=792, scale=1
+    // expected: left=50, top=(792-100-30)=662, width=200, height=30
+    const citation: Citation = {
+      id: 'c2',
+      anchor: {
+        kind: 'hybrid',
+        range: {page: 2, charStart: 5, charEnd: 20},
+        rect: {x: 50, y: 100, width: 200, height: 30},
+        quote: 'some text',
+      },
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('c2');
+
+    const {container} = renderWithStore(store, 2);
+
+    const box = container.querySelector('[aria-hidden="true"]') as HTMLElement | null;
+    expect(box).not.toBeNull();
+    expect(box!.style.top).toBe('662px');
+  });
+
+  it('renders nothing for a TEXT-only citation (handled by TextLayer)', () => {
+    const citation: Citation = {
+      id: 'c3',
+      anchor: {kind: 'text', range: {page: 1, charStart: 0, charEnd: 10}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('c3');
+
+    const {container} = renderWithStore(store, 1);
+
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('renders nothing when active citation is on a DIFFERENT page', () => {
+    const citation: Citation = {
+      id: 'c4',
+      anchor: {kind: 'region', page: 5, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('c4');
+
+    // Render for page 3, citation is on page 5.
+    const {container} = renderWithStore(store, 3);
+
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('renders nothing in READER mode', () => {
+    const readerStore = createViewerStore({mode: 'reader'});
+    const citation: Citation = {
+      id: 'c5',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    readerStore.getState().actions.addCitation(citation);
+    readerStore.getState().actions.setActiveCitation('c5');
+
+    const {container} = renderWithStore(readerStore, 1);
+
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('renders nothing when there is no active citation', () => {
+    const {container} = renderWithStore(store, 1);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it('scales the projected rect with store.scale', () => {
+    const scaledStore = createViewerStore({scale: 1.5});
+    // rect={x:100, y:200, width:150, height:50}, pageHeight=792, scale=1.5
+    // expected: left=150, top=(792-200-50)*1.5=813, width=225, height=75
+    const citation: Citation = {
+      id: 'c6',
+      anchor: {kind: 'region', page: 2, rect: {x: 100, y: 200, width: 150, height: 50}},
+    };
+    scaledStore.getState().actions.addCitation(citation);
+    scaledStore.getState().actions.setActiveCitation('c6');
+
+    const {container} = renderWithStore(scaledStore, 2);
+
+    const box = container.querySelector('[aria-hidden="true"]') as HTMLElement | null;
+    expect(box).not.toBeNull();
+    expect(box!.style.left).toBe('150px');
+    expect(box!.style.top).toBe('813px');
+    expect(box!.style.width).toBe('225px');
+    expect(box!.style.height).toBe('75px');
+  });
+});

--- a/frontend/pdf-viewer/__tests__/CitationOverlay.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationOverlay.test.tsx
@@ -4,6 +4,9 @@
  * Strategy: wrap in ViewerProvider backed by a real createViewerStore, mock
  * usePageHandle to return a known page size (height=792), and assert rendered
  * box geometry or null render based on mode / anchor kind / page.
+ *
+ * Note: the overlay box is now focusable (tabIndex=-1, aria-label) and no
+ * longer has aria-hidden — queries use tabIndex=-1 or firstElementChild.
  */
 import {render} from '@testing-library/react';
 import {createElement, type ReactNode} from 'react';
@@ -38,6 +41,12 @@ function renderWithStore(
   return render(createElement(CitationOverlay, {pageNumber}), {wrapper});
 }
 
+// The active overlay box is now a focusable div (tabIndex=-1, aria-label).
+// Helper to grab it from the container.
+function getBox(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('[tabindex="-1"]') as HTMLElement | null;
+}
+
 describe('<CitationOverlay>', () => {
   let store: ReturnType<typeof createViewerStore>;
 
@@ -57,7 +66,7 @@ describe('<CitationOverlay>', () => {
 
     const {container} = renderWithStore(store, 3);
 
-    const box = container.querySelector('[aria-hidden="true"]') as HTMLElement | null;
+    const box = getBox(container);
     expect(box).not.toBeNull();
     expect(box!.style.left).toBe('100px');
     expect(box!.style.top).toBe('542px');
@@ -84,7 +93,7 @@ describe('<CitationOverlay>', () => {
 
     const {container} = renderWithStore(store, 2);
 
-    const box = container.querySelector('[aria-hidden="true"]') as HTMLElement | null;
+    const box = getBox(container);
     expect(box).not.toBeNull();
     expect(box!.style.top).toBe('662px');
   });
@@ -99,7 +108,7 @@ describe('<CitationOverlay>', () => {
 
     const {container} = renderWithStore(store, 1);
 
-    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(getBox(container)).toBeNull();
   });
 
   it('renders nothing when active citation is on a DIFFERENT page', () => {
@@ -113,7 +122,7 @@ describe('<CitationOverlay>', () => {
     // Render for page 3, citation is on page 5.
     const {container} = renderWithStore(store, 3);
 
-    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(getBox(container)).toBeNull();
   });
 
   it('renders nothing in READER mode', () => {
@@ -127,12 +136,12 @@ describe('<CitationOverlay>', () => {
 
     const {container} = renderWithStore(readerStore, 1);
 
-    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(getBox(container)).toBeNull();
   });
 
   it('renders nothing when there is no active citation', () => {
     const {container} = renderWithStore(store, 1);
-    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(getBox(container)).toBeNull();
   });
 
   it('scales the projected rect with store.scale', () => {
@@ -148,7 +157,7 @@ describe('<CitationOverlay>', () => {
 
     const {container} = renderWithStore(scaledStore, 2);
 
-    const box = container.querySelector('[aria-hidden="true"]') as HTMLElement | null;
+    const box = getBox(container);
     expect(box).not.toBeNull();
     expect(box!.style.left).toBe('150px');
     expect(box!.style.top).toBe('813px');

--- a/frontend/pdf-viewer/__tests__/CitationOverlay.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationOverlay.test.tsx
@@ -37,7 +37,7 @@ function renderWithStore(
   pageNumber: number,
 ) {
   const wrapper = ({children}: {children: ReactNode}) =>
-    createElement(ViewerProvider, {store}, children);
+    createElement(ViewerProvider, {store, children});
   return render(createElement(CitationOverlay, {pageNumber}), {wrapper});
 }
 

--- a/frontend/pdf-viewer/__tests__/coordinates.test.ts
+++ b/frontend/pdf-viewer/__tests__/coordinates.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from 'vitest';
+import {projectPdfRectToCss} from '../core/coordinates';
+
+describe('projectPdfRectToCss', () => {
+  it('projects at scale=1 with Y-flip', () => {
+    // pageHeight=792, rect={x:100, y:200, width:150, height:50}
+    // expected: left=100, top=(792-200-50)*1=542, width=150, height=50
+    const result = projectPdfRectToCss({x: 100, y: 200, width: 150, height: 50}, 792, 1);
+    expect(result).toEqual({left: 100, top: 542, width: 150, height: 50});
+  });
+
+  it('projects at scale=1.5 with Y-flip', () => {
+    // scale=1.5: left=100*1.5=150, top=(792-200-50)*1.5=813, width=150*1.5=225, height=50*1.5=75
+    const result = projectPdfRectToCss({x: 100, y: 200, width: 150, height: 50}, 792, 1.5);
+    expect(result).toEqual({left: 150, top: 813, width: 225, height: 75});
+  });
+
+  it('projects at scale=2 with Y-flip', () => {
+    // rect at origin bottom: x=0, y=0, width=50, height=30
+    // top=(792-0-30)*2=1524, left=0, width=100, height=60
+    const result = projectPdfRectToCss({x: 0, y: 0, width: 50, height: 30}, 792, 2);
+    expect(result).toEqual({left: 0, top: 1524, width: 100, height: 60});
+  });
+
+  it('projects at scale=0.5', () => {
+    // left=10*0.5=5, top=(200-50-20)*0.5=65, width=100*0.5=50, height=20*0.5=10
+    const result = projectPdfRectToCss({x: 10, y: 50, width: 100, height: 20}, 200, 0.5);
+    expect(result).toEqual({left: 5, top: 65, width: 50, height: 10});
+  });
+
+  it('projects a rect at the top of the page (near pageHeight)', () => {
+    // rect near top: y=750, height=30 → top=(792-750-30)*1=12
+    const result = projectPdfRectToCss({x: 0, y: 750, width: 100, height: 30}, 792, 1);
+    expect(result).toEqual({left: 0, top: 12, width: 100, height: 30});
+  });
+});

--- a/frontend/pdf-viewer/__tests__/injected-store.test.tsx
+++ b/frontend/pdf-viewer/__tests__/injected-store.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Proves that PrumoPdfViewer (and Viewer.Root beneath it) use an injected
+ * store rather than creating a fresh internal one.
+ *
+ * The mechanism under test:
+ *   PrumoPdfViewer(store) → Viewer.Root(store) → ViewerProvider(store)
+ *   → React context → useViewerStore / useViewerStoreApi
+ *
+ * We dispatch an action directly on the externally-owned store and assert
+ * that components inside the viewer reflect the mutation — which would be
+ * impossible if the viewer had silently spun up its own second store.
+ */
+
+import {render, renderHook, screen, act} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import {ViewerProvider, useViewerStore, useViewerStoreApi} from '../core/context';
+import {createViewerStore} from '../core/store';
+import type {ViewerState} from '../core/state';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Mocks (same setup as primitives.test.tsx / scaffolding.test.ts)
+// pdfjs-dist uses browser APIs unavailable in jsdom; swap in the legacy Node
+// build so import resolution succeeds without crashing.
+import * as legacyPdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
+vi.mock('pdfjs-dist', () => legacyPdfjs);
+
+// articleFileSource (transitively imported by PrumoPdfViewer via adapters/)
+// reaches for the Supabase client. Stub it to a neutral no-op so the test
+// module graph resolves cleanly without real env vars.
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: () => ({select: () => ({eq: () => ({eq: () => ({maybeSingle: async () => ({data: null, error: null})})})})}),
+    storage: {from: () => ({createSignedUrl: async () => ({data: null, error: null})})},
+  },
+}));
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers — mirrors context.test.tsx
+
+function CurrentPage() {
+  const page = useViewerStore((s: ViewerState) => s.currentPage);
+  return <span data-testid="current-page">{page}</span>;
+}
+
+function CurrentScale() {
+  const scale = useViewerStore((s: ViewerState) => s.scale);
+  return <span data-testid="scale">{scale.toFixed(2)}</span>;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('injected store: ViewerProvider + Viewer.Root + PrumoPdfViewer', () => {
+  // ── 1. ViewerProvider with an external store ──────────────────────────────
+  it('ViewerProvider: external store is used (not replaced by an internal one)', () => {
+    const external = createViewerStore({scale: 2.5});
+    render(
+      <ViewerProvider store={external}>
+        <CurrentScale />
+      </ViewerProvider>,
+    );
+    // The custom initial scale is visible → the external store is in use.
+    expect(screen.getByTestId('scale').textContent).toBe('2.50');
+  });
+
+  it('ViewerProvider: action dispatched on external store is reflected inside', async () => {
+    const external = createViewerStore({scale: 1.0});
+    render(
+      <ViewerProvider store={external}>
+        <CurrentScale />
+      </ViewerProvider>,
+    );
+    expect(screen.getByTestId('scale').textContent).toBe('1.00');
+
+    await act(async () => {
+      external.getState().actions.setScale(3.0);
+    });
+
+    expect(screen.getByTestId('scale').textContent).toBe('3.00');
+  });
+
+  // ── 2. useViewerStoreApi returns the injected instance ────────────────────
+  it('useViewerStoreApi returns the exact same StoreApi that was injected', () => {
+    const external = createViewerStore();
+
+    // renderHook avoids the "captured =" pattern that the React Compiler
+    // rejects (mutation of outer-scope variable during render).
+    const {result} = renderHook(() => useViewerStoreApi(), {
+      wrapper: ({children}) => (
+        <ViewerProvider store={external}>{children}</ViewerProvider>
+      ),
+    });
+
+    // Object identity: the hook must return the same reference, not a copy.
+    expect(result.current).toBe(external);
+  });
+
+  // ── 3. Viewer.Root forwards store to ViewerProvider ───────────────────────
+  it('Viewer.Root: external store is used by child components', async () => {
+    const {Viewer} = await import('../primitives/Viewer');
+    const external = createViewerStore({currentPage: 7});
+
+    render(
+      <Viewer.Root source={null} store={external}>
+        <CurrentPage />
+      </Viewer.Root>,
+    );
+
+    // The custom initial currentPage is visible → Viewer.Root forwarded the store.
+    expect(screen.getByTestId('current-page').textContent).toBe('7');
+  });
+
+  it('Viewer.Root: action dispatched on external store is reflected inside', async () => {
+    const {Viewer} = await import('../primitives/Viewer');
+    const external = createViewerStore({currentPage: 1});
+
+    render(
+      <Viewer.Root source={null} store={external}>
+        <CurrentPage />
+      </Viewer.Root>,
+    );
+    expect(screen.getByTestId('current-page').textContent).toBe('1');
+
+    await act(async () => {
+      external.getState().actions.goToPage(5);
+    });
+
+    expect(screen.getByTestId('current-page').textContent).toBe('5');
+  });
+
+  // ── 4. PrumoPdfViewer forwards store end-to-end ───────────────────────────
+  it('PrumoPdfViewer: injected store is used (not a fresh internal one)', async () => {
+    const {PrumoPdfViewer} = await import('../PrumoPdfViewer');
+    const external = createViewerStore({scale: 1.75});
+
+    // We render PrumoPdfViewer with a sibling CurrentScale also wrapped in
+    // the same ViewerProvider so both components read from the same store.
+    // Without the injected store, PrumoPdfViewer would create its OWN
+    // ViewerProvider internally, making CurrentScale unreachable from it.
+    render(
+      <ViewerProvider store={external}>
+        {/* This component is in the OUTER ViewerProvider (the shared one). */}
+        <CurrentScale />
+        {/* PrumoPdfViewer receives the same store → Viewer.Root forwards it
+            → its internal ViewerProvider is the SAME context node. */}
+        <PrumoPdfViewer source={null} store={external} toolbar={false} />
+      </ViewerProvider>,
+    );
+
+    // Both CurrentScale (in outer provider) and the viewer use the same store.
+    expect(screen.getByTestId('scale').textContent).toBe('1.75');
+
+    // Mutate via the external store; the sibling component must update.
+    await act(async () => {
+      external.getState().actions.setScale(2.25);
+    });
+
+    expect(screen.getByTestId('scale').textContent).toBe('2.25');
+  });
+
+  it('PrumoPdfViewer: goToPage on injected store is reflected outside the viewer', async () => {
+    const {PrumoPdfViewer} = await import('../PrumoPdfViewer');
+    const external = createViewerStore({currentPage: 1});
+
+    render(
+      <ViewerProvider store={external}>
+        <CurrentPage />
+        <PrumoPdfViewer source={null} store={external} toolbar={false} />
+      </ViewerProvider>,
+    );
+    expect(screen.getByTestId('current-page').textContent).toBe('1');
+
+    await act(async () => {
+      external.getState().actions.goToPage(3);
+    });
+
+    // The CurrentPage component (outside the viewer) reflects the mutation —
+    // proving ONE store is shared, not two isolated ones.
+    expect(screen.getByTestId('current-page').textContent).toBe('3');
+  });
+});

--- a/frontend/pdf-viewer/core/context.tsx
+++ b/frontend/pdf-viewer/core/context.tsx
@@ -64,3 +64,14 @@ export function useViewerStoreApi(): StoreApi<ViewerState> {
   }
   return store;
 }
+
+/**
+ * Return the raw StoreApi for the nearest ViewerProvider's store, or `null`
+ * when called outside a Provider. Use this variant in components / hooks that
+ * may render in contexts where no ViewerProvider exists (e.g. QA screen).
+ *
+ * Unlike `useViewerStoreApi`, this never throws — callers must handle `null`.
+ */
+export function useViewerStoreApiOptional(): StoreApi<ViewerState> | null {
+  return useContext(ViewerStoreContext);
+}

--- a/frontend/pdf-viewer/core/coordinates.ts
+++ b/frontend/pdf-viewer/core/coordinates.ts
@@ -28,3 +28,39 @@ export interface PDFTextRange {
   charStart: number;
   charEnd: number;
 }
+
+/**
+ * CSS pixel rect (relative to the page canvas element) produced by projecting
+ * a PDFRect from PDF user space.
+ */
+export interface CSSRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Project a PDF user-space rect to CSS pixels, relative to the top-left of
+ * the rendered page canvas element.
+ *
+ * PDF user space has its origin at the bottom-left of the page; CSS has its
+ * origin at the top-left. The Y-flip formula is:
+ *   top = (pageHeightPts - rect.y - rect.height) * scale
+ *
+ * @param rect           Bounding box in PDF user space (points).
+ * @param pageHeightPts  Page height in PDF points (from PDFPageHandle.size.height).
+ * @param scale          Current viewer render scale (1.0 = 100%).
+ */
+export function projectPdfRectToCss(
+  rect: PDFRect,
+  pageHeightPts: number,
+  scale: number,
+): CSSRect {
+  return {
+    left: rect.x * scale,
+    top: (pageHeightPts - rect.y - rect.height) * scale,
+    width: rect.width * scale,
+    height: rect.height * scale,
+  };
+}

--- a/frontend/pdf-viewer/primitives/CitationLiveRegion.tsx
+++ b/frontend/pdf-viewer/primitives/CitationLiveRegion.tsx
@@ -1,0 +1,48 @@
+/**
+ * CitationLiveRegion — polite aria-live region that announces citation jumps.
+ *
+ * Subscribes to `activeCitationId` and the `citations` map in the viewer
+ * store.  When a citation becomes active it emits a screen-reader-only
+ * message: "Jumped to cited source on page N".
+ *
+ * Mount once inside a ViewerProvider (e.g. at the root of PrumoPdfViewer).
+ * Both canvas and reader modes benefit — the announcement fires regardless
+ * of the current viewer mode.
+ *
+ * React Compiler constraint: no try/finally, no throw inside try.
+ */
+import {useViewerStore} from '../core/context';
+import {t} from '@/lib/copy';
+
+export function CitationLiveRegion() {
+  const activeCitationId = useViewerStore((s) => s.activeCitationId);
+  const activeCitation = useViewerStore((s) =>
+    s.activeCitationId != null ? s.citations.get(s.activeCitationId) : undefined,
+  );
+
+  let announcement = '';
+
+  if (activeCitationId != null && activeCitation != null) {
+    const {anchor} = activeCitation;
+    const page =
+      anchor.kind === 'region'
+        ? anchor.page
+        : anchor.range.page;
+
+    announcement = t('extraction', 'citationJumpAnnouncement').replace(
+      '{{n}}',
+      String(page),
+    );
+  }
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+    >
+      {announcement}
+    </span>
+  );
+}

--- a/frontend/pdf-viewer/primitives/CitationOverlay.tsx
+++ b/frontend/pdf-viewer/primitives/CitationOverlay.tsx
@@ -8,11 +8,22 @@
  * Text-only anchors are handled by TextLayer search highlights; this component
  * renders nothing for them.
  *
+ * A11y:
+ *   - The active box is focusable (`tabIndex=-1`) and labelled so screen
+ *     readers can inspect it after the CitationLiveRegion announcement.
+ *   - `aria-hidden` is NOT set — a focusable element must never be
+ *     aria-hidden (WCAG 4.1.2 violation).
+ *   - A `useEffect` moves focus to the box on activation so keyboard users
+ *     land in the right place immediately after the jump.
+ *
  * React Compiler constraint: no try/finally, no throw inside try.
  */
+import {useEffect, useRef} from 'react';
 import {useViewerStore} from '../core/context';
 import {usePageHandle} from '../hooks/usePageHandle';
 import {projectPdfRectToCss} from '../core/coordinates';
+import type {RegionCitationAnchor, HybridCitationAnchor} from '../core/citation';
+import {t} from '@/lib/copy';
 
 export interface CitationOverlayProps {
   pageNumber: number;
@@ -27,34 +38,55 @@ export function CitationOverlay({pageNumber}: CitationOverlayProps) {
   );
 
   const pageHandle = usePageHandle(pageNumber);
+  const boxRef = useRef<HTMLDivElement>(null);
 
-  // Only render in canvas mode.
-  if (mode !== 'canvas') return null;
-
-  // No active citation or citation not yet in the map.
-  if (activeCitationId == null || citation == null) return null;
-
-  const {anchor} = citation;
-
+  // Derive whether the overlay should be shown for this page.
   // Text-only anchors are rendered by TextLayer — skip here.
-  if (anchor.kind === 'text') return null;
+  const anchor = citation?.anchor;
+  const isRegionOrHybrid =
+    anchor != null && anchor.kind !== 'text';
 
-  // Only render on the correct page.
-  const anchorPage = anchor.kind === 'region' ? anchor.page : anchor.range.page;
-  if (anchorPage !== pageNumber) return null;
+  const anchorPage =
+    isRegionOrHybrid
+      ? anchor!.kind === 'region'
+        ? (anchor as RegionCitationAnchor).page
+        : (anchor as HybridCitationAnchor).range.page
+      : null;
 
-  // Need the page handle to know the page height in PDF points.
-  if (pageHandle == null) return null;
+  const isActiveOnThisPage =
+    mode === 'canvas' &&
+    activeCitationId != null &&
+    isRegionOrHybrid &&
+    anchorPage === pageNumber &&
+    pageHandle != null;
+
+  // Move focus to the overlay box when it becomes the active highlight.
+  // useEffect is allowed by React Compiler all_errors — no try/finally.
+  useEffect(() => {
+    if (isActiveOnThisPage && boxRef.current) {
+      boxRef.current.focus();
+    }
+  }, [isActiveOnThisPage, activeCitationId]);
+
+  if (!isActiveOnThisPage) return null;
+
+  // anchor is region or hybrid at this point — both have a top-level `rect`.
+  const rect =
+    anchor!.kind === 'region'
+      ? (anchor as RegionCitationAnchor).rect
+      : (anchor as HybridCitationAnchor).rect;
 
   const {left, top, width, height} = projectPdfRectToCss(
-    anchor.rect,
-    pageHandle.size.height,
+    rect,
+    pageHandle!.size.height,
     scale,
   );
 
   return (
     <div
-      aria-hidden="true"
+      ref={boxRef}
+      tabIndex={-1}
+      aria-label={t('extraction', 'citationHighlightLabel')}
       style={{
         position: 'absolute',
         left,

--- a/frontend/pdf-viewer/primitives/CitationOverlay.tsx
+++ b/frontend/pdf-viewer/primitives/CitationOverlay.tsx
@@ -1,0 +1,73 @@
+/**
+ * CitationOverlay — renders a single region/hybrid citation highlight box
+ * as a `position:absolute` child of the Viewer.Page div.
+ *
+ * Only renders in `canvas` mode: in `reader` mode there is no canvas surface
+ * and the region coordinates are meaningless in the DOM flow.
+ *
+ * Text-only anchors are handled by TextLayer search highlights; this component
+ * renders nothing for them.
+ *
+ * React Compiler constraint: no try/finally, no throw inside try.
+ */
+import {useViewerStore} from '../core/context';
+import {usePageHandle} from '../hooks/usePageHandle';
+import {projectPdfRectToCss} from '../core/coordinates';
+
+export interface CitationOverlayProps {
+  pageNumber: number;
+}
+
+export function CitationOverlay({pageNumber}: CitationOverlayProps) {
+  const mode = useViewerStore((s) => s.mode);
+  const scale = useViewerStore((s) => s.scale);
+  const activeCitationId = useViewerStore((s) => s.activeCitationId);
+  const citation = useViewerStore((s) =>
+    s.activeCitationId != null ? s.citations.get(s.activeCitationId) : undefined,
+  );
+
+  const pageHandle = usePageHandle(pageNumber);
+
+  // Only render in canvas mode.
+  if (mode !== 'canvas') return null;
+
+  // No active citation or citation not yet in the map.
+  if (activeCitationId == null || citation == null) return null;
+
+  const {anchor} = citation;
+
+  // Text-only anchors are rendered by TextLayer — skip here.
+  if (anchor.kind === 'text') return null;
+
+  // Only render on the correct page.
+  const anchorPage = anchor.kind === 'region' ? anchor.page : anchor.range.page;
+  if (anchorPage !== pageNumber) return null;
+
+  // Need the page handle to know the page height in PDF points.
+  if (pageHandle == null) return null;
+
+  const {left, top, width, height} = projectPdfRectToCss(
+    anchor.rect,
+    pageHandle.size.height,
+    scale,
+  );
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        left,
+        top,
+        width,
+        height,
+        pointerEvents: 'none',
+        // Subtle ring + translucent fill so the underlying content stays readable.
+        backgroundColor: 'rgba(250, 204, 21, 0.25)',
+        outline: '2px solid rgba(234, 179, 8, 0.8)',
+        borderRadius: '2px',
+        boxSizing: 'border-box',
+      }}
+    />
+  );
+}

--- a/frontend/pdf-viewer/primitives/Viewer.tsx
+++ b/frontend/pdf-viewer/primitives/Viewer.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useRef, type ReactNode} from 'react';
 import {ViewerProvider, useViewerStore, useViewerStoreApi} from '../core/context';
 import {useDocumentLoader} from '../hooks/useDocumentLoader';
+import {CitationOverlay} from './CitationOverlay';
 import type {PDFSource} from '../core/source';
 import type {StoreApi} from 'zustand';
 import type {ViewerState} from '../core/state';
@@ -180,6 +181,7 @@ function Page({
     // and colour the document author intended.
     <div data-page-number={pageNumber} className="relative shadow-md bg-white">
       {children}
+      <CitationOverlay pageNumber={pageNumber} />
     </div>
   );
 }

--- a/frontend/services/citationsService.ts
+++ b/frontend/services/citationsService.ts
@@ -1,0 +1,101 @@
+/**
+ * Citations service — fetches per-article citation anchors from the backend.
+ *
+ * Service-layer contract (zero-bailouts spec): exported functions never throw
+ * across the boundary; they return ErrorResult<T>. IO lives here; the React
+ * Compiler never sees try/catch inside a hook body.
+ */
+
+import {apiClient} from '@/integrations/api/client';
+import {toResult, type ErrorResult} from '@/lib/error-utils';
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ArticleCitationItem {
+  id: string;
+  verified: boolean;
+  anchorKind: 'text' | 'region' | 'hybrid' | null;
+  anchor: CitationAnchor | null;
+  metadata: {
+    pageNumber: number | null;
+    textContent: string | null;
+    source: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all citations for a given article.
+ * Returns an empty array when the article has no citations yet.
+ */
+export function fetchArticleCitations(
+  articleId: string,
+): Promise<ErrorResult<ArticleCitationItem[]>> {
+  return toResult(async () => {
+    const data = await apiClient<ArticleCitationItem[]>(
+      `/api/v1/articles/${articleId}/citations`,
+    );
+    return data ?? [];
+  }, 'citationsService.fetchArticleCitations');
+}
+
+// ---------------------------------------------------------------------------
+// Pure matcher — no IO, deterministic
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalizes a string for fuzzy comparison: trim, collapse whitespace,
+ * lowercase.
+ */
+function normalize(s: string): string {
+  return s.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+/**
+ * Attempts to match an AI evidence quote to a citation in the list.
+ *
+ * Matching strategy (in priority order):
+ *  1. Same page number AND (normalized textContent equals OR contains the
+ *     evidence text)
+ *  2. Text-only match (page is null/absent) — normalized textContent equals
+ *     or contains the evidence text
+ *
+ * Ties are broken by list order (earliest first).
+ * Returns null when no citation matches.
+ */
+export function matchEvidenceToCitation(
+  evidence: {text: string; pageNumber?: number | null},
+  citations: ArticleCitationItem[],
+): ArticleCitationItem | null {
+  const normalizedEvidence = normalize(evidence.text);
+  const hasPage =
+    evidence.pageNumber !== null && evidence.pageNumber !== undefined;
+
+  const textMatches = (item: ArticleCitationItem): boolean => {
+    const tc = item.metadata.textContent;
+    if (!tc) return false;
+    const normalizedTc = normalize(tc);
+    return (
+      normalizedTc === normalizedEvidence ||
+      normalizedTc.includes(normalizedEvidence)
+    );
+  };
+
+  // Pass 1: page + text match
+  if (hasPage) {
+    const pageAndText = citations.find(
+      (item) =>
+        item.metadata.pageNumber === evidence.pageNumber && textMatches(item),
+    );
+    if (pageAndText) return pageAndText;
+  }
+
+  // Pass 2: text-only match
+  return citations.find(textMatches) ?? null;
+}

--- a/frontend/test/hooks/useArticleCitations.test.tsx
+++ b/frontend/test/hooks/useArticleCitations.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for useArticleCitations hook.
+ *
+ * Covers:
+ *  - Queries with the correct key (articleKeys.citations)
+ *  - Returns items when service succeeds
+ *  - Disabled when articleId is falsy
+ *  - Surfaces error via useQuery error state when service returns ok:false
+ */
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react';
+import type {ReactElement, ReactNode} from 'react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/services/citationsService', () => ({
+  fetchArticleCitations: vi.fn(),
+}));
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+import {fetchArticleCitations} from '@/services/citationsService';
+import {useArticleCitations} from '@/hooks/articles/useArticleCitations';
+import {articleKeys} from '@/lib/query-keys';
+import type {ArticleCitationItem} from '@/services/citationsService';
+
+const fetchMock = fetchArticleCitations as unknown as ReturnType<typeof vi.fn>;
+
+function createWrapper(): {
+  wrapper: (props: {children: ReactNode}) => ReactElement;
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {retry: false},
+    },
+  });
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return {wrapper, queryClient};
+}
+
+function makeItem(id: string): ArticleCitationItem {
+  return {
+    id,
+    verified: false,
+    anchorKind: 'text',
+    anchor: null,
+    metadata: {pageNumber: 1, textContent: 'Some text', source: 'ai'},
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useArticleCitations', () => {
+  it('returns items when service resolves ok:true', async () => {
+    const items = [makeItem('c-1'), makeItem('c-2')];
+    fetchMock.mockResolvedValueOnce({ok: true, data: items});
+
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(() => useArticleCitations('art-abc'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(items);
+    expect(fetchMock).toHaveBeenCalledWith('art-abc');
+  });
+
+  it('uses the correct query key (articleKeys.citations)', async () => {
+    fetchMock.mockResolvedValueOnce({ok: true, data: []});
+
+    const {wrapper, queryClient} = createWrapper();
+    const {result} = renderHook(() => useArticleCitations('art-xyz'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = queryClient.getQueryData(articleKeys.citations('art-xyz'));
+    expect(cached).toEqual([]);
+  });
+
+  it('is disabled when articleId is null', async () => {
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useArticleCitations(null),
+      {wrapper},
+    );
+
+    // Give async ticks a chance
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('is disabled when articleId is empty string', async () => {
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useArticleCitations(''),
+      {wrapper},
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('surfaces error when service returns ok:false', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      error: new Error('API failure'),
+    });
+
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(() => useArticleCitations('art-err'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe('API failure');
+  });
+});

--- a/frontend/test/services/citationsService.test.ts
+++ b/frontend/test/services/citationsService.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for citationsService.
+ *
+ * Covers:
+ *  - fetchArticleCitations: correct URL, data mapping, ErrorResult on failure
+ *  - matchEvidenceToCitation: page+text, whitespace/case normalisation,
+ *    page-null text-only fallback, no-match → null, tie → earliest
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/integrations/api/client', () => ({
+  apiClient: vi.fn(),
+}));
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {debug: vi.fn(), error: vi.fn(), warn: vi.fn()},
+}));
+
+import {apiClient} from '@/integrations/api/client';
+import {
+  fetchArticleCitations,
+  matchEvidenceToCitation,
+  type ArticleCitationItem,
+} from '@/services/citationsService';
+
+const apiClientMock = apiClient as unknown as ReturnType<typeof vi.fn>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeItem(
+  id: string,
+  textContent: string | null,
+  pageNumber: number | null,
+): ArticleCitationItem {
+  return {
+    id,
+    verified: false,
+    anchorKind: 'text',
+    anchor: null,
+    metadata: {pageNumber, textContent, source: 'ai'},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// fetchArticleCitations
+// ---------------------------------------------------------------------------
+
+describe('fetchArticleCitations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls the correct URL and returns ok:true with mapped data', async () => {
+    const items = [makeItem('c-1', 'Hello world', 1)];
+    apiClientMock.mockResolvedValueOnce(items);
+
+    const result = await fetchArticleCitations('art-123');
+
+    expect(apiClientMock).toHaveBeenCalledWith(
+      '/api/v1/articles/art-123/citations',
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual(items);
+    }
+  });
+
+  it('returns empty array when apiClient resolves to null/undefined', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
+
+    const result = await fetchArticleCitations('art-456');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it('returns ok:false when apiClient throws', async () => {
+    apiClientMock.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await fetchArticleCitations('art-789');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('Network error');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchEvidenceToCitation
+// ---------------------------------------------------------------------------
+
+describe('matchEvidenceToCitation', () => {
+  it('returns null for empty citation list', () => {
+    expect(
+      matchEvidenceToCitation({text: 'some text', pageNumber: 1}, []),
+    ).toBeNull();
+  });
+
+  it('matches by exact page + text content', () => {
+    const c1 = makeItem('c-1', 'The quick brown fox', 2);
+    const c2 = makeItem('c-2', 'Another sentence', 2);
+    expect(
+      matchEvidenceToCitation(
+        {text: 'The quick brown fox', pageNumber: 2},
+        [c1, c2],
+      ),
+    ).toBe(c1);
+  });
+
+  it('matches when textContent contains the evidence text', () => {
+    const c1 = makeItem('c-1', 'Prefix. The evidence text. Suffix.', 3);
+    expect(
+      matchEvidenceToCitation(
+        {text: 'The evidence text.', pageNumber: 3},
+        [c1],
+      ),
+    ).toBe(c1);
+  });
+
+  it('matches despite different whitespace and casing', () => {
+    const c1 = makeItem('c-1', 'Hello   World', 1);
+    expect(
+      matchEvidenceToCitation({text: '  hello world  ', pageNumber: 1}, [c1]),
+    ).toBe(c1);
+  });
+
+  it('falls back to text-only match when evidence pageNumber is null', () => {
+    const c1 = makeItem('c-1', 'Specific phrase', 5);
+    expect(
+      matchEvidenceToCitation({text: 'Specific phrase', pageNumber: null}, [c1]),
+    ).toBe(c1);
+  });
+
+  it('falls back to text-only match when evidence pageNumber is undefined', () => {
+    const c1 = makeItem('c-1', 'Another phrase', 7);
+    expect(
+      matchEvidenceToCitation({text: 'Another phrase'}, [c1]),
+    ).toBe(c1);
+  });
+
+  it('prefers page+text match over text-only match on a different page', () => {
+    const wrongPage = makeItem('c-wrong', 'Target text', 99);
+    const rightPage = makeItem('c-right', 'Target text', 4);
+    expect(
+      matchEvidenceToCitation(
+        {text: 'Target text', pageNumber: 4},
+        [wrongPage, rightPage],
+      ),
+    ).toBe(rightPage);
+  });
+
+  it('returns null when no citation matches', () => {
+    const c1 = makeItem('c-1', 'Completely different content', 1);
+    expect(
+      matchEvidenceToCitation({text: 'No match here', pageNumber: 1}, [c1]),
+    ).toBeNull();
+  });
+
+  it('breaks ties by list order — returns earliest match', () => {
+    const first = makeItem('c-first', 'Same text', 2);
+    const second = makeItem('c-second', 'Same text', 2);
+    expect(
+      matchEvidenceToCitation({text: 'Same text', pageNumber: 2}, [first, second]),
+    ).toBe(first);
+  });
+
+  it('returns null when textContent is null on all items', () => {
+    const c1 = makeItem('c-1', null, 1);
+    expect(
+      matchEvidenceToCitation({text: 'any text', pageNumber: 1}, [c1]),
+    ).toBeNull();
+  });
+});

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -5030,7 +5030,7 @@
     },
     "/api/v1/articles/{article_id}/citations": {
       "get": {
-        "description": "Return all v1-shape citations attached to ``article_id``.",
+        "description": "Return all v1-shape citations attached to ``article_id``.\n\nUnanchored rows (hallucinated or pre-ingestion) are included with\n``verified=False``; anchored rows carry ``verified=True`` + ``anchorKind``.",
         "operationId": "list_article_citations_endpoint_api_v1_articles__article_id__citations_get",
         "parameters": [
           {

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -131,6 +131,9 @@ export interface paths {
         /**
          * List Article Citations Endpoint
          * @description Return all v1-shape citations attached to ``article_id``.
+         *
+         *     Unanchored rows (hallucinated or pre-ingestion) are included with
+         *     ``verified=False``; anchored rows carry ``verified=True`` + ``anchorKind``.
          */
         get: operations["list_article_citations_endpoint_api_v1_articles__article_id__citations_get"];
         put?: never;


### PR DESCRIPTION
## What

The **grounded-extraction backbone + reviewer click-to-highlight mechanism** (ADR-0011, plan `2026-06-19-grounded-extraction-and-hitl-highlight.md`), built on the structured-PDF backbone from #322. It turns AI evidence into *traceable* citations and lets a reviewer click an AI value to highlight its source span in the PDF.

**Backend (grounding):**
- `extraction_block_assembler.py` — pure, section-aware assembler (reuses the canonical `concat_page_text`; whole-section, never mid-table, over-budget selection). *Built but intentionally unwired — the 15k-truncation retirement is a separate deferred plan.*
- `evidence_anchor_service.py` — the quote→block **matcher** (NFKC + whitespace/punctuation folding with an exact normalized→original index map, bounded `difflib` fuzz, multi-block spans, bbox union, deterministic ties, a fold-back invariant that now degrades to `None` rather than raising) + `build_anchor` (quote → `PositionV1`; prose→`Text`, table/figure→`Hybrid`).
- `section_extraction_service.py` — the `position={}` write site now anchors evidence, with a **safe fallback** to today's behavior when no blocks/no match.
- `citation_read_service.py` + `validators.py` — derive `verified` + `anchorKind` from the stored position (no migration); unanchored evidence is returned flagged `verified=false` (not skipped); pure, never-raising predicates.

**Frontend (highlight):** `citationsService` + `useArticleCitations` + a pure `matchEvidenceToCitation`; a **shared viewer store** lifted into `ExtractionFullScreen` (both panels share one instance); `useCitationHighlight` (scroll + text-layer highlight + region overlay; **degrades gracefully** to a no-op outside a `ViewerProvider`); `AISuggestionEvidence` click→highlight + a "couldn't locate in source" affordance; `CitationOverlay` (canvas region box) + `CitationLiveRegion` (polite aria-live jump announcement) + a focusable highlight.

## Why / safety

The structured-PDF read path (`PositionV1`, `citation_read_service`) already shipped; this fills the middle (anchor + verify) and the reviewer UI. It is **dark-but-correct**: no `article_text_blocks` are populated yet (the parser is the deferred bake-off), so at runtime no evidence anchors and the live `section_extraction_service` change is a **verified no-op** — production behavior is unchanged.

## Deferred (gated, not defects)

The parser bake-off + block population (so the feature lights up); the live design-review + Playwright E2E (need anchored data); the QA-screen shared-store lift (highlight hook degrades gracefully there); reader-mode per-block emphasis; a `jest-axe` harness (a11y verified via role/aria assertions); the 15k-truncation retirement + backfill + dead-schema cleanup (separate plan). Follow-ups noted: a typed `CitationItem` response model (vs `dict[str, Any]`) and an overlay CSS-var.

## Verification

- Backend: **120** new tests green (assembler, matcher incl. a `match()`-never-raises suite, anchor writer, citation read, section-extraction regression) + full collection clean + ruff clean.
- Frontend: **618/618** green + `tsc` typecheck clean + eslint clean.
- Per-task spec+quality reviews (opus on the matcher) + an opus whole-branch review: **Ready to merge = Yes**, no Critical/Important.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
