### PR TITLE
fix(tests): self-provision sibling coordinate in cross-coordinate consensus test

### DIFF
--- a/backend/tests/integration/test_extraction_consensus_service.py
+++ b/backend/tests/integration/test_extraction_consensus_service.py
@@ -341,34 +341,42 @@ async def test_select_existing_rejects_cross_coordinate_decision(
         pytest.skip("Missing fixtures.")
     run_id, instance_id, field_id, profile_id, decision_id = fx
 
-    # Find a different (instance, field) coordinate in the same template.
-    other_row = await db_session.execute(
-        text(
-            """
-            SELECT i.id, f.id
-            FROM public.extraction_instances i
-            JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
-            JOIN public.extraction_fields f ON f.entity_type_id = et.id
-            WHERE (i.id <> :iid OR f.id <> :fid)
-              AND i.template_id = (
-                  SELECT template_id FROM public.extraction_instances WHERE id = :iid
-              )
-            LIMIT 1
-            """
-        ),
-        {"iid": instance_id, "fid": field_id},
-    )
-    other = other_row.first()
-    if other is None:
-        pytest.skip("Need a second coordinate in the same template.")
-    other_instance_id, other_field_id = other
+    # Build a second coordinate that is coherent for this run by adding a field
+    # to the run instance's own entity_type. (instance_id, other_field_id) then
+    # belongs to the run's article + template, so it passes the #189 coherence
+    # guard (assert_coords_coherent) and the call actually reaches the
+    # "belongs to" guard this test asserts. We cannot borrow a coordinate from
+    # the DB: the seed gives the article exactly one field, and scoping by
+    # template alone would pick a *different article's* instance, which the
+    # coherence guard rejects first (CoordinateMismatchError, not the
+    # InvalidConsensusError under test).
+    entity_type_id = (
+        await db_session.execute(
+            text("SELECT entity_type_id FROM public.extraction_instances WHERE id = :iid"),
+            {"iid": instance_id},
+        )
+    ).scalar()
+    other_field_id = (
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO public.extraction_fields (entity_type_id, name, label, field_type)
+                VALUES (:etid, 'xcoord_probe', 'Cross-coordinate probe', 'text')
+                RETURNING id
+                """
+            ),
+            {"etid": entity_type_id},
+        )
+    ).scalar()
 
     service = ExtractionConsensusService(db_session)
-    # decision_id is for (instance_id, field_id); call consensus on the OTHER coord.
+    # decision_id targets (instance_id, field_id); recording consensus on the
+    # sibling coordinate (instance_id, other_field_id) with that decision must
+    # trip the "belongs to" guard on the field mismatch.
     with pytest.raises(InvalidConsensusError, match="belongs to"):
         await service.record_consensus(
             run_id=run_id,
-            instance_id=other_instance_id,
+            instance_id=instance_id,
             field_id=other_field_id,
             consensus_user_id=profile_id,
             mode=ExtractionConsensusMode.SELECT_EXISTING,


### PR DESCRIPTION
## Problem

`test_select_existing_rejects_cross_coordinate_decision` (integration) is under-constrained and behaves inconsistently:

- It searched for "a different `(instance, field)` coordinate in the same template" with a bare `LIMIT 1` and **no article scope**.
- The `#189` coherence guard (`assert_coords_coherent`, added *after* this `#42` test) requires the instance to belong to the **run's article**, not just the template. When the query returned a *different article's* instance, `record_consensus` raised `CoordinateMismatchError` **before** reaching the `"belongs to"` guard the test asserts → failure.
- Worse: in a **clean CI seed each article has exactly one field**, so the query returned nothing → `pytest.skip`. The test has effectively **never exercised the guard in CI**; it only "ran" locally when a shared/populated DB happened to contain a cross-article instance, at which point it failed.

This surfaced during a local preflight where the only red test was this one, against a dev DB shared across several worktrees.

## Fix

Stop borrowing a coordinate from the DB. Build a coherent sibling coordinate **deterministically**: add a field to the run instance's own `entity_type`, then record consensus on `(instance_id, other_field_id)` using the decision for `(instance_id, field_id)`.

- `(instance_id, other_field_id)` is coherent for the run (same article + template) → passes the coherence guard.
- It differs only in `field_id` → reliably trips the `"belongs to"` guard.
- No dependency on seed contents or DB state; the probe field rolls back with the test transaction (verified: 0 leaked rows).

## Verification

Run against the same populated local DB where the test previously failed:

- Target test ×3: `1 passed` each (no longer skips)
- `test_extraction_consensus_service.py` (integration): `10 passed`
- `test_extraction_consensus_service.py` (unit): `29 passed`
- `make test-backend`: `1857 passed, 3 skipped, 0 failed`
- `ruff check` + `ruff format --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)