### PR TITLE
Promote dev → main (data-path consolidation #324 + grounded-extraction #325 + consensus test fix #326)

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -24,6 +24,7 @@ docs/superpowers/plans/2026-06-17-extraction-ux-iteration.md
 docs/superpowers/plans/2026-06-18-extraction-review-stage-restore.md
 docs/superpowers/plans/2026-06-19-manager-blind-review.md
 docs/superpowers/plans/2026-06-19-blind-review-cleanup.md
+docs/superpowers/plans/2026-06-19-extraction-data-path-finish.md
 docs/superpowers/plans/2026-06-19-structured-pdf-parsing-at-ingest.md
 docs/superpowers/plans/2026-06-19-grounded-extraction-and-hitl-highlight.md
 

--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -1,0 +1,174 @@
+"""Article-scoped run-resolution and AI-suggestion endpoints.
+
+Provides endpoints for the frontend to resolve extraction runs by article
+and to read AI suggestions, replacing the PostgREST queries in
+ExtractionValueService and AISuggestionService:
+
+  GET  /{article_id}/active-run?template_id=    -> RunSummaryResponse | None
+  GET  /{article_id}/finalized-run?template_id= -> RunSummaryResponse | None
+  POST /form-runs                               -> list[ArticleRunRef]
+  GET  /{article_id}/instance-ids               -> list[UUID]
+  GET  /{article_id}/suggestions                -> AISuggestionsResponse
+  GET  /{article_id}/suggestions/history        -> list[AISuggestionHistoryItem]
+
+BOLA enforcement (all endpoints):
+  - article-scoped: derive project_id from the article row via
+    get_article_project_id, then call ensure_project_member.
+  - form-runs: project_id is supplied in the request body; call
+    ensure_project_member directly.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from app.api.deps.security import ensure_project_member, get_current_user_sub
+from app.core.deps import DbSession
+from app.schemas.common import ApiResponse
+from app.schemas.extraction_run import ArticleRunRef, FormRunsRequest, RunSummaryResponse
+from app.schemas.extraction_suggestion import AISuggestionHistoryItem, AISuggestionsResponse
+from app.services.citation_read_service import ArticleNotFoundError, get_article_project_id
+from app.services.extraction_run_read_service import (
+    find_active_run,
+    find_finalized_run,
+    resolve_form_runs,
+)
+from app.services.extraction_suggestion_read_service import (
+    get_article_instance_ids,
+    get_suggestion_history,
+    load_suggestions,
+)
+
+router = APIRouter()
+
+
+def _trace(request: Request) -> str | None:
+    return getattr(request.state, "trace_id", None)
+
+
+async def _gate_article(db: DbSession, article_id: UUID, caller_id: UUID) -> None:
+    """404 if article missing; 403 if caller is not a project member."""
+    try:
+        project_id = await get_article_project_id(db, article_id)
+    except ArticleNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    await ensure_project_member(db, project_id, caller_id)
+
+
+@router.get("/{article_id}/active-run")
+async def get_active_run(
+    article_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+    template_id: UUID | None = None,
+) -> ApiResponse[RunSummaryResponse | None]:
+    """Return the latest non-terminal extraction run for the article.
+
+    Returns null (data: null) when no active run exists. 404 when the
+    article is not found; 403 when the caller is not a project member.
+    """
+    await _gate_article(db, article_id, current_user_sub)
+    run = await find_active_run(db, article_id, template_id=template_id)
+    return ApiResponse.success(run, trace_id=_trace(request))
+
+
+@router.get("/{article_id}/finalized-run")
+async def get_finalized_run(
+    article_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+    template_id: UUID | None = None,
+) -> ApiResponse[RunSummaryResponse | None]:
+    """Return the latest finalized extraction run for the article.
+
+    Returns null (data: null) when no finalized run exists. 404 when the
+    article is not found; 403 when the caller is not a project member.
+    """
+    await _gate_article(db, article_id, current_user_sub)
+    run = await find_finalized_run(db, article_id, template_id=template_id)
+    return ApiResponse.success(run, trace_id=_trace(request))
+
+
+@router.post("/form-runs")
+async def post_form_runs(
+    body: FormRunsRequest,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse[list[ArticleRunRef]]:
+    """Resolve the latest relevant run per article for the extraction form.
+
+    Per article: returns the latest non-terminal run; falls back to the
+    latest finalized run; returns run_id=null when no run exists.
+    Cancelled runs are excluded. BOLA-gated via project_id in the body.
+    """
+    await ensure_project_member(db, body.project_id, current_user_sub)
+
+    refs = await resolve_form_runs(db, body.article_ids, template_id=body.template_id)
+    return ApiResponse.success(refs, trace_id=_trace(request))
+
+
+@router.get("/{article_id}/instance-ids")
+async def get_instance_ids(
+    article_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse[list[UUID]]:
+    """Return all extraction_instance ids for the article.
+
+    404 when article is not found; 403 when caller is not a project member.
+    """
+    await _gate_article(db, article_id, current_user_sub)
+    ids = await get_article_instance_ids(db, article_id)
+    return ApiResponse.success(ids, trace_id=_trace(request))
+
+
+@router.get("/{article_id}/suggestions/history")
+async def get_suggestions_history(
+    article_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+    instance_id: UUID = Query(...),
+    field_id: UUID = Query(...),
+    limit: int = Query(default=10, ge=1, le=100),
+) -> ApiResponse[list[AISuggestionHistoryItem]]:
+    """Return AI proposal history for a single (instance, field) coord.
+
+    Newest-first; no status (history is the raw proposal trail).
+    404 when article is not found; 403 when caller is not a project member.
+    """
+    await _gate_article(db, article_id, current_user_sub)
+    items = await get_suggestion_history(
+        db, instance_id, field_id, article_id=article_id, limit=limit
+    )
+    return ApiResponse.success(items, trace_id=_trace(request))
+
+
+@router.get("/{article_id}/suggestions")
+async def get_suggestions(
+    article_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+    instance_ids: list[UUID] = Query(default=[]),
+    run_id: UUID | None = None,
+) -> ApiResponse[AISuggestionsResponse]:
+    """Return latest AI proposals per (instance, field) with caller-scoped status.
+
+    Status is derived exclusively from the caller's own reviewer_state rows —
+    never another reviewer's (blind boundary, Constraint 3).
+    404 when article is not found; 403 when caller is not a project member.
+    """
+    await _gate_article(db, article_id, current_user_sub)
+    result = await load_suggestions(
+        db,
+        instance_ids,
+        article_id=article_id,
+        caller_id=current_user_sub,
+        run_id=run_id,
+    )
+    return ApiResponse.success(result, trace_id=_trace(request))

--- a/backend/app/api/v1/endpoints/citations.py
+++ b/backend/app/api/v1/endpoints/citations.py
@@ -3,12 +3,13 @@
 Read-side of Phase 3 (Citation API + ExtractionEvidence integration).
 Writes still flow through the existing extraction services
 (``section_extraction_service``, ``ExtractionProposalService``);
-this endpoint surfaces the rows with their ``position`` JSONB validated
-against ``PositionV1`` so the frontend viewer can render them without
-a translation layer.
+this endpoint surfaces the rows with their ``position`` JSONB, adding
+``verified`` + ``anchorKind`` derived fields so callers can distinguish
+confirmed-present quotes from hallucinated / not-yet-verifiable ones.
 
-Rows whose ``position`` is the legacy empty ``{}`` are skipped — they
-predate the citation contract and have no anchor to render.
+All evidence rows are returned — unanchored rows (empty or unparseable
+``position``) are included with ``verified=False`` and ``anchorKind=None``
+rather than skipped.  The read path never raises on a bad position.
 """
 
 from typing import Any
@@ -39,7 +40,11 @@ async def list_article_citations_endpoint(
     db: DbSession,
     current_user_sub: UUID = Depends(get_current_user_sub),
 ) -> ApiResponse[list[dict[str, Any]]]:
-    """Return all v1-shape citations attached to ``article_id``."""
+    """Return all v1-shape citations attached to ``article_id``.
+
+    Unanchored rows (hallucinated or pre-ingestion) are included with
+    ``verified=False``; anchored rows carry ``verified=True`` + ``anchorKind``.
+    """
     try:
         project_id = await get_article_project_id(db, article_id)
     except ArticleNotFoundError as e:

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter
 
 from app.api.v1.endpoints import (
     article_text_blocks,
+    articles,
     articles_export,
     citations,
     extraction_export,
@@ -90,6 +91,12 @@ api_router.include_router(
     citations.router,
     prefix="/articles",
     tags=["citations"],
+)
+
+api_router.include_router(
+    articles.router,
+    prefix="/articles",
+    tags=["articles"],
 )
 
 api_router.include_router(

--- a/backend/app/llm/validators.py
+++ b/backend/app/llm/validators.py
@@ -3,11 +3,19 @@
 Raising ModelRetry feeds the message back to the model for another
 attempt — the structured replacement for the legacy silent-empty-dict
 fallback. Pydantic itself already enforces types, enums, and the 0-1
-confidence range; these validators cover what a type system cannot."""
+confidence range; these validators cover what a type system cannot.
 
-from typing import Any
+Read-time predicates (``evidence_is_grounded``, ``anchor_kind``) are
+pure, never-raising helpers used in the citation read path — they are
+distinct from the extraction-time ``evidence_is_plausible`` validator
+and must never raise ``ModelRetry`` or any exception."""
 
+from typing import Any, Literal
+
+from pydantic import ValidationError
 from pydantic_ai import ModelRetry
+
+from app.schemas.extraction import PositionV1, parse_position
 
 
 def evidence_is_plausible(output: Any) -> Any:
@@ -34,3 +42,39 @@ def evidence_is_plausible(output: Any) -> Any:
                 f"Field '{label}': evidence.page_number must be a 1-based page number or null."
             )
     return output
+
+
+def evidence_is_grounded(position: dict[str, Any] | None) -> bool:
+    """Return True iff ``position`` parses to a valid anchored ``PositionV1``.
+
+    Pure read-time predicate — never raises. Used by ``citation_read_service``
+    to derive the ``verified`` flag without a schema migration.
+
+    Returns False for:
+    - None or empty dict  (no position stored / legacy row)
+    - dicts that fail ``PositionV1`` validation  (corrupted data)
+    """
+    if not position:
+        return False
+    try:
+        parsed: PositionV1 | None = parse_position(position)
+    except ValidationError:
+        return False
+    return parsed is not None
+
+
+def anchor_kind(position: dict[str, Any] | None) -> Literal["text", "region", "hybrid"] | None:
+    """Return the anchor ``kind`` string when ``position`` is a valid ``PositionV1``.
+
+    Returns None for unanchored / invalid positions. Pure, never raises.
+    Possible non-None values: ``"text"``, ``"region"``, ``"hybrid"``.
+    """
+    if not position:
+        return None
+    try:
+        parsed: PositionV1 | None = parse_position(position)
+    except ValidationError:
+        return None
+    if parsed is None:
+        return None
+    return parsed.anchor.kind

--- a/backend/app/schemas/extraction_run.py
+++ b/backend/app/schemas/extraction_run.py
@@ -197,13 +197,39 @@ class RunViewCurrentValue(BaseModel):
     decision: str
 
 
+class RunViewInstance(BaseModel):
+    """A single extraction instance, sourced from extraction_instances and scoped
+    to the run's (article_id, template_id) pair. The ``metadata`` ORM column maps
+    to ``metadata_`` on the ORM object; ``validation_alias`` ensures
+    ``model_validate(orm_obj)`` reads the right attribute while the JSON output
+    key stays ``metadata``."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: UUID
+    entity_type_id: UUID
+    parent_instance_id: UUID | None
+    label: str
+    sort_order: int
+    status: str
+    metadata: dict[str, Any] = Field(validation_alias="metadata_")
+    project_id: UUID
+    article_id: UUID | None
+    template_id: UUID
+    created_by: UUID
+    created_at: datetime
+    updated_at: datetime
+
+
 class RunViewResponse(RunDetailResponse):
-    """``RunDetailResponse`` (run + blind-filtered workflow rows) plus the two
-    pieces the run-open form needs server-side: the frozen entity_types tree and
-    the caller's current_values. (``instances`` is added in Task 12.)"""
+    """``RunDetailResponse`` (run + blind-filtered workflow rows) plus the three
+    pieces the run-open form needs server-side: the frozen entity_types tree,
+    the caller's current_values, and the instances for the run's
+    (article_id, template_id) scope."""
 
     entity_types: list[RunViewEntityType]
     current_values: list[RunViewCurrentValue]
+    instances: list[RunViewInstance]
 
 
 class RunReviewerProfile(BaseModel):
@@ -225,3 +251,28 @@ class RunReviewersResponse(BaseModel):
     """
 
     reviewers: list[RunReviewerProfile]
+
+
+# ----- Article-scoped run-resolution schemas -----
+
+
+class ArticleRunRef(BaseModel):
+    """Per-article run reference returned by POST /articles/form-runs.
+
+    ``run_id`` is None when the article has no matching run.
+    """
+
+    article_id: UUID
+    run_id: UUID | None
+
+
+class FormRunsRequest(BaseModel):
+    """Request body for POST /api/v1/articles/form-runs.
+
+    Resolves the latest relevant run for each article_id in the batch.
+    ``project_id`` is used for BOLA enforcement.
+    """
+
+    article_ids: list[UUID]
+    template_id: UUID
+    project_id: UUID

--- a/backend/app/schemas/extraction_suggestion.py
+++ b/backend/app/schemas/extraction_suggestion.py
@@ -1,0 +1,62 @@
+"""Pydantic schemas for AI-suggestion read endpoints."""
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class EvidenceResponse(BaseModel):
+    """Evidence snippet attached to a proposal record."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    proposal_record_id: UUID | None
+    text_content: str | None
+    page_number: int | None
+
+
+class AISuggestionItem(BaseModel):
+    """A single AI suggestion (latest proposal per coord) with caller-scoped status."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    run_id: UUID
+    instance_id: UUID
+    field_id: UUID
+    # Raw JSONB envelope — the frontend unwraps the inner value in Task 6.
+    proposed_value: dict[str, Any]
+    confidence_score: float | None
+    rationale: str | None
+    created_at: datetime
+    evidence: EvidenceResponse | None
+    # Caller-scoped: 'accepted' | 'rejected' | 'pending'
+    status: str
+
+
+class AISuggestionsResponse(BaseModel):
+    """Response for the suggestions endpoint."""
+
+    suggestions: list[AISuggestionItem]
+    count: int
+
+
+class AISuggestionHistoryItem(BaseModel):
+    """One entry in the proposal history for a single (instance, field) coord.
+
+    Same shape as AISuggestionItem minus `status` — history is proposal trail only.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    run_id: UUID
+    instance_id: UUID
+    field_id: UUID
+    proposed_value: dict[str, Any]
+    confidence_score: float | None
+    rationale: str | None
+    created_at: datetime
+    evidence: EvidenceResponse | None

--- a/backend/app/services/citation_read_service.py
+++ b/backend/app/services/citation_read_service.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
-from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.llm.validators import anchor_kind, evidence_is_grounded
 from app.models.article import Article
 from app.models.extraction import ExtractionEvidence
-from app.schemas.extraction import PositionV1, parse_position
+from app.schemas.extraction import parse_position
 
 
 class ArticleNotFoundError(Exception):
@@ -40,10 +40,17 @@ async def get_article_project_id(db: AsyncSession, article_id: UUID) -> UUID:
 async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dict[str, Any]]:
     """Return all v1-shape citations attached to the article (chronological).
 
-    Rows without a parseable PositionV1 anchor are skipped — they predate
-    the citation contract (legacy empty `{}` position) or fail schema
-    validation. Skipping (rather than 500-ing) preserves list semantics
-    for partial-failure cases.
+    Every evidence row is returned — unanchored rows (empty or unparseable
+    ``position``) are included with ``verified=False`` and ``anchorKind=None``
+    rather than skipped. This surfaces hallucination / no-blocks-yet signals
+    to callers without ever raising in the read path.
+
+    Wire shape per item:
+    - ``id``         — UUID string
+    - ``verified``   — True iff position parses to a valid PositionV1 anchor
+    - ``anchorKind`` — "text" | "region" | "hybrid" when verified, else None
+    - ``anchor``     — camelCase anchor dict when verified, else None (always present; check ``c["anchor"] is None`` for unanchored rows)
+    - ``metadata``   — pageNumber / textContent / source (always present)
     """
     rows = (
         (
@@ -60,21 +67,17 @@ async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dic
     citations: list[dict[str, Any]] = []
     for row in rows:
         position = row.position
-        if not position:
-            continue
-        try:
-            parsed: PositionV1 | None = parse_position(position)
-        except ValidationError:
-            continue
-        if parsed is None:
-            continue
+        verified = evidence_is_grounded(position)
+        kind = anchor_kind(position)
 
         metadata: dict[str, Any] = {}
         if row.page_number is not None:
             metadata["pageNumber"] = row.page_number
         if row.text_content is not None:
             metadata["textContent"] = row.text_content
-        # Source attribution — exactly one of these is set (CHECK constraint).
+        # Source attribution — at least one of proposal/reviewer/consensus is set
+        # (workflow_target_present CHECK enforces an OR, not exactly-one);
+        # the if/elif picks the first by priority.
         if row.proposal_record_id is not None:
             metadata["source"] = "ai"
         elif row.reviewer_decision_id is not None:
@@ -82,12 +85,25 @@ async def list_article_citations(db: AsyncSession, article_id: UUID) -> list[dic
         elif row.consensus_decision_id is not None:
             metadata["source"] = "review"
 
-        citations.append(
-            {
-                "id": str(row.id),
-                "anchor": parsed.anchor.model_dump(by_alias=True, exclude_none=True),
-                "metadata": metadata,
-            }
-        )
+        item: dict[str, Any] = {
+            "id": str(row.id),
+            "verified": verified,
+            "anchorKind": kind,
+            "metadata": metadata,
+        }
+        if verified:
+            # parse_position is safe here: evidence_is_grounded already confirmed it parses.
+            parsed = parse_position(position)
+            if parsed is None:
+                # Defensive guard: logic regression — treat as unanchored.
+                item["anchor"] = None
+                item["verified"] = False
+                item["anchorKind"] = None
+            else:
+                item["anchor"] = parsed.anchor.model_dump(by_alias=True, exclude_none=True)
+        else:
+            item["anchor"] = None
+
+        citations.append(item)
 
     return citations

--- a/backend/app/services/evidence_anchor_service.py
+++ b/backend/app/services/evidence_anchor_service.py
@@ -1,0 +1,630 @@
+"""
+Evidence-anchor service — the quote → block matcher.
+
+This is the core grounding algorithm of the grounded-extraction pipeline.  It
+anchors an LLM's free-text evidence *quote* back to a verifiable span in the
+source document, returning the page, the char range in the canonical
+``concat_page_text`` coordinate space, the overlapping block ids, and the union
+bounding box for PDF highlighting.
+
+Design
+------
+
+**Matching surface.**  The quote is searched against the per-page text produced
+by the canonical ``concat_page_text`` (imported from
+``app.infrastructure.parsing.base`` — the single source of truth).  Both the
+page text and the quote are normalised before comparison.
+
+**Normalisation (both sides).**  Unicode **NFKC** + whitespace folding (runs of
+whitespace collapse to a single space; leading/trailing whitespace stripped).
+This makes a quote that differs only by ligatures (``ﬁ`` → ``fi``), smart
+quotes (``'`` → ``'``), or collapsed whitespace still match.
+
+**Offset coordinate space (the crucial part).**  NFKC and whitespace folding
+*change* string length and character positions.  The ``char_start`` /
+``char_end`` returned by :func:`match`, however, MUST be offsets into the
+ORIGINAL (un-normalised) ``concat_page_text`` page string — the same coordinate
+space every block's own ``char_start`` / ``char_end`` lives in.  So for each
+page we build a *normalised* surface together with an index map
+``norm_to_orig`` such that ``norm_to_orig[i]`` is the original index at which
+normalised character ``i`` began.  A matched normalised span ``[ns, ne)`` maps
+back to the original span ``[norm_to_orig[ns], norm_to_orig[ne])`` (with
+``ne == len(norm)`` mapping to ``len(original)``).
+
+**Bounded, deterministic fuzz.**  OCR noise (a few wrong characters) should
+still match.  Matching is tried in two tiers:
+
+1. *Exact* substring search of the folded quote inside the folded page text.
+2. If absent, a bounded sliding-window fuzzy search using
+   :class:`difflib.SequenceMatcher` (stdlib — pure, deterministic, no new
+   dependency).  Candidate windows are sized around the quote length; the best
+   similarity ratio ≥ ``fuzz_threshold`` wins.  The window length band is
+   bounded (``±FUZZ_LEN_SLACK`` fraction of the quote length) so cost stays
+   linear-ish and the result is reproducible.
+
+The fuzz unit is a **similarity ratio in [0.0, 1.0]** (``SequenceMatcher.ratio``
+— ``2*M/T`` where ``M`` is matched chars and ``T`` is total chars of both
+strings).  ``fuzz_threshold=1.0`` means *exact only*; the default
+``DEFAULT_FUZZ_THRESHOLD`` tolerates a handful of OCR errors in a sentence-length
+quote.  The threshold is a PARAMETER with a sensible default — it is NOT read
+from config (config wiring is deferred to a later task).
+
+**Multi-block span + bbox union.**  After mapping the match back to an original
+``[char_start, char_end)`` range, ``block_ids`` is every block whose own
+``[char_start, char_end)`` overlaps that range (ascending ``block_index``).
+``bbox_union`` is the union rectangle over those blocks:
+``x = min(x)``, ``y = min(y)``, ``width = max(x+width) - x``,
+``height = max(y+height) - y``.
+
+**Deterministic tie-breaking.**  Earliest page, then earliest matched original
+``char_start`` (which, because blocks are concatenated in ``block_index`` order,
+is the earliest block), then the longest contiguous overlap.  Same inputs always
+produce the same output.
+
+**Purity.**  No DB, no IO, no globals.  Input blocks are NEVER mutated: local
+``ParsedBlock`` copies are built so that ``assign_char_offsets_to_blocks`` (which
+mutates in place) only ever touches the copies, never the caller's
+``ArticleTextBlock`` ORM rows (mutating those would dirty the SQLAlchemy
+session).
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Sequence
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Protocol, runtime_checkable
+
+from app.infrastructure.parsing.base import (
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+)
+from app.schemas.extraction import (
+    HybridCitationAnchor,
+    PDFRect,
+    PDFTextRange,
+    PositionV1,
+    TextCitationAnchor,
+)
+
+# ---------------------------------------------------------------------------
+# Tuning constants (parameters, not config)
+# ---------------------------------------------------------------------------
+
+#: Default minimum ``SequenceMatcher.ratio`` for a fuzzy match to be accepted.
+#: 0.85 tolerates a handful of OCR-style character substitutions in a
+#: sentence-length quote while rejecting unrelated text.  ``1.0`` disables fuzz
+#: (exact match only).
+DEFAULT_FUZZ_THRESHOLD: float = 0.85
+
+#: Fractional slack on the candidate window length during fuzzy search.  We try
+#: window lengths from ``(1 - slack) * len(quote)`` to ``(1 + slack) * len(quote)``
+#: so OCR noise that inserts/deletes a few characters is still reachable while
+#: the search stays bounded.
+_FUZZ_LEN_SLACK: float = 0.25
+
+#: Step (in characters) of the longer window length probed during fuzzy search.
+#: Length 1 below the upper bound is always probed too; this only coarsens the
+#: *length* sweep, not the *position* sweep (which is exhaustive).
+_FUZZ_LEN_STEP: int = 1
+
+#: Block types considered "prose" for anchor-variant selection.
+#: Any block whose type is NOT in this set (i.e. ``table_cell`` or
+#: ``figure_caption``) triggers a ``HybridCitationAnchor`` (range + bbox).
+_PROSE_BLOCK_TYPES: frozenset[str] = frozenset(
+    {"paragraph", "heading", "list_item", "header", "footer"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Public result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AnchorMatch:
+    """A grounded anchor for an evidence quote.
+
+    Attributes:
+        page: 1-indexed page number the quote was found on.
+        char_start: Start offset (inclusive) of the matched span inside the
+            ORIGINAL ``concat_page_text`` string for ``page`` — the same
+            coordinate space as each block's ``char_start``.
+        char_end: End offset (exclusive) of the matched span, same space.
+        block_ids: ``block_index`` of every block whose ``[char_start, char_end)``
+            overlaps the matched range, in ascending order.
+        bbox_union: Union bounding box over ``block_ids`` in PDF user space,
+            with keys ``x``, ``y``, ``width``, ``height``.
+    """
+
+    page: int
+    char_start: int
+    char_end: int
+    block_ids: list[int]
+    bbox_union: dict[str, float]
+
+
+# ---------------------------------------------------------------------------
+# Internal: structural protocol (ParsedBlock and ArticleTextBlock both satisfy)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _Block(Protocol):
+    """Structural protocol satisfied by both ``ParsedBlock`` and ``ArticleTextBlock``."""
+
+    page_number: int
+    block_index: int
+    text: str
+    char_start: int
+    char_end: int
+    bbox: dict[str, float]
+    block_type: str
+
+
+# ---------------------------------------------------------------------------
+# Normalisation + index map
+# ---------------------------------------------------------------------------
+
+_WHITESPACE = frozenset(" \t\n\r\f\v\xa0  ")
+#: Typographic punctuation that NFKC does NOT fold but which routinely differs
+#: between an LLM's quote and the source PDF.  Each mapping is a 1:1 character
+#: replacement so the normalised → original index map stays exact (length is
+#: preserved).  Curly single/double quotes and primes fold to their ASCII
+#: equivalents; the various dashes fold to a hyphen-minus.
+_PUNCT_FOLD: dict[str, str] = {
+    "‘": "'",  # left single quote
+    "’": "'",  # right single quote / apostrophe
+    "‚": "'",  # single low-9 quote
+    "‛": "'",  # single high-reversed-9 quote
+    "′": "'",  # prime
+    "“": '"',  # left double quote
+    "”": '"',  # right double quote
+    "„": '"',  # double low-9 quote
+    "‟": '"',  # double high-reversed-9 quote
+    "″": '"',  # double prime
+    "‐": "-",  # hyphen
+    "‑": "-",  # non-breaking hyphen
+    "‒": "-",  # figure dash
+    "–": "-",  # en dash
+    "—": "-",  # em dash
+    "―": "-",  # horizontal bar
+    "−": "-",  # minus sign
+}
+
+
+def _normalize_with_index_map(original: str) -> tuple[str, list[int]]:
+    """Return ``(normalised, norm_to_orig)`` for *original*.
+
+    Normalisation is **NFKC + whitespace folding**: each original character is
+    NFKC-normalised individually (which may expand it to several characters,
+    e.g. the ligature ``ﬁ`` → ``"fi"``), runs of whitespace collapse to a single
+    space, and leading/trailing whitespace is stripped.
+
+    ``norm_to_orig[i]`` is the index into *original* at which normalised
+    character ``i`` began.  Mapping the normalised half-open span ``[ns, ne)``
+    back to the original is ``original[norm_to_orig[ns] : end]`` where ``end`` is
+    ``norm_to_orig[ne]`` if ``ne < len(norm)`` else ``len(original)``.
+
+    Processing character-by-character (rather than normalising the whole string
+    at once) is what keeps the index map exact: we always know which ORIGINAL
+    offset produced each emitted normalised character.
+    """
+    norm_chars: list[str] = []
+    norm_to_orig: list[int] = []
+    pending_space = False  # a folded-whitespace run is pending emission
+
+    for orig_idx, ch in enumerate(original):
+        if ch in _WHITESPACE:
+            # Collapse any run of whitespace; defer the single space so that
+            # trailing whitespace never gets emitted.
+            pending_space = True
+            continue
+
+        nfkc = unicodedata.normalize("NFKC", ch)
+        # NFKC of a single non-whitespace char can itself contain whitespace
+        # (rare), so fold those too rather than emit them verbatim.
+        for sub in nfkc:
+            sub = _PUNCT_FOLD.get(sub, sub)  # 1:1 punctuation fold; length-stable
+            if sub in _WHITESPACE:
+                pending_space = True
+                continue
+            if pending_space and norm_chars:
+                # Emit the single folded space only between real characters.
+                norm_chars.append(" ")
+                norm_to_orig.append(orig_idx)
+            pending_space = False
+            norm_chars.append(sub)
+            norm_to_orig.append(orig_idx)
+
+    return "".join(norm_chars), norm_to_orig
+
+
+def _normalize(text: str) -> str:
+    """NFKC + punctuation + whitespace fold (used for the quote side).
+
+    Mirrors :func:`_normalize_with_index_map` minus the index map: the result
+    must be byte-identical to the page side so exact substring search works.
+    """
+    nfkc = unicodedata.normalize("NFKC", text)
+    folded = "".join(_PUNCT_FOLD.get(c, c) for c in nfkc)
+    return " ".join(folded.split())
+
+
+# ---------------------------------------------------------------------------
+# Internal: candidate match within one page
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _PageCandidate:
+    """The best match found on a single page (in normalised coordinates)."""
+
+    norm_start: int
+    norm_end: int
+    ratio: float
+
+
+def _best_exact(norm_page: str, norm_quote: str) -> _PageCandidate | None:
+    """Return the EARLIEST exact occurrence of *norm_quote* in *norm_page*."""
+    idx = norm_page.find(norm_quote)
+    if idx == -1:
+        return None
+    return _PageCandidate(norm_start=idx, norm_end=idx + len(norm_quote), ratio=1.0)
+
+
+def _best_fuzzy(
+    norm_page: str,
+    norm_quote: str,
+    fuzz_threshold: float,
+) -> _PageCandidate | None:
+    """Return the best fuzzy match of *norm_quote* in *norm_page* (or ``None``).
+
+    Slides windows of length within ``±_FUZZ_LEN_SLACK`` of the quote length and
+    keeps the highest ``SequenceMatcher.ratio`` ≥ *fuzz_threshold*.  Ties on
+    ratio break toward the earliest ``norm_start`` then the shortest window,
+    which keeps the result deterministic.
+    """
+    q_len = len(norm_quote)
+    page_len = len(norm_page)
+    if q_len == 0 or page_len == 0:
+        return None
+
+    min_len = max(1, int(q_len * (1.0 - _FUZZ_LEN_SLACK)))
+    max_len = min(page_len, int(q_len * (1.0 + _FUZZ_LEN_SLACK)) + 1)
+
+    matcher = SequenceMatcher(autojunk=False)
+    matcher.set_seq2(norm_quote)
+
+    best: _PageCandidate | None = None
+    # Probe a small band of window lengths so insertions/deletions are reachable.
+    window_lengths = sorted(set(range(min_len, max_len + 1, _FUZZ_LEN_STEP)) | {q_len})
+    for win_len in window_lengths:
+        if win_len <= 0 or win_len > page_len:
+            continue
+        for start in range(0, page_len - win_len + 1):
+            end = start + win_len
+            matcher.set_seq1(norm_page[start:end])
+            # real_quick_ratio / quick_ratio are deterministic upper bounds;
+            # use them to skip windows that cannot beat the current best.
+            if best is not None and matcher.real_quick_ratio() < best.ratio:
+                continue
+            if matcher.quick_ratio() < fuzz_threshold:
+                continue
+            ratio = matcher.ratio()
+            if ratio < fuzz_threshold:
+                continue
+            if best is None or _fuzzy_better(ratio, start, win_len, best):
+                best = _PageCandidate(norm_start=start, norm_end=end, ratio=ratio)
+    return best
+
+
+def _fuzzy_better(
+    ratio: float,
+    start: int,
+    win_len: int,
+    incumbent: _PageCandidate,
+) -> bool:
+    """Deterministic ordering: higher ratio, then earlier start, then shorter."""
+    inc_len = incumbent.norm_end - incumbent.norm_start
+    return (ratio, -start, -win_len) > (incumbent.ratio, -incumbent.norm_start, -inc_len)
+
+
+# ---------------------------------------------------------------------------
+# Internal: map a normalised span back to the original, then to blocks
+# ---------------------------------------------------------------------------
+
+
+def _trim_whitespace(original: str, char_start: int, char_end: int) -> tuple[int, int]:
+    """Tighten ``[char_start, char_end)`` over leading/trailing ORIGINAL whitespace.
+
+    Whitespace folding means a match can map back onto a span that begins or
+    ends inside a collapsed-whitespace run (or across a block separator), so the
+    returned slice would carry stray ``\\n`` / spaces a highlighter would render.
+    Trim the start forward over leading whitespace and the end back over trailing
+    whitespace.  Fold-equality is preserved because folding strips exactly this
+    leading/trailing whitespace anyway.
+    """
+    while char_start < char_end and original[char_start] in _WHITESPACE:
+        char_start += 1
+    while char_end > char_start and original[char_end - 1] in _WHITESPACE:
+        char_end -= 1
+    return char_start, char_end
+
+
+def _resolve_original_span(
+    candidate: _PageCandidate,
+    norm_page: str,
+    norm_to_orig: list[int],
+    original: str,
+) -> tuple[int, int] | None:
+    """Map a matched normalised span to an ORIGINAL span that honours the invariant.
+
+    Returns ``(char_start, char_end)`` such that
+    ``_normalize(original[char_start:char_end]) == _normalize(norm_span)`` (the
+    advertised fold-back guarantee), or ``None`` when no such span exists.
+
+    The naive map-back (``norm_to_orig[ns]`` … ``norm_to_orig[ne]``) can break in
+    two ways; both are corrected here with fold-equality as the source of truth:
+
+    * **Whitespace padding.**  A boundary can land inside a collapsed-whitespace
+      run / across a block separator, so the span carries stray leading/trailing
+      ``\\n`` / spaces a highlighter would render.  These are trimmed first
+      (:func:`_trim_whitespace`); folding strips exactly that whitespace, so
+      trimming never disturbs fold-equality.
+
+    * **Expansion boundary.**  ``norm_to_orig`` maps every sub-character of a
+      1→many NFKC expansion (e.g. the ligature ``ﬁ`` → ``f``, ``i``) to the SAME
+      original index.  When the match *starts* on a non-first sub-character, the
+      naive span includes the WHOLE original expansion char and folds one char too
+      WIDE.  We snap the start forward to original-character granularity (dropping
+      the partially-covered expansion char) only when that repairs fold-equality.
+      If the quote genuinely begins/ends mid-expansion — a degenerate input a real
+      LLM quote never produces — no original slice folds to it and we return
+      ``None`` rather than a span that violates the guarantee.
+
+    Fold-equality is re-checked after every adjustment, so a valid exact span
+    (the overwhelmingly common case) is accepted untouched and a non-representable
+    one is rejected rather than silently widened.
+    """
+    target = _normalize(norm_page[candidate.norm_start : candidate.norm_end])
+
+    char_start = norm_to_orig[candidate.norm_start]
+    char_end = (
+        norm_to_orig[candidate.norm_end]
+        if candidate.norm_end < len(norm_to_orig)
+        else len(original)
+    )
+    char_start, char_end = _trim_whitespace(original, char_start, char_end)
+
+    if char_end > char_start and _normalize(original[char_start:char_end]) == target:
+        return char_start, char_end
+
+    # The naive span folds wider than the match: the start fell inside an NFKC
+    # expansion.  Snap the start forward to the next original character (dropping
+    # the over-included expansion char) and re-check.  If it still does not fold
+    # to the match the quote is not representable as any original slice — honour
+    # the guarantee by reporting no anchor.
+    if char_start < char_end:
+        snapped_start, snapped_end = _trim_whitespace(original, char_start + 1, char_end)
+        if (
+            snapped_end > snapped_start
+            and _normalize(original[snapped_start:snapped_end]) == target
+        ):
+            return snapped_start, snapped_end
+
+    return None
+
+
+def _overlapping_blocks(
+    page_blocks: list[ParsedBlock],
+    char_start: int,
+    char_end: int,
+) -> list[ParsedBlock]:
+    """Return blocks whose ``[char_start, char_end)`` overlaps ``[char_start, char_end)``.
+
+    *page_blocks* must carry offsets in ``concat_page_text`` coordinates and be
+    sorted by ``block_index`` (the local copies built in :func:`match` satisfy
+    both).  Half-open overlap: ``b.char_start < char_end and b.char_end > char_start``.
+    """
+    return [b for b in page_blocks if b.char_start < char_end and b.char_end > char_start]
+
+
+def _bbox_union(blocks: list[ParsedBlock]) -> dict[str, float]:
+    """Union rectangle over *blocks* in PDF user space.
+
+    ``x = min(x)``, ``y = min(y)``, ``width = max(x+width) - x``,
+    ``height = max(y+height) - y``.
+    """
+    xs = [float(b.bbox["x"]) for b in blocks]
+    ys = [float(b.bbox["y"]) for b in blocks]
+    x_maxes = [float(b.bbox["x"]) + float(b.bbox["width"]) for b in blocks]
+    y_maxes = [float(b.bbox["y"]) + float(b.bbox["height"]) for b in blocks]
+    min_x = min(xs)
+    min_y = min(ys)
+    return {
+        "x": min_x,
+        "y": min_y,
+        "width": max(x_maxes) - min_x,
+        "height": max(y_maxes) - min_y,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def match(
+    quote: str,
+    blocks: Sequence[_Block],
+    *,
+    fuzz_threshold: float = DEFAULT_FUZZ_THRESHOLD,
+) -> AnchorMatch | None:
+    """Anchor *quote* to a span in *blocks*, or return ``None`` if absent.
+
+    Args:
+        quote: The LLM's evidence quote (free text).  Normalised with NFKC +
+            whitespace folding before matching.
+        blocks: ``ArticleTextBlock`` ORM rows or ``ParsedBlock`` dataclasses.
+            May be in any order and may carry placeholder ``char_start`` /
+            ``char_end`` — the matcher derives canonical offsets itself and
+            NEVER mutates the input blocks.
+        fuzz_threshold: Minimum ``SequenceMatcher.ratio`` in ``[0.0, 1.0]`` for a
+            fuzzy (OCR-tolerant) match.  ``1.0`` accepts exact matches only.
+            Defaults to :data:`DEFAULT_FUZZ_THRESHOLD`.  This is a parameter, not
+            a config value.
+
+    Returns:
+        An :class:`AnchorMatch` whose ``char_start`` / ``char_end`` index the
+        ORIGINAL ``concat_page_text`` page string, or ``None`` if the quote is
+        not found (exactly or within the fuzz threshold) on any page.
+
+    Tie-breaking is deterministic: earliest page, then earliest original
+    ``char_start``, then the longest contiguous overlap.
+    """
+    norm_quote = _normalize(quote)
+    if not norm_quote or not blocks:
+        return None
+
+    # Build LOCAL copies so assign_char_offsets_to_blocks mutates only the
+    # copies, never the caller's ORM rows.  This also makes the matcher robust
+    # to inputs whose char_start/char_end are placeholders.
+    copies = [
+        ParsedBlock(
+            page_number=b.page_number,
+            block_index=b.block_index,
+            text=b.text,
+            char_start=0,
+            char_end=0,
+            bbox=getattr(b, "bbox", {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}),
+            block_type=b.block_type,
+        )
+        for b in blocks
+    ]
+    assign_char_offsets_to_blocks(copies)  # mutates the COPIES only
+    page_texts = concat_page_text(copies)
+
+    blocks_by_page: dict[int, list[ParsedBlock]] = {}
+    for c in copies:
+        blocks_by_page.setdefault(c.page_number, []).append(c)
+    for page_blocks in blocks_by_page.values():
+        page_blocks.sort(key=lambda b: b.block_index)
+
+    best_result: AnchorMatch | None = None
+    best_key: tuple[int, int, int] | None = None  # (page, char_start, -overlap_len)
+
+    # Iterate pages in ascending order for deterministic earliest-page tie-break.
+    for page in sorted(page_texts):
+        original = page_texts[page]
+        norm_page, norm_to_orig = _normalize_with_index_map(original)
+        if not norm_page:
+            continue
+
+        candidate = _best_exact(norm_page, norm_quote)
+        if candidate is None and fuzz_threshold < 1.0:
+            candidate = _best_fuzzy(norm_page, norm_quote, fuzz_threshold)
+        if candidate is None:
+            continue
+
+        resolved = _resolve_original_span(candidate, norm_page, norm_to_orig, original)
+        if resolved is None:
+            continue
+        char_start, char_end = resolved
+
+        overlapping = _overlapping_blocks(blocks_by_page[page], char_start, char_end)
+        if not overlapping:
+            continue
+
+        # Post-condition: the fold-back invariant MUST hold for every non-None
+        # return — the returned span, sliced from the ORIGINAL page text and
+        # folded, equals the folded matched region.  ``_resolve_original_span``
+        # guarantees this for well-formed inputs.  If it does NOT hold (a
+        # degenerate edge case the upstream pipeline cannot produce), degrade
+        # gracefully: treat the quote as unlocatable rather than raising in the
+        # extraction write path.  A non-None return ALWAYS satisfies the invariant.
+        if _normalize(original[char_start:char_end]) != _normalize(
+            norm_page[candidate.norm_start : candidate.norm_end]
+        ):
+            continue
+
+        overlap_len = char_end - char_start
+        key = (page, char_start, -overlap_len)
+        if best_key is None or key < best_key:
+            best_key = key
+            best_result = AnchorMatch(
+                page=page,
+                char_start=char_start,
+                char_end=char_end,
+                block_ids=[b.block_index for b in overlapping],
+                bbox_union=_bbox_union(overlapping),
+            )
+
+    return best_result
+
+
+def build_anchor(
+    quote: str,
+    blocks: Sequence[_Block],
+    *,
+    fuzz_threshold: float = DEFAULT_FUZZ_THRESHOLD,
+) -> PositionV1 | None:
+    """Build a :class:`PositionV1` anchor for *quote* against *blocks*.
+
+    Calls :func:`match` to locate the quote, then picks the
+    :class:`~app.schemas.extraction.CitationAnchor` variant based on the
+    matched blocks' ``block_type``:
+
+    * **All matched blocks are prose** (``paragraph``, ``heading``,
+      ``list_item``, ``header``, ``footer``) →
+      :class:`~app.schemas.extraction.TextCitationAnchor` (char range only).
+    * **Any matched block is** ``table_cell`` **or** ``figure_caption`` →
+      :class:`~app.schemas.extraction.HybridCitationAnchor` (char range +
+      bbox union + quote).  Hybrid carries the region for table/figure
+      highlighting and is the recommended AI anchor shape.
+
+    The function is **pure** (no DB, no IO).  Idempotent on re-run — same
+    inputs always produce the same output.
+
+    Args:
+        quote: The LLM's free-text evidence quote.
+        blocks: ``ArticleTextBlock`` ORM rows (or ``ParsedBlock`` dataclasses).
+            Must cover the full document; typically obtained from
+            ``ArticleTextBlockRepository.list_ordered_for_file``.
+        fuzz_threshold: Passed through to :func:`match`.  ``1.0`` = exact only.
+
+    Returns:
+        A :class:`PositionV1` whose ``anchor`` is set to the appropriate
+        variant, or ``None`` if the quote cannot be located in *blocks*.
+    """
+    m = match(quote, blocks, fuzz_threshold=fuzz_threshold)
+    if m is None:
+        return None
+
+    # Look up the block_type for each matched block_index on m.page.
+    matched_block_types: set[str] = set()
+    for b in blocks:
+        if b.page_number == m.page and b.block_index in m.block_ids:
+            matched_block_types.add(b.block_type)
+
+    text_range = PDFTextRange(page=m.page, char_start=m.char_start, char_end=m.char_end)
+
+    # Hybrid if any matched block is a non-prose type (table_cell / figure_caption).
+    non_prose = matched_block_types - _PROSE_BLOCK_TYPES
+    if non_prose:
+        anchor = HybridCitationAnchor(
+            kind="hybrid",
+            range=text_range,
+            rect=PDFRect(**m.bbox_union),
+            quote=quote,
+        )
+    else:
+        anchor = TextCitationAnchor(
+            kind="text",
+            range=text_range,
+            quote=quote,
+        )
+
+    return PositionV1(version=1, anchor=anchor)

--- a/backend/app/services/extraction_block_assembler.py
+++ b/backend/app/services/extraction_block_assembler.py
@@ -1,0 +1,463 @@
+"""
+Section-aware block assembler for the grounded-extraction pipeline.
+
+Converts a flat list of ``ArticleTextBlock`` (or ``ParsedBlock``) objects into
+a structured prompt text that:
+
+1. Preserves reading order (page_number asc, block_index asc).
+2. Emits ``## <heading>`` markers from ``heading`` blocks (IMRaD-aware).
+3. Coalesces contiguous ``table_cell`` runs into a reconstructed markdown
+   table instead of emitting one cell per line.
+4. When the serialised text exceeds ``budget`` chars, drops WHOLE sections
+   (never a mid-sentence or mid-table prefix cut) according to a deterministic
+   IMRaD-aware ranking, and records what was dropped in ``DroppedSection``
+   objects.
+
+Design decisions
+----------------
+**Budget unit**: characters (``len(text)``).  Characters are the simplest
+defensible unit for a pure, deterministic function that has no tokeniser
+dependency.  The call site that wires this into the extraction prompts can
+apply a safety multiplier if needed (e.g. chars × 0.25 ≈ tokens for typical
+scientific prose).
+
+**Section ranking (deterministic)**:
+Sections are ranked for inclusion in priority order:
+
+    Abstract > Results > Methods > Introduction > Discussion > Conclusion
+    > Figures/Tables > Other > References > Appendix > Header/Footer chrome
+
+When a ``focus`` hint is supplied (e.g. ``focus="Methods"``), the named
+section is promoted to rank 0 (highest priority), ahead of Abstract.  All
+other ranks shift down by one.  The ranking is a static look-up — no
+embeddings or ML.
+
+**Table reconstruction**: contiguous ``table_cell`` runs on the same page
+are detected by scanning blocks in reading order.  A run break occurs when a
+non-cell block is encountered OR when the page changes.  Each run is
+serialised as a simple markdown table.  The column count is inferred from the
+first row (the longest prefix of cells before the grid wraps — estimated by
+looking for repeated column-count patterns; if inference fails, all cells
+are placed in a single-column table).
+
+**concat_page_text reuse**: the assembler calls the canonical
+``concat_page_text`` imported from ``app.infrastructure.parsing.base`` to
+produce per-page text strings.  Local copies of the input blocks are built
+so that ``assign_char_offsets_to_blocks`` can mutate them without ever
+touching the caller's ORM objects (which would cause spurious SQLAlchemy
+dirty-tracking and unwanted UPDATEs).  Prose blocks are sourced from the
+canonical surface via ``page_texts[page][cs:ce]``, which is content-identical
+to ``block.text`` by construction but guarantees byte-for-byte alignment with
+what the evidence-anchorer will index.
+
+**Scope**: pure function, no DB, no IO, no globals.  This module is
+intentionally unwired — the call sites in ``section_extraction_service`` and
+``model_extraction_service`` are wired in a separate follow-up task.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from app.infrastructure.parsing.base import (
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+)
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DroppedSection:
+    """Metadata about a section that was excluded because of budget constraints.
+
+    Attributes:
+        title: The heading text (or ``"<preamble>"`` for content before the
+            first heading).
+        char_count: Approximate character count of the dropped section's
+            serialised text (including the heading marker).
+        rank: The priority rank assigned to this section (lower = higher
+            priority, i.e. kept sections have lower rank numbers).
+    """
+
+    title: str
+    char_count: int
+    rank: int
+
+
+# ---------------------------------------------------------------------------
+# Internal: block protocol (works on both ParsedBlock and ArticleTextBlock ORM rows)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class _Block(Protocol):
+    """Structural protocol satisfied by both ``ParsedBlock`` and ``ArticleTextBlock``."""
+
+    page_number: int
+    block_index: int
+    text: str
+    char_start: int
+    char_end: int
+    block_type: str
+
+
+# ---------------------------------------------------------------------------
+# IMRaD section ranking
+# ---------------------------------------------------------------------------
+
+# Canonical IMRaD priority: lower index = higher priority (kept first).
+# The ranking is applied to the *heading text* after normalisation to lower
+# case and stripping of trailing punctuation/numbering.
+_IMRAD_KEYWORDS: list[tuple[int, tuple[str, ...]]] = [
+    (0, ("abstract", "summary")),
+    (1, ("result", "finding")),
+    (2, ("method", "material", "patient", "participant", "procedure", "protocol")),
+    (3, ("introduction", "background", "objective", "aim", "purpose")),
+    (4, ("discussion",)),
+    (5, ("conclusion", "implication")),
+    (6, ("figure", "table", "supplementary", "supplement")),
+    (7, ()),  # catch-all "other" — assigned dynamically
+    (8, ("reference", "bibliography", "cited")),
+    (9, ("appendix", "annex")),
+    (10, ()),  # page chrome (header / footer type blocks that leaked through)
+]
+
+_DEFAULT_RANK = 7  # "other"
+
+
+def _section_rank(heading_text: str, focus: str | None) -> int:
+    """Return a priority rank for *heading_text* (lower = higher priority).
+
+    If *focus* is provided and matches the heading, the section is promoted
+    to rank -1 (highest possible priority, above Abstract).
+    """
+    normalised = re.sub(r"^\d[\d.\s]*", "", heading_text.lower().strip(" :.-"))
+    if focus and normalised == focus.lower().strip():
+        return -1
+    for rank, keywords in _IMRAD_KEYWORDS:
+        if not keywords:
+            continue
+        if any(kw in normalised for kw in keywords):
+            return rank
+    return _DEFAULT_RANK
+
+
+# ---------------------------------------------------------------------------
+# Internal: Section dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Section:
+    """One logical section: a heading (optional) followed by its body blocks."""
+
+    title: str  # "" for pre-heading preamble
+    rank: int
+    blocks: list[_Block] = field(default_factory=list)
+
+
+def _is_chrome(block: _Block) -> bool:
+    """Return True for page chrome blocks (header / footer) that add noise."""
+    return block.block_type in ("header", "footer")
+
+
+# ---------------------------------------------------------------------------
+# Table reconstruction
+# ---------------------------------------------------------------------------
+
+_CELL_SEP = " | "
+_ROW_SEP_CHAR = "-"
+
+
+def _infer_column_count(cell_texts: list[str]) -> int:
+    """Heuristically infer the number of columns in a table.
+
+    Tries column counts from 2 to min(8, n) and picks the one where
+    n % cols == 0 (exact fit) and cols is smallest.  Falls back to 1.
+    """
+    n = len(cell_texts)
+    if n <= 1:
+        return 1
+    for cols in range(2, min(9, n + 1)):
+        if n % cols == 0:
+            return cols
+    # No exact fit — use the square-root heuristic (rounded up), capped at 8
+    return min(8, max(2, math.ceil(math.sqrt(n))))
+
+
+def _render_table(cell_texts: list[str]) -> str:
+    """Render *cell_texts* as a markdown table string."""
+    if not cell_texts:
+        return ""
+    cols = _infer_column_count(cell_texts)
+    rows: list[list[str]] = []
+    for i in range(0, len(cell_texts), cols):
+        row = cell_texts[i : i + cols]
+        # Pad the last row if it is short
+        while len(row) < cols:
+            row.append("")
+        rows.append(row)
+
+    # Compute column widths
+    col_widths = [max(len(r[c]) for r in rows) for c in range(cols)]
+
+    def _fmt_row(row: list[str]) -> str:
+        cells = [r.ljust(w) for r, w in zip(row, col_widths, strict=True)]
+        return "| " + _CELL_SEP.join(cells) + " |"
+
+    def _separator() -> str:
+        return "|-" + "-|-".join(_ROW_SEP_CHAR * w for w in col_widths) + "-|"
+
+    lines = [_fmt_row(rows[0]), _separator()]
+    for row in rows[1:]:
+        lines.append(_fmt_row(row))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Internal: serialize a section's blocks into a text string
+# ---------------------------------------------------------------------------
+
+
+def _serialize_section(
+    section: _Section,
+    page_texts: dict[int, str],
+    offsets: dict[tuple[int, int], tuple[int, int]],
+) -> str:
+    """Serialise *section* into a text string (heading marker + body).
+
+    Prose blocks are sourced from *page_texts* via *offsets* — the canonical
+    surface produced by ``concat_page_text`` — so that the assembler's output
+    is byte-for-byte consistent with what the evidence-anchorer indexes.
+    Table-cell text is taken directly from the block (cells are not indexed by
+    the anchorer via char offsets).
+
+    Args:
+        section: The section to serialise.
+        page_texts: Mapping of ``page_number → concatenated page string``
+            produced by ``concat_page_text`` on local block copies.
+        offsets: Mapping of ``(page_number, block_index) → (char_start, char_end)``
+            derived from ``assign_char_offsets_to_blocks`` on local block copies.
+    """
+    parts: list[str] = []
+
+    if section.title:
+        parts.append(f"## {section.title}")
+
+    # Walk blocks, coalescing contiguous table_cell runs.
+    # A run breaks when block type changes away from table_cell, or page changes.
+    i = 0
+    blocks = section.blocks
+    while i < len(blocks):
+        block = blocks[i]
+
+        if _is_chrome(block):
+            i += 1
+            continue
+
+        if block.block_type == "table_cell":
+            # Collect the contiguous run — cells use .text directly
+            run: list[str] = []
+            current_page = block.page_number
+            while (
+                i < len(blocks)
+                and blocks[i].block_type == "table_cell"
+                and blocks[i].page_number == current_page
+            ):
+                run.append(blocks[i].text)
+                i += 1
+            parts.append(_render_table(run))
+        else:
+            # Route prose through the canonical surface so offsets align with
+            # what the evidence-anchorer will index in concat_page_text.
+            cs, ce = offsets[(block.page_number, block.block_index)]
+            prose = page_texts[block.page_number][cs:ce]
+            parts.append(prose)
+            i += 1
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Internal: segment blocks into sections
+# ---------------------------------------------------------------------------
+
+
+def _segment_into_sections(
+    sorted_blocks: list[_Block],
+    focus: str | None,
+) -> list[_Section]:
+    """Group *sorted_blocks* (in reading order) into ``_Section`` objects.
+
+    A new section begins every time a ``heading`` block is encountered.
+    Blocks before the first heading are grouped into a preamble section
+    with title ``""`` (empty string) and rank equal to Abstract's rank (0),
+    since the preamble usually contains the abstract or title.
+    """
+    sections: list[_Section] = []
+    current = _Section(title="", rank=_section_rank("abstract", focus))
+
+    for block in sorted_blocks:
+        if block.block_type == "heading":
+            # Only start a new section if the current one has content
+            # (to avoid empty preamble sections when the doc starts with a heading).
+            if current.blocks or current.title:
+                sections.append(current)
+            current = _Section(
+                title=block.text,
+                rank=_section_rank(block.text, focus),
+                blocks=[],
+            )
+        else:
+            current.blocks.append(block)
+
+    # Don't forget the last in-progress section
+    if current.blocks or current.title:
+        sections.append(current)
+
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def assemble(
+    blocks: list[_Block],
+    budget: int,
+    focus: str | None = None,
+) -> tuple[str, list[DroppedSection]]:
+    """Assemble *blocks* into structured prompt text within *budget* characters.
+
+    Args:
+        blocks: ``ArticleTextBlock`` ORM rows or ``ParsedBlock`` dataclasses.
+            May be in any order; this function sorts by (page_number, block_index).
+            Input blocks are NEVER mutated.
+        budget: Maximum number of characters in the returned text (inclusive).
+            When the full document exceeds this limit, whole sections are dropped
+            according to the deterministic IMRaD-aware ranking (lower rank =
+            higher priority = kept first).  Budget is measured in characters
+            (``len(text)``).
+        focus: Optional section-title hint (case-insensitive exact match after
+            normalisation).  The matching section is promoted to the highest
+            priority rank, ensuring it is never dropped before lower-priority
+            sections.
+
+    Returns:
+        A tuple ``(text, dropped_sections)`` where:
+        - *text* is the assembled prompt string, ≤ *budget* chars.
+        - *dropped_sections* is a list of ``DroppedSection`` objects describing
+          every section that was omitted due to budget constraints (empty list
+          when everything fits).
+
+    Notes:
+        - Pure function: no DB, no IO, no globals.
+        - Input blocks are never mutated; local ``ParsedBlock`` copies are used
+          so that ``assign_char_offsets_to_blocks`` does not dirty SQLAlchemy
+          ORM objects.
+        - Prose text is sourced from ``concat_page_text`` (canonical surface)
+          so char offsets match what the evidence-anchorer indexes.
+        - ``header`` and ``footer`` blocks are suppressed (page chrome).
+        - Contiguous ``table_cell`` blocks on the same page are coalesced into
+          a markdown table.
+        - When over budget, WHOLE sections are dropped — never a mid-sentence
+          or mid-table prefix cut.
+    """
+    if not blocks:
+        return "", []
+
+    # 1. Sort into reading order (page asc, block_index asc).
+    sorted_blocks: list[_Block] = sorted(blocks, key=lambda b: (b.page_number, b.block_index))
+
+    # 2. Build local ParsedBlock copies so assign_char_offsets_to_blocks can
+    #    mutate them without ever touching the caller's ORM objects.
+    copies = [
+        ParsedBlock(
+            page_number=b.page_number,
+            block_index=b.block_index,
+            text=b.text,
+            char_start=0,
+            char_end=0,
+            bbox=getattr(b, "bbox", {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}),
+            block_type=b.block_type,
+        )
+        for b in sorted_blocks
+    ]
+    assign_char_offsets_to_blocks(copies)  # mutates the COPIES only
+    page_texts = concat_page_text(copies)  # canonical per-page text
+    offsets: dict[tuple[int, int], tuple[int, int]] = {
+        (c.page_number, c.block_index): (c.char_start, c.char_end) for c in copies
+    }
+
+    # 3. Segment into sections.
+    sections = _segment_into_sections(sorted_blocks, focus)
+
+    # 4. Serialise each section to compute its character cost.
+    serialised: list[tuple[_Section, str]] = [
+        (sec, _serialize_section(sec, page_texts, offsets)) for sec in sections
+    ]
+
+    # 5. Check if everything fits within budget.
+    #    Join with double newline between sections.
+    separator = "\n\n"
+    full_text_parts = [text for _, text in serialised if text]
+    full_text = separator.join(full_text_parts)
+
+    if len(full_text) <= budget:
+        return full_text, []
+
+    # 6. Over budget: select whole sections greedily, highest priority first.
+    #    Within the same rank, preserve original document order (stable sort).
+    #    We keep track of original indices so we can reconstruct document order
+    #    for kept sections.
+    indexed: list[tuple[int, _Section, str]] = [
+        (i, sec, text) for i, (sec, text) in enumerate(serialised) if text
+    ]
+
+    # Sort by (rank asc, original_index asc) — deterministic.
+    priority_order = sorted(indexed, key=lambda t: (t[1].rank, t[0]))
+
+    kept_indices: set[int] = set()
+    running_chars = 0
+    dropped: list[DroppedSection] = []
+
+    for orig_idx, sec, text in priority_order:
+        # Cost: text length + separator if this is not the first kept section
+        extra = len(separator) if kept_indices else 0
+        cost = len(text) + extra
+        if running_chars + cost <= budget:
+            kept_indices.add(orig_idx)
+            running_chars += cost
+        else:
+            dropped.append(
+                DroppedSection(
+                    title=sec.title or "<preamble>",
+                    char_count=len(text),
+                    rank=sec.rank,
+                )
+            )
+
+    # 7. Reconstruct in original document order.
+    kept_parts = [text for i, _, text in indexed if i in kept_indices]
+    result_text = separator.join(kept_parts)
+
+    # Defensive: ensure we never exceed budget (rounding/separator edge cases).
+    # Track kept sections as a list and pop WHOLE sections from the back —
+    # never string-split the serialized output (which would break on separator
+    # strings that appear inside block text).
+    if len(result_text) > budget:
+        # Rebuild the kept list in document order so we can pop whole sections.
+        kept_list: list[str] = list(kept_parts)
+        while kept_list and len(separator.join(kept_list)) > budget:
+            kept_list.pop()
+        result_text = separator.join(kept_list)
+
+    return result_text, dropped

--- a/backend/app/services/extraction_run_read_service.py
+++ b/backend/app/services/extraction_run_read_service.py
@@ -17,7 +17,12 @@ from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.extraction import ExtractionEntityType, ExtractionRun, ExtractionRunStage
+from app.models.extraction import (
+    ExtractionEntityType,
+    ExtractionInstance,
+    ExtractionRun,
+    ExtractionRunStage,
+)
 from app.models.extraction_versioning import ExtractionTemplateVersion
 from app.models.extraction_workflow import (
     ExtractionConsensusDecision,
@@ -40,6 +45,7 @@ from app.repositories.extraction_reviewer_decision_repository import (
 )
 from app.repositories.project_repository import ProjectMemberRepository, ProjectRepository
 from app.schemas.extraction_run import (
+    ArticleRunRef,
     ConsensusDecisionResponse,
     ProposalRecordResponse,
     PublishedStateResponse,
@@ -49,6 +55,7 @@ from app.schemas.extraction_run import (
     RunSummaryResponse,
     RunViewCurrentValue,
     RunViewEntityType,
+    RunViewInstance,
     RunViewResponse,
 )
 
@@ -183,6 +190,31 @@ async def _entity_types_for_run(
     return result
 
 
+async def _instances_for_run(db: AsyncSession, run: RunSummaryResponse) -> list[RunViewInstance]:
+    """Instances scoped to the run's (article_id, template_id) pair.
+
+    Instances are NOT run-scoped (no run_id column on extraction_instances).
+    The canonical scope is (article_id, template_id) — identical to the
+    predicate used in ExtractionExportService._load_instances_for_runs.
+    Ordered by (entity_type_id, sort_order) for stable, grouped rendering.
+    """
+    rows = (
+        (
+            await db.execute(
+                select(ExtractionInstance)
+                .where(
+                    ExtractionInstance.article_id == run.article_id,
+                    ExtractionInstance.template_id == run.template_id,
+                )
+                .order_by(ExtractionInstance.entity_type_id, ExtractionInstance.sort_order)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [RunViewInstance.model_validate(i) for i in rows]
+
+
 async def resolve_caller_current_values(
     db: AsyncSession, run_id: UUID, *, caller_id: UUID
 ) -> list[RunViewCurrentValue]:
@@ -286,7 +318,8 @@ async def build_run_view(
     db: AsyncSession, run_id: UUID, *, caller_id: UUID, can_see_peers: bool
 ) -> RunViewResponse:
     """The one-round-trip run-open view: the blind-filtered run detail plus the
-    frozen entity_types tree and the caller's current_values. COMPOSES
+    frozen entity_types tree, the caller's current_values, and the instances
+    scoped to the run's (article_id, template_id). COMPOSES
     get_run_with_workflow_history (the single blind filter) — it never re-queries
     the workflow tables, so the blind boundary cannot drift. The composed
     ``detail.run`` (a RunSummaryResponse) already carries ``version_id`` /
@@ -302,6 +335,7 @@ async def build_run_view(
         if detail.run.stage in _CURRENT_VALUE_STAGES
         else []
     )
+    instances = await _instances_for_run(db, detail.run)
 
     return RunViewResponse(
         run=detail.run,
@@ -311,6 +345,7 @@ async def build_run_view(
         published_states=detail.published_states,
         entity_types=entity_types,
         current_values=current_values,
+        instances=instances,
     )
 
 
@@ -415,4 +450,133 @@ async def list_run_participants(db: AsyncSession, run_id: UUID) -> list[RunRevie
             avatar_url=p.avatar_url,
         )
         for p in profiles
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Article-scoped run-resolution queries
+# ---------------------------------------------------------------------------
+
+_ACTIVE_STAGES = (
+    ExtractionRunStage.PENDING.value,
+    ExtractionRunStage.PROPOSAL.value,
+    ExtractionRunStage.REVIEW.value,
+    ExtractionRunStage.CONSENSUS.value,
+)
+
+
+async def find_active_run(
+    db: AsyncSession,
+    article_id: UUID,
+    *,
+    template_id: UUID | None = None,
+) -> RunSummaryResponse | None:
+    """Return the latest non-terminal extraction run for the article, or None.
+
+    Parity with frontend ``findActiveRun``:
+    - kind = 'extraction'
+    - stage IN (pending, proposal, review, consensus)
+    - optional template_id filter
+    - ordered by created_at DESC, newest wins
+    """
+    stmt = (
+        select(ExtractionRun)
+        .where(
+            ExtractionRun.article_id == article_id,
+            ExtractionRun.kind == "extraction",
+            ExtractionRun.stage.in_(_ACTIVE_STAGES),
+        )
+        .order_by(ExtractionRun.created_at.desc())
+        .limit(1)
+    )
+    if template_id is not None:
+        stmt = stmt.where(ExtractionRun.template_id == template_id)
+
+    run = (await db.execute(stmt)).scalars().first()
+    return RunSummaryResponse.model_validate(run) if run is not None else None
+
+
+async def find_finalized_run(
+    db: AsyncSession,
+    article_id: UUID,
+    *,
+    template_id: UUID | None = None,
+) -> RunSummaryResponse | None:
+    """Return the latest finalized extraction run for the article, or None.
+
+    Parity with frontend ``findLatestFinalizedRun``:
+    - kind = 'extraction'
+    - stage = 'finalized'
+    - optional template_id filter
+    - ordered by created_at DESC, newest wins
+    """
+    stmt = (
+        select(ExtractionRun)
+        .where(
+            ExtractionRun.article_id == article_id,
+            ExtractionRun.kind == "extraction",
+            ExtractionRun.stage == ExtractionRunStage.FINALIZED.value,
+        )
+        .order_by(ExtractionRun.created_at.desc())
+        .limit(1)
+    )
+    if template_id is not None:
+        stmt = stmt.where(ExtractionRun.template_id == template_id)
+
+    run = (await db.execute(stmt)).scalars().first()
+    return RunSummaryResponse.model_validate(run) if run is not None else None
+
+
+async def resolve_form_runs(
+    db: AsyncSession,
+    article_ids: list[UUID],
+    *,
+    template_id: UUID,
+) -> list[ArticleRunRef]:
+    """Resolve the latest relevant run per article for the extraction form.
+
+    Parity with frontend ``findFormRunsByArticle``:
+    - Per article: latest non-terminal run; else latest finalized run.
+    - Cancelled runs are excluded.
+    - Returns one ArticleRunRef per input article_id (run_id=None when no run).
+    """
+    if not article_ids:
+        return []
+
+    non_terminal_stages = list(_ACTIVE_STAGES)
+    # Fetch all candidate runs in one query, ordered so that non-terminal
+    # stages sort before finalized (within each article, newest first).
+    stmt = (
+        select(ExtractionRun)
+        .where(
+            ExtractionRun.article_id.in_(article_ids),
+            ExtractionRun.template_id == template_id,
+            ExtractionRun.kind == "extraction",
+            ExtractionRun.stage.in_([*non_terminal_stages, ExtractionRunStage.FINALIZED.value]),
+        )
+        .order_by(
+            ExtractionRun.article_id,
+            ExtractionRun.created_at.desc(),
+        )
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+
+    # Build a per-article result: prefer non-terminal over finalized, newest first.
+    # The ORDER BY created_at DESC means within each article the newest appears first.
+    best: dict[UUID, ExtractionRun] = {}
+    for row in rows:
+        aid = row.article_id
+        if aid not in best:
+            best[aid] = row
+            continue
+        existing = best[aid]
+        # Prefer non-terminal over finalized
+        existing_active = existing.stage in non_terminal_stages
+        row_active = row.stage in non_terminal_stages
+        if row_active and not existing_active:
+            best[aid] = row
+
+    return [
+        ArticleRunRef(article_id=aid, run_id=best[aid].id if aid in best else None)
+        for aid in article_ids
     ]

--- a/backend/app/services/extraction_suggestion_read_service.py
+++ b/backend/app/services/extraction_suggestion_read_service.py
@@ -1,0 +1,296 @@
+"""Read-side service for AI suggestion data (proposal records + evidence + status).
+
+Owns the three queries the frontend's AISuggestionService currently issues
+directly via Supabase PostgREST:
+
+  load_suggestions       — latest AI proposal per (instance, field), with
+                           caller-scoped status derived from the caller's
+                           reviewer_states. NEVER reads another reviewer's
+                           states — this is the blind boundary (Constraint 3).
+  get_suggestion_history — all AI proposals for a single coord, newest first.
+  get_article_instance_ids — extraction_instances for an article.
+
+The status overlay reads ONLY reviewer_states.reviewer_id == caller_id.
+A test in test_suggestion_read.py pins this invariant explicitly.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.extraction import ExtractionEvidence, ExtractionInstance
+from app.models.extraction_workflow import (
+    ExtractionProposalRecord,
+    ExtractionProposalSource,
+    ExtractionReviewerDecision,
+    ExtractionReviewerDecisionType,
+    ExtractionReviewerState,
+)
+from app.schemas.extraction_suggestion import (
+    AISuggestionHistoryItem,
+    AISuggestionItem,
+    AISuggestionsResponse,
+    EvidenceResponse,
+)
+
+
+async def get_article_instance_ids(db: AsyncSession, article_id: UUID) -> list[UUID]:
+    """Return all extraction_instance ids for an article."""
+    rows = (
+        (
+            await db.execute(
+                select(ExtractionInstance.id).where(ExtractionInstance.article_id == article_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return list(rows)
+
+
+def _resolve_status(decision: str | None) -> str:
+    """Map a reviewer decision string to a suggestion status string."""
+    if decision is None:
+        return "pending"
+    if decision == ExtractionReviewerDecisionType.REJECT.value:
+        return "rejected"
+    return "accepted"
+
+
+async def load_suggestions(
+    db: AsyncSession,
+    instance_ids: list[UUID],
+    *,
+    article_id: UUID,
+    caller_id: UUID,
+    run_id: UUID | None = None,
+) -> AISuggestionsResponse:
+    """Return the latest AI proposal per (instance, field) with caller-scoped status.
+
+    Mirrors AISuggestionService.loadSuggestions:
+    1. Read ExtractionProposalRecord WHERE source='ai', instance_id IN instance_ids,
+       optional run_id, ORDER BY created_at DESC.
+       Scoped to article_id via JOIN on ExtractionInstance — instances that do not
+       belong to the path article are silently dropped (cross-project IDOR guard).
+    2. Dedup: first-per-(instance_id, field_id) wins (desc order → latest wins).
+    3. Load evidence for the deduplicated proposal_ids.
+    4. Load ExtractionReviewerState WHERE reviewer_id == caller_id (blind boundary)
+       joined to ExtractionReviewerDecision via the composite FK for `.decision`.
+    5. Derive status per (instance, field): reject → 'rejected', other → 'accepted', else 'pending'.
+    """
+    if not instance_ids:
+        return AISuggestionsResponse(suggestions=[], count=0)
+
+    # --- Step 1: fetch AI proposals ordered newest-first ---
+    # JOIN through ExtractionInstance to enforce article_id scope.
+    # Any instance_id that does not belong to this article is excluded
+    # at the database level — no second round-trip needed.
+    proposal_stmt = (
+        select(ExtractionProposalRecord)
+        .join(
+            ExtractionInstance,
+            and_(
+                ExtractionInstance.id == ExtractionProposalRecord.instance_id,
+                ExtractionInstance.article_id == article_id,
+            ),
+        )
+        .where(
+            ExtractionProposalRecord.instance_id.in_(instance_ids),
+            ExtractionProposalRecord.source == ExtractionProposalSource.AI.value,
+        )
+        .order_by(ExtractionProposalRecord.created_at.desc())
+    )
+    if run_id is not None:
+        proposal_stmt = proposal_stmt.where(ExtractionProposalRecord.run_id == run_id)
+
+    proposals = (await db.execute(proposal_stmt)).scalars().all()
+
+    # --- Step 2: dedup to latest-per-(instance_id, field_id) ---
+    seen: set[tuple[UUID, UUID]] = set()
+    deduped: list[ExtractionProposalRecord] = []
+    for p in proposals:
+        key = (p.instance_id, p.field_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(p)
+
+    if not deduped:
+        return AISuggestionsResponse(suggestions=[], count=0)
+
+    # --- Step 3: load evidence keyed by proposal_record_id ---
+    proposal_ids = [p.id for p in deduped]
+    evidence_rows = (
+        (
+            await db.execute(
+                select(ExtractionEvidence).where(
+                    ExtractionEvidence.proposal_record_id.in_(proposal_ids)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    evidence_by_proposal: dict[UUID, ExtractionEvidence] = {}
+    for ev in evidence_rows:
+        if ev.proposal_record_id and ev.proposal_record_id not in evidence_by_proposal:
+            evidence_by_proposal[ev.proposal_record_id] = ev
+
+    # --- Step 4: load CALLER's reviewer_states → decisions (blind boundary) ---
+    # NOTE: this query is intentionally NOT filtered by article — article scope is
+    # enforced transitively: the resulting decision_by_coord map is only consulted
+    # for proposals that passed the article-scoped dedup above, so a status row
+    # for a foreign instance can never attach to a returned item.  Do NOT add an
+    # article join here; the intersection IS the guard.
+    state_stmt = (
+        select(ExtractionReviewerState, ExtractionReviewerDecision)
+        .join(
+            ExtractionReviewerDecision,
+            and_(
+                ExtractionReviewerDecision.run_id == ExtractionReviewerState.run_id,
+                ExtractionReviewerDecision.id == ExtractionReviewerState.current_decision_id,
+            ),
+        )
+        .where(
+            ExtractionReviewerState.instance_id.in_(instance_ids),
+            ExtractionReviewerState.reviewer_id == caller_id,  # BLIND BOUNDARY
+        )
+    )
+    if run_id is not None:
+        state_stmt = state_stmt.where(ExtractionReviewerState.run_id == run_id)
+
+    state_rows = (await db.execute(state_stmt)).all()
+
+    # Map (instance_id, field_id) → decision string
+    decision_by_coord: dict[tuple[UUID, UUID], str] = {}
+    for state, decision in state_rows:
+        coord = (state.instance_id, state.field_id)
+        decision_by_coord[coord] = decision.decision
+
+    # --- Step 5: build response items ---
+    items: list[AISuggestionItem] = []
+    for p in deduped:
+        ev = evidence_by_proposal.get(p.id)
+        evidence_resp = (
+            EvidenceResponse(
+                proposal_record_id=p.id,
+                text_content=ev.text_content,
+                page_number=ev.page_number,
+            )
+            if ev is not None
+            else None
+        )
+        coord = (p.instance_id, p.field_id)
+        status = _resolve_status(decision_by_coord.get(coord))
+        items.append(
+            AISuggestionItem(
+                id=p.id,
+                run_id=p.run_id,
+                instance_id=p.instance_id,
+                field_id=p.field_id,
+                proposed_value=p.proposed_value,
+                confidence_score=float(p.confidence_score)
+                if p.confidence_score is not None
+                else None,
+                rationale=p.rationale,
+                created_at=p.created_at,
+                evidence=evidence_resp,
+                status=status,
+            )
+        )
+
+    return AISuggestionsResponse(suggestions=items, count=len(items))
+
+
+async def get_suggestion_history(
+    db: AsyncSession,
+    instance_id: UUID,
+    field_id: UUID,
+    *,
+    article_id: UUID,
+    limit: int = 10,
+) -> list[AISuggestionHistoryItem]:
+    """Return AI proposals for a single (instance, field) coord, newest first.
+
+    No status — history is the proposal trail only.
+    Scoped to article_id via JOIN on ExtractionInstance — if the instance does
+    not belong to the path article, an empty list is returned (cross-project
+    IDOR guard, mirrors the RLS protection the old PostgREST path had).
+    Mirrors AISuggestionService.getHistory.
+    """
+    proposals = (
+        (
+            await db.execute(
+                select(ExtractionProposalRecord)
+                .join(
+                    ExtractionInstance,
+                    and_(
+                        ExtractionInstance.id == ExtractionProposalRecord.instance_id,
+                        ExtractionInstance.article_id == article_id,
+                    ),
+                )
+                .where(
+                    ExtractionProposalRecord.instance_id == instance_id,
+                    ExtractionProposalRecord.field_id == field_id,
+                    ExtractionProposalRecord.source == ExtractionProposalSource.AI.value,
+                )
+                .order_by(ExtractionProposalRecord.created_at.desc())
+                .limit(limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    if not proposals:
+        return []
+
+    proposal_ids = [p.id for p in proposals]
+    evidence_rows = (
+        (
+            await db.execute(
+                select(ExtractionEvidence).where(
+                    ExtractionEvidence.proposal_record_id.in_(proposal_ids)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    evidence_by_proposal: dict[UUID, ExtractionEvidence] = {}
+    for ev in evidence_rows:
+        if ev.proposal_record_id and ev.proposal_record_id not in evidence_by_proposal:
+            evidence_by_proposal[ev.proposal_record_id] = ev
+
+    items: list[AISuggestionHistoryItem] = []
+    for p in proposals:
+        ev = evidence_by_proposal.get(p.id)
+        evidence_resp = (
+            EvidenceResponse(
+                proposal_record_id=p.id,
+                text_content=ev.text_content,
+                page_number=ev.page_number,
+            )
+            if ev is not None
+            else None
+        )
+        items.append(
+            AISuggestionHistoryItem(
+                id=p.id,
+                run_id=p.run_id,
+                instance_id=p.instance_id,
+                field_id=p.field_id,
+                proposed_value=p.proposed_value,
+                confidence_score=float(p.confidence_score)
+                if p.confidence_score is not None
+                else None,
+                rationale=p.rationale,
+                created_at=p.created_at,
+                evidence=evidence_resp,
+            )
+        )
+
+    return items

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -44,6 +44,8 @@ from app.repositories import (
     ExtractionInstanceRepository,
     ExtractionRunRepository,
 )
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+from app.services.evidence_anchor_service import build_anchor
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.pdf_processor import PDFProcessor
 from app.services.run_lifecycle_service import RunLifecycleService
@@ -1219,6 +1221,23 @@ class SectionExtractionService(LoggerMixin):
                 entity_type_id=str(entity_type_id),
             )
 
+        # Resolve the article's main PDF file and its text blocks once, so
+        # build_anchor can ground each evidence quote to a PositionV1 anchor.
+        # Guard: missing main file or no blocks → empty list; safe fallback
+        # keeps position={} and the LLM's page_number (no exception raised).
+        _anchor_blocks: list = []
+        _anchor_file_id: UUID | None = None
+        try:
+            _main_file = await self._article_files.get_latest_pdf(article_id)
+            if _main_file is not None:
+                _anchor_file_id = _main_file.id
+                _anchor_blocks = await ArticleTextBlockRepository(self.db).list_ordered_for_file(
+                    _main_file.id
+                )
+        except Exception:
+            _anchor_blocks = []
+            _anchor_file_id = None
+
         # Record one ProposalRecord per extracted field. Evidence cited by
         # the LLM is stored as a real extraction_evidence row linked to
         # the proposal via proposal_record_id.
@@ -1269,15 +1288,24 @@ class SectionExtractionService(LoggerMixin):
             )
 
             if evidence_meta:
+                _quote = evidence_meta.get("text") or ""
+                _pos = build_anchor(_quote, _anchor_blocks) if _anchor_blocks and _quote else None
+                if _pos is not None:
+                    _position: dict = _pos.model_dump(by_alias=True, mode="json")
+                    _page_num = _pos.anchor.range.page
+                else:
+                    _position = {}
+                    _page_num = evidence_meta.get("page_number")
                 self.db.add(
                     ExtractionEvidence(
                         project_id=project_id,
                         article_id=article_id,
+                        article_file_id=_anchor_file_id if _pos is not None else None,
                         run_id=run.id,
                         proposal_record_id=proposal.id,
-                        page_number=evidence_meta.get("page_number"),
+                        page_number=_page_num,
                         text_content=evidence_meta.get("text"),
-                        position={},
+                        position=_position,
                         created_by=UUID(self.user_id),
                     )
                 )

--- a/backend/tests/integration/test_build_run_view.py
+++ b/backend/tests/integration/test_build_run_view.py
@@ -4,10 +4,14 @@ blind leak, and current_values must be empty in proposal stage."""
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.extraction_run_read_service import build_run_view
+from tests.integration.conftest import SEED
 from tests.integration.test_blind_review_isolation import (
     _build_two_reviewer_review_run,
 )
@@ -42,4 +46,86 @@ async def test_build_run_view_current_values_empty_in_proposal(
     assert view.run.stage == "proposal"
     assert view.current_values == [], (
         "proposal stage must use proposals[] on the client, not server current_values"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_run_view_instances_populated_and_scoped(
+    db_session: AsyncSession,
+) -> None:
+    """build_run_view must populate instances scoped to (article_id, template_id).
+
+    Creates a fresh run via _proposal_stage_coord (same builder used by
+    test_build_run_view_current_values_empty_in_proposal) so the test always
+    executes — it no longer depends on a pre-existing run surviving the seed
+    purge.
+
+    Scope assertions:
+    1. view.instances is a non-empty list.
+    2. Every returned instance has article_id == run.article_id AND
+       template_id == run.template_id.
+    3. Cross-contamination proof: a foreign instance inserted under a different
+       article_id is NOT returned by build_run_view.
+    """
+    fx = await _proposal_stage_coord(db_session)
+    if fx is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, _instance_id, _field_id, user_id = fx
+
+    view = await build_run_view(db_session, run_id, caller_id=user_id, can_see_peers=True)
+
+    assert isinstance(view.instances, list), "instances must be a list"
+    assert len(view.instances) >= 1, (
+        "build_run_view must return at least the seed instance for this article+template"
+    )
+
+    run_article_id = view.run.article_id
+    run_template_id = view.run.template_id
+
+    # Scope check: every instance must match the run's (article_id, template_id).
+    for inst in view.instances:
+        assert inst.article_id == run_article_id, (
+            f"Instance {inst.id} has article_id {inst.article_id!r} but run has {run_article_id!r}"
+        )
+        assert inst.template_id == run_template_id, (
+            f"Instance {inst.id} has template_id {inst.template_id!r} "
+            f"but run has {run_template_id!r}"
+        )
+
+    # Cross-contamination proof: insert an instance under a DIFFERENT article_id
+    # (using a fresh article in the same project) and confirm it is excluded.
+    foreign_article_id = uuid4()
+    foreign_instance_id = uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, 'Foreign Article (scope test)', 1)"
+        ),
+        {"id": str(foreign_article_id), "pid": str(SEED.primary_project)},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO public.extraction_instances "
+            "(id, project_id, template_id, entity_type_id, article_id, "
+            " label, status, created_by) "
+            "VALUES (:id, :pid, :tid, :etid, :aid, "
+            " 'Foreign Instance (scope test)', 'pending', :created_by)"
+        ),
+        {
+            "id": str(foreign_instance_id),
+            "pid": str(SEED.primary_project),
+            "tid": str(run_template_id),
+            "etid": str(SEED.primary_entity_type),
+            "aid": str(foreign_article_id),
+            "created_by": str(user_id),
+        },
+    )
+    await db_session.flush()
+
+    # Re-query after inserting the foreign instance.
+    view2 = await build_run_view(db_session, run_id, caller_id=user_id, can_see_peers=True)
+    returned_ids = {i.id for i in view2.instances}
+    assert foreign_instance_id not in returned_ids, (
+        "_instances_for_run must exclude instances from other articles; "
+        f"foreign instance {foreign_instance_id} leaked into view"
     )

--- a/backend/tests/integration/test_extraction_consensus_service.py
+++ b/backend/tests/integration/test_extraction_consensus_service.py
@@ -341,34 +341,42 @@ async def test_select_existing_rejects_cross_coordinate_decision(
         pytest.skip("Missing fixtures.")
     run_id, instance_id, field_id, profile_id, decision_id = fx
 
-    # Find a different (instance, field) coordinate in the same template.
-    other_row = await db_session.execute(
-        text(
-            """
-            SELECT i.id, f.id
-            FROM public.extraction_instances i
-            JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
-            JOIN public.extraction_fields f ON f.entity_type_id = et.id
-            WHERE (i.id <> :iid OR f.id <> :fid)
-              AND i.template_id = (
-                  SELECT template_id FROM public.extraction_instances WHERE id = :iid
-              )
-            LIMIT 1
-            """
-        ),
-        {"iid": instance_id, "fid": field_id},
-    )
-    other = other_row.first()
-    if other is None:
-        pytest.skip("Need a second coordinate in the same template.")
-    other_instance_id, other_field_id = other
+    # Build a second coordinate that is coherent for this run by adding a field
+    # to the run instance's own entity_type. (instance_id, other_field_id) then
+    # belongs to the run's article + template, so it passes the #189 coherence
+    # guard (assert_coords_coherent) and the call actually reaches the
+    # "belongs to" guard this test asserts. We cannot borrow a coordinate from
+    # the DB: the seed gives the article exactly one field, and scoping by
+    # template alone would pick a *different article's* instance, which the
+    # coherence guard rejects first (CoordinateMismatchError, not the
+    # InvalidConsensusError under test).
+    entity_type_id = (
+        await db_session.execute(
+            text("SELECT entity_type_id FROM public.extraction_instances WHERE id = :iid"),
+            {"iid": instance_id},
+        )
+    ).scalar()
+    other_field_id = (
+        await db_session.execute(
+            text(
+                """
+                INSERT INTO public.extraction_fields (entity_type_id, name, label, field_type)
+                VALUES (:etid, 'xcoord_probe', 'Cross-coordinate probe', 'text')
+                RETURNING id
+                """
+            ),
+            {"etid": entity_type_id},
+        )
+    ).scalar()
 
     service = ExtractionConsensusService(db_session)
-    # decision_id is for (instance_id, field_id); call consensus on the OTHER coord.
+    # decision_id targets (instance_id, field_id); recording consensus on the
+    # sibling coordinate (instance_id, other_field_id) with that decision must
+    # trip the "belongs to" guard on the field mismatch.
     with pytest.raises(InvalidConsensusError, match="belongs to"):
         await service.record_consensus(
             run_id=run_id,
-            instance_id=other_instance_id,
+            instance_id=instance_id,
             field_id=other_field_id,
             consensus_user_id=profile_id,
             mode=ExtractionConsensusMode.SELECT_EXISTING,

--- a/backend/tests/integration/test_hitl_session_embeds_run_view.py
+++ b/backend/tests/integration/test_hitl_session_embeds_run_view.py
@@ -100,10 +100,12 @@ async def test_extraction_session_open_embeds_run_view(
     assert view["run"]["id"] == run_id, "Embedded run id must match run_id in response"
     assert "entity_types" in view, "run_view must contain entity_types"
     assert "current_values" in view, "run_view must contain current_values"
+    assert "instances" in view, "run_view must contain instances"
     assert view["run"]["stage"] == "proposal", "Session open must advance the run to proposal stage"
     assert view["current_values"] == [], (
         "current_values must be empty for a freshly-opened proposal-stage run"
     )
+    assert isinstance(view["instances"], list), "instances must be a list"
     # RunDetailResponse keys inherited by RunViewResponse
     assert "proposals" in view
     assert "decisions" in view

--- a/backend/tests/integration/test_position_v1_anchoring.py
+++ b/backend/tests/integration/test_position_v1_anchoring.py
@@ -1,0 +1,700 @@
+"""Integration tests for PositionV1 evidence anchoring (Task 2.2).
+
+Verifies the full write path:
+  build_anchor(quote, blocks) → PositionV1 → ExtractionEvidence.position (JSONB)
+
+Four cases:
+  1. prose quote  → TextCitationAnchor  (kind="text")
+  2. table_cell quote → HybridCitationAnchor (kind="hybrid", rect present)
+  3. unmatched quote / no blocks → position == {} (safe fallback, run continues)
+  4. citation_read_service emits the stored anchor camelCase for an anchored row
+
+Uses db_session_real because ExtractionEvidence is inserted inside
+_create_suggestions, which calls flush() (not commit()); we commit at
+the end of each test body and clean up in finally blocks.
+"""
+
+from __future__ import annotations
+
+import uuid
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.extraction import ExtractionEvidence
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+from app.schemas.extraction import (
+    HybridCitationAnchor,
+    PositionV1,
+    TextCitationAnchor,
+    parse_position,
+)
+from app.services.citation_read_service import list_article_citations
+from app.services.evidence_anchor_service import build_anchor
+from tests.integration.conftest import SEED
+
+# ---------------------------------------------------------------------------
+# Shared helpers  (mirror the pattern from test_article_text_block_repository)
+# ---------------------------------------------------------------------------
+
+
+async def _insert_article_file(
+    db: AsyncSession,
+    *,
+    project_id: UUID,
+    article_id: UUID,
+) -> UUID:
+    file_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": str(file_id),
+            "pid": str(project_id),
+            "aid": str(article_id),
+            "key": f"test-anchor/{file_id}.pdf",
+        },
+    )
+    await db.commit()
+    return file_id
+
+
+async def _cleanup_file(db: AsyncSession, *, file_id: UUID) -> None:
+    """Cascade-delete the article_file and everything under it."""
+    await db.execute(
+        text("DELETE FROM public.article_files WHERE id = :id"),
+        {"id": str(file_id)},
+    )
+    await db.commit()
+
+
+async def _cleanup_evidence(db: AsyncSession, *, article_id: UUID) -> None:
+    """Remove evidence rows inserted by the test."""
+    await db.execute(
+        text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+        {"aid": str(article_id)},
+    )
+    await db.commit()
+
+
+async def _insert_run_and_proposal(
+    db: AsyncSession,
+    *,
+    project_id: UUID,
+    article_id: UUID,
+) -> tuple[UUID, UUID]:
+    """Create a minimal extraction_run + proposal_record so evidence rows
+    satisfy the ``workflow_target_present`` CHECK constraint.
+
+    Returns (run_id, proposal_record_id).
+    """
+    # Resolve template + active version + instance + field from seed rows.
+    template_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.project_extraction_templates "
+                "WHERE project_id = :pid AND kind='extraction' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
+        )
+    ).scalar()
+    version_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.extraction_template_versions "
+                "WHERE project_template_id = :tid AND is_active LIMIT 1"
+            ),
+            {"tid": str(template_id)},
+        )
+    ).scalar()
+    entity_type_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.extraction_entity_types "
+                "WHERE project_template_id = :tid LIMIT 1"
+            ),
+            {"tid": str(template_id)},
+        )
+    ).scalar()
+    field_id = (
+        await db.execute(
+            text("SELECT id FROM public.extraction_fields WHERE entity_type_id = :etid LIMIT 1"),
+            {"etid": str(entity_type_id)},
+        )
+    ).scalar()
+
+    # Auto-create an instance for this article if one doesn't exist yet.
+    instance_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.extraction_instances "
+                "WHERE article_id = :aid AND entity_type_id = :etid LIMIT 1"
+            ),
+            {"aid": str(article_id), "etid": str(entity_type_id)},
+        )
+    ).scalar()
+    if instance_id is None:
+        instance_id = uuid.uuid4()
+        await db.execute(
+            text(
+                "INSERT INTO public.extraction_instances "
+                "(id, project_id, template_id, entity_type_id, article_id, "
+                " label, status, created_by) "
+                "VALUES (:id, :pid, :tid, :etid, :aid, 'anchor-test', 'pending', :cb)"
+            ),
+            {
+                "id": str(instance_id),
+                "pid": str(project_id),
+                "tid": str(template_id),
+                "etid": str(entity_type_id),
+                "aid": str(article_id),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+
+    run_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.extraction_runs "
+            "(id, project_id, article_id, template_id, version_id, kind, stage, "
+            " status, created_by) "
+            "VALUES (:id, :pid, :aid, :tid, :vid, 'extraction', 'pending', "
+            " 'pending', :cb)"
+        ),
+        {
+            "id": str(run_id),
+            "pid": str(project_id),
+            "aid": str(article_id),
+            "tid": str(template_id),
+            "vid": str(version_id),
+            "cb": str(SEED.primary_profile),
+        },
+    )
+    proposal_id = uuid.uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.extraction_proposal_records "
+            "(id, run_id, instance_id, field_id, source, proposed_value) "
+            "VALUES (:id, :rid, :inst, :fid, 'ai', '{}'::jsonb)"
+        ),
+        {
+            "id": str(proposal_id),
+            "rid": str(run_id),
+            "inst": str(instance_id),
+            "fid": str(field_id),
+        },
+    )
+    await db.commit()
+    return run_id, proposal_id
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_anchor_prose_block_returns_text_citation(
+    db_session_real: AsyncSession,
+) -> None:
+    """A quote from a prose block produces a TextCitationAnchor written to the DB."""
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        prose_text = "The sample consisted of one hundred adult participants."
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(
+                    page_number=1,
+                    block_index=0,
+                    text=prose_text,
+                    char_start=0,
+                    char_end=len(prose_text),
+                    bbox={"x": 10.0, "y": 100.0, "width": 400.0, "height": 12.0},
+                    block_type="paragraph",
+                )
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        pos = build_anchor(prose_text, blocks)
+        assert pos is not None, "Expected a PositionV1 for a prose quote"
+        assert isinstance(pos, PositionV1)
+        assert pos.version == 1
+        assert isinstance(pos.anchor, TextCitationAnchor)
+        assert pos.anchor.kind == "text"
+        assert pos.anchor.range.page == 1
+        assert pos.anchor.range.char_start == 0
+        assert pos.anchor.range.char_end == len(prose_text)
+        assert pos.anchor.quote == prose_text
+
+        # Round-trip: model_dump (camelCase) → parse_position
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        assert "charStart" in dumped["anchor"]["range"]
+        assert "charEnd" in dumped["anchor"]["range"]
+        reparsed = parse_position(dumped)
+        assert reparsed is not None
+        assert isinstance(reparsed.anchor, TextCitationAnchor)
+
+        # Create a run + proposal so the workflow_target_present CHECK passes.
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real,
+            project_id=SEED.primary_project,
+            article_id=SEED.primary_article,
+        )
+
+        # Write a real evidence row and verify the JSONB round-trip from the DB
+        evidence_id = uuid.uuid4()
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, "
+                " run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, :pg, :tc, CAST(:pos AS jsonb), :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(SEED.primary_article),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "pg": 1,
+                "tc": prose_text,
+                "pos": __import__("json").dumps(dumped),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        row = (
+            await db_session_real.execute(
+                select(ExtractionEvidence).where(ExtractionEvidence.id == evidence_id)
+            )
+        ).scalar_one()
+        db_pos = parse_position(row.position)
+        assert db_pos is not None
+        assert isinstance(db_pos.anchor, TextCitationAnchor)
+        assert db_pos.anchor.range.char_start == 0
+    finally:
+        # Clean up evidence, run (CASCADE handles evidence + proposal), and file.
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE id = :id"),
+            {"id": str(evidence_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :id"),
+            {"id": str(run_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_build_anchor_table_cell_block_returns_hybrid_citation(
+    db_session_real: AsyncSession,
+) -> None:
+    """A quote from a table_cell block produces a HybridCitationAnchor with rect."""
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+    )
+    try:
+        table_text = "RR 0.72 (95% CI 0.55-0.94)"
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(
+                    page_number=2,
+                    block_index=0,
+                    text=table_text,
+                    char_start=0,
+                    char_end=len(table_text),
+                    bbox={"x": 50.0, "y": 200.0, "width": 150.0, "height": 10.0},
+                    block_type="table_cell",
+                )
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        pos = build_anchor(table_text, blocks)
+        assert pos is not None, "Expected a PositionV1 for a table_cell quote"
+        assert isinstance(pos, PositionV1)
+        assert isinstance(pos.anchor, HybridCitationAnchor)
+        assert pos.anchor.kind == "hybrid"
+        assert pos.anchor.range.page == 2
+        assert pos.anchor.rect.x == 50.0
+        assert pos.anchor.rect.width == 150.0
+        assert pos.anchor.quote == table_text
+
+        # camelCase round-trip
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        assert "rect" in dumped["anchor"]
+        reparsed = parse_position(dumped)
+        assert reparsed is not None
+        assert isinstance(reparsed.anchor, HybridCitationAnchor)
+    finally:
+        await _cleanup_file(db_session_real, file_id=file_id)
+
+
+@pytest.mark.asyncio
+async def test_build_anchor_no_match_returns_none() -> None:
+    """build_anchor returns None when the quote is not found in the blocks."""
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    blocks = [
+        ParsedBlock(
+            page_number=1,
+            block_index=0,
+            text="Completely different text that shares nothing with the query.",
+            char_start=0,
+            char_end=59,
+            bbox={"x": 0.0, "y": 0.0, "width": 400.0, "height": 12.0},
+            block_type="paragraph",
+        )
+    ]
+    pos = build_anchor("The sky is green and pigs can fly over rainbows.", blocks)
+    assert pos is None
+
+
+@pytest.mark.asyncio
+async def test_build_anchor_empty_blocks_returns_none() -> None:
+    """build_anchor returns None when the block list is empty (no PDF ingested)."""
+    pos = build_anchor("Any quote at all", [])
+    assert pos is None
+
+
+@pytest.mark.asyncio
+async def test_citation_read_service_verified_true_for_anchored_row(
+    db_session_real: AsyncSession,
+) -> None:
+    """An evidence row with a valid PositionV1 is returned with verified=True, anchorKind='text'."""
+    import json
+
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    fresh_article_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {
+            "id": str(fresh_article_id),
+            "pid": str(SEED.primary_project),
+            "title": "Verified True Test Article",
+        },
+    )
+    await db_session_real.commit()
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=fresh_article_id,
+    )
+
+    try:
+        quote = "Beta-blocker therapy reduced all-cause mortality by 34%."
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(
+                    page_number=5,
+                    block_index=0,
+                    text=quote,
+                    char_start=0,
+                    char_end=len(quote),
+                    bbox={"x": 72.0, "y": 400.0, "width": 380.0, "height": 12.0},
+                    block_type="paragraph",
+                )
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        pos = build_anchor(quote, blocks)
+        assert pos is not None
+
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real,
+            project_id=SEED.primary_project,
+            article_id=fresh_article_id,
+        )
+
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        evidence_id = uuid.uuid4()
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, "
+                " run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, :pg, :tc, CAST(:pos AS jsonb), :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(fresh_article_id),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "pg": pos.anchor.range.page,
+                "tc": quote,
+                "pos": json.dumps(dumped),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        citations = await list_article_citations(db_session_real, fresh_article_id)
+        assert len(citations) == 1
+        c = citations[0]
+        assert c["id"] == str(evidence_id)
+        # verified / anchorKind presence (Task 2.3)
+        assert c["verified"] is True
+        assert c["anchorKind"] == "text"
+        assert "anchor" in c
+        assert c["anchor"]["kind"] == "text"
+    finally:
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+            {"aid": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :id"),
+            {"id": str(run_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+        await db_session_real.execute(
+            text("DELETE FROM public.articles WHERE id = :id"),
+            {"id": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+
+
+@pytest.mark.asyncio
+async def test_citation_read_service_verified_false_for_unanchored_row(
+    db_session_real: AsyncSession,
+) -> None:
+    """An evidence row with position={} is returned verified=False, anchorKind=None, not skipped."""
+    fresh_article_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {
+            "id": str(fresh_article_id),
+            "pid": str(SEED.primary_project),
+            "title": "Verified False Test Article",
+        },
+    )
+    await db_session_real.commit()
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=fresh_article_id,
+    )
+
+    try:
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real,
+            project_id=SEED.primary_project,
+            article_id=fresh_article_id,
+        )
+
+        evidence_id = uuid.uuid4()
+        # Insert with position={} — the hallucinated / no-blocks-yet case.
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, "
+                " run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, NULL, :tc, '{}'::jsonb, :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(fresh_article_id),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "tc": "This quote was hallucinated by the AI.",
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        citations = await list_article_citations(db_session_real, fresh_article_id)
+        # Must NOT be skipped — the row should be present
+        assert len(citations) == 1, f"Expected 1 citation (not skipped), got {len(citations)}"
+        c = citations[0]
+        assert c["id"] == str(evidence_id)
+        # verified=False, anchorKind=None (unanchored)
+        assert c["verified"] is False
+        assert c["anchorKind"] is None
+        # anchor is absent or None for unanchored rows
+        assert c.get("anchor") is None
+        # metadata still present
+        assert c["metadata"]["textContent"] == "This quote was hallucinated by the AI."
+        # nothing raised — we got here
+    finally:
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+            {"aid": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :id"),
+            {"id": str(run_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+        await db_session_real.execute(
+            text("DELETE FROM public.articles WHERE id = :id"),
+            {"id": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+
+
+@pytest.mark.asyncio
+async def test_citation_read_service_emits_anchored_evidence_camelcase(
+    db_session_real: AsyncSession,
+) -> None:
+    """citation_read_service returns the stored TextCitationAnchor camelCase for an anchored row."""
+    import json
+
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    # Use a fresh article so we don't collide with other test rows
+    fresh_article_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {
+            "id": str(fresh_article_id),
+            "pid": str(SEED.primary_project),
+            "title": "Anchor Read Service Test Article",
+        },
+    )
+    await db_session_real.commit()
+
+    file_id = await _insert_article_file(
+        db_session_real,
+        project_id=SEED.primary_project,
+        article_id=fresh_article_id,
+    )
+
+    try:
+        quote = "Patients were randomized in a 1:1 ratio."
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(
+                    page_number=3,
+                    block_index=0,
+                    text=quote,
+                    char_start=0,
+                    char_end=len(quote),
+                    bbox={"x": 72.0, "y": 300.0, "width": 380.0, "height": 12.0},
+                    block_type="paragraph",
+                )
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        pos = build_anchor(quote, blocks)
+        assert pos is not None
+
+        # Create a run + proposal so the workflow_target_present CHECK passes.
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real,
+            project_id=SEED.primary_project,
+            article_id=fresh_article_id,
+        )
+
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        evidence_id = uuid.uuid4()
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, "
+                " run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, :pg, :tc, CAST(:pos AS jsonb), :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(fresh_article_id),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "pg": pos.anchor.range.page,
+                "tc": quote,
+                "pos": json.dumps(dumped),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        citations = await list_article_citations(db_session_real, fresh_article_id)
+        assert len(citations) == 1
+        c = citations[0]
+        assert c["id"] == str(evidence_id)
+        anchor = c["anchor"]
+        assert anchor["kind"] == "text"
+        assert "range" in anchor
+        assert "charStart" in anchor["range"]
+        assert "charEnd" in anchor["range"]
+        assert anchor["range"]["charStart"] == 0
+        assert anchor["range"]["charEnd"] == len(quote)
+        meta = c["metadata"]
+        assert meta["pageNumber"] == 3
+        assert meta["textContent"] == quote
+    finally:
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+            {"aid": str(fresh_article_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE id = :id"),
+            {"id": str(run_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+        await db_session_real.execute(
+            text("DELETE FROM public.articles WHERE id = :id"),
+            {"id": str(fresh_article_id)},
+        )
+        await db_session_real.commit()

--- a/backend/tests/integration/test_run_resolution_endpoints.py
+++ b/backend/tests/integration/test_run_resolution_endpoints.py
@@ -1,0 +1,341 @@
+"""Integration tests for article-scoped run-resolution endpoints.
+
+Tests three endpoints:
+  GET /api/v1/articles/{article_id}/active-run?template_id=...
+  GET /api/v1/articles/{article_id}/finalized-run?template_id=...
+  POST /api/v1/articles/form-runs  body: {article_ids, template_id, project_id}
+
+TDD: written RED first, then made GREEN by the implementation.
+
+Pattern mirrors test_run_view_endpoint.py:
+- db_client / db_session fixtures from conftest
+- auth_as_profile / outsider_user for BOLA tests
+- _create_run_via_api for seeding runs
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from tests.integration.conftest import SEED
+
+_RUNS_URL = "/api/v1/runs"
+_ARTICLES_URL = "/api/v1/articles"
+
+
+# =================== FIXTURES ===================
+
+
+@pytest_asyncio.fixture
+async def auth_as_profile(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Pin JWT sub to SEED.primary_profile (manager of primary_project)."""
+    del db_session  # fixture ordering: seed runs first
+    profile_id = SEED.primary_profile
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="primary@integration-test.prumo.local",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield profile_id
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest_asyncio.fixture
+async def outsider_user(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Create a fresh profile that has no project membership (BOLA test)."""
+    import uuid as _uuid_mod
+
+    outsider_id = _uuid_mod.uuid4()
+    email = f"outsider-resolution-{outsider_id}@run-resolution-test.local"
+
+    await db_session.execute(
+        text(
+            "INSERT INTO auth.users (id, email, instance_id, aud, role) "
+            "VALUES (:id, :email, '00000000-0000-0000-0000-000000000000', "
+            "'authenticated', 'authenticated')"
+        ),
+        {"id": str(outsider_id), "email": email},
+    )
+    await db_session.commit()
+
+    profile_id = (
+        await db_session.execute(
+            text("SELECT id FROM public.profiles WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+    ).scalar()
+    if profile_id is None:
+        await db_session.execute(
+            text("INSERT INTO public.profiles (id, full_name) VALUES (:id, 'Outsider Resolution')"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.commit()
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(outsider_id),
+            email=email,
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield outsider_id
+    finally:
+        await db_session.execute(
+            text("DELETE FROM public.profiles WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.execute(
+            text("DELETE FROM auth.users WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.commit()
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+# =================== HELPERS ===================
+
+
+async def _create_extraction_run(client: AsyncClient) -> dict[str, Any]:
+    """Create a new extraction run via POST /api/v1/runs."""
+    body = {
+        "project_id": str(SEED.primary_project),
+        "article_id": str(SEED.primary_article),
+        "project_template_id": str(SEED.primary_template),
+    }
+    resp = await client.post(_RUNS_URL, json=body)
+    assert resp.status_code == 201, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    return payload["data"]
+
+
+async def _force_finalize_run(db: AsyncSession, run_id: str) -> None:
+    """Directly set a run to finalized stage (bypasses business rules)."""
+    await db.execute(
+        text(
+            "UPDATE public.extraction_runs SET stage='finalized', status='completed' WHERE id=:id"
+        ),
+        {"id": run_id},
+    )
+    await db.commit()
+
+
+# =================== TESTS ===================
+
+
+@pytest.mark.asyncio
+async def test_active_run_returns_200_with_run_id(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001 — seed ordering
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """Happy path: a member gets 200 with the active run's id."""
+    created = await _create_extraction_run(db_client)
+    run_id = created["id"]
+    article_id = str(SEED.primary_article)
+
+    resp = await db_client.get(f"{_ARTICLES_URL}/{article_id}/active-run")
+    assert resp.status_code == 200, resp.text
+
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+    assert data is not None
+    assert data["id"] == run_id
+
+
+@pytest.mark.asyncio
+async def test_active_run_with_template_id_filter(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """active-run with correct template_id still returns the run."""
+    created = await _create_extraction_run(db_client)
+    run_id = created["id"]
+    article_id = str(SEED.primary_article)
+    template_id = str(SEED.primary_template)
+
+    resp = await db_client.get(
+        f"{_ARTICLES_URL}/{article_id}/active-run",
+        params={"template_id": template_id},
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    assert payload["data"]["id"] == run_id
+
+
+@pytest.mark.asyncio
+async def test_active_run_returns_null_when_finalized(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """active-run returns null when the only run for that article is finalized."""
+    created = await _create_extraction_run(db_client)
+    run_id = created["id"]
+    await _force_finalize_run(db_session, run_id)
+
+    article_id = str(SEED.primary_article)
+    resp = await db_client.get(f"{_ARTICLES_URL}/{article_id}/active-run")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    assert payload["data"] is None
+
+
+@pytest.mark.asyncio
+async def test_finalized_run_returns_null_when_no_finalized_run(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """finalized-run returns null when the only run for the article is active."""
+    await _create_extraction_run(db_client)
+    article_id = str(SEED.primary_article)
+
+    resp = await db_client.get(f"{_ARTICLES_URL}/{article_id}/finalized-run")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    assert payload["data"] is None
+
+
+@pytest.mark.asyncio
+async def test_finalized_run_returns_run_when_finalized(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """finalized-run returns the run id once it reaches finalized stage."""
+    created = await _create_extraction_run(db_client)
+    run_id = created["id"]
+    await _force_finalize_run(db_session, run_id)
+
+    article_id = str(SEED.primary_article)
+    resp = await db_client.get(f"{_ARTICLES_URL}/{article_id}/finalized-run")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    assert payload["data"] is not None
+    assert payload["data"]["id"] == run_id
+
+
+@pytest.mark.asyncio
+async def test_active_run_returns_403_for_non_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    outsider_user: UUID,  # noqa: ARG001
+) -> None:
+    """BOLA gate: non-member gets 403 on active-run."""
+    # Seed an article owned by primary_project (outsider is not a member)
+    article_id = str(SEED.primary_article)
+    resp = await db_client.get(f"{_ARTICLES_URL}/{article_id}/active-run")
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_finalized_run_returns_403_for_non_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    outsider_user: UUID,  # noqa: ARG001
+) -> None:
+    """BOLA gate: non-member gets 403 on finalized-run."""
+    article_id = str(SEED.primary_article)
+    resp = await db_client.get(f"{_ARTICLES_URL}/{article_id}/finalized-run")
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_form_runs_returns_article_run_refs(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """POST /form-runs returns one ArticleRunRef per input article."""
+    created = await _create_extraction_run(db_client)
+    run_id = created["id"]
+    article_id = str(SEED.primary_article)
+
+    body = {
+        "article_ids": [article_id],
+        "template_id": str(SEED.primary_template),
+        "project_id": str(SEED.primary_project),
+    }
+    resp = await db_client.post(f"{_ARTICLES_URL}/form-runs", json=body)
+    assert resp.status_code == 200, resp.text
+
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+    assert isinstance(data, list)
+    assert len(data) == 1
+    ref = data[0]
+    assert ref["article_id"] == article_id
+    assert ref["run_id"] == run_id
+
+
+@pytest.mark.asyncio
+async def test_form_runs_returns_null_run_id_when_no_run(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """POST /form-runs returns run_id=null when article has no runs."""
+    article_id = str(SEED.primary_article)
+
+    body = {
+        "article_ids": [article_id],
+        "template_id": str(SEED.primary_template),
+        "project_id": str(SEED.primary_project),
+    }
+    resp = await db_client.post(f"{_ARTICLES_URL}/form-runs", json=body)
+    assert resp.status_code == 200, resp.text
+
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+    assert len(data) == 1
+    assert data[0]["article_id"] == article_id
+    assert data[0]["run_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_form_runs_returns_403_for_non_member(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    outsider_user: UUID,  # noqa: ARG001
+) -> None:
+    """BOLA gate: non-member of project gets 403 on /form-runs."""
+    body = {
+        "article_ids": [str(SEED.primary_article)],
+        "template_id": str(SEED.primary_template),
+        "project_id": str(SEED.primary_project),
+    }
+    resp = await db_client.post(f"{_ARTICLES_URL}/form-runs", json=body)
+    assert resp.status_code == 403, resp.text

--- a/backend/tests/integration/test_run_view_endpoint.py
+++ b/backend/tests/integration/test_run_view_endpoint.py
@@ -234,6 +234,7 @@ async def test_get_run_view_returns_200_with_required_keys(
     # RunViewResponse additional fields
     assert "entity_types" in data
     assert "current_values" in data
+    assert "instances" in data, "RunViewResponse must include instances"
 
     # Freshly-created run in pending stage: no workflow rows yet; no
     # current_values (pending stage bypasses value resolution).
@@ -242,6 +243,15 @@ async def test_get_run_view_returns_200_with_required_keys(
     # entity_types may be empty when the seed template has no entity types
     # stored in the version snapshot, which is valid.
     assert isinstance(data["entity_types"], list)
+    assert isinstance(data["instances"], list)
+
+    # Wire-key assertion: instance dicts must emit "metadata" not "metadata_".
+    assert len(data["instances"]) >= 1, (
+        "need at least one instance to exercise the metadata wire key"
+    )
+    for inst in data["instances"]:
+        assert "metadata" in inst, "instance wire key must be 'metadata' not 'metadata_'"
+        assert "metadata_" not in inst, "ORM attribute name must not leak into JSON"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_suggestion_read.py
+++ b/backend/tests/integration/test_suggestion_read.py
@@ -1,0 +1,764 @@
+"""Integration tests for AI-suggestion read service + article endpoints.
+
+Tests:
+1. Service: load_suggestions returns AI proposals with status resolved from
+   the CALLER's reviewer_state — and reviewer A's overlay never reflects
+   reviewer B's decisions (blind boundary / Constraint 3).
+2. Service: get_suggestion_history returns proposals newest-first, no status.
+3. Service: get_article_instance_ids returns instance ids for an article.
+4. Endpoint GET /{article_id}/instance-ids — 200 + 403 BOLA.
+5. Endpoint GET /{article_id}/suggestions — 200 + 403 BOLA.
+6. Endpoint GET /{article_id}/suggestions/history — 200 + 403 BOLA.
+
+Pattern: mirrors test_run_view_endpoint.py / test_run_resolution_endpoints.py
+  - db_client (real-DB AsyncClient from backend/tests/conftest.py)
+  - auth_as_profile pins JWT sub to SEED.primary_profile
+  - outsider_user for BOLA tests
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from app.models.extraction import ExtractionRunStage
+from app.models.extraction_workflow import (
+    ExtractionProposalSource,
+    ExtractionReviewerDecisionType,
+)
+from app.services.extraction_proposal_service import ExtractionProposalService
+from app.services.extraction_review_service import ExtractionReviewService
+from app.services.extraction_suggestion_read_service import (
+    get_article_instance_ids,
+    get_suggestion_history,
+    load_suggestions,
+)
+from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
+
+_ARTICLES_URL = "/api/v1/articles"
+
+# ---------------------------------------------------------------------------
+# Helpers re-used across service + endpoint tests
+# ---------------------------------------------------------------------------
+
+SECOND_REVIEWER_ID = UUID("ffffffff-9999-0000-0000-0000000000bb")
+
+
+async def _build_suggestion_review_run(
+    db: AsyncSession,
+) -> tuple[UUID, UUID, UUID, UUID, UUID] | None:
+    """Create a run in REVIEW stage with an AI proposal + two reviewer decisions.
+
+    Returns ``(run_id, instance_id, field_id, reviewer_a, reviewer_b)``
+    or ``None`` if the seed graph is incomplete.
+
+    reviewer_a = SEED.reviewer_profile (existing reviewer member)
+    reviewer_b = SECOND_REVIEWER_ID (added here, rolled back with test)
+    """
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
+
+    # Resolve a reviewer from the seed
+    reviewer_a = SEED.reviewer_profile
+
+    # Ensure reviewer_a is actually a member
+    row = (
+        await db.execute(
+            text(
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND user_id = :uid LIMIT 1"
+            ),
+            {"pid": str(project_id), "uid": str(reviewer_a)},
+        )
+    ).scalar()
+    if row is None:
+        return None
+
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+
+    # Add second reviewer (in-test row, rolled back with session savepoint)
+    await db.execute(
+        text(
+            "INSERT INTO auth.users (id, email, instance_id, aud, role) "
+            "VALUES (:id, :email, '00000000-0000-0000-0000-000000000000', "
+            "'authenticated', 'authenticated') ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": str(SECOND_REVIEWER_ID), "email": "reviewer-b-suggest@integration-test.prumo.local"},
+    )
+    await db.execute(
+        text(
+            "INSERT INTO public.profiles (id, email, full_name) "
+            "VALUES (:id, :email, 'Integration Reviewer B (Suggest)') "
+            "ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email"
+        ),
+        {"id": str(SECOND_REVIEWER_ID), "email": "reviewer-b-suggest@integration-test.prumo.local"},
+    )
+    await db.execute(
+        text(
+            "INSERT INTO public.project_members (id, project_id, user_id, role) "
+            "VALUES (gen_random_uuid(), :pid, :uid, 'reviewer') "
+            "ON CONFLICT (project_id, user_id) DO NOTHING"
+        ),
+        {"pid": str(project_id), "uid": str(SECOND_REVIEWER_ID)},
+    )
+
+    manager_id = SEED.primary_profile
+    lifecycle = RunLifecycleService(db)
+    run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.PROPOSAL, user_id=manager_id
+    )
+
+    proposal_svc = ExtractionProposalService(db)
+    await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": "AI-PROPOSED"},
+        confidence_score=0.85,
+        rationale="AI rationale",
+    )
+
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.REVIEW, user_id=manager_id
+    )
+
+    review = ExtractionReviewService(db)
+    # reviewer_a accepts the proposal (EDIT decision)
+    await review.record_decision(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        reviewer_id=reviewer_a,
+        decision=ExtractionReviewerDecisionType.EDIT,
+        value={"value": "REVIEWER-A-VALUE"},
+    )
+    # reviewer_b rejects
+    await review.record_decision(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        reviewer_id=SECOND_REVIEWER_ID,
+        decision=ExtractionReviewerDecisionType.REJECT,
+        value=None,
+    )
+    await db.flush()
+
+    return run.id, instance_id, field_id, reviewer_a, SECOND_REVIEWER_ID
+
+
+# ---------------------------------------------------------------------------
+# Auth fixtures (same pattern as test_run_view_endpoint.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def auth_as_profile(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Pin JWT sub to SEED.primary_profile (manager of primary_project)."""
+    del db_session  # fixture ordering: seed runs first
+    profile_id = SEED.primary_profile
+
+    async def _override() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="primary@integration-test.prumo.local",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = _override
+    try:
+        yield profile_id
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest_asyncio.fixture
+async def auth_as_reviewer(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """Pin JWT sub to SEED.reviewer_profile."""
+    del db_session
+    profile_id = SEED.reviewer_profile
+
+    async def _override() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="reviewer@integration-test.prumo.local",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = _override
+    try:
+        yield profile_id
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest_asyncio.fixture
+async def outsider_user(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """A profile with no project membership — for BOLA tests."""
+    import uuid as _uuid_mod
+
+    outsider_id = _uuid_mod.uuid4()
+    email = f"outsider-suggest-{outsider_id}@test.local"
+
+    await db_session.execute(
+        text(
+            "INSERT INTO auth.users (id, email, instance_id, aud, role) "
+            "VALUES (:id, :email, '00000000-0000-0000-0000-000000000000', "
+            "'authenticated', 'authenticated')"
+        ),
+        {"id": str(outsider_id), "email": email},
+    )
+    await db_session.commit()
+
+    profile_id = (
+        await db_session.execute(
+            text("SELECT id FROM public.profiles WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+    ).scalar()
+    if profile_id is None:
+        await db_session.execute(
+            text("INSERT INTO public.profiles (id, full_name) VALUES (:id, 'Outsider Suggest')"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.commit()
+
+    async def _override() -> TokenPayload:
+        return TokenPayload(
+            sub=str(outsider_id),
+            email=email,
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = _override
+    try:
+        yield outsider_id
+    finally:
+        await db_session.execute(
+            text("DELETE FROM public.profiles WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.execute(
+            text("DELETE FROM auth.users WHERE id = :id"),
+            {"id": str(outsider_id)},
+        )
+        await db_session.commit()
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+# ---------------------------------------------------------------------------
+# SERVICE TESTS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_returns_ai_proposals(
+    db_session: AsyncSession,
+) -> None:
+    """load_suggestions returns AI proposals for the given instance_ids."""
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, field_id, reviewer_a, _reviewer_b = built
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=reviewer_a,
+        run_id=run_id,
+    )
+
+    assert result.count >= 1
+    assert len(result.suggestions) == result.count
+    suggestion = result.suggestions[0]
+    assert suggestion.instance_id == instance_id
+    assert suggestion.field_id == field_id
+    # proposed_value is the raw JSONB envelope
+    assert suggestion.proposed_value == {"value": "AI-PROPOSED"}
+    assert suggestion.confidence_score == pytest.approx(0.85)
+    assert suggestion.rationale == "AI rationale"
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_reviewer_a_status_is_accepted(
+    db_session: AsyncSession,
+) -> None:
+    """reviewer_a's EDIT decision → status 'accepted' for caller=reviewer_a."""
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, _field_id, reviewer_a, _reviewer_b = built
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=reviewer_a,
+        run_id=run_id,
+    )
+
+    assert result.count >= 1
+    assert result.suggestions[0].status == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_reviewer_b_status_is_rejected(
+    db_session: AsyncSession,
+) -> None:
+    """reviewer_b's REJECT decision → status 'rejected' for caller=reviewer_b."""
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, _field_id, _reviewer_a, reviewer_b = built
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=reviewer_b,
+        run_id=run_id,
+    )
+
+    assert result.count >= 1
+    assert result.suggestions[0].status == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_caller_scope_blind_boundary(
+    db_session: AsyncSession,
+) -> None:
+    """Blind boundary: reviewer_a's status never reflects reviewer_b's decisions.
+
+    reviewer_a has EDIT (accepted), reviewer_b has REJECT.
+    When caller=reviewer_a, status must be 'accepted' — NOT 'rejected' (B's).
+    When caller=reviewer_b, status must be 'rejected' — NOT 'accepted' (A's).
+    Neither caller should see the other's decision bled in.
+    """
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, _field_id, reviewer_a, reviewer_b = built
+
+    result_a = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=reviewer_a,
+        run_id=run_id,
+    )
+    result_b = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=reviewer_b,
+        run_id=run_id,
+    )
+
+    assert result_a.suggestions[0].status == "accepted", (
+        f"Reviewer A's status should be 'accepted' (EDIT decision) "
+        f"but got '{result_a.suggestions[0].status}' — "
+        "did reviewer B's REJECT bleed through?"
+    )
+    assert result_b.suggestions[0].status == "rejected", (
+        f"Reviewer B's status should be 'rejected' "
+        f"but got '{result_b.suggestions[0].status}' — "
+        "did reviewer A's EDIT bleed through?"
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_pending_when_no_decision(
+    db_session: AsyncSession,
+) -> None:
+    """A caller with no reviewer_state for a coord gets status 'pending'."""
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, _field_id, _reviewer_a, _reviewer_b = built
+
+    # Use the manager (primary_profile) as caller — they never recorded a decision
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=SEED.primary_profile,
+        run_id=run_id,
+    )
+
+    assert result.count >= 1
+    assert result.suggestions[0].status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_dedup_latest_per_coord(
+    db_session: AsyncSession,
+) -> None:
+    """Only the LATEST AI proposal per (instance, field) is returned."""
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+    manager_id = SEED.primary_profile
+
+    lifecycle = RunLifecycleService(db_session)
+    run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.PROPOSAL, user_id=manager_id
+    )
+
+    proposal_svc = ExtractionProposalService(db_session)
+    # Insert two AI proposals for the same coord — only latest wins.
+    # Both proposals land in the same DB transaction so they share the same
+    # created_at (PostgreSQL now() is constant within a transaction).  To make
+    # the ordering deterministic we back-date the OLDER row by 1 second via a
+    # raw UPDATE after the flush, before calling load_suggestions.
+    older = await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": "OLDER"},
+    )
+    await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": "NEWER"},
+    )
+    await db_session.flush()
+    # Back-date the OLDER row so created_at ordering is unambiguous.
+    await db_session.execute(
+        text(
+            "UPDATE public.extraction_proposal_records "
+            "SET created_at = created_at - interval '1 second' "
+            "WHERE id = :id"
+        ),
+        {"id": str(older.id)},
+    )
+    await db_session.flush()
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=manager_id,
+        run_id=run.id,
+    )
+
+    assert result.count == 1
+    assert result.suggestions[0].proposed_value == {"value": "NEWER"}
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_empty_instance_ids(
+    db_session: AsyncSession,
+) -> None:
+    """Empty instance_ids returns empty result."""
+    result = await load_suggestions(
+        db_session,
+        [],
+        article_id=SEED.primary_article,
+        caller_id=SEED.primary_profile,
+    )
+    assert result.count == 0
+    assert result.suggestions == []
+
+
+@pytest.mark.asyncio
+async def test_get_suggestion_history_no_status(
+    db_session: AsyncSession,
+) -> None:
+    """get_suggestion_history returns AI proposals newest-first, no status field."""
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, field_id, _reviewer_a, _reviewer_b = built  # noqa: F841
+
+    history = await get_suggestion_history(
+        db_session, instance_id, field_id, article_id=SEED.primary_article
+    )
+
+    assert len(history) >= 1
+    item = history[0]
+    assert item.instance_id == instance_id
+    assert item.field_id == field_id
+    assert item.proposed_value == {"value": "AI-PROPOSED"}
+    # AISuggestionHistoryItem has no `status` attribute
+    assert not hasattr(item, "status")
+
+
+@pytest.mark.asyncio
+async def test_get_suggestion_history_limit(
+    db_session: AsyncSession,
+) -> None:
+    """get_suggestion_history respects the limit parameter."""
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+    manager_id = SEED.primary_profile
+
+    lifecycle = RunLifecycleService(db_session)
+    run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.PROPOSAL, user_id=manager_id
+    )
+    proposal_svc = ExtractionProposalService(db_session)
+    for i in range(3):
+        await proposal_svc.record_proposal(
+            run_id=run.id,
+            instance_id=instance_id,
+            field_id=field_id,
+            source=ExtractionProposalSource.AI,
+            proposed_value={"value": f"v{i}"},
+        )
+    await db_session.flush()
+
+    history = await get_suggestion_history(
+        db_session, instance_id, field_id, article_id=SEED.primary_article, limit=2
+    )
+    assert len(history) <= 2
+
+
+@pytest.mark.asyncio
+async def test_get_article_instance_ids(
+    db_session: AsyncSession,
+) -> None:
+    """get_article_instance_ids returns instance ids for the article."""
+    ids = await get_article_instance_ids(db_session, SEED.primary_article)
+    assert SEED.primary_instance in ids
+
+
+# ---------------------------------------------------------------------------
+# ENDPOINT TESTS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_instance_ids_endpoint_200(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """GET /articles/{article_id}/instance-ids returns 200 with instance ids."""
+    resp = await db_client.get(f"{_ARTICLES_URL}/{SEED.primary_article}/instance-ids")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    ids = payload["data"]
+    assert isinstance(ids, list)
+    assert str(SEED.primary_instance) in ids
+
+
+@pytest.mark.asyncio
+async def test_instance_ids_endpoint_403_bola(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    outsider_user: UUID,  # noqa: ARG001
+) -> None:
+    """BOLA gate: non-member gets 403 on instance-ids."""
+    resp = await db_client.get(f"{_ARTICLES_URL}/{SEED.primary_article}/instance-ids")
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_suggestions_endpoint_200(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """GET /articles/{article_id}/suggestions?instance_ids= returns 200."""
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, _field_id, _reviewer_a, _reviewer_b = built
+
+    resp = await db_client.get(
+        f"{_ARTICLES_URL}/{SEED.primary_article}/suggestions",
+        params={
+            "instance_ids": str(instance_id),
+            "run_id": str(run_id),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+    assert "suggestions" in data
+    assert "count" in data
+    assert data["count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_suggestions_endpoint_403_bola(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    outsider_user: UUID,  # noqa: ARG001
+) -> None:
+    """BOLA gate: non-member gets 403 on suggestions."""
+    resp = await db_client.get(
+        f"{_ARTICLES_URL}/{SEED.primary_article}/suggestions",
+        params={"instance_ids": str(SEED.primary_instance)},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_suggestions_history_endpoint_200(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """GET /articles/{article_id}/suggestions/history returns 200."""
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    _run_id, instance_id, field_id, _reviewer_a, _reviewer_b = built
+
+    resp = await db_client.get(
+        f"{_ARTICLES_URL}/{SEED.primary_article}/suggestions/history",
+        params={
+            "instance_id": str(instance_id),
+            "field_id": str(field_id),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["ok"] is True
+    data = payload["data"]
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    item = data[0]
+    assert "proposed_value" in item
+    assert "status" not in item
+
+
+@pytest.mark.asyncio
+async def test_suggestions_history_endpoint_403_bola(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    outsider_user: UUID,  # noqa: ARG001
+) -> None:
+    """BOLA gate: non-member gets 403 on suggestions/history."""
+    resp = await db_client.get(
+        f"{_ARTICLES_URL}/{SEED.primary_article}/suggestions/history",
+        params={
+            "instance_id": str(SEED.primary_instance),
+            "field_id": str(SEED.primary_field),
+        },
+    )
+    assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# IDOR REGRESSION TESTS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_excludes_foreign_article_instance(
+    db_session: AsyncSession,
+) -> None:
+    """IDOR guard: load_suggestions with a foreign article_id returns nothing.
+
+    The instance_id belongs to SEED.primary_article.  Passing a different
+    (non-existent) article_id must yield count=0 / suggestions=[] — the JOIN
+    on ExtractionInstance.article_id excludes it at the DB level.
+    Regression test for the cross-project IDOR fixed in extraction_suggestion_read_service.py.
+    """
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, _field_id, reviewer_a, _reviewer_b = built
+
+    foreign_article_id = uuid4()  # does not exist — primary_article's instance excluded
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=foreign_article_id,
+        caller_id=reviewer_a,
+        run_id=run_id,
+    )
+
+    assert result.count == 0, (
+        "IDOR guard failed: load_suggestions returned suggestions for an instance "
+        "that belongs to a different article than the one passed as article_id. "
+        f"Got count={result.count}, expected 0."
+    )
+    assert result.suggestions == [], (
+        "IDOR guard failed: suggestions list should be empty when article_id "
+        "does not match the instance's article."
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_suggestion_history_excludes_foreign_article_instance(
+    db_session: AsyncSession,
+) -> None:
+    """IDOR guard: get_suggestion_history with a foreign article_id returns [].
+
+    The instance_id belongs to SEED.primary_article.  Passing a different
+    article_id must yield an empty list — the JOIN on ExtractionInstance.article_id
+    excludes it at the DB level.
+    Regression test for the cross-project IDOR fixed in extraction_suggestion_read_service.py.
+    """
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    _run_id, instance_id, field_id, _reviewer_a, _reviewer_b = built
+
+    foreign_article_id = uuid4()  # does not exist — primary_article's instance excluded
+
+    history = await get_suggestion_history(
+        db_session,
+        instance_id,
+        field_id,
+        article_id=foreign_article_id,
+    )
+
+    assert history == [], (
+        "IDOR guard failed: get_suggestion_history returned history for an instance "
+        "that belongs to a different article than the one passed as article_id. "
+        f"Got {len(history)} items, expected 0."
+    )

--- a/backend/tests/unit/test_block_assembler.py
+++ b/backend/tests/unit/test_block_assembler.py
@@ -1,0 +1,511 @@
+"""
+Unit tests for the section-aware block assembler.
+
+Tests cover:
+- Reading-order preservation across pages.
+- Heading → section markers (IMRaD-aware).
+- Contiguous ``table_cell`` blocks → reconstructed table (markdown).
+- Over-budget → whole-section selection with ``dropped_sections`` populated,
+  no mid-section/mid-table cut.
+- In-budget: nothing past a naive 15k char cut is silently lost.
+- Optional ``focus`` hint biases section priority deterministically.
+- Prose routes through canonical concat_page_text surface.
+- Input blocks are never mutated by assemble().
+- Over-budget fallback pops WHOLE sections (never string-splits on separator).
+"""
+
+from app.infrastructure.parsing.base import (
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+)
+from app.services.extraction_block_assembler import DroppedSection, assemble
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BBOX = {"x": 0.0, "y": 0.0, "width": 100.0, "height": 20.0}
+
+
+def _b(
+    page: int,
+    idx: int,
+    text: str,
+    block_type: str = "paragraph",
+) -> ParsedBlock:
+    """Convenience factory for ParsedBlock with dummy offsets."""
+    return ParsedBlock(
+        page_number=page,
+        block_index=idx,
+        text=text,
+        char_start=0,
+        char_end=len(text),
+        bbox=_BBOX,
+        block_type=block_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Reading-order preservation across pages
+# ---------------------------------------------------------------------------
+
+
+class TestReadingOrder:
+    def test_single_page_order(self) -> None:
+        blocks = [
+            _b(1, 2, "Third"),
+            _b(1, 0, "First"),
+            _b(1, 1, "Second"),
+        ]
+        text, dropped = assemble(blocks, budget=10_000)
+        assert dropped == []
+        # Reading order: First, Second, Third
+        pos_first = text.index("First")
+        pos_second = text.index("Second")
+        pos_third = text.index("Third")
+        assert pos_first < pos_second < pos_third
+
+    def test_multi_page_order(self) -> None:
+        blocks = [
+            _b(2, 0, "Page two content"),
+            _b(1, 0, "Page one content"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        assert text.index("Page one content") < text.index("Page two content")
+
+    def test_multi_page_multi_block_order(self) -> None:
+        blocks = [
+            _b(2, 1, "P2B2"),
+            _b(1, 1, "P1B2"),
+            _b(2, 0, "P2B1"),
+            _b(1, 0, "P1B1"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        positions = [text.index(t) for t in ("P1B1", "P1B2", "P2B1", "P2B2")]
+        assert positions == sorted(positions)
+
+    def test_pages_not_necessarily_contiguous(self) -> None:
+        blocks = [
+            _b(5, 0, "Last"),
+            _b(1, 0, "First"),
+            _b(3, 0, "Middle"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        assert text.index("First") < text.index("Middle") < text.index("Last")
+
+
+# ---------------------------------------------------------------------------
+# 2. Heading → section markers
+# ---------------------------------------------------------------------------
+
+
+class TestSectionMarkers:
+    def test_heading_emits_section_marker(self) -> None:
+        blocks = [
+            _b(1, 0, "Introduction", "heading"),
+            _b(1, 1, "Some paragraph text.", "paragraph"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        # The heading text must appear as a marker (e.g. ## Introduction or === Introduction)
+        assert "Introduction" in text
+        # The section marker must appear before the paragraph text
+        assert text.index("Introduction") < text.index("Some paragraph text.")
+
+    def test_multiple_headings_in_order(self) -> None:
+        blocks = [
+            _b(1, 0, "Methods", "heading"),
+            _b(1, 1, "We did X.", "paragraph"),
+            _b(2, 0, "Results", "heading"),
+            _b(2, 1, "We found Y.", "paragraph"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        assert text.index("Methods") < text.index("We did X.")
+        assert text.index("Results") < text.index("We found Y.")
+        assert text.index("We did X.") < text.index("Results")
+
+    def test_header_footer_blocks_excluded_or_suppressed(self) -> None:
+        """header/footer blocks (page chrome) should not produce content markers."""
+        blocks = [
+            _b(1, 0, "Journal Name", "header"),
+            _b(1, 1, "Introduction", "heading"),
+            _b(1, 2, "Real content.", "paragraph"),
+            _b(1, 3, "Page 1 of 10", "footer"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        # Main content must appear
+        assert "Introduction" in text
+        assert "Real content." in text
+        # Chrome text must NOT appear in the output
+        assert "Journal Name" not in text
+        assert "Page 1 of 10" not in text
+
+
+# ---------------------------------------------------------------------------
+# 3. Contiguous table_cell blocks → reconstructed table
+# ---------------------------------------------------------------------------
+
+
+class TestTableReconstruction:
+    def test_contiguous_cells_become_table_not_scattered_lines(self) -> None:
+        """Four cells (2 rows × 2 cols) must not appear as four separate lines."""
+        blocks = [
+            _b(1, 0, "Name", "table_cell"),
+            _b(1, 1, "Age", "table_cell"),
+            _b(1, 2, "Alice", "table_cell"),
+            _b(1, 3, "30", "table_cell"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        # All cell texts must be present
+        for cell_text in ("Name", "Age", "Alice", "30"):
+            assert cell_text in text
+        # The cells should NOT appear as four completely isolated lines separated by
+        # no table structure (a good proxy: they must appear close together, not with
+        # non-table content between them).
+        # More precisely: the reconstructed text for this run should form a
+        # recognisable table block (markdown | separators). Just assert that
+        # the content is not interleaved with non-table text in a raw line-per-cell
+        # manner by checking there is no non-table content between the first and
+        # last cell.
+        start = min(text.index(c) for c in ("Name", "Age", "Alice", "30"))
+        end = max(text.index(c) + len(c) for c in ("Name", "Age", "Alice", "30"))
+        table_span = text[start:end]
+        # The span must contain all four cells
+        for cell_text in ("Name", "Age", "Alice", "30"):
+            assert cell_text in table_span
+
+    def test_cells_not_interleaved_with_paragraphs(self) -> None:
+        """Paragraph text between two sets of cells must not appear inside
+        a reconstructed table."""
+        blocks = [
+            _b(1, 0, "Cell A1", "table_cell"),
+            _b(1, 1, "Cell A2", "table_cell"),
+            _b(1, 2, "Mid paragraph text.", "paragraph"),
+            _b(1, 3, "Cell B1", "table_cell"),
+            _b(1, 4, "Cell B2", "table_cell"),
+        ]
+        text, _ = assemble(blocks, budget=10_000)
+        # Both cell groups and paragraph must appear
+        for content in ("Cell A1", "Cell A2", "Mid paragraph text.", "Cell B1", "Cell B2"):
+            assert content in text
+        # The paragraph must separate the two table runs — it must appear
+        # between the end of the first pair and the start of the second pair.
+        end_of_first_table = max(
+            text.index("Cell A1") + len("Cell A1"), text.index("Cell A2") + len("Cell A2")
+        )
+        start_of_second_table = min(text.index("Cell B1"), text.index("Cell B2"))
+        mid_pos = text.index("Mid paragraph text.")
+        assert end_of_first_table < mid_pos < start_of_second_table
+
+    def test_single_cell_renders(self) -> None:
+        blocks = [_b(1, 0, "Only cell", "table_cell")]
+        text, _ = assemble(blocks, budget=10_000)
+        assert "Only cell" in text
+
+
+# ---------------------------------------------------------------------------
+# 4. Over-budget: whole-section selection, dropped_sections populated
+# ---------------------------------------------------------------------------
+
+
+TINY_BUDGET = 200  # chars — forces section dropping for most test docs
+
+
+class TestOverBudgetSectionSelection:
+    def _imrad_doc(self) -> list[ParsedBlock]:
+        """Return a small IMRaD document whose full text exceeds TINY_BUDGET."""
+        return [
+            _b(1, 0, "Abstract", "heading"),
+            _b(1, 1, "A" * 60, "paragraph"),
+            _b(2, 0, "Introduction", "heading"),
+            _b(2, 1, "B" * 60, "paragraph"),
+            _b(3, 0, "Methods", "heading"),
+            _b(3, 1, "C" * 60, "paragraph"),
+            _b(4, 0, "Results", "heading"),
+            _b(4, 1, "D" * 60, "paragraph"),
+            _b(5, 0, "Discussion", "heading"),
+            _b(5, 1, "E" * 60, "paragraph"),
+            _b(6, 0, "References", "heading"),
+            _b(6, 1, "F" * 60, "paragraph"),
+        ]
+
+    def test_dropped_sections_populated_when_over_budget(self) -> None:
+        blocks = self._imrad_doc()
+        text, dropped = assemble(blocks, budget=TINY_BUDGET)
+        assert len(dropped) > 0
+
+    def test_dropped_sections_are_DroppedSection_instances(self) -> None:
+        blocks = self._imrad_doc()
+        _, dropped = assemble(blocks, budget=TINY_BUDGET)
+        for d in dropped:
+            assert isinstance(d, DroppedSection)
+
+    def test_no_mid_section_cut(self) -> None:
+        """Every section that appears in the output must be FULLY included.
+
+        Strategy: for each kept section heading, assert its paragraph body
+        also appears.
+        """
+        section_map = {
+            "Abstract": "A" * 60,
+            "Introduction": "B" * 60,
+            "Methods": "C" * 60,
+            "Results": "D" * 60,
+            "Discussion": "E" * 60,
+            "References": "F" * 60,
+        }
+        blocks = self._imrad_doc()
+        text, dropped = assemble(blocks, budget=TINY_BUDGET)
+        dropped_names = {d.title for d in dropped}
+        for heading, body in section_map.items():
+            if heading in dropped_names:
+                # Dropped sections must not appear in text
+                assert body not in text, f"Dropped section '{heading}' body leaked into text"
+            else:
+                # Kept sections must be fully present
+                assert body in text, f"Kept section '{heading}' body missing from text"
+
+    def test_output_within_budget(self) -> None:
+        blocks = self._imrad_doc()
+        text, _ = assemble(blocks, budget=TINY_BUDGET)
+        assert len(text) <= TINY_BUDGET
+
+    def test_deterministic_output(self) -> None:
+        """Same input must always produce the same output."""
+        blocks = self._imrad_doc()
+        results = [assemble(blocks, budget=TINY_BUDGET) for _ in range(3)]
+        assert all(r[0] == results[0][0] for r in results)
+        assert all(r[1] == results[0][1] for r in results)
+
+    def test_references_dropped_before_results(self) -> None:
+        """IMRaD priority: Results/Methods rank higher than References/Discussion.
+
+        When the budget is tight, References should be dropped before Results.
+        """
+        blocks = self._imrad_doc()
+        # Budget big enough to keep Results but not everything
+        # Each section is ~heading(~10-15 chars) + body(60 chars) ~ 75 chars per section
+        # 3 sections fit in ~225 chars
+        text, dropped = assemble(blocks, budget=225)
+        dropped_names = {d.title for d in dropped}
+        # If any sections are dropped, Results should not be dropped before References
+        if dropped_names:
+            # References should appear in dropped before Results would be dropped
+            if "Results" not in dropped_names:
+                pass  # Results kept — good
+            else:
+                # If Results is dropped, References must also be dropped
+                assert "References" in dropped_names
+
+    def test_no_table_mid_cut(self) -> None:
+        """A table run must never be split across budget boundary."""
+        # Build a doc where a table plus surrounding sections exceed the budget.
+        # The table must appear in full or not at all.
+        table_blocks = [
+            _b(2, 0, "Results Table", "heading"),
+            _b(2, 1, "T" * 10, "table_cell"),
+            _b(2, 2, "U" * 10, "table_cell"),
+            _b(2, 3, "V" * 10, "table_cell"),
+            _b(2, 4, "W" * 10, "table_cell"),
+        ]
+        other_blocks = [
+            _b(1, 0, "Introduction", "heading"),
+            _b(1, 1, "I" * 60, "paragraph"),
+            _b(3, 0, "Discussion", "heading"),
+            _b(3, 1, "J" * 60, "paragraph"),
+        ]
+        blocks = other_blocks + table_blocks
+        text, dropped = assemble(blocks, budget=150)
+        table_cells = ["T" * 10, "U" * 10, "V" * 10, "W" * 10]
+        cells_present = [c in text for c in table_cells]
+        # Either all cells are present or none are (whole-table constraint)
+        assert all(cells_present) or not any(cells_present)
+
+    def test_fallback_whole_section_drop_not_string_split(self) -> None:
+        """Defensive fallback drops WHOLE sections, never fragments on separator.
+
+        Build a block whose text contains the inter-section separator ("\\n\\n").
+        With a budget that forces a drop, the survivor must be intact and
+        dropped_sections must name the dropped section — no fragment leak.
+        """
+        # Section A: text that contains the separator string inside it.
+        # This would corrupt result if we did result_text.split(separator).pop().
+        separator_in_body = "first part\n\nsecond part"  # contains "\n\n"
+        blocks = [
+            _b(1, 0, "Alpha", "heading"),
+            _b(1, 1, separator_in_body, "paragraph"),
+            _b(2, 0, "Beta", "heading"),
+            _b(2, 1, "B" * 80, "paragraph"),
+        ]
+        # Alpha section text = "## Alpha\n" + separator_in_body  ≈ 41 chars
+        # Beta section text  = "## Beta\n"  + "B"*80             ≈ 89 chars
+        # Full text = ~41 + 2 (sep) + 89 = ~132 chars
+        # Budget just big enough for Beta but not both
+        text, dropped = assemble(blocks, budget=100)
+        # Exactly one section must be dropped
+        assert len(dropped) == 1
+        dropped_title = dropped[0].title
+        # The survivor must be fully intact — no partial content from dropped section
+        if dropped_title == "Alpha":
+            # Beta survives: must be whole
+            assert "B" * 80 in text
+            # Alpha body must not appear (even the fragment "first part")
+            assert "first part" not in text
+            assert "second part" not in text
+        else:
+            # Alpha survives: must be whole including the embedded separator
+            assert separator_in_body in text
+            # Beta body must not appear
+            assert "B" * 80 not in text
+
+
+# ---------------------------------------------------------------------------
+# 5. In-budget: nothing past naive 15k cut is silently lost
+# ---------------------------------------------------------------------------
+
+
+class TestInBudgetNoSilentLoss:
+    def test_content_beyond_15k_preserved_when_in_budget(self) -> None:
+        """For a doc whose total text > 15 000 chars but fits within budget,
+        assemble() must include ALL content — not silently drop what lies beyond
+        a hypothetical 15 000-char cut."""
+        # Build ~18 000 chars of content spread across pages.
+        blocks: list[ParsedBlock] = []
+        for page in range(1, 7):  # 6 pages
+            blocks.append(_b(page, 0, f"Section {page}", "heading"))
+            blocks.append(_b(page, 1, "X" * 2_900, "paragraph"))  # ~2 900 chars/page
+
+        # Total text ≈ 6 × (len("Section N") + 2900) ≈ 17 454 chars → > 15 000
+        full_text = "\n".join(
+            b.text for b in sorted(blocks, key=lambda b: (b.page_number, b.block_index))
+        )
+        assert len(full_text) > 15_000, "Pre-condition: doc must exceed 15k chars"
+
+        # Budget large enough to fit everything
+        large_budget = 20_000
+        text, dropped = assemble(blocks, budget=large_budget)
+
+        assert dropped == [], f"No sections should be dropped when in-budget; got {dropped}"
+        # Every section heading and every paragraph must appear
+        for page in range(1, 7):
+            assert f"Section {page}" in text, f"Section {page} heading missing"
+            assert "X" * 2_900 in text, f"Section {page} paragraph missing"
+
+    def test_last_section_fully_included_when_at_budget_boundary(self) -> None:
+        """If adding the last section would just fit, it must be fully included."""
+        # A small two-section doc that fits in budget
+        blocks = [
+            _b(1, 0, "First Section", "heading"),
+            _b(1, 1, "Content A", "paragraph"),
+            _b(2, 0, "Second Section", "heading"),
+            _b(2, 1, "Content B", "paragraph"),
+        ]
+        budget = 10_000  # Obviously fits
+        text, dropped = assemble(blocks, budget=budget)
+        assert "Content A" in text
+        assert "Content B" in text
+        assert dropped == []
+
+
+# ---------------------------------------------------------------------------
+# 6. focus hint biases section priority
+# ---------------------------------------------------------------------------
+
+
+class TestFocusHint:
+    def test_focus_keeps_matching_section(self) -> None:
+        """When focus='Methods', Methods should be kept even at tight budget."""
+        blocks = [
+            _b(1, 0, "Introduction", "heading"),
+            _b(1, 1, "A" * 80, "paragraph"),
+            _b(2, 0, "Methods", "heading"),
+            _b(2, 1, "B" * 80, "paragraph"),
+            _b(3, 0, "Results", "heading"),
+            _b(3, 1, "C" * 80, "paragraph"),
+        ]
+        # Budget fits 2 sections, not all 3
+        text, dropped = assemble(blocks, budget=200, focus="Methods")
+        assert "B" * 80 in text, "Focus section body must be present"
+        dropped_names = {d.title for d in dropped}
+        assert "Methods" not in dropped_names
+
+    def test_focus_is_deterministic(self) -> None:
+        blocks = [
+            _b(1, 0, "Introduction", "heading"),
+            _b(1, 1, "A" * 80, "paragraph"),
+            _b(2, 0, "Results", "heading"),
+            _b(2, 1, "B" * 80, "paragraph"),
+        ]
+        result1 = assemble(blocks, budget=150, focus="Results")
+        result2 = assemble(blocks, budget=150, focus="Results")
+        assert result1[0] == result2[0]
+        assert result1[1] == result2[1]
+
+
+# ---------------------------------------------------------------------------
+# 7. Prose routes through canonical concat_page_text surface
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalSurface:
+    def test_prose_matches_concat_page_text_slice(self) -> None:
+        """For a multi-block page, prose in assemble() output equals
+        concat_page_text(copies)[page][cs:ce] for the block's offsets.
+
+        This verifies that assemble() genuinely routes prose through the
+        canonical surface rather than just copying block.text.
+        """
+        blocks = [
+            _b(1, 0, "First block", "paragraph"),
+            _b(1, 1, "Second block", "paragraph"),
+            _b(1, 2, "Third block", "paragraph"),
+        ]
+        # Build copies and compute canonical offsets the same way assemble() does.
+        copies = [
+            ParsedBlock(
+                page_number=b.page_number,
+                block_index=b.block_index,
+                text=b.text,
+                char_start=0,
+                char_end=0,
+                bbox=b.bbox,
+                block_type=b.block_type,
+            )
+            for b in blocks
+        ]
+        assign_char_offsets_to_blocks(copies)
+        page_texts = concat_page_text(copies)
+        offsets = {(c.page_number, c.block_index): (c.char_start, c.char_end) for c in copies}
+
+        text, dropped = assemble(blocks, budget=10_000)
+        assert dropped == []
+
+        # Each block's prose must equal the canonical slice.
+        for b in blocks:
+            cs, ce = offsets[(b.page_number, b.block_index)]
+            canonical_slice = page_texts[b.page_number][cs:ce]
+            assert canonical_slice == b.text  # by construction
+            assert canonical_slice in text, (
+                f"Block '{b.text}' canonical slice not found in assembled output"
+            )
+
+    def test_input_blocks_not_mutated_by_assemble(self) -> None:
+        """assemble() must not mutate char_start/char_end on input blocks."""
+        # Use dummy offsets that are intentionally wrong (0 / len) to detect mutation.
+        blocks = [
+            _b(1, 0, "Alpha paragraph"),
+            _b(1, 1, "Beta paragraph"),
+            _b(2, 0, "Gamma paragraph"),
+        ]
+        original_starts = [b.char_start for b in blocks]
+        original_ends = [b.char_end for b in blocks]
+
+        assemble(blocks, budget=10_000)
+
+        for i, b in enumerate(blocks):
+            assert b.char_start == original_starts[i], (
+                f"Block {i} char_start was mutated: {original_starts[i]} → {b.char_start}"
+            )
+            assert b.char_end == original_ends[i], (
+                f"Block {i} char_end was mutated: {original_ends[i]} → {b.char_end}"
+            )

--- a/backend/tests/unit/test_evidence_anchor_service.py
+++ b/backend/tests/unit/test_evidence_anchor_service.py
@@ -1,0 +1,617 @@
+"""
+Unit tests for the evidence-anchor service (quote → block matcher).
+
+The matcher anchors an LLM's evidence quote back to a verifiable span in the
+source document.  It is a PURE function: no DB, no IO, deterministic.
+
+Coverage:
+- exact quote → correct block + char range (offsets index the ORIGINAL page
+  string produced by ``concat_page_text``).
+- ligature / smart-quote / collapsed-whitespace quote still matches under
+  Unicode NFKC + whitespace folding, AND the returned offsets index the
+  ORIGINAL (un-normalised) page text.
+- a quote spanning two adjacent blocks → merged char range + both block_ids +
+  unioned bbox.
+- a genuinely absent quote → ``None``.
+- bounded fuzz: an OCR-noisy quote within threshold matches; beyond threshold
+  returns ``None``.
+- deterministic tie-break: when the quote appears twice, the earliest page /
+  block wins.
+
+The key invariant asserted throughout: slicing the returned
+``[char_start, char_end)`` out of the ORIGINAL ``concat_page_text`` page string
+and applying the SAME NFKC + whitespace fold yields the folded quote.
+"""
+
+from __future__ import annotations
+
+from app.infrastructure.parsing.base import (
+    ParsedBlock,
+    assign_char_offsets_to_blocks,
+    concat_page_text,
+)
+from app.services.evidence_anchor_service import (
+    AnchorMatch,
+    _normalize,
+    match,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_block(
+    page_number: int,
+    block_index: int,
+    text: str,
+    *,
+    block_type: str = "paragraph",
+    bbox: dict[str, float] | None = None,
+) -> ParsedBlock:
+    """Build a ParsedBlock with PLACEHOLDER char offsets (0/0).
+
+    The matcher must derive offsets itself from ``concat_page_text`` /
+    ``assign_char_offsets_to_blocks``, so the offsets passed in here are
+    intentionally wrong (0/0) to prove the matcher does not trust them.
+    """
+    return ParsedBlock(
+        page_number=page_number,
+        block_index=block_index,
+        text=text,
+        char_start=0,
+        char_end=0,
+        bbox=bbox if bbox is not None else {"x": 0.0, "y": 0.0, "width": 100.0, "height": 20.0},
+        block_type=block_type,
+    )
+
+
+def _fold(s: str) -> str:
+    """The canonical comparison surface (NFKC + punctuation + whitespace fold).
+
+    Delegates to the service's own ``_normalize`` so the test asserts against
+    the real folding surface rather than a reimplementation that could drift.
+    """
+    return _normalize(s)
+
+
+def _original_page_text(blocks: list[ParsedBlock]) -> dict[int, str]:
+    """Build the ORIGINAL per-page text the matcher's offsets must index.
+
+    Uses LOCAL copies so the test's input blocks are never mutated (mirrors
+    what the matcher does internally).
+    """
+    copies = [
+        ParsedBlock(
+            page_number=b.page_number,
+            block_index=b.block_index,
+            text=b.text,
+            char_start=0,
+            char_end=0,
+            bbox=b.bbox,
+            block_type=b.block_type,
+        )
+        for b in blocks
+    ]
+    assign_char_offsets_to_blocks(copies)
+    return concat_page_text(copies)
+
+
+def _assert_slice_folds_to_quote(
+    result: AnchorMatch,
+    blocks: list[ParsedBlock],
+    quote: str,
+) -> None:
+    """Core invariant: the returned span, sliced from the ORIGINAL page text
+    and folded, equals the folded quote."""
+    page_text = _original_page_text(blocks)[result.page]
+    sliced = page_text[result.char_start : result.char_end]
+    assert _fold(sliced) == _fold(quote), (
+        f"sliced original {sliced!r} folds to {_fold(sliced)!r}, "
+        f"expected folded quote {_fold(quote)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exact match
+# ---------------------------------------------------------------------------
+
+
+class TestExactMatch:
+    def test_exact_quote_anchors_to_correct_block_and_range(self) -> None:
+        blocks = [
+            make_block(1, 0, "The mitochondria is the powerhouse of the cell."),
+            make_block(1, 1, "Ribosomes synthesize proteins from amino acids."),
+        ]
+        quote = "powerhouse of the cell"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.page == 1
+        assert result.block_ids == [0]
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+        page_text = _original_page_text(blocks)[1]
+        assert page_text[result.char_start : result.char_end] == "powerhouse of the cell"
+
+    def test_exact_full_block_quote(self) -> None:
+        blocks = [
+            make_block(2, 0, "Alpha beta gamma."),
+            make_block(2, 1, "Delta epsilon zeta."),
+        ]
+        quote = "Delta epsilon zeta."
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.page == 2
+        assert result.block_ids == [1]
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+    def test_match_on_second_page(self) -> None:
+        blocks = [
+            make_block(1, 0, "First page content here."),
+            make_block(2, 0, "Second page has the target sentence."),
+        ]
+        result = match("the target sentence", blocks)
+        assert result is not None
+        assert result.page == 2
+        assert result.block_ids == [0]
+        _assert_slice_folds_to_quote(result, blocks, "the target sentence")
+
+
+# ---------------------------------------------------------------------------
+# Normalization: ligatures / smart quotes / collapsed whitespace
+# ---------------------------------------------------------------------------
+
+
+class TestNormalization:
+    def test_ligature_quote_matches_and_offsets_index_original(self) -> None:
+        # Block contains the ligature 'ﬁ' (U+FB01); quote uses ASCII "fi".
+        blocks = [make_block(1, 0, "The classiﬁcation of cells is complex.")]
+        quote = "classification of cells"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.block_ids == [0]
+        # Offsets index the ORIGINAL string, which still contains the ligature.
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "ﬁ" in sliced  # original ligature preserved in the slice
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+    def test_smart_quotes_match_straight_quotes(self) -> None:
+        # Block uses a curly apostrophe (U+2019); quote uses a straight one.
+        blocks = [make_block(1, 0, "The cell’s membrane is selectively permeable.")]
+        quote = "cell's membrane"
+        result = match(quote, blocks)
+        assert result is not None
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+    def test_collapsed_whitespace_matches(self) -> None:
+        # Block has a newline + multiple spaces; quote has single spaces.
+        blocks = [make_block(1, 0, "The   sample\n   was   incubated   overnight.")]
+        quote = "sample was incubated overnight"
+        result = match(quote, blocks)
+        assert result is not None
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+    def test_quote_with_extra_whitespace_matches(self) -> None:
+        blocks = [make_block(1, 0, "Results were significant.")]
+        quote = "  Results   were    significant.  "
+        result = match(quote, blocks)
+        assert result is not None
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+
+# ---------------------------------------------------------------------------
+# Multi-block span
+# ---------------------------------------------------------------------------
+
+
+class TestMultiBlockSpan:
+    def test_quote_spanning_two_adjacent_blocks(self) -> None:
+        blocks = [
+            make_block(
+                1,
+                0,
+                "the treatment group showed",
+                bbox={"x": 10.0, "y": 100.0, "width": 200.0, "height": 20.0},
+            ),
+            make_block(
+                1,
+                1,
+                "a marked improvement in outcomes",
+                bbox={"x": 12.0, "y": 70.0, "width": 220.0, "height": 22.0},
+            ),
+        ]
+        # The quote crosses the block boundary (the "\n" separator folds to " ").
+        quote = "treatment group showed a marked improvement"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.page == 1
+        assert result.block_ids == [0, 1]
+        _assert_slice_folds_to_quote(result, blocks, quote)
+
+        # bbox_union: min x, min y, max (x+width), max (y+height).
+        # block 0: x in [10, 210], y in [100, 120]
+        # block 1: x in [12, 232], y in [70, 92]
+        assert result.bbox_union["x"] == 10.0
+        assert result.bbox_union["y"] == 70.0
+        assert result.bbox_union["width"] == 232.0 - 10.0
+        assert result.bbox_union["height"] == 120.0 - 70.0
+
+    def test_single_block_bbox_union_is_that_block(self) -> None:
+        bbox = {"x": 5.0, "y": 50.0, "width": 80.0, "height": 12.0}
+        blocks = [make_block(1, 0, "A single isolated sentence here.", bbox=bbox)]
+        result = match("isolated sentence", blocks)
+        assert result is not None
+        assert result.block_ids == [0]
+        assert result.bbox_union == bbox
+
+
+# ---------------------------------------------------------------------------
+# Absent quote
+# ---------------------------------------------------------------------------
+
+
+class TestAbsentQuote:
+    def test_absent_quote_returns_none(self) -> None:
+        blocks = [
+            make_block(1, 0, "The mitochondria is the powerhouse of the cell."),
+        ]
+        assert match("quantum entanglement of photons", blocks) is None
+
+    def test_empty_quote_returns_none(self) -> None:
+        blocks = [make_block(1, 0, "Some text.")]
+        assert match("", blocks) is None
+
+    def test_empty_blocks_returns_none(self) -> None:
+        assert match("anything", []) is None
+
+    def test_whitespace_only_quote_returns_none(self) -> None:
+        blocks = [make_block(1, 0, "Some text.")]
+        assert match("   \n  ", blocks) is None
+
+
+# ---------------------------------------------------------------------------
+# Bounded fuzz
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedFuzz:
+    def test_ocr_noisy_quote_within_threshold_matches(self) -> None:
+        # Source is clean; quote has a couple of OCR-style character errors.
+        blocks = [
+            make_block(
+                1,
+                0,
+                "The patients received a daily dose of the experimental compound.",
+            )
+        ]
+        # "patients" -> "patlents", "experimental" -> "experirnental" (rn for m)
+        quote = "patlents received a daily dose of the experirnental compound"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.block_ids == [0]
+        # The matched original slice corresponds to the clean source span.
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "received a daily dose" in sliced
+
+    def test_quote_beyond_fuzz_threshold_returns_none(self) -> None:
+        blocks = [
+            make_block(
+                1,
+                0,
+                "The patients received a daily dose of the experimental compound.",
+            )
+        ]
+        # Garble most of the characters — far beyond any sane threshold.
+        quote = "Xhq zatuqxlk rqmqwxqg z xzuzk xqkq"
+        assert match(quote, blocks) is None
+
+    def test_tight_threshold_rejects_noisy_quote(self) -> None:
+        blocks = [make_block(1, 0, "The quick brown fox jumps over the lazy dog.")]
+        noisy = "The qulck brown fox jximps over the lazy dog"
+        # With fuzz disabled (threshold 1.0 = exact only) the noisy quote fails.
+        assert match(noisy, blocks, fuzz_threshold=1.0) is None
+        # With the default (looser) threshold it matches.
+        assert match(noisy, blocks) is not None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic tie-break
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicTieBreak:
+    def test_duplicate_quote_earliest_page_wins(self) -> None:
+        blocks = [
+            make_block(2, 0, "The repeated phrase appears here."),
+            make_block(1, 0, "The repeated phrase appears here."),
+        ]
+        result = match("repeated phrase", blocks)
+        assert result is not None
+        assert result.page == 1  # earliest page wins, not list order
+
+    def test_duplicate_quote_earliest_block_wins(self) -> None:
+        blocks = [
+            make_block(1, 0, "The repeated phrase appears here."),
+            make_block(1, 1, "The repeated phrase appears here too."),
+        ]
+        result = match("repeated phrase", blocks)
+        assert result is not None
+        assert result.page == 1
+        assert result.block_ids == [0]  # earliest block within the page
+
+    def test_same_inputs_same_output(self) -> None:
+        blocks = [
+            make_block(1, 0, "Alpha beta gamma delta."),
+            make_block(1, 1, "Epsilon zeta eta theta."),
+            make_block(2, 0, "Iota kappa lambda."),
+        ]
+        quote = "zeta eta"
+        first = match(quote, blocks)
+        second = match(quote, blocks)
+        assert first == second
+        assert first is not None
+        assert first.block_ids == [1]
+
+
+# ---------------------------------------------------------------------------
+# Input integrity
+# ---------------------------------------------------------------------------
+
+
+class TestInputIntegrity:
+    def test_input_blocks_are_not_mutated(self) -> None:
+        blocks = [
+            make_block(1, 0, "Alpha beta."),
+            make_block(1, 1, "Gamma delta."),
+        ]
+        # Offsets start as placeholders (0/0).
+        match("Gamma delta", blocks)
+        # Matcher must NOT have written real offsets onto the input blocks.
+        assert all(b.char_start == 0 and b.char_end == 0 for b in blocks)
+
+
+class TestAnchorMatchShape:
+    def test_anchor_match_fields(self) -> None:
+        blocks = [make_block(3, 0, "Find me in here please.")]
+        result = match("Find me", blocks)
+        assert result is not None
+        assert result.page == 3
+        assert isinstance(result.char_start, int)
+        assert isinstance(result.char_end, int)
+        assert result.char_start < result.char_end
+        assert result.block_ids == [0]
+        assert set(result.bbox_union.keys()) == {"x", "y", "width", "height"}
+
+
+# ---------------------------------------------------------------------------
+# Fold-back invariant at NFKC-expansion boundaries (Fix 1)
+# ---------------------------------------------------------------------------
+
+
+class TestExpansionBoundaryInvariant:
+    """A match boundary that lands inside a 1→many NFKC expansion must never
+    return a span that folds WIDER than the matched text.
+
+    ``norm_to_orig`` maps every sub-character of an expansion (e.g. the ligature
+    ``ﬁ`` → ``f``, ``i``) to the SAME original index, so the naive map-back of a
+    boundary on a non-first sub-char would include the whole original expansion
+    char.  The matcher must instead honour the advertised guarantee:
+    ``_fold(original[char_start:char_end]) == _fold(matched span)``.
+    """
+
+    def test_quote_starting_mid_ligature_is_unrepresentable_returns_none(self) -> None:
+        # NFKC-normalised "aﬁnal result" == "afinal result"; the quote "inal
+        # result" starts on the SECOND sub-char ('i') of the ligature 'ﬁ'.  No
+        # original slice folds to exactly "inal result" (the ligature is one
+        # indivisible original char), so the matcher must return None rather than
+        # the span-too-wide [1:12] -> "ﬁnal result" -> "final result".
+        blocks = [make_block(1, 0, "aﬁnal result")]
+        assert match("inal result", blocks) is None
+
+    def test_quote_covering_whole_ligature_matches_and_folds_exactly(self) -> None:
+        # "final result" starts BEFORE the ligature and covers the whole 'ﬁ'
+        # expansion, so it is representable: the original slice still contains the
+        # ligature and folds exactly to the quote.
+        blocks = [make_block(1, 0, "aﬁnal result")]
+        result = match("final result", blocks)
+        assert result is not None
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "ﬁ" in sliced
+        assert _fold(sliced) == _fold("final result")
+        _assert_slice_folds_to_quote(result, blocks, "final result")
+
+    def test_quote_starting_after_ligature_snaps_to_narrower_span(self) -> None:
+        # "nal result" starts AFTER the full ligature expansion ('fi'); the start
+        # boundary fell inside the expansion but the quote is representable as the
+        # narrower original slice beginning at 'n'.  The matcher must snap to that
+        # narrower span (dropping the ligature), not widen to include it.
+        blocks = [make_block(1, 0, "aﬁnal result")]
+        result = match("nal result", blocks)
+        assert result is not None
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "ﬁ" not in sliced  # ligature dropped by the snap
+        assert _fold(sliced) == _fold("nal result")
+        _assert_slice_folds_to_quote(result, blocks, "nal result")
+
+
+# ---------------------------------------------------------------------------
+# Whitespace-tight span (Fix 2)
+# ---------------------------------------------------------------------------
+
+
+class TestWhitespaceTrim:
+    """The returned span must not carry leading/trailing ORIGINAL whitespace.
+
+    When a match ends just before a collapsed-whitespace run or a block
+    separator, the naive map-back can include that trailing ``\\n`` / spaces.  A
+    downstream highlighter would render them, so the span is trimmed tight.
+    """
+
+    def test_match_adjacent_to_block_separator_has_no_trailing_newline(self) -> None:
+        # The quote ends exactly at the end of block 0; the naive map-back would
+        # carry the "\n" block separator into the slice.
+        blocks = [
+            make_block(1, 0, "the result was"),
+            make_block(1, 1, "clearly positive"),
+        ]
+        result = match("result was", blocks)
+        assert result is not None
+        assert result.block_ids == [0]
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert sliced == "result was"
+        assert sliced == sliced.strip()  # no leading/trailing whitespace
+        _assert_slice_folds_to_quote(result, blocks, "result was")
+
+    def test_match_adjacent_to_collapsed_whitespace_run_is_tight(self) -> None:
+        # In-block whitespace run after the matched word; the slice must stop at
+        # the word, not run into the spaces/newline.
+        blocks = [make_block(1, 0, "The   sample\n   was   incubated   overnight.")]
+        result = match("sample", blocks)
+        assert result is not None
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert sliced == "sample"
+        assert sliced == sliced.strip()
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy tier: determinism + multi-block coverage (Fix 3)
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzyDeterminismAndCoverage:
+    def test_fuzzy_quote_spanning_two_blocks_merges_range_and_bboxes(self) -> None:
+        # An OCR-noisy quote (within threshold) that crosses the block boundary
+        # must still return the merged char range, BOTH block_ids, and the bbox
+        # union over both blocks.
+        blocks = [
+            make_block(
+                1,
+                0,
+                "the treatment group showed",
+                bbox={"x": 10.0, "y": 100.0, "width": 200.0, "height": 20.0},
+            ),
+            make_block(
+                1,
+                1,
+                "a marked improvement in outcomes",
+                bbox={"x": 12.0, "y": 70.0, "width": 220.0, "height": 22.0},
+            ),
+        ]
+        # "treatment" -> "treatrnent" (rn for m), "improvement" -> "irnprovement".
+        quote = "treatrnent group showed a marked irnprovement"
+        result = match(quote, blocks)
+        assert result is not None
+        assert result.page == 1
+        assert result.block_ids == [0, 1]
+        # Merged range covers text from block 0 into block 1.
+        page_text = _original_page_text(blocks)[1]
+        sliced = page_text[result.char_start : result.char_end]
+        assert "treatment group showed" in sliced
+        assert "marked improvement" in sliced
+        # bbox union over both blocks.
+        assert result.bbox_union["x"] == 10.0
+        assert result.bbox_union["y"] == 70.0
+        assert result.bbox_union["width"] == 232.0 - 10.0
+        assert result.bbox_union["height"] == 120.0 - 70.0
+
+    def test_fuzzy_equal_ratio_windows_resolve_to_earliest_start(self) -> None:
+        # Two windows match the noisy quote with the SAME ratio; the earliest
+        # start must win and repeated calls must agree (determinism).
+        blocks = [
+            make_block(
+                1,
+                0,
+                "alpha bravo charlie delta alpha bravo charlie delta",
+            )
+        ]
+        # OCR-noisy version of "alpha bravo charlie" — present twice in the source
+        # with identical surrounding context, so both windows score equally.
+        noisy = "alpha bravo charlle"
+        first = match(noisy, blocks)
+        second = match(noisy, blocks)
+        assert first is not None
+        assert first == second  # fully deterministic
+        # Earliest start wins: the matched slice is the FIRST occurrence.
+        page_text = _original_page_text(blocks)[1]
+        assert page_text[: first.char_start] == ""  # anchored at the very start
+        sliced = page_text[first.char_start : first.char_end]
+        assert sliced.startswith("alpha bravo")
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation — match() must never raise (Fix: graceful post-condition)
+# ---------------------------------------------------------------------------
+
+
+class TestMatchNeverRaises:
+    """The post-condition in ``match`` is now a guarded ``continue`` rather than
+    an ``assert``.  This class pins the contract: ``match(...)`` NEVER raises for
+    any combination of degenerate inputs; it always returns either a
+    fold-back-valid ``AnchorMatch`` or ``None``.
+
+    The defensive branch (invariant violated → skip candidate) cannot be triggered
+    through the public ``match`` API because ``_resolve_original_span`` already
+    returns ``None`` whenever no valid original span satisfies fold-equality.
+    We therefore exercise the contract via a broad sweep of degenerate inputs and
+    assert two properties:
+      1. No call raises any exception.
+      2. Every non-None result satisfies the fold-back invariant.
+    """
+
+    # Degenerate inputs: quotes that stress boundary conditions.
+    DEGENERATE_QUOTES = [
+        "",  # empty
+        "   ",  # whitespace only
+        "\n\t\r",  # only control whitespace
+        "inal result",  # begins mid-ligature-expansion in the fixture below
+        "ﬁ",  # the raw ligature itself (1 original char → 2 normalised)
+        "a" * 5000,  # much longer than any page — no match possible
+        "\x00\x01\xff",  # non-printable / high-byte characters
+        "αβγ",  # non-ASCII entirely absent from the ASCII pages
+        "  leading and trailing  ",  # extra whitespace around real content
+    ]
+
+    BLOCKS = [
+        make_block(1, 0, "aﬁnal result"),
+        make_block(1, 1, "The mitochondria is the powerhouse of the cell."),
+        make_block(2, 0, "Results were significant (p < 0.001)."),
+    ]
+
+    def test_degenerate_quotes_never_raise(self) -> None:
+        for quote in self.DEGENERATE_QUOTES:
+            # Must not raise — any exception (including AssertionError) is a bug.
+            result = match(quote, self.BLOCKS)
+            # Non-None results must satisfy the fold-back invariant.
+            if result is not None:
+                _assert_slice_folds_to_quote(result, self.BLOCKS, quote)
+
+    def test_empty_blocks_never_raise(self) -> None:
+        for quote in self.DEGENERATE_QUOTES:
+            result = match(quote, [])
+            assert result is None  # no blocks → always None
+
+    def test_single_empty_block_never_raise(self) -> None:
+        empty_text_block = [make_block(1, 0, "")]
+        for quote in self.DEGENERATE_QUOTES:
+            result = match(quote, empty_text_block)
+            assert result is None  # empty page text → always None
+
+    def test_real_quote_mid_ligature_returns_none_not_raises(self) -> None:
+        # The canonical degenerate case: a quote that begins on the SECOND
+        # sub-char of a ligature expansion.  The post-condition (now guarded)
+        # would fire here if ``_resolve_original_span`` ever returned a
+        # span that doesn't satisfy fold-equality.  It must return None, not raise.
+        blocks = [make_block(1, 0, "aﬁnal result")]
+        result = match("inal result", blocks)
+        assert result is None  # unrepresentable → unanchored, not an error
+
+    def test_quote_longer_than_page_returns_none_not_raises(self) -> None:
+        blocks = [make_block(1, 0, "Short text.")]
+        result = match("x" * 10_000, blocks)
+        assert result is None

--- a/backend/tests/unit/test_extraction_run_schemas.py
+++ b/backend/tests/unit/test_extraction_run_schemas.py
@@ -588,9 +588,11 @@ class TestRunViewResponse:
             published_states=[],
             entity_types=[],
             current_values=[],
+            instances=[],
         )
         assert resp.entity_types == []
         assert resp.current_values == []
+        assert resp.instances == []
 
     def test_inherits_detail_requirements(self) -> None:
         with pytest.raises(ValidationError):
@@ -626,6 +628,7 @@ class TestRunViewResponse:
             published_states=[],
             entity_types=[et],
             current_values=[cv],
+            instances=[],
         )
         assert resp.entity_types[0].name == "patient"
         assert resp.current_values[0].decision == "review"

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -41,6 +41,9 @@ def service(mock_db, mock_storage):
         patch("app.services.section_extraction_service.PDFProcessor") as mock_pdf,
         patch("app.services.section_extraction_service.ArticleFileRepository") as mock_article_repo,
         patch(
+            "app.services.section_extraction_service.ArticleTextBlockRepository"
+        ) as mock_block_repo,
+        patch(
             "app.services.section_extraction_service.ExtractionEntityTypeRepository"
         ) as mock_entity_repo,
         patch(
@@ -57,7 +60,16 @@ def service(mock_db, mock_storage):
 
         # Mock repositories
         mock_article_repo_instance = MagicMock()
+        # get_latest_pdf is async; return None so _create_suggestions falls
+        # back to position={} (no blocks → safe fallback, no anchor attempt).
+        mock_article_repo_instance.get_latest_pdf = AsyncMock(return_value=None)
         mock_article_repo.return_value = mock_article_repo_instance
+
+        # ArticleTextBlockRepository is instantiated inside _create_suggestions;
+        # mock the class so the constructor returns a proper async mock.
+        mock_block_repo_instance = MagicMock()
+        mock_block_repo_instance.list_ordered_for_file = AsyncMock(return_value=[])
+        mock_block_repo.return_value = mock_block_repo_instance
 
         mock_entity_repo_instance = MagicMock()
         mock_entity_repo.return_value = mock_entity_repo_instance
@@ -270,13 +282,22 @@ class TestSectionExtractionFullFlow:
         )
 
         # Mock SQLAlchemy model class to avoid mapper issues
-        with patch(
-            "app.services.section_extraction_service.ExtractionInstance"
-        ) as mock_instance_class:
+        with (
+            patch(
+                "app.services.section_extraction_service.ExtractionInstance"
+            ) as mock_instance_class,
+            patch(
+                "app.services.section_extraction_service.ArticleTextBlockRepository"
+            ) as mock_blk_repo,
+        ):
             mock_created_instance = MagicMock()
             mock_created_instance.id = uuid4()
             mock_instance_class.return_value = mock_created_instance
             service._instances.create = AsyncMock(return_value=mock_created_instance)
+
+            mock_blk_repo_inst = MagicMock()
+            mock_blk_repo_inst.list_ordered_for_file = AsyncMock(return_value=[])
+            mock_blk_repo.return_value = mock_blk_repo_inst
 
             result = await service.extract_section(
                 project_id=project_id,
@@ -377,13 +398,22 @@ class TestExtractSectionWithExistingRun:
 
         self._wire_pipeline(service, mock_storage, existing_run, entity_type_id)
 
-        with patch(
-            "app.services.section_extraction_service.ExtractionInstance"
-        ) as mock_instance_class:
+        with (
+            patch(
+                "app.services.section_extraction_service.ExtractionInstance"
+            ) as mock_instance_class,
+            patch(
+                "app.services.section_extraction_service.ArticleTextBlockRepository"
+            ) as mock_blk_repo,
+        ):
             inst = MagicMock()
             inst.id = uuid4()
             mock_instance_class.return_value = inst
             service._instances.create = AsyncMock(return_value=inst)
+
+            mock_blk_repo_inst = MagicMock()
+            mock_blk_repo_inst.list_ordered_for_file = AsyncMock(return_value=[])
+            mock_blk_repo.return_value = mock_blk_repo_inst
 
             result = await service.extract_section(
                 project_id=project_id,

--- a/docs/superpowers/plans/2026-06-19-extraction-data-path-finish.md
+++ b/docs/superpowers/plans/2026-06-19-extraction-data-path-finish.md
@@ -1,0 +1,403 @@
+---
+status: completed
+last_reviewed: 2026-06-19
+owner: '@raphaelfh'
+---
+
+# Finish the extraction data-path consolidation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development
+> (same-session, fresh implementer per task + task review). Steps use checkbox
+> (`- [ ]`) syntax for tracking.
+
+> **STATUS — implementation complete & locally verified 2026-06-19 (pending merge to `dev`).**
+> All three gaps shipped via subagent-driven-development (Tasks 1–9 + cleanup),
+> each task spec+quality reviewed, plus a final whole-branch review (verdict:
+> ready to merge). Verification: backend 44 targeted integration tests + the
+> blind-filter/migration regression anchors green; frontend `npm run test:run`
+> **552/552**; `make lint-backend` clean; `scripts/fitness/run_all.sh` all 8
+> checks OK; `npm run generate:api-types` no drift; `npm run typecheck` clean.
+> Zero `supabase` reads remain across the extraction run-open/run-resolution
+> path. The broader app-schema API buildout (template/project/QA/article-admin
+> services) remains the separate, out-of-scope effort.
+
+**Goal:** Close the three remaining gaps of the extraction data-path
+consolidation so the extraction run-open + run-resolution path reads/writes
+through the typed API client only (ADR-0007), with **no** direct
+`supabase.from(...)` PostgREST reads left in the extraction services/hooks on
+that path:
+
+- **(a)** Re-point `ExtractionValueService.findActiveRun` /
+  `findLatestFinalizedRun` / `findFormRunsByArticle` and `AISuggestionService`
+  off direct PostgREST onto new typed backend endpoints.
+- **(b)** Phase 2 **Task 12**: serve `instances` (and the already-served
+  `entity_types`) from the server `RunView`, source the run-open form from
+  `runDetail` via adapters, and strip the direct `extraction_entity_types` +
+  `extraction_instances` reads from `useExtractionData` (+ the
+  `useModelManagement` double-read).
+- **(c)** Route all run query-keys through the `runsKeys` factory.
+
+**Scope boundary:** ONLY the extraction run-open / run-resolution path. The
+~15 other service files (template/project/QA/article-admin/profile/zotero CRUD)
+remain on PostgREST — that is the separate, larger app-schema API buildout, out
+of scope here. No `supabase.auth`/`supabase.storage` usage is touched (ADR-0007
+allow-list).
+
+**No migration:** every new backend read uses existing tables/columns. Do NOT
+create an Alembic migration.
+
+**Tech Stack:** Backend FastAPI + SQLAlchemy 2.0 async + Pydantic v2, pytest
+integration (local Supabase @ alembic head `0026`). Frontend React 18 + TS
+strict + TanStack Query + vitest. Branch: `claude/strange-spence-9f6e39`
+(worktree off `dev`). Verify: `cd backend && uv run pytest`, `make lint-backend`,
+`npm run typecheck`, `npm run test:run`, `bash scripts/fitness/run_all.sh`.
+
+---
+
+## Global Constraints (the reviewer attention lens)
+
+1. **ADR-0007 single read path.** New extraction-path reads go through
+   `apiClient` (`frontend/integrations/api`). After the re-points, a
+   multiline-aware grep of `extractionValueService.ts`, `aiSuggestionService.ts`,
+   and `useExtractionData.ts` must show **zero** `supabase.from(`.
+2. **Behavior parity.** Each re-point returns the **identical shape** the old
+   Supabase read produced: `findActiveRun`/`findLatestFinalizedRun` → `RunRef |
+   null` (`{id, stage, status, template_id}`); `findFormRunsByArticle` →
+   `Map<articleId, runId>`; `AISuggestionService.loadSuggestions` →
+   `{suggestions: Record<key,AISuggestion>, count}`; `getHistory` →
+   `AISuggestionHistoryItem[]`. Do not change caller contracts.
+3. **Caller-scoped suggestion status (blind).** The accepted/rejected status in
+   `load_suggestions` is derived from the CALLER's own
+   `extraction_reviewer_states` only (`reviewer_id == caller_id`). Never read or
+   leak another reviewer's decisions. AI proposals (`source='ai'`) are shared
+   (not blinded); only the *status overlay* is caller-scoped.
+4. **BOLA on every new endpoint.** Article-scoped reads gate via
+   `get_article_project_id(db, article_id)` → `ensure_project_member(db,
+   project_id, user_sub)`; the batch endpoint gates on the body's `project_id`
+   via `ensure_project_member`. Mirror the citations endpoint pattern.
+5. **API contract types.** After backend endpoint/schema changes, run
+   `npm run generate:api-types` and commit the diff (the `api-contract` CI job
+   fails otherwise).
+6. **React Compiler.** No `try/finally` or `throw`-inside-`try` in component/hook
+   bodies. IO stays in `frontend/services/*`. `apiClient` throws `ApiError` on
+   failure; service methods that currently throw keep throwing (preserve the
+   existing contract — do not silently convert throw→ErrorResult here).
+7. **TanStack keys from factories** (`runsKeys`); the key-factory fitness check
+   (`scripts/fitness/check_react_query_keys.py`) must stay green.
+8. **`instances` are NOT run-scoped.** `_instances_for_run` scopes by
+   `(article_id, template_id)` — the canonical rule from
+   `ExtractionExportService._load_instances_for_runs`. Do not import that method;
+   replicate the scope.
+9. **`metadata` wire key.** The `ExtractionInstance` ORM attr is `metadata_`
+   (DB/wire column `metadata`). `RunViewInstance` must serialize JSON key
+   `metadata` (validation_alias `metadata_`), asserted by a test.
+
+---
+
+## Reference designs (verified against the code 2026-06-19)
+
+- BOLA helpers: `ensure_project_member(db, project_id, user_sub)` in
+  `app/api/deps/security.py`; `get_article_project_id(db, article_id)` in
+  `app/services/citation_read_service.py`. Endpoint template: `get_run` in
+  `app/api/v1/endpoints/extraction_runs.py` (DbSession dep,
+  `get_current_user_sub`, `ApiResponse.success(..., trace_id=_trace(request))`).
+- `RunSummaryResponse` (already exists) carries `id, project_id, article_id,
+  template_id, kind, version_id, stage, status, ... created_at, created_by` and
+  has `from_attributes=True`.
+- ORM: `ExtractionRun` (run repo `app/repositories/extraction_run_repository.py`
+  has `get_by_article`/`get_latest_by_article` as structural references — none
+  cover kind+template+multi-stage, so add new service methods).
+  `ExtractionProposalRecord`/`ExtractionReviewerState`/`ExtractionReviewerDecision`
+  in `app/models/extraction_workflow.py`; `ExtractionEvidence`/`ExtractionInstance`
+  in `app/models/extraction.py` (`ExtractionInstance.metadata_` → column
+  `"metadata"`; all RunViewInstance fields exist on the ORM).
+- `build_run_view(db, run_id, *, caller_id, can_see_peers)` in
+  `app/services/extraction_run_read_service.py` builds `RunViewResponse(...)`; it
+  is called by BOTH `GET /runs/{id}/view` (extraction_runs.py) and the session
+  embed (hitl_sessions.py:89) — adding `instances` flows to both.
+- apiClient: `apiClient<T>(endpoint, options?)` returns the UNWRAPPED `data` (type
+  `T`), throws `ApiError` (from `@/integrations/api`) on `ok:false`/non-2xx
+  (reads `error.message`). GET query params are built inline into the path
+  string. Import `{ apiClient }` from `@/integrations/api`.
+- `runsKeys` lives in `frontend/hooks/runs/types.ts` (`all`, `detail`). Inline
+  literals to fold in: `["runs","disabled"]` (useRun:22),
+  `["runs", runId, "reviewers"]` + `["runs","no-run","reviewers"]`
+  (useRunReviewers:38,47). These are NOT a current CI failure (ternary form
+  hides them from the regex) — this is centralization, not a forced fix.
+- Hazard audit (ExtractionFullScreen): the 6 `refreshInstances()` sites
+  (144, 516, 538, 584, 692, 728, 958) are all fire-and-forget — NONE reads the
+  `instances` array synchronously after the await. `handleFinalize` reads
+  `instances.map(i=>i.id)` (805) but NOT after a refresh in the same flow. So
+  deriving `instances` from a `useMemo(()=>instancesFromRunView(runDetail))` and
+  replacing `refreshInstances()`→`refetchRun()` is safe. The implementer MUST
+  re-confirm no refresh-then-synchronous-read site exists before relying on this.
+
+---
+
+## Tasks
+
+### Task 1 — [BE] Run-resolution service + `/articles` endpoints (gap a, part 1)
+
+Replace `findActiveRun` / `findLatestFinalizedRun` / `findFormRunsByArticle`'s
+PostgREST queries with server endpoints.
+
+**Files:**
+- Modify: `backend/app/services/extraction_run_read_service.py` —
+  `find_active_run(db, article_id, *, template_id=None) -> RunSummaryResponse |
+  None`, `find_finalized_run(db, article_id, *, template_id=None) ->
+  RunSummaryResponse | None`, `resolve_form_runs(db, article_ids, *,
+  template_id) -> list[ArticleRunRef]`.
+- Modify: `backend/app/schemas/extraction_run.py` — `ArticleRunRef {article_id:
+  UUID, run_id: UUID | None}`, `FormRunsRequest {article_ids: list[UUID],
+  template_id: UUID, project_id: UUID}`.
+- Create: `backend/app/api/v1/endpoints/articles.py` — router with
+  `GET /{article_id}/active-run?template_id=`,
+  `GET /{article_id}/finalized-run?template_id=`,
+  `POST /form-runs` (body `FormRunsRequest`).
+- Modify: `backend/app/api/v1/router.py` — register `articles.router` under
+  `/articles` (a citations router is already under `/articles`; FastAPI merges).
+- Test: `backend/tests/integration/test_run_resolution_endpoints.py` (new).
+
+Resolution semantics (parity with current frontend):
+- active: `kind='extraction'`, `stage IN (pending,proposal,review,consensus)`,
+  optional `template_id`, latest `created_at`.
+- finalized: same with `stage='finalized'`.
+- form-runs (batch): per article, latest non-terminal run; else latest
+  finalized; cancelled excluded. (Mirror `findFormRunsByArticle`'s scan.)
+
+- [ ] **Step 1 (RED):** Write `test_run_resolution_endpoints.py` — seed (or reuse
+  a seeded) extraction run, assert: `GET /api/v1/articles/{aid}/active-run`
+  returns the active run (200, `data.id`), `finalized-run` returns null/empty when
+  none, `POST /api/v1/articles/form-runs` returns one `{article_id, run_id}` per
+  input article, and a non-member caller gets **403** on each. Run; expect
+  failures (routes/methods absent).
+- [ ] **Step 2 (GREEN):** Implement the service methods + schemas + endpoints +
+  router registration. Gate each via the BOLA helpers (Constraint 4). Endpoints
+  return `ApiResponse.success(...)`.
+- [ ] **Step 3:** `cd backend && uv run pytest
+  tests/integration/test_run_resolution_endpoints.py -v` — PASS.
+- [ ] **Step 4:** `make lint-backend` for the touched files — clean.
+- [ ] **Step 5: Commit** `feat(api): article-scoped run-resolution endpoints (active/finalized/form-runs)`.
+
+### Task 2 — [BE] AI-suggestion read service + `/articles` endpoints (gap a, part 2)
+
+**Files:**
+- Create: `backend/app/services/extraction_suggestion_read_service.py` —
+  `get_article_instance_ids(db, article_id) -> list[UUID]`;
+  `load_suggestions(db, instance_ids, *, caller_id, run_id=None) ->
+  AISuggestionsResponse` (proposals `source='ai'` for the instances/run, evidence
+  joined by `proposal_record_id`, per-coord status from the CALLER's
+  `reviewer_states`→`reviewer_decisions.decision`, latest-per-`(instance,field)`);
+  `get_suggestion_history(db, instance_id, field_id, *, limit=10) ->
+  list[AISuggestionHistoryItem]`.
+- Modify: `backend/app/schemas/` (new module `extraction_suggestion.py` or add to
+  `extraction_run.py`) — `EvidenceResponse {proposal_record_id, text_content,
+  page_number}`, `AISuggestionItem {id, run_id, instance_id, field_id,
+  proposed_value, confidence_score, rationale, created_at, evidence, status}`,
+  `AISuggestionsResponse {suggestions: list[AISuggestionItem], count}`,
+  `AISuggestionHistoryItem` (same item shape minus status).
+- Modify: `backend/app/api/v1/endpoints/articles.py` —
+  `GET /{article_id}/instance-ids`,
+  `GET /{article_id}/suggestions?instance_ids=&run_id=`,
+  `GET /{article_id}/suggestions/history?instance_id=&field_id=&limit=`.
+- Test: `backend/tests/integration/test_suggestion_read.py` (new).
+
+- [ ] **Step 1 (RED):** Write `test_suggestion_read.py` — using the two-reviewer
+  helper (`tests/integration/test_blind_review_isolation._build_two_reviewer_review_run`
+  or the seed graph): assert `load_suggestions` returns AI proposals with
+  `status` resolved from the CALLER's reviewer_state (and that reviewer A's
+  status overlay never reflects reviewer B's decisions — caller scope);
+  `instance-ids` returns the article's instances; `suggestions/history` returns
+  AI proposals for a coord. Endpoint tests: 200 + 403 BOLA. Run; expect failures.
+- [ ] **Step 2 (GREEN):** Implement the service + schemas + endpoints. The status
+  overlay reads ONLY `reviewer_states.reviewer_id == caller_id` (Constraint 3).
+- [ ] **Step 3:** `cd backend && uv run pytest tests/integration/test_suggestion_read.py -v` — PASS.
+- [ ] **Step 4:** `make lint-backend` touched files — clean.
+- [ ] **Step 5: Commit** `feat(api): caller-scoped AI-suggestion read endpoints`.
+
+### Task 3 — [BE] `instances` on the RunView (gap b backend / Phase 2 Task 12 step 0)
+
+**Files:**
+- Modify: `backend/app/schemas/extraction_run.py` — `RunViewInstance` (fields:
+  `id, entity_type_id, parent_instance_id, label, sort_order, status, metadata,
+  project_id, article_id, template_id, created_by, created_at, updated_at`;
+  `ConfigDict(from_attributes=True, populate_by_name=True)`; `metadata` field via
+  `validation_alias="metadata_"` so JSON emits `metadata`). Add
+  `instances: list[RunViewInstance]` to `RunViewResponse`.
+- Modify: `backend/app/services/extraction_run_read_service.py` —
+  `_instances_for_run(db, run: RunSummaryResponse) -> list[RunViewInstance]`
+  (select `ExtractionInstance` where `article_id == run.article_id AND
+  template_id == run.template_id`, order by `(entity_type_id, sort_order)`,
+  `model_validate`); call it in `build_run_view` and add `instances=` to the
+  `RunViewResponse(...)`.
+- Test: extend `test_build_run_view.py` (instances present + scoped),
+  `test_run_view_endpoint.py` (`data.instances` present + `metadata` wire key),
+  `test_hitl_session_embeds_run_view.py` (embed carries instances).
+
+- [ ] **Step 1 (RED):** Extend the three tests to assert `instances` is present on
+  `build_run_view`, on `GET /runs/{id}/view` (`data["instances"]`), and on the
+  session embed — plus one assertion that an instance dict has key `"metadata"`
+  (not `"metadata_"`). Run; expect failures.
+- [ ] **Step 2 (GREEN):** Add the schema + `_instances_for_run` + wire into
+  `build_run_view`. (Mirror the `metadata_` handling of any existing schema; else
+  use `validation_alias`.)
+- [ ] **Step 3:** `cd backend && uv run pytest
+  tests/integration/test_build_run_view.py tests/integration/test_run_view_endpoint.py
+  tests/integration/test_hitl_session_embeds_run_view.py -v` — PASS.
+- [ ] **Step 4:** `make lint-backend` touched files — clean.
+- [ ] **Step 5: Commit** `feat(extraction): serve instances from build_run_view (Task 12 step 0)`.
+
+### Task 4 — [FE] Regenerate API types + frontend response types
+
+**Files:**
+- Modify: `frontend/types/api/{openapi.json,schema.d.ts}` (generated).
+- Modify: `frontend/hooks/runs/types.ts` — add `RunViewInstanceResponse` and
+  `instances: RunViewInstanceResponse[]` to `RunViewResponse` (remove the
+  Task-12-deferred comment). Add a `RunRefResponse` (`{id, stage, status,
+  template_id}`) + `ArticleRunRef` (`{article_id, run_id: string|null}`) if not
+  already exported, for the service re-points.
+
+- [ ] **Step 1:** `npm run generate:api-types`.
+- [ ] **Step 2:** Add the hand-mirrored run/instance types above.
+- [ ] **Step 3:** `npm run typecheck` — clean.
+- [ ] **Step 4: Commit** `chore(api-types): regenerate for run-resolution + suggestions + RunViewInstance`.
+
+### Task 5 — [FE] Re-point `extractionValueService` run-resolution (gap a)
+
+**Files:**
+- Modify: `frontend/services/extractionValueService.ts` — `findActiveRun`,
+  `findLatestFinalizedRun`, `findFormRunsByArticle` call `apiClient` against the
+  Task-1 endpoints; drop the `supabase` import if it becomes unused (the
+  decisions writes already use apiClient). Preserve return shapes + the
+  `kind='extraction'` semantics (now server-side).
+- Test: `frontend/test/...` for this service (mock `@/integrations/api`'s
+  `apiClient`; assert path + parity shapes + that `supabase.from` is not called).
+
+- [ ] **Step 1 (RED):** Write/extend the service test to assert each method hits
+  the right endpoint path and maps the response to the existing return shape
+  (`RunRef|null`, `Map`). Run; expect failure (still PostgREST).
+- [ ] **Step 2 (GREEN):** Re-point onto `apiClient`. `findFormRunsByArticle` POSTs
+  `{article_ids, template_id, project_id}` — note: it needs `project_id`; thread
+  it from the caller (check the call site; if the current signature lacks it,
+  add a `projectId` param and update callers minimally).
+- [ ] **Step 3:** `npm run test:run -- <this test>` — PASS.
+- [ ] **Step 4:** `npm run typecheck` + eslint touched files — clean.
+- [ ] **Step 5: Commit** `refactor(extraction): run-resolution reads via typed API client`.
+
+### Task 6 — [FE] Re-point `aiSuggestionService` (gap a)
+
+**Files:**
+- Modify: `frontend/services/aiSuggestionService.ts` — `loadSuggestions`,
+  `getHistory`, `getArticleInstanceIds` call the Task-2 endpoints; drop the
+  `supabase` import + the `supabase.auth.getUser()` (status is now server-derived
+  caller-scoped). Preserve the `AISuggestion`/`AISuggestionHistoryItem` shapes
+  and `getSuggestionKey` mapping.
+- Test: the `aiSuggestionService`/`useAISuggestions` test (mock apiClient).
+
+- [ ] **Step 1 (RED):** Test asserts `loadSuggestions` maps the server response to
+  the `{suggestions, count}` shape with statuses, `getHistory` returns the list,
+  no `supabase.from`/`supabase.auth` calls. Run; expect failure.
+- [ ] **Step 2 (GREEN):** Re-point onto `apiClient`.
+- [ ] **Step 3:** `npm run test:run -- <this test>` — PASS.
+- [ ] **Step 4:** `npm run typecheck` + eslint — clean.
+- [ ] **Step 5: Commit** `refactor(extraction): AI-suggestion reads via typed API client`.
+
+### Task 7 — [FE] `runViewAdapters.ts` (gap b)
+
+**Files:**
+- Create: `frontend/lib/extraction/runViewAdapters.ts` —
+  `entityTypesFromRunView(view) -> ExtractionEntityTypeWithFields[]` (inject
+  `template_id: view.run.template_id`; `created_at` placeholder `view.run.created_at`;
+  cast `cardinality`/`role`/`allowed_values`/`allowed_units`/`validation_schema`),
+  `instancesFromRunView(view) -> ExtractionInstance[]` (straight map from
+  `view.instances`; `label ?? ''`).
+- Test: `frontend/test/lib/runViewAdapters.test.ts` (new) — shape parity, the
+  injected `template_id`, empty inputs.
+
+- [ ] **Step 1 (RED):** Write the adapter unit tests. Run; expect failure (module
+  absent).
+- [ ] **Step 2 (GREEN):** Implement the adapters.
+- [ ] **Step 3:** `npm run test:run -- frontend/test/lib/runViewAdapters.test.ts` — PASS.
+- [ ] **Step 4:** `npm run typecheck` + eslint — clean.
+- [ ] **Step 5: Commit** `feat(extraction): runViewAdapters map the view onto form types`.
+
+### Task 8 — [FE] Source the form from the view; strip direct reads (gap b)
+
+**Files:**
+- Modify: `frontend/pages/ExtractionFullScreen.tsx` — derive `entityTypes`/
+  `instances` via `useMemo(()=>adapter(runDetail))`; replace every
+  `refreshInstances()` with `refetchRun()`; pass a `modelInstances` derived prop
+  to `useModelManagement`. Stop destructuring `entityTypes`/`instances`/
+  `refreshInstances` from `useExtractionData`.
+- Modify: `frontend/hooks/extraction/useModelManagement.ts` — accept optional
+  `modelInstances`; when provided, skip `loadModelInstances` (drop that
+  `supabase.from('extraction_instances')` read); keep the `calculate_model_progress`
+  RPC.
+- Modify: `frontend/hooks/extraction/useExtractionData.ts` — remove the
+  `extraction_entity_types` + `extraction_instances` reads (`loadEntityTypesWithFields`,
+  `loadInstances`, `refreshInstances`, `mergeInstancesById`); keep
+  article/project/template/articles. Re-point any other consumer of the removed
+  exports (`grep -rn useExtractionData frontend/`).
+- Test: extend the ExtractionFullScreen / useExtractionData / useModelManagement
+  tests to cover the view-sourced render + the model-instances prop path.
+
+- [ ] **Step 1:** Re-confirm no refresh-then-synchronous-read site exists (re-grep
+  `instances`/`refreshInstances` in ExtractionFullScreen). If any exists, convert
+  it to refetch-and-derive (`const {data}=await refetchRun(); const fresh=
+  instancesFromRunView(data); ...`).
+- [ ] **Step 2 (RED→GREEN):** Update tests, then make the edits. Frozen-snapshot
+  `entity_types` now drive rendering (verify study/model partition still works via
+  `role`).
+- [ ] **Step 3:** `npm run test:run` for the touched suites — PASS.
+- [ ] **Step 4:** `npm run typecheck` + eslint — clean. Confirm a multiline grep
+  shows `useExtractionData.ts` has **no** `supabase.from`.
+- [ ] **Step 5: Commit** `feat(extraction): run-open form sources entity_types+instances from the view`.
+
+### Task 9 — [FE] Route run query-keys through the factory (gap c)
+
+**Files:**
+- Modify: `frontend/hooks/runs/types.ts` — add `reviewers: (runId) => ["runs",
+  runId, "reviewers"]`, `disabled: ["runs","disabled"]`, `noRunReviewers:
+  ["runs","no-run","reviewers"]` to `runsKeys`.
+- Modify: `frontend/hooks/runs/useRun.ts` (use `runsKeys.disabled`),
+  `frontend/hooks/runs/useRunReviewers.ts` (drop local `reviewersKey`; use
+  `runsKeys.reviewers` / `runsKeys.noRunReviewers`).
+- Test: extend `frontend/test/hooks-runs.test.tsx` / reviewers test as needed.
+
+- [ ] **Step 1 (RED):** Assert `useRunReviewers` uses `runsKeys.reviewers(runId)`
+  and `useRun`'s disabled key comes from the factory. Run; expect failure.
+- [ ] **Step 2 (GREEN):** Add the factory entries + route consumers.
+- [ ] **Step 3:** `npm run test:run -- <these tests>` — PASS.
+- [ ] **Step 4:** `python3 scripts/fitness/check_react_query_keys.py` — green;
+  `npm run typecheck` + eslint — clean.
+- [ ] **Step 5: Commit** `refactor(runs): all run query-keys come from the runsKeys factory`.
+
+### Task 10 — [VERIFY] Full sweep + plan registration
+
+- [ ] **Step 1:** `npm run generate:api-types` — confirm no further diff (drift gate).
+- [ ] **Step 2:** `cd backend && uv run pytest tests/integration/test_run_resolution_endpoints.py
+  test_suggestion_read.py test_build_run_view.py test_run_view_endpoint.py
+  test_hitl_session_embeds_run_view.py test_run_read_blind_filter.py
+  test_migration_roundtrip.py -v` — PASS. `make lint-backend` — clean.
+- [ ] **Step 3:** `npm run typecheck && npm run test:run` — clean/green.
+- [ ] **Step 4:** `bash scripts/fitness/run_all.sh` — all checks OK.
+- [ ] **Step 5:** Multiline-aware audit: `rg -U "supabase\s*\.?\s*\n?\s*\.from\("
+  frontend/services/extractionValueService.ts frontend/services/aiSuggestionService.ts
+  frontend/hooks/extraction/useExtractionData.ts` returns **nothing**.
+- [ ] **Step 6:** Add this plan doc to `.markdownlintignore`; flip frontmatter
+  `status: shipped` with a verification note. Commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** (a) Tasks 1–2 (BE endpoints) + 5–6 (FE re-points); (b)
+  Tasks 3 (BE instances) + 7–8 (FE adapters/strip); (c) Task 9. ✓
+- **No migration** (all reads use existing columns); no `supabase.auth`/`storage`
+  touched (ADR-0007 allow-list). ✓
+- **Blind/BOLA:** suggestion status caller-scoped (Constraint 3); every new
+  endpoint membership-gated (Constraint 4). ✓
+- **Parity:** re-points preserve return shapes (Constraint 2); Task 8 relies on
+  the verified zero-Hazard-1 audit (re-confirmed in Task 8 Step 1). ✓
+- **Out of scope:** the broader app-schema API buildout + the ADR-0007 enforcing
+  fitness function (would flag the out-of-scope services) are NOT in this plan.

--- a/frontend/components/extraction/ExtractionPDFPanel.tsx
+++ b/frontend/components/extraction/ExtractionPDFPanel.tsx
@@ -7,18 +7,26 @@
  */
 
 import {memo} from 'react';
+import type {StoreApi} from 'zustand';
 import {ResizableHandle, ResizablePanel} from '@/components/ui/resizable';
 import {PrumoPdfViewer, articleFileSource} from '@prumo/pdf-viewer';
+import type {ViewerState} from '@prumo/pdf-viewer';
 
 export interface ExtractionPDFPanelProps {
   articleId: string;
   projectId: string;
   showPDF: boolean;
+  /** Shared viewer store. When provided, the PDF viewer joins the caller's
+   *  ViewerProvider instead of creating its own — required for the
+   *  click-evidence → highlight flow where the form panel must reach the
+   *  same store instance. */
+  store?: StoreApi<ViewerState>;
 }
 
 function ExtractionPDFPanelComponent({
   articleId,
   showPDF,
+  store,
 }: ExtractionPDFPanelProps) {
   const source = articleId ? articleFileSource(articleId) : null;
 
@@ -35,7 +43,7 @@ function ExtractionPDFPanelComponent({
         minSize={30}
         maxSize={70}
       >
-        <PrumoPdfViewer source={source} className="h-full" />
+        <PrumoPdfViewer source={source} store={store} className="h-full" />
       </ResizablePanel>
       <ResizableHandle withHandle />
     </>
@@ -48,7 +56,8 @@ export const ExtractionPDFPanel = memo(
   (prev, next) =>
     prev.articleId === next.articleId &&
     prev.projectId === next.projectId &&
-    prev.showPDF === next.showPDF,
+    prev.showPDF === next.showPDF &&
+    prev.store === next.store,
 );
 
 ExtractionPDFPanel.displayName = 'ExtractionPDFPanel';

--- a/frontend/components/extraction/FieldInput.tsx
+++ b/frontend/components/extraction/FieldInput.tsx
@@ -58,7 +58,7 @@ interface FieldInputProps {
 // =================== COMPONENT ===================
 
 export function FieldInput(props: FieldInputProps) {
-  const { field, instanceId, value, onChange, disabled, aiSuggestion, onAcceptAI, onRejectAI, getSuggestionsHistory, isActionLoading } = props;
+  const { field, instanceId, value, onChange, disabled, aiSuggestion, onAcceptAI, onRejectAI, getSuggestionsHistory, isActionLoading, articleId } = props;
   const [validationError, setValidationError] = useState<string | null>(null);
   // Briefly highlights this field when its value was just updated (e.g. by an
   // AI extraction refresh) so the user sees what changed without having to
@@ -457,6 +457,7 @@ export function FieldInput(props: FieldInputProps) {
             suggestion={aiSuggestion}
             instanceId={instanceId}
             fieldId={field.id}
+            articleId={articleId}
             onAccept={onAcceptAI}
             onReject={onRejectAI}
             loading={isActionLoading ? isActionLoading(instanceId, field.id) === 'accept' || isActionLoading(instanceId, field.id) === 'reject' : false}

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -20,6 +20,7 @@ interface AISuggestionDisplayProps {
   suggestion: AISuggestion;
   instanceId: string;
   fieldId: string;
+  articleId?: string;
   onAccept?: () => void;
   onReject?: () => void;
   loading?: boolean;
@@ -39,6 +40,7 @@ export function AISuggestionDisplay({
   suggestion,
   instanceId: _instanceId,
   fieldId: _fieldId,
+  articleId,
   onAccept,
   onReject,
   loading = false,
@@ -56,6 +58,7 @@ export function AISuggestionDisplay({
           {hasDetails ? (
             <AISuggestionDetailsPopover
               suggestion={suggestion}
+              articleId={articleId}
               trigger={
                 <div
                   className={triggerAreaClass}

--- a/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Tests for AISuggestionEvidence (presentational component).
+ *
+ * Three scenarios:
+ *  (a) citation verified + anchor + onHighlight spy → clicking calls onHighlight
+ *  (b) citation present but unverified / no anchor → "couldn't locate" affordance,
+ *      no onHighlight call, no dead jump
+ *  (c) no citation / no onHighlight → renders as before (quote + page badge),
+ *      no crash, no click handler
+ *  (d) handleCopy fix — setCopied(true) only fires on clipboard success
+ *
+ * The component is purely presentational: no hooks, safe outside ViewerProvider.
+ * (Tooltip still needs TooltipProvider — that is a Radix requirement, not
+ *  a viewer-store requirement; we wrap all renders with TooltipProvider.)
+ */
+
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, expect, it, vi} from 'vitest';
+import type {ReactNode} from 'react';
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+import {AISuggestionEvidence} from './AISuggestionEvidence';
+import {TooltipProvider} from '@/components/ui/tooltip';
+import type {ArticleCitationItem} from '@/services/citationsService';
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+
+function Wrapper({children}: {children: ReactNode}) {
+  return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+const anchor: CitationAnchor = {
+  kind: 'text',
+  range: {page: 3, charStart: 10, charEnd: 50},
+  quote: 'some evidence text',
+};
+
+const verifiedCitation: ArticleCitationItem = {
+  id: 'cit-1',
+  verified: true,
+  anchorKind: 'text',
+  anchor,
+  metadata: {pageNumber: 3, textContent: 'some evidence text', source: 'pdf'},
+};
+
+const unverifiedCitation: ArticleCitationItem = {
+  id: 'cit-2',
+  verified: false,
+  anchorKind: null,
+  anchor: null,
+  metadata: {pageNumber: null, textContent: null, source: 'pdf'},
+};
+
+const evidence = {text: 'some evidence text', pageNumber: 3};
+
+describe('AISuggestionEvidence', () => {
+  describe('(a) verified citation + anchor + onHighlight', () => {
+    it('renders a jump-to-source button', () => {
+      const onHighlight = vi.fn();
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={verifiedCitation}
+          onHighlight={onHighlight}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(
+        screen.getByRole('button', {name: 'evidenceJumpToSource'}),
+      ).toBeInTheDocument();
+    });
+
+    it('calls onHighlight with the anchor when the jump button is clicked', async () => {
+      const user = userEvent.setup();
+      const onHighlight = vi.fn();
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={verifiedCitation}
+          onHighlight={onHighlight}
+        />,
+        {wrapper: Wrapper},
+      );
+      await user.click(screen.getByRole('button', {name: 'evidenceJumpToSource'}));
+      expect(onHighlight).toHaveBeenCalledOnce();
+      expect(onHighlight).toHaveBeenCalledWith(anchor);
+    });
+
+    it('does NOT show the evidenceNotLocated affordance', () => {
+      const onHighlight = vi.fn();
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={verifiedCitation}
+          onHighlight={onHighlight}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('(b) citation present but unverified / no anchor', () => {
+    it('renders the evidenceNotLocated affordance', () => {
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={unverifiedCitation}
+          onHighlight={vi.fn()}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(screen.getByText('evidenceNotLocated')).toBeInTheDocument();
+    });
+
+    it('does NOT render a jump-to-source button', () => {
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={unverifiedCitation}
+          onHighlight={vi.fn()}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(
+        screen.queryByRole('button', {name: 'evidenceJumpToSource'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT call onHighlight even if provided', () => {
+      const onHighlight = vi.fn();
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={unverifiedCitation}
+          onHighlight={onHighlight}
+        />,
+        {wrapper: Wrapper},
+      );
+      // No jump button exists — onHighlight is never invoked on render
+      expect(onHighlight).not.toHaveBeenCalled();
+    });
+
+    it('also shows "not located" when citation has no anchor (verified=true but anchor=null)', () => {
+      const noAnchorCitation: ArticleCitationItem = {
+        ...verifiedCitation,
+        anchor: null,
+        anchorKind: null,
+      };
+      render(
+        <AISuggestionEvidence
+          evidence={evidence}
+          citation={noAnchorCitation}
+          onHighlight={vi.fn()}
+        />,
+        {wrapper: Wrapper},
+      );
+      expect(screen.getByText('evidenceNotLocated')).toBeInTheDocument();
+    });
+  });
+
+  describe('(c) no citation / no onHighlight — backward compat', () => {
+    it('renders the quote text', () => {
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      expect(screen.getByText(/some evidence text/)).toBeInTheDocument();
+    });
+
+    it('renders the page badge', () => {
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      // t() mock returns key as-is; component replaces {{n}} → "pageLabel3" effectively
+      // The component does: t('extraction', 'pageLabel').replace('{{n}}', '3')
+      // Mock returns 'pageLabel', then .replace → 'pageLabel' (no {{n}} in key string itself)
+      // Actually the key is 'pageLabel', mock returns 'pageLabel', replace is no-op → 'pageLabel'
+      expect(screen.getByText('pageLabel')).toBeInTheDocument();
+    });
+
+    it('does NOT render a jump button', () => {
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      expect(
+        screen.queryByRole('button', {name: 'evidenceJumpToSource'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT render evidenceNotLocated', () => {
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
+    });
+
+    it('renders without crashing when no citation/onHighlight (no viewer state needed)', () => {
+      // Component must not access viewer store — purely presentational path
+      const {unmount} = render(
+        <AISuggestionEvidence evidence={{text: 'safe'}} />,
+        {wrapper: Wrapper},
+      );
+      expect(screen.getByText(/safe/)).toBeInTheDocument();
+      unmount();
+    });
+  });
+
+  describe('(d) handleCopy — only shows success on clipboard success', () => {
+    // jsdom provides navigator.clipboard but its writeText always rejects with
+    // a DOMException ("not implemented"). We spy on it per-test instead of
+    // trying to redefine the whole clipboard object, which is non-configurable
+    // in some jsdom versions.
+
+    it('sets copied=true when clipboard write succeeds', async () => {
+      const spy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      const copyBtn = screen.getByRole('button', {name: 'copySnippet'});
+
+      await user.click(copyBtn);
+      // After success the button label should change to "copyCopied"
+      expect(screen.getByRole('button', {name: 'copyCopied'})).toBeInTheDocument();
+      spy.mockRestore();
+    });
+
+    it('does NOT set copied=true when clipboard write rejects', async () => {
+      const spy = vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(
+        new Error('permission denied'),
+      );
+      const user = userEvent.setup();
+      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      const copyBtn = screen.getByRole('button', {name: 'copySnippet'});
+
+      await user.click(copyBtn);
+      // Button label must NOT switch to "copyCopied" on failure
+      expect(screen.queryByRole('button', {name: 'copyCopied'})).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'copySnippet'})).toBeInTheDocument();
+      spy.mockRestore();
+    });
+  });
+});

--- a/frontend/components/extraction/ai/AISuggestionEvidence.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.tsx
@@ -3,16 +3,26 @@
  *
  * Shows the text passage cited by the LLM as evidence for extraction,
  * including page number (if available).
- * 
+ *
+ * Optional citation highlight: when a matched `citation` and `onHighlight`
+ * are provided (by a parent inside a ViewerProvider), the evidence block
+ * becomes clickable to jump to the source in the PDF viewer.
+ * When `citation` is provided but unverified / anchor-less, renders a
+ * non-alarming "Couldn't locate in source" affordance instead.
+ * When neither prop is provided the component renders exactly as before —
+ * backward compatible, safe to use outside a ViewerProvider.
+ *
  * @component
  */
 
-import {Check, Copy, FileText} from 'lucide-react';
+import {Check, Copy, FileText, MapPin, MapPinOff} from 'lucide-react';
 import {Button} from '@/components/ui/button';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {useState} from 'react';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
+import type {ArticleCitationItem} from '@/services/citationsService';
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
 
 // =================== INTERFACES ===================
 
@@ -23,67 +33,122 @@ interface AISuggestionEvidenceProps {
   };
   className?: string;
   showCopyButton?: boolean;
+  /** The matched citation for this evidence, or null = no match. Optional. */
+  citation?: ArticleCitationItem | null;
+  /** Called with the anchor when the user clicks to jump. Provided by a parent
+   *  inside a ViewerProvider. Optional. */
+  onHighlight?: (anchor: CitationAnchor) => void;
 }
 
 // =================== COMPONENT ===================
 
 export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
-  const { evidence, className, showCopyButton = true } = props;
+  const {
+    evidence,
+    className,
+    showCopyButton = true,
+    citation,
+    onHighlight,
+  } = props;
   const [copied, setCopied] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(evidence.text);
+    const ok = await navigator.clipboard.writeText(evidence.text).then(() => true).catch((err: unknown) => {
+      console.error('Failed to copy evidence text:', err);
+      return false;
+    });
+    if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy evidence text:', err);
     }
   };
 
+  // Determine citation-highlight state:
+  // - canHighlight: we have everything needed for a real jump
+  // - showNotLocated: citation provided but cannot jump (unverified or no anchor)
+  const canHighlight =
+    citation != null &&
+    citation.verified &&
+    citation.anchor != null &&
+    onHighlight != null;
+
+  const showNotLocated =
+    citation != null && !canHighlight;
+
   return (
-    <div className={cn("flex flex-col gap-4 p-4 bg-muted/50 rounded-lg border", className)}>
-        {/* Header with icon and page */}
+    <div className={cn('flex flex-col gap-4 p-4 bg-muted/50 rounded-lg border', className)}>
+      {/* Header with icon and page */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
         <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap">
           <FileText className="h-4 w-4 shrink-0" />
-            <span className="font-medium">{t('extraction', 'evidenceCited')}</span>
+          <span className="font-medium">{t('extraction', 'evidenceCited')}</span>
           {evidence.pageNumber !== null && evidence.pageNumber !== undefined && (
             <span className="px-2 py-1 bg-background rounded text-xs shrink-0">
               {t('extraction', 'pageLabel').replace('{{n}}', String(evidence.pageNumber))}
             </span>
           )}
+          {showNotLocated && (
+            <span className="flex items-center gap-1 text-muted-foreground/70">
+              <MapPinOff className="h-3 w-3 shrink-0" />
+              <span>{t('extraction', 'evidenceNotLocated')}</span>
+            </span>
+          )}
         </div>
-        
-        {showCopyButton && (
-          <Tooltip open={showTooltip && !copied} delayDuration={300}>
-            <TooltipTrigger asChild>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-8 w-8 p-0 shrink-0 hover:bg-muted"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleCopy();
-                  setShowTooltip(false);
-                }}
-                onMouseEnter={() => setShowTooltip(true)}
-                onMouseLeave={() => setShowTooltip(false)}
-                aria-label={copied ? t('extraction', 'copyCopied') : t('extraction', 'copySnippet')}
-              >
-                {copied ? (
-                  <Check className="h-4 w-4 text-success" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="top" onPointerDownOutside={() => setShowTooltip(false)}>
+
+        <div className="flex items-center gap-1 shrink-0">
+          {canHighlight && (
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 w-8 p-0 hover:bg-muted"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    // citation.anchor is guaranteed non-null by canHighlight
+                    onHighlight(citation.anchor!);
+                  }}
+                  aria-label={t('extraction', 'evidenceJumpToSource')}
+                >
+                  <MapPin className="h-4 w-4 text-primary" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                <p>{t('extraction', 'evidenceJumpToSource')}</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          {showCopyButton && (
+            <Tooltip open={showTooltip && !copied} delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 w-8 p-0 shrink-0 hover:bg-muted"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCopy();
+                    setShowTooltip(false);
+                  }}
+                  onMouseEnter={() => setShowTooltip(true)}
+                  onMouseLeave={() => setShowTooltip(false)}
+                  aria-label={copied ? t('extraction', 'copyCopied') : t('extraction', 'copySnippet')}
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4 text-success" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" onPointerDownOutside={() => setShowTooltip(false)}>
                 <p>{t('extraction', 'copySnippet')}</p>
-            </TooltipContent>
-          </Tooltip>
-        )}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       </div>
 
       {/* Trecho do texto */}
@@ -93,4 +158,3 @@ export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
     </div>
   );
 }
-

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Wiring tests for AISuggestionDetailsPopover.
+ *
+ * Verifies that:
+ *  - A matched verified citation → AISuggestionEvidence receives the right
+ *    citation and an onHighlight that calls the highlight controller.
+ *  - No match → citation=null → evidenceNotLocated affordance path.
+ *  - isAvailable=false (no viewer) → onHighlight not passed → renders
+ *    non-clickable (no jump button) and does NOT crash.
+ *
+ * Mocks: useArticleCitations, matchEvidenceToCitation, useCitationHighlight.
+ */
+
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import type {ReactNode} from 'react';
+
+// Mock copy so all keys are returned as-is
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+// Mock useArticleCitations — returns controlled data
+vi.mock('@/hooks/articles/useArticleCitations', () => ({
+  useArticleCitations: vi.fn(),
+}));
+
+// Mock matchEvidenceToCitation — returns controlled result
+vi.mock('@/services/citationsService', () => ({
+  matchEvidenceToCitation: vi.fn(),
+}));
+
+// Mock useCitationHighlight — expose a spy for the highlight fn.
+// isAvailable defaults to true (simulates a component inside a ViewerProvider).
+// Individual tests can override via mockReturnValue.
+const highlightSpy = vi.fn();
+const useCitationHighlightMock = vi.fn(() => ({
+  highlight: highlightSpy,
+  clear: vi.fn(),
+  activeHighlight: null,
+  isAvailable: true,
+}));
+vi.mock('@/hooks/extraction/useCitationHighlight', () => ({
+  useCitationHighlight: () => useCitationHighlightMock(),
+}));
+
+import {AISuggestionDetailsPopover} from './AISuggestionDetailsPopover';
+import {useArticleCitations} from '@/hooks/articles/useArticleCitations';
+import {matchEvidenceToCitation} from '@/services/citationsService';
+import type {ArticleCitationItem} from '@/services/citationsService';
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+import {TooltipProvider} from '@/components/ui/tooltip';
+
+const useArticleCitationsMock = useArticleCitations as ReturnType<typeof vi.fn>;
+const matchEvidenceMock = matchEvidenceToCitation as ReturnType<typeof vi.fn>;
+
+const anchor: CitationAnchor = {
+  kind: 'text',
+  range: {page: 2, charStart: 0, charEnd: 30},
+  quote: 'test evidence',
+};
+
+const verifiedCitation: ArticleCitationItem = {
+  id: 'cit-x',
+  verified: true,
+  anchorKind: 'text',
+  anchor,
+  metadata: {pageNumber: 2, textContent: 'test evidence', source: 'pdf'},
+};
+
+const suggestion = {
+  id: 'sug-1',
+  runId: 'run-1',
+  value: 'some value',
+  status: 'pending' as const,
+  confidence: 0.9,
+  reasoning: 'Because of this evidence.',
+  timestamp: new Date('2024-01-01T00:00:00Z'),
+  evidence: {text: 'test evidence', pageNumber: 2},
+};
+
+function makeWrapper() {
+  const qc = new QueryClient({defaultOptions: {queries: {retry: false}}});
+  return function Wrapper({children}: {children: ReactNode}) {
+    return (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>{children}</TooltipProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  highlightSpy.mockClear();
+  useCitationHighlightMock.mockReturnValue({
+    highlight: highlightSpy,
+    clear: vi.fn(),
+    activeHighlight: null,
+    isAvailable: true,
+  });
+  // Default: citations loaded with one item
+  useArticleCitationsMock.mockReturnValue({data: [verifiedCitation], isLoading: false});
+});
+
+describe('AISuggestionDetailsPopover — citation wiring', () => {
+  it('matched verified citation → evidenceJumpToSource button present and calls highlight', async () => {
+    const user = userEvent.setup();
+    matchEvidenceMock.mockReturnValue(verifiedCitation);
+
+    render(
+      <AISuggestionDetailsPopover
+        suggestion={suggestion}
+        articleId="article-123"
+        trigger={<button>Open</button>}
+      />,
+      {wrapper: makeWrapper()},
+    );
+
+    // Open the dialog
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+
+    // Jump button should appear
+    const jumpBtn = await screen.findByRole('button', {name: 'evidenceJumpToSource'});
+    expect(jumpBtn).toBeInTheDocument();
+
+    // Clicking it calls highlight with the anchor
+    await user.click(jumpBtn);
+    expect(highlightSpy).toHaveBeenCalledOnce();
+    expect(highlightSpy).toHaveBeenCalledWith(anchor);
+  });
+
+  it('no match → citation=null → evidenceNotLocated affordance', async () => {
+    const user = userEvent.setup();
+    matchEvidenceMock.mockReturnValue(null);
+
+    render(
+      <AISuggestionDetailsPopover
+        suggestion={suggestion}
+        articleId="article-123"
+        trigger={<button>Open</button>}
+      />,
+      {wrapper: makeWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+
+    // No jump button
+    expect(screen.queryByRole('button', {name: 'evidenceJumpToSource'})).not.toBeInTheDocument();
+    // No "not located" affordance either — citation is null (not provided but unverified)
+    // (When citation=null, the component renders as before — no affordance)
+    expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
+  });
+
+  it('no articleId → no citation passed → renders as before (no jump, no not-located)', async () => {
+    const user = userEvent.setup();
+    matchEvidenceMock.mockReturnValue(null);
+
+    render(
+      <AISuggestionDetailsPopover
+        suggestion={suggestion}
+        trigger={<button>Open</button>}
+      />,
+      {wrapper: makeWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+
+    expect(screen.queryByRole('button', {name: 'evidenceJumpToSource'})).not.toBeInTheDocument();
+    expect(screen.queryByText('evidenceNotLocated')).not.toBeInTheDocument();
+    // Evidence text is still shown
+    expect(screen.getByText(/test evidence/)).toBeInTheDocument();
+  });
+
+  it('isAvailable=false (no viewer) → no jump button rendered, does NOT crash', async () => {
+    const user = userEvent.setup();
+    // Simulate the QA-screen path: hook returns isAvailable=false
+    useCitationHighlightMock.mockReturnValue({
+      highlight: vi.fn(),
+      clear: vi.fn(),
+      activeHighlight: null,
+      isAvailable: false,
+    });
+    matchEvidenceMock.mockReturnValue(verifiedCitation);
+
+    render(
+      <AISuggestionDetailsPopover
+        suggestion={suggestion}
+        articleId="article-123"
+        trigger={<button>Open</button>}
+      />,
+      {wrapper: makeWrapper()},
+    );
+
+    // Must not throw when opening
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+
+    // Evidence text is shown
+    expect(await screen.findByText(/test evidence/)).toBeInTheDocument();
+
+    // No jump button — onHighlight was not passed because isAvailable=false
+    expect(screen.queryByRole('button', {name: 'evidenceJumpToSource'})).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
@@ -1,8 +1,12 @@
 /**
  * AI suggestion details modal (rationale + evidence) - Extraction
  *
- * Uses viewport-centered Dialog so content is never clipped
+ * Uses viewport-centered Dialog so content is never clipped.
  * Same strategy as Assessment. Responsive, with internal scroll.
+ *
+ * When `articleId` is provided (and the component is mounted inside the shared
+ * ViewerProvider at ExtractionFullScreen level), the evidence block gains a
+ * "jump to source" button via useCitationHighlight.
  */
 
 import {useState} from 'react';
@@ -12,6 +16,9 @@ import {Sparkles} from 'lucide-react';
 import {AISuggestionEvidence} from '../AISuggestionEvidence';
 import {t} from '@/lib/copy';
 import type {AISuggestion} from '@/hooks/extraction/ai/useAISuggestions';
+import {useArticleCitations} from '@/hooks/articles/useArticleCitations';
+import {matchEvidenceToCitation} from '@/services/citationsService';
+import {useCitationHighlight} from '@/hooks/extraction/useCitationHighlight';
 
 // -----------------------------------------------------------------------------
 // Constantes de layout (viewport-safe, alinhado ao Assessment)
@@ -34,21 +41,61 @@ function hasSuggestionDetails(suggestion: AISuggestion): boolean {
 }
 
 // -----------------------------------------------------------------------------
-// Tipos
+// Types
 // -----------------------------------------------------------------------------
 
 interface AISuggestionDetailsPopoverProps {
   suggestion: AISuggestion;
   trigger: React.ReactNode;
+  /** Article id. When provided (and inside a ViewerProvider) enables the
+   *  citation highlight on the evidence block. */
+  articleId?: string;
 }
 
 // -----------------------------------------------------------------------------
-// Componente
+// Inner component — holds the citation-highlight hooks.
+// Separated so the hooks only run when the modal is open.
+// -----------------------------------------------------------------------------
+
+interface EvidenceSectionProps {
+  evidence: {text: string; pageNumber?: number | null};
+  articleId: string | undefined;
+}
+
+function EvidenceSection({evidence, articleId}: EvidenceSectionProps) {
+  const citations = useArticleCitations(articleId);
+  const {highlight, isAvailable} = useCitationHighlight();
+
+  const matched =
+    articleId != null
+      ? matchEvidenceToCitation(
+          {text: evidence.text, pageNumber: evidence.pageNumber ?? undefined},
+          citations.data ?? [],
+        )
+      : null;
+
+  return (
+    <section className="space-y-2" aria-label={t('extraction', 'evidenceCitedAria')}>
+      <AISuggestionEvidence
+        evidence={{
+          text: evidence.text,
+          pageNumber: evidence.pageNumber ?? null,
+        }}
+        citation={matched}
+        onHighlight={isAvailable && articleId != null ? highlight : undefined}
+      />
+    </section>
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Component
 // -----------------------------------------------------------------------------
 
 export function AISuggestionDetailsPopover({
   suggestion,
   trigger,
+  articleId,
 }: AISuggestionDetailsPopoverProps) {
   const [open, setOpen] = useState(false);
 
@@ -87,14 +134,13 @@ export function AISuggestionDetailsPopover({
             )}
 
             {evidence?.text?.trim() && (
-                <section className="space-y-2" aria-label={t('extraction', 'evidenceCitedAria')}>
-                <AISuggestionEvidence
-                  evidence={{
-                    text: evidence.text,
-                    pageNumber: evidence.pageNumber ?? null,
-                  }}
-                />
-              </section>
+              <EvidenceSection
+                evidence={{
+                  text: evidence.text,
+                  pageNumber: evidence.pageNumber ?? null,
+                }}
+                articleId={articleId}
+              />
             )}
           </div>
         </ScrollArea>

--- a/frontend/hooks/articles/useArticleCitations.ts
+++ b/frontend/hooks/articles/useArticleCitations.ts
@@ -1,0 +1,28 @@
+/**
+ * Fetches the citation list for an article.
+ *
+ * Used by the PDF viewer's reviewer-highlight feature to resolve AI evidence
+ * quotes to backend-stored citation anchors. Returns an empty array when the
+ * article has no citations or when the query is disabled.
+ */
+import {useQuery} from '@tanstack/react-query';
+
+import {articleKeys} from '@/lib/query-keys';
+import {fetchArticleCitations, type ArticleCitationItem} from '@/services/citationsService';
+
+const STALE_MS = 5 * 60_000;
+
+export function useArticleCitations(articleId: string | null | undefined) {
+  return useQuery({
+    queryKey: articleKeys.citations(articleId ?? ''),
+    enabled: Boolean(articleId),
+    staleTime: STALE_MS,
+    queryFn: async (): Promise<ArticleCitationItem[]> => {
+      const result = await fetchArticleCitations(articleId!);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return result.data;
+    },
+  });
+}

--- a/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
+++ b/frontend/hooks/extraction/__tests__/useCitationHighlight.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Tests for useCitationHighlight hook.
+ *
+ * Uses a real ViewerProvider wrapping the hook, a stubbed document that
+ * exposes numPages so goToPage clamping works, and a vi.mock for
+ * usePageHandle (so no pdfjs / network required).
+ *
+ * Also covers the no-provider (graceful degradation) path:
+ *  - isAvailable === false
+ *  - highlight() is a safe no-op
+ *  - activeHighlight stays null
+ */
+import {renderHook, act} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+
+import {ViewerProvider} from '@/pdf-viewer/core/context';
+import {createViewerStore} from '@/pdf-viewer/core/store';
+
+// --- stub usePageHandle to return a known page size ---
+vi.mock('@/pdf-viewer/hooks/usePageHandle', () => ({
+  usePageHandle: (_page: number) => ({
+    pageNumber: _page,
+    size: {width: 612, height: 792},
+    render: vi.fn(),
+    getTextContent: vi.fn(),
+    renderTextLayer: vi.fn(),
+    cleanup: vi.fn(),
+  }),
+}));
+
+import {useCitationHighlight} from '../useCitationHighlight';
+
+// Helper: render the hook inside a ViewerProvider backed by a store that
+// has numPages set so goToPage clamping resolves to the right page.
+function makeWrapper(storeRef: {current: ReturnType<typeof createViewerStore> | null}) {
+  return function Wrapper({children}: {children: ReactNode}) {
+    if (!storeRef.current) {
+      storeRef.current = createViewerStore();
+      // Simulate a loaded doc with 20 pages so goToPage doesn't clamp to 1.
+      storeRef.current.getState().actions.setDocument({
+        numPages: 20,
+        fingerprint: 'test',
+        metadata: async () => ({}),
+        outline: async () => [],
+        getPage: async () => {throw new Error('stub');},
+        destroy: () => {},
+      });
+    }
+    return createElement(ViewerProvider, {store: storeRef.current, children});
+  };
+}
+
+describe('useCitationHighlight', () => {
+  const storeRef: {current: ReturnType<typeof createViewerStore> | null} = {current: null};
+
+  beforeEach(() => {
+    storeRef.current = null;
+  });
+
+  it('TextCitationAnchor: goToPage(range.page) and setSearchMatches with correct charStart/charEnd', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    act(() => {
+      result.current.highlight({
+        kind: 'text',
+        range: {page: 3, charStart: 10, charEnd: 42},
+        quote: 'hello world',
+      });
+    });
+
+    const state = storeRef.current!.getState();
+    // Page navigation
+    expect(state.currentPage).toBe(3);
+    // Search match wired up
+    expect(state.search.matches).toHaveLength(1);
+    expect(state.search.matches[0]).toMatchObject({
+      pageNumber: 3,
+      charStart: 10,
+      charEnd: 42,
+      context: 'hello world',
+    });
+    // No projected rect for text-only
+    expect(result.current.activeHighlight).toBeNull();
+  });
+
+  it('RegionCitationAnchor: goToPage(anchor.page), no search match, projected rect with Y-flip', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    // scale=1 (default), pageHeight=792
+    // rect = {x:100, y:200, width:150, height:50}
+    // expected: left=100*1=100, top=(792-200-50)*1=542, width=150, height=50
+    act(() => {
+      result.current.highlight({
+        kind: 'region',
+        page: 5,
+        rect: {x: 100, y: 200, width: 150, height: 50},
+      });
+    });
+
+    const state = storeRef.current!.getState();
+    expect(state.currentPage).toBe(5);
+    // No text search
+    expect(state.search.matches).toHaveLength(0);
+    // Projected overlay rect
+    expect(result.current.activeHighlight).not.toBeNull();
+    expect(result.current.activeHighlight).toMatchObject({
+      page: 5,
+      left: 100,
+      top: 542,
+      width: 150,
+      height: 50,
+    });
+  });
+
+  it('RegionCitationAnchor: projected rect scales with store.scale', () => {
+    const storeRef2: {current: ReturnType<typeof createViewerStore> | null} = {current: null};
+    // Set scale to 1.5 before render
+    storeRef2.current = createViewerStore({scale: 1.5});
+    storeRef2.current.getState().actions.setDocument({
+      numPages: 20,
+      fingerprint: 'test2',
+      metadata: async () => ({}),
+      outline: async () => [],
+      getPage: async () => {throw new Error('stub');},
+      destroy: () => {},
+    });
+
+    const {result} = renderHook(() => useCitationHighlight(), {
+      wrapper: function W({children}: {children: ReactNode}) {
+        return createElement(ViewerProvider, {store: storeRef2.current!, children});
+      },
+    });
+
+    act(() => {
+      result.current.highlight({
+        kind: 'region',
+        page: 2,
+        rect: {x: 100, y: 200, width: 150, height: 50},
+      });
+    });
+
+    // scale=1.5: left=150, top=(792-200-50)*1.5=813, width=225, height=75
+    expect(result.current.activeHighlight).toMatchObject({
+      page: 2,
+      left: 150,
+      top: 813,
+      width: 225,
+      height: 75,
+    });
+  });
+
+  it('HybridCitationAnchor: both text match AND projected rect', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    act(() => {
+      result.current.highlight({
+        kind: 'hybrid',
+        range: {page: 7, charStart: 5, charEnd: 20},
+        rect: {x: 50, y: 100, width: 200, height: 30},
+        quote: 'some text',
+      });
+    });
+
+    const state = storeRef.current!.getState();
+    expect(state.currentPage).toBe(7);
+    // Text match
+    expect(state.search.matches).toHaveLength(1);
+    expect(state.search.matches[0]).toMatchObject({
+      pageNumber: 7,
+      charStart: 5,
+      charEnd: 20,
+      context: 'some text',
+    });
+    // Overlay rect: left=50, top=(792-100-30)*1=662, width=200, height=30
+    expect(result.current.activeHighlight).toMatchObject({
+      page: 7,
+      left: 50,
+      top: 662,
+      width: 200,
+      height: 30,
+    });
+  });
+
+  it('clear() resets search, activeCitationId, and activeHighlight', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    act(() => {
+      result.current.highlight({
+        kind: 'hybrid',
+        range: {page: 2, charStart: 0, charEnd: 5},
+        rect: {x: 10, y: 10, width: 50, height: 20},
+        quote: 'test',
+      });
+    });
+
+    act(() => {
+      result.current.clear();
+    });
+
+    const state = storeRef.current!.getState();
+    expect(state.search.matches).toHaveLength(0);
+    expect(state.activeCitationId).toBeNull();
+    expect(result.current.activeHighlight).toBeNull();
+  });
+
+  it('a second highlight() call replaces the previous (clears first)', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+    act(() => {
+      result.current.highlight({
+        kind: 'text',
+        range: {page: 1, charStart: 0, charEnd: 5},
+      });
+    });
+
+    act(() => {
+      result.current.highlight({
+        kind: 'text',
+        range: {page: 2, charStart: 10, charEnd: 15},
+      });
+    });
+
+    const state = storeRef.current!.getState();
+    // Only the second highlight is active
+    expect(state.search.matches).toHaveLength(1);
+    expect(state.search.matches[0].pageNumber).toBe(2);
+    expect(state.currentPage).toBe(2);
+  });
+
+  it('reader mode: still calls goToPage and setSearchMatches (no crash)', () => {
+    const storeRef3: {current: ReturnType<typeof createViewerStore> | null} = {current: null};
+    storeRef3.current = createViewerStore({mode: 'reader'});
+    storeRef3.current.getState().actions.setDocument({
+      numPages: 20,
+      fingerprint: 'reader-test',
+      metadata: async () => ({}),
+      outline: async () => [],
+      getPage: async () => {throw new Error('stub');},
+      destroy: () => {},
+    });
+
+    const {result} = renderHook(() => useCitationHighlight(), {
+      wrapper: function W({children}: {children: ReactNode}) {
+        return createElement(ViewerProvider, {store: storeRef3.current!, children});
+      },
+    });
+
+    act(() => {
+      result.current.highlight({
+        kind: 'region',
+        page: 3,
+        rect: {x: 0, y: 0, width: 100, height: 50},
+      });
+    });
+
+    const state = storeRef3.current.getState();
+    expect(state.currentPage).toBe(3);
+    // In reader mode the overlay rect is null (no canvas surface)
+    expect(result.current.activeHighlight).toBeNull();
+  });
+
+  it('with a ViewerProvider: isAvailable === true', () => {
+    const wrapper = makeWrapper(storeRef);
+    const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+    expect(result.current.isAvailable).toBe(true);
+  });
+
+  describe('no ViewerProvider — graceful degradation', () => {
+    it('isAvailable === false when rendered without a provider', () => {
+      const {result} = renderHook(() => useCitationHighlight());
+      expect(result.current.isAvailable).toBe(false);
+    });
+
+    it('activeHighlight is null when rendered without a provider', () => {
+      const {result} = renderHook(() => useCitationHighlight());
+      expect(result.current.activeHighlight).toBeNull();
+    });
+
+    it('highlight() does NOT throw and is a no-op when no provider is present', () => {
+      const {result} = renderHook(() => useCitationHighlight());
+      expect(() => {
+        act(() => {
+          result.current.highlight({
+            kind: 'text',
+            range: {page: 1, charStart: 0, charEnd: 10},
+            quote: 'test',
+          });
+        });
+      }).not.toThrow();
+      // State is unchanged — no store to mutate
+      expect(result.current.activeHighlight).toBeNull();
+      expect(result.current.isAvailable).toBe(false);
+    });
+
+    it('clear() does NOT throw when no provider is present', () => {
+      const {result} = renderHook(() => useCitationHighlight());
+      expect(() => {
+        act(() => {
+          result.current.clear();
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('shared store — anchor put into citations map', () => {
+    it('highlight(regionAnchor) puts the anchor into the store as an active citation', () => {
+      const wrapper = makeWrapper(storeRef);
+      const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+      const anchor = {
+        kind: 'region' as const,
+        page: 4,
+        rect: {x: 10, y: 20, width: 80, height: 30},
+      };
+
+      act(() => {
+        result.current.highlight(anchor);
+      });
+
+      const state = storeRef.current!.getState();
+      // activeCitationId must be set
+      expect(state.activeCitationId).not.toBeNull();
+      // The citations map must contain the citation with that id
+      const id = state.activeCitationId!;
+      const citation = state.citations.get(id);
+      expect(citation).not.toBeUndefined();
+      expect(citation!.anchor).toEqual(anchor);
+    });
+
+    it('highlight(hybridAnchor) puts the anchor into the store as an active citation', () => {
+      const wrapper = makeWrapper(storeRef);
+      const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+      const anchor = {
+        kind: 'hybrid' as const,
+        range: {page: 2, charStart: 0, charEnd: 10},
+        rect: {x: 0, y: 0, width: 50, height: 20},
+        quote: 'test quote',
+      };
+
+      act(() => {
+        result.current.highlight(anchor);
+      });
+
+      const state = storeRef.current!.getState();
+      expect(state.activeCitationId).not.toBeNull();
+      const id = state.activeCitationId!;
+      const citation = state.citations.get(id);
+      expect(citation).not.toBeUndefined();
+      expect(citation!.anchor).toEqual(anchor);
+    });
+
+    it('clear() removes the citation from the store (citations map is empty)', () => {
+      const wrapper = makeWrapper(storeRef);
+      const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+      act(() => {
+        result.current.highlight({
+          kind: 'region' as const,
+          page: 1,
+          rect: {x: 0, y: 0, width: 100, height: 50},
+        });
+      });
+
+      act(() => {
+        result.current.clear();
+      });
+
+      const state = storeRef.current!.getState();
+      expect(state.activeCitationId).toBeNull();
+      expect(state.citations.size).toBe(0);
+    });
+
+    it('second highlight() call clears the previous citation before adding the new one', () => {
+      const wrapper = makeWrapper(storeRef);
+      const {result} = renderHook(() => useCitationHighlight(), {wrapper});
+
+      act(() => {
+        result.current.highlight({
+          kind: 'region' as const,
+          page: 1,
+          rect: {x: 0, y: 0, width: 100, height: 50},
+        });
+      });
+
+      const firstId = storeRef.current!.getState().activeCitationId;
+
+      act(() => {
+        result.current.highlight({
+          kind: 'region' as const,
+          page: 2,
+          rect: {x: 10, y: 10, width: 50, height: 20},
+        });
+      });
+
+      const state = storeRef.current!.getState();
+      // Old id gone, only 1 citation in the map
+      expect(state.citations.size).toBe(1);
+      expect(state.activeCitationId).not.toBe(firstId);
+    });
+  });
+});

--- a/frontend/hooks/extraction/ai/useAISuggestions.ts
+++ b/frontend/hooks/extraction/ai/useAISuggestions.ts
@@ -310,7 +310,7 @@ export function useAISuggestions(props: UseAISuggestionsProps): UseAISuggestions
     instanceId: string,
     fieldId: string
   ): Promise<AISuggestionHistoryItem[]> =>
-    AISuggestionService.getHistory(instanceId, fieldId, 10).catch((err: unknown) => {
+    AISuggestionService.getHistory(articleId, instanceId, fieldId, 10).catch((err: unknown) => {
       console.error('Error loading suggestion history:', err);
       const message = getErrorMessage(err);
       toast.error(`${t('extraction', 'errors_loadSuggestionsHistory')}: ${message}`);

--- a/frontend/hooks/extraction/useArticleExtractionValues.ts
+++ b/frontend/hooks/extraction/useArticleExtractionValues.ts
@@ -74,6 +74,7 @@ export function useArticleExtractionValues(
         const formRunByArticle = await ExtractionValueService.findFormRunsByArticle(
           articleIds,
           templateId as string,
+          projectId as string,
         );
         runIds = Array.from(new Set(formRunByArticle.values()));
       }

--- a/frontend/hooks/extraction/useCitationHighlight.ts
+++ b/frontend/hooks/extraction/useCitationHighlight.ts
@@ -1,0 +1,170 @@
+/**
+ * useCitationHighlight — orchestrates the PDF viewer state to highlight a
+ * single CitationAnchor (text, region, or hybrid).
+ *
+ * Text / hybrid anchors reuse the viewer's existing search-highlight system
+ * (`setSearchMatches`): the TextLayer already renders `.highlight.selected`
+ * spans for matching char ranges and scrolls them into view — no new DOM
+ * selection logic needed.
+ *
+ * Region / hybrid anchors expose a `activeHighlight` projected rect
+ * (`{page, top, left, width, height}` in CSS pixels) so a consumer can
+ * render a `position:absolute` overlay inside the page canvas area.
+ *
+ * Projection formula (PDF user space → CSS pixels, Y-flip origin):
+ *   left   = rect.x * scale
+ *   top    = (pageHeightPts - rect.y - rect.height) * scale
+ *   width  = rect.width  * scale
+ *   height = rect.height * scale
+ *
+ * In `reader` mode there is no canvas surface; the overlay rect is set to
+ * null while navigation and text-highlight still work normally.
+ *
+ * React Compiler constraint: no try/finally, no throw inside try.
+ */
+import {useState, useCallback} from 'react';
+import type {StoreApi} from 'zustand';
+
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+import {projectPdfRectToCss} from '@/pdf-viewer/core/coordinates';
+import {useViewerStoreApiOptional} from '@/pdf-viewer/core/context';
+import type {ViewerState} from '@/pdf-viewer/core/state';
+import {usePageHandle} from '@/pdf-viewer/hooks/usePageHandle';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A projected rect in CSS pixels, relative to the page canvas element.
+ * `top`/`left` are the CSS-space coordinates of the PDF bbox top-left corner.
+ */
+export interface CitationOverlayRect {
+  page: number;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export interface UseCitationHighlightReturn {
+  /**
+   * Activate a citation anchor in the viewer.
+   * Navigates to the correct page, drives text highlighting (text/hybrid),
+   * and computes an overlay rect (region/hybrid, canvas mode only).
+   * Replaces any previously active highlight.
+   * Safe no-op when `isAvailable` is false (no ViewerProvider present).
+   */
+  highlight(anchor: CitationAnchor): void;
+  /** Clear the active highlight: search, activeCitation, and overlay rect.
+   * Safe no-op when `isAvailable` is false. */
+  clear(): void;
+  /** The projected overlay rect for the current anchor, or null. */
+  activeHighlight: CitationOverlayRect | null;
+  /**
+   * `true` when the hook is mounted inside a ViewerProvider and can drive
+   * the PDF viewer. `false` when outside a provider — highlight/clear are
+   * safe no-ops and activeHighlight stays null.
+   */
+  isAvailable: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper: compute the target page number from any anchor kind.
+// ---------------------------------------------------------------------------
+function anchorPage(anchor: CitationAnchor): number {
+  if (anchor.kind === 'region') return anchor.page;
+  return anchor.range.page;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Inner hook that runs AFTER we know which page to load.
+ * Separated so that `usePageHandle` receives a stable page number —
+ * the outer hook shell drives which page that is.
+ *
+ * Returns null immediately when `storeApi` is null (no provider present).
+ */
+function useCitationHighlightInner(
+  anchor: CitationAnchor | null,
+  storeApi: StoreApi<ViewerState> | null,
+): CitationOverlayRect | null {
+  const page = anchor != null ? anchorPage(anchor) : 1;
+  const pageHandle = usePageHandle(page);
+
+  if (storeApi == null || anchor == null || pageHandle == null) return null;
+
+  const {mode, scale} = storeApi.getState();
+
+  // Overlay rect only applies in canvas mode (canvas surface exists).
+  if (mode !== 'canvas') return null;
+
+  if (anchor.kind === 'text') return null;
+
+  const pageHeightPts = pageHandle.size.height;
+  const cssRect = projectPdfRectToCss(anchor.rect, pageHeightPts, scale);
+
+  return {
+    page,
+    ...cssRect,
+  };
+}
+
+export function useCitationHighlight(): UseCitationHighlightReturn {
+  const storeApi = useViewerStoreApiOptional();
+
+  // The anchor we are currently highlighting — drives usePageHandle.
+  const [activeAnchor, setActiveAnchor] = useState<CitationAnchor | null>(null);
+
+  // Overlay rect computed reactively from the active anchor + page handle.
+  const overlayRect = useCitationHighlightInner(activeAnchor, storeApi);
+
+  const clear = useCallback((): void => {
+    if (storeApi == null) return;
+    const {actions} = storeApi.getState();
+    actions.clearSearch();
+    actions.clearCitations();
+    setActiveAnchor(null);
+  }, [storeApi]);
+
+  const highlight = useCallback(
+    (anchor: CitationAnchor): void => {
+      if (storeApi == null) return;
+      const {actions} = storeApi.getState();
+
+      // Replace previous highlight — single active citation at a time.
+      actions.clearSearch();
+      actions.clearCitations();
+
+      const page = anchorPage(anchor);
+      actions.goToPage(page);
+
+      // Text range → drive the TextLayer search-highlight system.
+      if (anchor.kind === 'text' || anchor.kind === 'hybrid') {
+        const quote = anchor.kind === 'text' ? (anchor.quote ?? '') : anchor.quote;
+        actions.setSearchMatches([
+          {
+            pageNumber: anchor.range.page,
+            charStart: anchor.range.charStart,
+            charEnd: anchor.range.charEnd,
+            context: quote,
+          },
+        ]);
+      }
+
+      // Put the anchor in the shared store so CitationOverlay can render it.
+      // Use a stable synthetic id derived from anchor coords.
+      const id = `citation-highlight-${page}`;
+      actions.addCitation({id, anchor});
+      actions.setActiveCitation(id);
+
+      setActiveAnchor(anchor);
+    },
+    [storeApi],
+  );
+
+  return {highlight, clear, activeHighlight: overlayRect, isAvailable: storeApi != null};
+}

--- a/frontend/hooks/extraction/useExtractionData.ts
+++ b/frontend/hooks/extraction/useExtractionData.ts
@@ -1,10 +1,13 @@
 /**
- * Hook to load extraction data
+ * Hook to load extraction page bootstrap data.
  *
- * Centralizes all ExtractionFullScreen data loading:
- * - Article, project, template
- * - Entity types with fields
- * - Instances
+ * Centralizes the run-open page's non-run reads:
+ * - Article, project, active extraction template
+ * - The project's article list (header navigation)
+ *
+ * Entity types + instances are NOT loaded here anymore — the run-open
+ * page derives them from the server RunView (GET /api/v1/runs/:id/view)
+ * via ``runViewAdapters``. This hook holds zero ``supabase.from`` reads.
  *
  * Reduces main component complexity (SRP).
  */
@@ -12,79 +15,16 @@
 import {useEffect, useState} from 'react';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
-import {extractionInstanceService} from '@/services/extractionInstanceService';
-import {
-  loadExtractionPhase1,
-  loadEntityTypesWithFields,
-} from '@/services/extractionDataService';
+import {loadExtractionPhase1} from '@/services/extractionDataService';
 import type {Article} from '@/types/article';
 import type {Project} from '@/types/project';
-import type {
-    ExtractionEntityTypeWithFields,
-    ExtractionInstance,
-    ProjectExtractionTemplate
-} from '@/types/extraction';
-
-/**
- * Re-export the canonical type for callers that imported it from this
- * module before consolidation. New callers should import directly from
- * ``@/types/extraction``.
- */
-export type EntityTypeWithFields = ExtractionEntityTypeWithFields;
-
-/**
- * Returns a new array only when something actually changed (added, removed,
- * or shallow-different at the entry level keyed by id). Preserves the
- * reference of unchanged entries so React reuses the same Fiber and the
- * extraction form does not remount + scroll-reset on every refresh.
- */
-function mergeInstancesById(
-  prev: ExtractionInstance[],
-  next: ExtractionInstance[]
-): ExtractionInstance[] {
-  const prevById = new Map(prev.map((i) => [i.id, i] as const));
-  const nextById = new Map(next.map((i) => [i.id, i] as const));
-
-  let changed = prev.length !== next.length;
-  const merged = next.map((incoming) => {
-    const existing = prevById.get(incoming.id);
-    if (!existing) {
-      changed = true;
-      return incoming;
-    }
-    // Cheap shallow check on the surface fields the form actually reads.
-    const sameShape =
-      existing.label === incoming.label &&
-      existing.sort_order === incoming.sort_order &&
-      existing.status === incoming.status &&
-      existing.parent_instance_id === incoming.parent_instance_id;
-    if (!sameShape) {
-      changed = true;
-      return { ...existing, ...incoming };
-    }
-    return existing;
-  });
-
-  if (!changed) {
-    // Detect removals.
-    for (const id of prevById.keys()) {
-      if (!nextById.has(id)) {
-        changed = true;
-        break;
-      }
-    }
-  }
-
-  return changed ? merged : prev;
-}
+import type {ProjectExtractionTemplate} from '@/types/extraction';
 
 interface UseExtractionDataReturn {
     // Loaded data
   article: Article | null;
   project: Project | null;
   template: ProjectExtractionTemplate | null;
-  entityTypes: EntityTypeWithFields[];
-  instances: ExtractionInstance[];
   articles: Article[];
 
     // State
@@ -93,7 +33,6 @@ interface UseExtractionDataReturn {
 
     // Functions
   refresh: () => Promise<void>;
-  refreshInstances: () => Promise<void>;
 }
 
 interface UseExtractionDataProps {
@@ -103,7 +42,7 @@ interface UseExtractionDataProps {
 }
 
 /**
- * Hook to load all data needed for extraction
+ * Hook to load the page-bootstrap data needed for extraction.
  */
 export function useExtractionData({
   projectId,
@@ -113,31 +52,9 @@ export function useExtractionData({
   const [article, setArticle] = useState<Article | null>(null);
   const [project, setProject] = useState<Project | null>(null);
   const [template, setTemplate] = useState<ProjectExtractionTemplate | null>(null);
-  const [entityTypes, setEntityTypes] = useState<EntityTypeWithFields[]>([]);
-  const [instances, setInstances] = useState<ExtractionInstance[]>([]);
   const [articles, setArticles] = useState<Article[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-    // Load existing instances (without creating). Uses merge-by-id so a
-    // refresh keeps existing React keys stable for instances that didn't
-    // change — only added/updated entries trigger downstream re-renders. This
-    // removes the visual flash + scroll reset that came from replacing the
-    // whole array on every refresh.
-  const loadInstances = async (templateId: string) => {
-    if (!articleId || !templateId) {
-      setInstances([]);
-      return;
-    }
-
-    const result = await extractionInstanceService.getInstances({articleId, templateId});
-    const normalised: ExtractionInstance[] = result.map(instance => ({
-      ...instance,
-      article_id: instance.article_id!,
-      metadata: instance.metadata as unknown,
-    }));
-    setInstances(prev => mergeInstancesById(prev, normalised));
-  };
 
     // Load all data
   const loadData = () => {
@@ -150,14 +67,11 @@ export function useExtractionData({
     setError(null);
 
     const doLoad = async () => {
-      // Phase 1 — independent reads in parallel. Article, project, the
-      // active extraction template, and the navigation article list don't
-      // depend on one another, so awaiting them sequentially only stacked
-      // latency. Resolving the template ASAP matters most: the HITL session
-      // open (the single slowest critical-path call) is gated on
-      // ``template.id``, and the strictly-sequential version parked the
-      // template 3rd in line, stalling the whole extracted-values waterfall
-      // behind two unrelated round-trips.
+      // Independent reads in parallel. Article, project, the active
+      // extraction template, and the navigation article list don't depend
+      // on one another, so awaiting them sequentially only stacked latency.
+      // Resolving the template ASAP matters most: the HITL session open (the
+      // single slowest critical-path call) is gated on ``template.id``.
       const phase1 = await loadExtractionPhase1(
         articleId,
         projectId,
@@ -175,26 +89,6 @@ export function useExtractionData({
       setProject(phase1.data.project);
       setTemplate(phase1.data.template as ProjectExtractionTemplate);
       setArticles(phase1.data.articles);
-
-      // Phase 2 — entity types (with fields) and the already-materialised
-      // instances both depend only on the resolved template id, so load
-      // them together. Instances are seeded by the backend
-      // ``hitl_session_service._ensure_instances`` on session open;
-      // ``ExtractionFullScreen`` re-triggers ``refreshInstances`` once the
-      // session ``activeRunId`` is available, so we don't race the session.
-      const [entityTypesResult] = await Promise.all([
-        loadEntityTypesWithFields(phase1.data.template.id),
-        loadInstances(phase1.data.template.id),
-      ]);
-
-      if (!entityTypesResult.ok) {
-        const message = entityTypesResult.error.message || t('extraction', 'errors_loadExtractionData');
-        setError(message);
-        toast.error(message);
-        return;
-      }
-
-      setEntityTypes(entityTypesResult.data);
     };
 
     return doLoad()
@@ -218,24 +112,13 @@ export function useExtractionData({
     await loadData();
   };
 
-    // Refresh instances only (no new creation).
-  const activeTemplateId = template?.id;
-  const refreshInstances = async () => {
-    if (activeTemplateId) {
-      await loadInstances(activeTemplateId);
-    }
-  };
-
   return {
     article,
     project,
     template,
-    entityTypes,
-    instances,
     articles,
     loading,
     error,
     refresh,
-    refreshInstances,
   };
 }

--- a/frontend/hooks/extraction/useModelManagement.ts
+++ b/frontend/hooks/extraction/useModelManagement.ts
@@ -20,6 +20,7 @@ import {useAuth} from '@/contexts/AuthContext';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
 import {extractionInstanceService, loadModelInstances, fetchModelProgress} from '@/services/extractionInstanceService';
+import type {ModelInstanceRow} from '@/services/extractionInstanceService';
 import type {Model} from '@/components/extraction/hierarchy/ModelSelector';
 
 // =================== INTERFACES ===================
@@ -30,6 +31,14 @@ interface UseModelManagementProps {
   templateId: string;
   /** ID of the template's model container entity type (role='model_container'). */
   modelParentEntityTypeId: string | null;
+  /**
+   * Model-container instances supplied by the caller (derived from the
+   * server RunView). When provided, the hook uses these directly and
+   * skips the ``loadModelInstances`` Supabase read — the run-open page is
+   * the source of truth. When undefined the hook self-loads (standalone
+   * usage / tests).
+   */
+  modelInstances?: ModelInstanceRow[];
   enabled?: boolean;
 }
 
@@ -62,6 +71,7 @@ export function useModelManagement({
   articleId,
   templateId,
   modelParentEntityTypeId,
+  modelInstances,
   enabled = true
 }: UseModelManagementProps): UseModelManagementReturn {
   const { user } = useAuth();
@@ -69,6 +79,15 @@ export function useModelManagement({
   const [activeModelId, setActiveModelId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+    // Primitive signature of the supplied model instances. The mount-load
+    // effect keys on this (not the array reference) so an unstable
+    // ``modelInstances`` reference from a caller can't re-trigger the load
+    // loop — the loop-outage incident class. ``null`` when not supplied.
+  const modelInstancesSig =
+    modelInstances === undefined
+      ? null
+      : modelInstances.map(i => `${i.id}:${i.label}:${i.sort_order}`).join('|');
 
     // Ref to avoid infinite loop: track activeModelId without causing re-render
   const activeModelIdRef = useRef<string | null>(null);
@@ -99,16 +118,24 @@ export function useModelManagement({
 
     console.warn('[useModelManagement] Loading models for article:', articleId, ', entity_type:', modelParentEntityTypeId);
 
-    const result = await loadModelInstances(articleId, modelParentEntityTypeId);
+    // When the caller supplies the model-container instances (derived from
+    // the server RunView on the run-open page), use them directly — no
+    // ``extraction_instances`` read fires from this hook. Otherwise the hook
+    // self-loads via the service (standalone usage / tests).
+    let instances: ModelInstanceRow[];
+    if (modelInstances !== undefined) {
+      instances = modelInstances;
+    } else {
+      const result = await loadModelInstances(articleId, modelParentEntityTypeId);
 
-    if (!result.ok) {
-      console.error('Error loading models:', result.error);
-      setError(result.error.message);
-      setLoading(false);
-      return;
+      if (!result.ok) {
+        console.error('Error loading models:', result.error);
+        setError(result.error.message);
+        setLoading(false);
+        return;
+      }
+      instances = result.data;
     }
-
-    const instances = result.data;
     console.warn(`✅ Encontradas ${instances.length} instances de modelos:`, instances.map(i => i.label));
 
     if (instances.length === 0) {
@@ -263,7 +290,11 @@ export function useModelManagement({
         loadModelsRef.current();
       }
     }
-  }, [enabled, projectId, articleId, templateId, modelParentEntityTypeId]);
+    // ``modelInstancesSig`` (primitive) is in the deps so a fresh view
+    // (after refetchRun) re-derives the models from the supplied prop
+    // without a Supabase read — and an unstable array reference can't spin
+    // the load loop.
+  }, [enabled, projectId, articleId, templateId, modelParentEntityTypeId, modelInstancesSig]);
 
   return {
     models,

--- a/frontend/hooks/runs/types.ts
+++ b/frontend/hooks/runs/types.ts
@@ -166,11 +166,31 @@ export interface RunViewCurrentValue {
   decision: string;
 }
 
-// `instances` is added here in Task 12 (deferred), alongside its backend field
-// and the frontend adapter that consumes it.
+export interface RunViewInstanceResponse {
+  id: string;
+  entity_type_id: string;
+  parent_instance_id: string | null;
+  label: string;
+  sort_order: number;
+  status: string;
+  metadata: Record<string, unknown>;
+  project_id: string;
+  article_id: string | null;
+  template_id: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface RunViewResponse extends RunDetailResponse {
   entity_types: RunViewEntityType[];
   current_values: RunViewCurrentValue[];
+  instances: RunViewInstanceResponse[];
+}
+
+export interface ArticleRunRef {
+  article_id: string;
+  run_id: string | null;
 }
 
 /**
@@ -179,4 +199,7 @@ export interface RunViewResponse extends RunDetailResponse {
 export const runsKeys = {
   all: ["runs"] as const,
   detail: (runId: string) => ["runs", runId] as const,
+  reviewers: (runId: string) => ["runs", runId, "reviewers"] as const,
+  disabled: ["runs", "disabled"] as const,
+  noRunReviewers: ["runs", "no-run", "reviewers"] as const,
 };

--- a/frontend/hooks/runs/useRun.ts
+++ b/frontend/hooks/runs/useRun.ts
@@ -19,7 +19,7 @@ export function useRun(runId: string | null | undefined, options: UseRunOptions 
   const { enabled = true } = options;
 
   return useQuery<RunViewResponse>({
-    queryKey: runId ? runsKeys.detail(runId) : ["runs", "disabled"],
+    queryKey: runId ? runsKeys.detail(runId) : runsKeys.disabled,
     queryFn: async () => {
       if (!runId) {
         throw new Error("Missing run ID");

--- a/frontend/hooks/runs/useRunReviewers.ts
+++ b/frontend/hooks/runs/useRunReviewers.ts
@@ -12,6 +12,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "@/integrations/api";
+import { runsKeys } from "./types";
 
 export interface RunReviewerProfile {
   id: string;
@@ -35,8 +36,6 @@ export interface UseRunReviewersResult {
   error: Error | null;
 }
 
-const reviewersKey = (runId: string) => ["runs", runId, "reviewers"] as const;
-
 export function useRunReviewers(
   runId: string | null | undefined,
   options: UseRunReviewersOptions = {},
@@ -44,7 +43,7 @@ export function useRunReviewers(
   const { enabled = true } = options;
 
   const query = useQuery<RunReviewersResponse>({
-    queryKey: runId ? reviewersKey(runId) : ["runs", "no-run", "reviewers"],
+    queryKey: runId ? runsKeys.reviewers(runId) : runsKeys.noRunReviewers,
     queryFn: async () => {
       if (!runId) throw new Error("Missing run ID");
       return apiClient<RunReviewersResponse>(

--- a/frontend/hooks/usePreserveScroll.ts
+++ b/frontend/hooks/usePreserveScroll.ts
@@ -8,7 +8,7 @@
  *     '[data-scroll-container="true"]', // PDF viewer
  *   ]);
  *   await preserve(async () => {
- *     await refreshInstances();
+ *     await refetchRun();
  *     await refreshValues();
  *   });
  *

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -819,6 +819,13 @@ export const extraction = {
     aiEvidenceClickTitle: 'Click to view evidence',
     aiEvidenceClickAria: 'View evidence for this suggestion',
     evidenceCitedAria: 'Cited evidence',
+    // AISuggestionEvidence – citation highlight
+    evidenceNotLocated: "Couldn't locate in source",
+    evidenceJumpToSource: 'Jump to source in PDF',
+    // CitationLiveRegion – aria-live jump announcement
+    citationJumpAnnouncement: 'Jumped to cited source on page {{n}}',
+    // CitationOverlay – focusable active highlight box
+    citationHighlightLabel: 'Cited source highlight',
 } as const;
 
 export type ExtractionCopy = typeof extraction;

--- a/frontend/lib/extraction/runViewAdapters.ts
+++ b/frontend/lib/extraction/runViewAdapters.ts
@@ -1,0 +1,125 @@
+/**
+ * Pure adapter functions that map a ``RunViewResponse`` (the typed API shape
+ * returned by GET /api/v1/runs/:id/view) onto the form's internal types
+ * (``ExtractionEntityTypeWithFields[]`` and ``ExtractionInstance[]``).
+ *
+ * No hooks, no side-effects, no component imports — safe to import anywhere.
+ */
+
+import type {
+  ExtractionCardinality,
+  ExtractionEntityRole,
+  ExtractionEntityTypeWithFields,
+  ExtractionField,
+  ExtractionFieldType,
+  ExtractionInstance,
+} from '@/types/extraction';
+
+import type {
+  RunViewFieldResponse,
+  RunViewResponse,
+} from '@/hooks/runs/types';
+
+// ---------------------------------------------------------------------------
+// Internal helper — field mapper (curried on entity_type_id)
+// ---------------------------------------------------------------------------
+
+function fieldFromRunView(
+  entityTypeId: string,
+  createdAt: string,
+  f: RunViewFieldResponse,
+): ExtractionField {
+  return {
+    id: f.id,
+    entity_type_id: entityTypeId,
+    name: f.name,
+    label: f.label,
+    description: f.description,
+    field_type: f.field_type as ExtractionFieldType,
+    is_required: f.is_required,
+    validation_schema: f.validation_schema,
+    allowed_values: f.allowed_values as string[] | null,
+    unit: f.unit,
+    allowed_units: f.allowed_units as string[] | null,
+    llm_description: f.llm_description,
+    sort_order: f.sort_order,
+    created_at: createdAt,
+    allow_other: f.allow_other,
+    other_label: f.other_label,
+    other_placeholder: f.other_placeholder,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// entityTypesFromRunView
+// ---------------------------------------------------------------------------
+
+/**
+ * Map ``view.entity_types`` (``RunViewEntityType[]``) onto the form's
+ * ``ExtractionEntityTypeWithFields[]``.
+ *
+ * Two fields are injected because ``RunViewEntityType`` omits them:
+ * - ``template_id``: sourced from ``view.run.template_id``
+ * - ``created_at``: placeholder from ``view.run.created_at`` (the form
+ *   never reads this field; it is required by the interface)
+ */
+export function entityTypesFromRunView(
+  view: RunViewResponse,
+): ExtractionEntityTypeWithFields[] {
+  const {template_id, created_at} = view.run;
+
+  return view.entity_types.map(et => ({
+    id: et.id,
+    template_id,
+    name: et.name,
+    label: et.label,
+    description: et.description,
+    parent_entity_type_id: et.parent_entity_type_id,
+    cardinality: et.cardinality as ExtractionCardinality,
+    role: et.role as ExtractionEntityRole,
+    sort_order: et.sort_order,
+    is_required: et.is_required,
+    created_at,
+    fields: et.fields.map(f => fieldFromRunView(et.id, created_at, f)),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// instancesFromRunView
+// ---------------------------------------------------------------------------
+
+/**
+ * Map ``view.instances`` (``RunViewInstanceResponse[]``) onto
+ * ``ExtractionInstance[]``.
+ *
+ * - ``article_id``: ``RunViewInstanceResponse.article_id`` is
+ *   ``string | null``; falls back to ``view.run.article_id`` (always a
+ *   ``string``) to satisfy ``ExtractionInstance.article_id: string``.
+ * - ``label``: guarded with ``?? ''`` — the interface models it as a
+ *   required string.
+ * - ``status``: cast to the union literal type; the server is the source
+ *   of truth.
+ *
+ * Returns ``[]`` when ``view.instances`` is undefined or empty.
+ */
+export function instancesFromRunView(view: RunViewResponse): ExtractionInstance[] {
+  if (!view.instances?.length) {
+    return [];
+  }
+
+  return view.instances.map(inst => ({
+    id: inst.id,
+    project_id: inst.project_id,
+    article_id: inst.article_id ?? view.run.article_id,
+    template_id: inst.template_id,
+    entity_type_id: inst.entity_type_id,
+    parent_instance_id: inst.parent_instance_id,
+    label: inst.label ?? '',
+    sort_order: inst.sort_order,
+    status: inst.status as ExtractionInstance['status'],
+    metadata: inst.metadata,
+    created_by: inst.created_by,
+    created_at: inst.created_at,
+    updated_at: inst.updated_at,
+  }));
+}

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -64,6 +64,7 @@ import {FullAIExtractionProgress} from '@/components/extraction/FullAIExtraction
 import {useModelManagement} from '@/hooks/extraction/useModelManagement';
 import {usePreserveScroll} from '@/hooks/usePreserveScroll';
 import {t} from '@/lib/copy';
+import {ViewerProvider, createViewerStore} from '@prumo/pdf-viewer';
 
 const SCROLL_CONTAINERS_TO_PRESERVE = [
   // Form panel — actual scroll happens on radix' inner viewport node.
@@ -77,6 +78,15 @@ const SCROLL_CONTAINERS_TO_PRESERVE = [
 export default function ExtractionFullScreen() {
   const { projectId, articleId } = useParams();
   const navigate = useNavigate();
+
+  // ONE stable viewer store shared between the PDF panel and the form panel.
+  // useState lazy initializer creates the store exactly once per mount —
+  // the React-Compiler-approved pattern (mirrors ViewerProvider's own
+  // internal creation). Both <ExtractionPDFPanel store={viewerStore}> and
+  // <ViewerProvider store={viewerStore}> below point at this instance —
+  // that is the prerequisite for the click-evidence → highlight feature
+  // (Task 4B follow-up).
+  const [viewerStore] = useState(createViewerStore);
 
     // Load data using dedicated hook (SRP: separation of concerns)
   const {
@@ -1123,14 +1133,21 @@ export default function ExtractionFullScreen() {
         </div>
       ) : null}
 
-      {/* Main content */}
+      {/* Main content — wrapped in ViewerProvider so both the PDF viewer and
+          the form panel resolve useViewerStore/useViewerStoreApi to the same
+          store instance. The viewer also receives store={viewerStore} so
+          Viewer.Root forwards it rather than creating a second store.
+          QA-screen shared-store lift is deferred (AssessmentShell passes the
+          viewer as a ReactNode prop; out of scope here). */}
       <div className="flex-1 overflow-hidden">
+        <ViewerProvider store={viewerStore}>
         <ResizablePanelGroup direction="horizontal">
             {/* PDF Viewer (optional) - Extracted to isolated component */}
-          <ExtractionPDFPanel 
-            articleId={articleId || ''} 
-            projectId={projectId || ''} 
+          <ExtractionPDFPanel
+            articleId={articleId || ''}
+            projectId={projectId || ''}
             showPDF={showPDF}
+            store={viewerStore}
           />
 
             {/* Extraction form - Extracted to isolated component */}
@@ -1183,6 +1200,7 @@ export default function ExtractionFullScreen() {
             />
           </ResizablePanel>
         </ResizablePanelGroup>
+        </ViewerProvider>
       </div>
 
       {/* Dialogs */}

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -15,13 +15,14 @@
  * @page
  */
 
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
 import {toast} from 'sonner';
 import {extractionInstanceService, markInstancesCompleted} from '@/services/extractionInstanceService';
 import {getRequiredUserId} from '@/services/authService';
 import {extractionLogger} from '@/lib/extraction/observability';
 import {useEntityTypePartition} from '@/lib/extraction/entityTypeRoles';
+import {entityTypesFromRunView, instancesFromRunView} from '@/lib/extraction/runViewAdapters';
 import {errorTracker} from '@/services/errorTracking';
 import {ResizablePanel, ResizablePanelGroup} from '@/components/ui/resizable';
 import {Button} from '@/components/ui/button';
@@ -88,17 +89,16 @@ export default function ExtractionFullScreen() {
   // (Task 4B follow-up).
   const [viewerStore] = useState(createViewerStore);
 
-    // Load data using dedicated hook (SRP: separation of concerns)
+  // Load page-bootstrap data using dedicated hook (SRP). Entity types +
+  // instances are NOT read here anymore — they are derived from the
+  // server RunView (runDetail) below via the adapters.
   const {
     article,
     project,
     template,
-    entityTypes,
-    instances,
     articles,
     loading,
     error: dataError,
-    refreshInstances,
   } = useExtractionData({
     projectId,
     articleId,
@@ -144,24 +144,31 @@ export default function ExtractionFullScreen() {
   });
   const activeRunId = sessionResult.session?.runId ?? null;
 
-  // The backend's ``hitl_session_service._ensure_instances`` materialises
-  // study-level + per-model singletons on the first session open. The
-  // data hook initially reads what's there; once the session reports a
-  // runId, those new rows exist — refresh so the form binds to them
-  // instead of "no instances created" placeholders.
-  useEffect(() => {
-    if (activeRunId) {
-      void refreshInstances();
-    }
-  }, [activeRunId, refreshInstances]);
-
   // Detail fetch on the active run — drives the "Revision" badge when
   // `parameters.parent_run_id` is present, the stage-aware read path of
   // useExtractedValues, and the reviewer-summary + ConsensusPanel below.
+  // The view also carries the frozen-snapshot ``entity_types`` + the
+  // materialised ``instances`` — the single source of truth for the form.
+  // The session embed seeds this cache on open, so ``runDetail`` is present
+  // on first paint and the derived memos populate immediately.
   const { data: runDetail, refetch: refetchRun } = useRun(
     activeRunId ?? null,
     { enabled: !!activeRunId },
   );
+
+  // Entity types + instances are derived from the view (not direct
+  // Supabase). ``entityTypesFromRunView`` / ``instancesFromRunView`` are
+  // pure adapters; the memos keep references stable across renders that
+  // don't change ``runDetail``.
+  const entityTypes = useMemo(
+    () => (runDetail ? entityTypesFromRunView(runDetail) : []),
+    [runDetail],
+  );
+  const instances = useMemo(
+    () => (runDetail ? instancesFromRunView(runDetail) : []),
+    [runDetail],
+  );
+
   const stage = runDetail?.run.stage ?? null;
   const proposals = runDetail?.proposals;
   const isFinalized = stage === 'finalized';
@@ -216,10 +223,10 @@ export default function ExtractionFullScreen() {
   const inConsensusStage = runDetail?.run.stage === 'consensus';
 
   // {instance::field} → "Section · Field" label map for ConsensusPanel.
-  // Built from the loaded entity_types + their child fields. The field
-  // join lives in useExtractionData; for now we use the instance label
-  // alone (entityType.label) plus the field label fetched off the run
-  // detail's proposals/decisions when available.
+  // Built from the loaded entity_types + their child fields. entity_types
+  // and fields now come from RunView (runDetail) via the adapters — not
+  // from useExtractionData. We use the instance label (entityType.label)
+  // plus a truncated field id from the run detail's decisions when available.
   const fieldLabelByCoordMap: Record<string, string> = {};
   for (const inst of instances) {
     const et = entityTypes.find((e) => e.id === inst.entity_type_id);
@@ -470,6 +477,26 @@ export default function ExtractionFullScreen() {
     modelChildren: modelChildSections,
   } = useEntityTypePartition(entityTypes);
 
+  // The model-container instances, sourced from the view-derived
+  // ``instances`` and shaped to ``ModelInstanceRow``. Passed to
+  // useModelManagement so it derives models from the view instead of
+  // issuing its own ``extraction_instances`` read. ``undefined`` until a
+  // container entity type exists so the hook keeps its standalone behavior.
+  const modelInstances = useMemo(
+    () =>
+      modelParentEntityType
+        ? instances
+            .filter((i) => i.entity_type_id === modelParentEntityType.id)
+            .map((i) => ({
+              id: i.id,
+              label: i.label,
+              sort_order: i.sort_order,
+              created_at: i.created_at,
+            }))
+        : undefined,
+    [instances, modelParentEntityType],
+  );
+
   // Hook for model management
   const {
     models,
@@ -485,6 +512,7 @@ export default function ExtractionFullScreen() {
     articleId: articleId || '',
     templateId: template?.id || '',
     modelParentEntityTypeId: modelParentEntityType?.id || null,
+    modelInstances,
     enabled: !!template && !!modelParentEntityType
   });
 
@@ -521,9 +549,10 @@ export default function ExtractionFullScreen() {
     );
   };
 
-    // Function to reload instances (used after model extraction)
+    // Function to reload the run view (and thus the derived instances).
+    // Used after model / instance mutations and AI extraction.
   const handleRefreshInstances = async () => {
-    await refreshInstances();
+    await refetchRun();
   };
 
   const handleBack = () => {
@@ -543,9 +572,9 @@ export default function ExtractionFullScreen() {
     const result = await createModel(modelName, modellingMethod);
     if (result) {
       setShowAddModelDialog(false);
-      // Reload instances (child instances will be included).
+      // Reload the run view (child instances will be included).
       // refreshModels() is NOT called — the createModel hook already updated local state.
-      await preserveScroll(refreshInstances);
+      await preserveScroll(refetchRun);
     }
   };
 
@@ -590,10 +619,10 @@ export default function ExtractionFullScreen() {
       setModelToRemove(null);
 
       // Do not call refreshModels() - hook already updates local state
-      // Only reload instances so child instances are removed from UI
-      await refreshInstances().catch((refreshError: unknown) => {
+      // Only reload the run view so child instances are removed from UI
+      await refetchRun().catch((refreshError: unknown) => {
         // Log error but do not re-throw - model was already removed successfully
-        extractionLogger.error('removeModelHandler', 'Error reloading instances after removal', refreshError instanceof Error ? refreshError : undefined, {
+        extractionLogger.error('removeModelHandler', 'Error reloading run view after removal', refreshError instanceof Error ? refreshError : undefined, {
           modelId: modelIdToRemove,
         });
         // Do not block flow - model was already removed from local state
@@ -698,8 +727,8 @@ export default function ExtractionFullScreen() {
       userId,
     }).then(async (result) => {
       if (result.wasCreated) {
-        // Reload instances after create
-        await refreshInstances();
+        // Reload the run view after create (derived instances refresh)
+        await refetchRun();
         extractionLogger.info('handleAddInstance', 'Instance created successfully', {
           instanceId: result.instance.id,
           label: result.instance.label
@@ -735,7 +764,7 @@ export default function ExtractionFullScreen() {
       return false;
     });
     if (removed !== false) {
-      await refreshInstances();
+      await refetchRun();
       toast.success(t('pages', 'extractionScreenInstanceRemoved'));
     }
   };
@@ -959,16 +988,12 @@ export default function ExtractionFullScreen() {
             console.error('Error refetching session (non-critical):', err);
           }
           try {
+            // Refetching the run view also re-derives entity_types +
+            // instances (the form's single source of truth) — no separate
+            // instance refresh is needed.
             await refetchRun();
           } catch (err) {
             console.error('Error refetching run (non-critical):', err);
-          }
-          if (template) {
-            try {
-              await refreshInstances();
-            } catch (err) {
-              console.error('Error reloading instances (non-critical):', err);
-            }
           }
           await refreshValues();
         });

--- a/frontend/pdf-viewer/PrumoPdfViewer.tsx
+++ b/frontend/pdf-viewer/PrumoPdfViewer.tsx
@@ -1,14 +1,17 @@
 import {useEffect, useRef, useState} from 'react';
+import type {StoreApi} from 'zustand';
 import {Viewer} from './primitives/Viewer';
 import {CanvasLayer} from './primitives/CanvasLayer';
 import {TextLayer} from './primitives/TextLayer';
 import {Reader, type ReaderTextBlock} from './primitives/Reader';
+import {CitationLiveRegion} from './primitives/CitationLiveRegion';
 import {Toolbar} from './ui/Toolbar';
 import {SearchBar} from './ui/SearchBar';
 import {LoadingState} from './ui/LoadingState';
 import {ErrorState} from './ui/ErrorState';
 import {useViewerStore} from './core/context';
 import type {PDFSource} from './core/source';
+import type {ViewerState} from './core/state';
 
 export interface PrumoPdfViewerProps {
   source: PDFSource | null;
@@ -23,6 +26,14 @@ export interface PrumoPdfViewerProps {
    */
   readerBlocks?: readonly ReaderTextBlock[];
   readerLoading?: boolean;
+  /**
+   * Optional pre-built store. When provided, the viewer uses this store
+   * instead of creating its own — enabling a parent to share ONE store
+   * between the viewer and a sibling panel (e.g. the AI-suggestion form).
+   * When omitted, the default behaviour (internal store creation) is
+   * unchanged.
+   */
+  store?: StoreApi<ViewerState>;
 }
 
 /**
@@ -39,6 +50,7 @@ export function PrumoPdfViewer({
   toolbar = true,
   readerBlocks,
   readerLoading,
+  store,
 }: PrumoPdfViewerProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -62,9 +74,11 @@ export function PrumoPdfViewer({
 
   return (
     <div ref={rootRef} className={`flex flex-col h-full ${className ?? ''}`} tabIndex={-1}>
-      <Viewer.Root source={source} className="flex flex-col flex-1 min-h-0">
+      <Viewer.Root source={source} store={store} className="flex flex-col flex-1 min-h-0">
         {toolbar && <Toolbar onSearchToggle={() => setSearchOpen((v) => !v)} />}
         <SearchBar open={searchOpen} onClose={() => setSearchOpen(false)} />
+        {/* aria-live region: announces citation jumps to screen readers (canvas + reader mode) */}
+        <CitationLiveRegion />
         <ViewerContent
           readerBlocks={readerBlocks}
           readerLoading={readerLoading}

--- a/frontend/pdf-viewer/__tests__/CitationLiveRegion.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationLiveRegion.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for CitationLiveRegion — the aria-live jump announcement component.
+ *
+ * TDD: these tests are written before the implementation.
+ * Expected behaviors:
+ *   - No active citation → live region is empty.
+ *   - Active region/hybrid citation on page N → announces
+ *     "Jumped to cited source on page N".
+ *   - Active text citation on page N → also announces (mode-independent).
+ *   - Changing active citation updates the announcement.
+ *   - The region has aria-live="polite" and is visually hidden (sr-only).
+ */
+import {render, act} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
+import {describe, expect, it, beforeEach} from 'vitest';
+
+import {ViewerProvider} from '../core/context';
+import {createViewerStore} from '../core/store';
+import type {Citation} from '../core/citation';
+
+// Import after store is available
+const {CitationLiveRegion} = await import('../primitives/CitationLiveRegion');
+
+function renderWithStore(
+  store: ReturnType<typeof createViewerStore>,
+) {
+  const wrapper = ({children}: {children: ReactNode}) =>
+    createElement(ViewerProvider, {store, children});
+  return render(createElement(CitationLiveRegion, {}), {wrapper});
+}
+
+describe('<CitationLiveRegion>', () => {
+  let store: ReturnType<typeof createViewerStore>;
+
+  beforeEach(() => {
+    store = createViewerStore();
+  });
+
+  it('renders a polite aria-live region', () => {
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region).not.toBeNull();
+  });
+
+  it('is empty when there is no active citation', () => {
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toBe('');
+  });
+
+  it('announces the page when a REGION citation becomes active', () => {
+    const citation: Citation = {
+      id: 'live1',
+      anchor: {kind: 'region', page: 4, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('live1');
+
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toContain('4');
+    // Should contain a "Jumped to" / "page" style announcement
+    expect(region.textContent).toMatch(/jump|cited|source|page/i);
+  });
+
+  it('announces for a HYBRID citation', () => {
+    const citation: Citation = {
+      id: 'live2',
+      anchor: {
+        kind: 'hybrid',
+        range: {page: 7, charStart: 0, charEnd: 10},
+        rect: {x: 0, y: 0, width: 100, height: 50},
+        quote: 'test',
+      },
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('live2');
+
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toContain('7');
+  });
+
+  it('announces for a TEXT citation (mode-independent)', () => {
+    const citation: Citation = {
+      id: 'live3',
+      anchor: {kind: 'text', range: {page: 2, charStart: 0, charEnd: 5}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('live3');
+
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toContain('2');
+  });
+
+  it('clears the announcement when citation is cleared', async () => {
+    const citation: Citation = {
+      id: 'live4',
+      anchor: {kind: 'region', page: 5, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('live4');
+
+    const {container} = renderWithStore(store);
+
+    // Wrap the store mutation in act so React flushes the re-render.
+    await act(async () => {
+      store.getState().actions.clearCitations();
+    });
+
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(region.textContent).toBe('');
+  });
+
+  it('is visually hidden (has sr-only class or equivalent style)', () => {
+    const {container} = renderWithStore(store);
+    const region = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    // Should have sr-only class or position:absolute style for screen-reader-only
+    const hasSrOnly = region.className.includes('sr-only');
+    const hasAbsolutePosition =
+      region.style.position === 'absolute' ||
+      getComputedStyle(region).position === 'absolute';
+    expect(hasSrOnly || hasAbsolutePosition).toBe(true);
+  });
+});

--- a/frontend/pdf-viewer/__tests__/CitationOverlay.a11y.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationOverlay.a11y.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Accessibility tests for CitationOverlay.
+ *
+ * NOTE: The repo has no axe-core / jest-axe / vitest-axe harness installed.
+ * These tests use focused role/aria assertions instead of a full automated
+ * axe pass.  A future task should add `@axe-core/react` or `jest-axe` to the
+ * devDependencies and convert these to `toHaveNoViolations()` sweeps.
+ *
+ * TDD: written before implementation changes to CitationOverlay.
+ *
+ * Covered behaviors:
+ *   - Active overlay box is NOT aria-hidden (an aria-hidden focusable element
+ *     is an a11y violation per WCAG 4.1.2).
+ *   - Active overlay box has tabIndex=-1 (programmatically focusable).
+ *   - Active overlay box has an aria-label (non-empty).
+ *   - Active overlay box has pointer-events:none (visual-only, accessible).
+ *   - Inactive / non-matching-page overlay renders nothing.
+ */
+import {render, act} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+
+import {ViewerProvider} from '../core/context';
+import {createViewerStore} from '../core/store';
+import type {Citation} from '../core/citation';
+
+vi.mock('../hooks/usePageHandle', () => ({
+  usePageHandle: (_page: number) => ({
+    pageNumber: _page,
+    size: {width: 612, height: 792},
+    render: vi.fn(),
+    getTextContent: vi.fn(),
+    renderTextLayer: vi.fn(),
+    cleanup: vi.fn(),
+  }),
+}));
+
+const {CitationOverlay} = await import('../primitives/CitationOverlay');
+
+function renderWithStore(
+  store: ReturnType<typeof createViewerStore>,
+  pageNumber: number,
+) {
+  const wrapper = ({children}: {children: ReactNode}) =>
+    createElement(ViewerProvider, {store, children});
+  return render(createElement(CitationOverlay, {pageNumber}), {wrapper});
+}
+
+function getBox(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('[tabindex="-1"]') as HTMLElement | null;
+}
+
+describe('<CitationOverlay> — a11y (role/aria assertions)', () => {
+  let store: ReturnType<typeof createViewerStore>;
+
+  beforeEach(() => {
+    store = createViewerStore();
+    vi.clearAllMocks();
+  });
+
+  it('active box is NOT aria-hidden (focusable elements must not be aria-hidden)', () => {
+    const citation: Citation = {
+      id: 'a1',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a1');
+
+    const {container} = renderWithStore(store, 1);
+
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    // Must NOT be aria-hidden when it is the focusable active box.
+    expect(box!.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('active box has tabIndex=-1', () => {
+    const citation: Citation = {
+      id: 'a2',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a2');
+
+    const {container} = renderWithStore(store, 1);
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.tabIndex).toBe(-1);
+  });
+
+  it('active box has a non-empty aria-label', () => {
+    const citation: Citation = {
+      id: 'a3',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a3');
+
+    const {container} = renderWithStore(store, 1);
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.getAttribute('aria-label')).toBeTruthy();
+    expect(box!.getAttribute('aria-label')!.length).toBeGreaterThan(0);
+  });
+
+  it('active box keeps pointer-events:none (visual only)', () => {
+    const citation: Citation = {
+      id: 'a4',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a4');
+
+    const {container} = renderWithStore(store, 1);
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.style.pointerEvents).toBe('none');
+  });
+
+  it('active box for HYBRID citation has aria-label and tabIndex=-1', () => {
+    const citation: Citation = {
+      id: 'a5',
+      anchor: {
+        kind: 'hybrid',
+        range: {page: 2, charStart: 0, charEnd: 5},
+        rect: {x: 10, y: 20, width: 100, height: 50},
+        quote: 'test',
+      },
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a5');
+
+    const {container} = renderWithStore(store, 2);
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.tabIndex).toBe(-1);
+    expect(box!.getAttribute('aria-label')).toBeTruthy();
+    expect(box!.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('receives focus on activation (useEffect calls .focus())', async () => {
+    const citation: Citation = {
+      id: 'a6',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+
+    await act(async () => {
+      store.getState().actions.addCitation(citation);
+      store.getState().actions.setActiveCitation('a6');
+    });
+
+    const {container} = renderWithStore(store, 1);
+
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    // jsdom supports programmatic focus; after mount with an active citation
+    // the useEffect fires and the box should be document.activeElement.
+    expect(document.activeElement).toBe(box);
+  });
+
+  it('renders nothing when citation is on a different page', () => {
+    const citation: Citation = {
+      id: 'a7',
+      anchor: {kind: 'region', page: 3, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('a7');
+
+    const {container} = renderWithStore(store, 1);
+    expect(getBox(container)).toBeNull();
+  });
+});

--- a/frontend/pdf-viewer/__tests__/CitationOverlay.test.tsx
+++ b/frontend/pdf-viewer/__tests__/CitationOverlay.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Tests for CitationOverlay component.
+ *
+ * Strategy: wrap in ViewerProvider backed by a real createViewerStore, mock
+ * usePageHandle to return a known page size (height=792), and assert rendered
+ * box geometry or null render based on mode / anchor kind / page.
+ *
+ * Note: the overlay box is now focusable (tabIndex=-1, aria-label) and no
+ * longer has aria-hidden — queries use tabIndex=-1 or firstElementChild.
+ */
+import {render} from '@testing-library/react';
+import {createElement, type ReactNode} from 'react';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+
+import {ViewerProvider} from '../core/context';
+import {createViewerStore} from '../core/store';
+import type {Citation} from '../core/citation';
+
+// Stub usePageHandle — returns a fixed 612×792 page handle.
+vi.mock('../hooks/usePageHandle', () => ({
+  usePageHandle: (_page: number) => ({
+    pageNumber: _page,
+    size: {width: 612, height: 792},
+    render: vi.fn(),
+    getTextContent: vi.fn(),
+    renderTextLayer: vi.fn(),
+    cleanup: vi.fn(),
+  }),
+}));
+
+// Import component AFTER mock is registered.
+const {CitationOverlay} = await import('../primitives/CitationOverlay');
+
+// Helper to render CitationOverlay inside a ViewerProvider.
+function renderWithStore(
+  store: ReturnType<typeof createViewerStore>,
+  pageNumber: number,
+) {
+  const wrapper = ({children}: {children: ReactNode}) =>
+    createElement(ViewerProvider, {store, children});
+  return render(createElement(CitationOverlay, {pageNumber}), {wrapper});
+}
+
+// The active overlay box is now a focusable div (tabIndex=-1, aria-label).
+// Helper to grab it from the container.
+function getBox(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('[tabindex="-1"]') as HTMLElement | null;
+}
+
+describe('<CitationOverlay>', () => {
+  let store: ReturnType<typeof createViewerStore>;
+
+  beforeEach(() => {
+    store = createViewerStore();
+  });
+
+  it('renders a box with correct projected geometry for a REGION citation on the matching page', () => {
+    // rect={x:100, y:200, width:150, height:50}, pageHeight=792, scale=1
+    // expected: left=100, top=(792-200-50)*1=542, width=150, height=50
+    const citation: Citation = {
+      id: 'c1',
+      anchor: {kind: 'region', page: 3, rect: {x: 100, y: 200, width: 150, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('c1');
+
+    const {container} = renderWithStore(store, 3);
+
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.style.left).toBe('100px');
+    expect(box!.style.top).toBe('542px');
+    expect(box!.style.width).toBe('150px');
+    expect(box!.style.height).toBe('50px');
+    expect(box!.style.position).toBe('absolute');
+    expect(box!.style.pointerEvents).toBe('none');
+  });
+
+  it('renders a box for a HYBRID citation on the matching page', () => {
+    // rect={x:50, y:100, width:200, height:30}, pageHeight=792, scale=1
+    // expected: left=50, top=(792-100-30)=662, width=200, height=30
+    const citation: Citation = {
+      id: 'c2',
+      anchor: {
+        kind: 'hybrid',
+        range: {page: 2, charStart: 5, charEnd: 20},
+        rect: {x: 50, y: 100, width: 200, height: 30},
+        quote: 'some text',
+      },
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('c2');
+
+    const {container} = renderWithStore(store, 2);
+
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.style.top).toBe('662px');
+  });
+
+  it('renders nothing for a TEXT-only citation (handled by TextLayer)', () => {
+    const citation: Citation = {
+      id: 'c3',
+      anchor: {kind: 'text', range: {page: 1, charStart: 0, charEnd: 10}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('c3');
+
+    const {container} = renderWithStore(store, 1);
+
+    expect(getBox(container)).toBeNull();
+  });
+
+  it('renders nothing when active citation is on a DIFFERENT page', () => {
+    const citation: Citation = {
+      id: 'c4',
+      anchor: {kind: 'region', page: 5, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    store.getState().actions.addCitation(citation);
+    store.getState().actions.setActiveCitation('c4');
+
+    // Render for page 3, citation is on page 5.
+    const {container} = renderWithStore(store, 3);
+
+    expect(getBox(container)).toBeNull();
+  });
+
+  it('renders nothing in READER mode', () => {
+    const readerStore = createViewerStore({mode: 'reader'});
+    const citation: Citation = {
+      id: 'c5',
+      anchor: {kind: 'region', page: 1, rect: {x: 0, y: 0, width: 100, height: 50}},
+    };
+    readerStore.getState().actions.addCitation(citation);
+    readerStore.getState().actions.setActiveCitation('c5');
+
+    const {container} = renderWithStore(readerStore, 1);
+
+    expect(getBox(container)).toBeNull();
+  });
+
+  it('renders nothing when there is no active citation', () => {
+    const {container} = renderWithStore(store, 1);
+    expect(getBox(container)).toBeNull();
+  });
+
+  it('scales the projected rect with store.scale', () => {
+    const scaledStore = createViewerStore({scale: 1.5});
+    // rect={x:100, y:200, width:150, height:50}, pageHeight=792, scale=1.5
+    // expected: left=150, top=(792-200-50)*1.5=813, width=225, height=75
+    const citation: Citation = {
+      id: 'c6',
+      anchor: {kind: 'region', page: 2, rect: {x: 100, y: 200, width: 150, height: 50}},
+    };
+    scaledStore.getState().actions.addCitation(citation);
+    scaledStore.getState().actions.setActiveCitation('c6');
+
+    const {container} = renderWithStore(scaledStore, 2);
+
+    const box = getBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.style.left).toBe('150px');
+    expect(box!.style.top).toBe('813px');
+    expect(box!.style.width).toBe('225px');
+    expect(box!.style.height).toBe('75px');
+  });
+});

--- a/frontend/pdf-viewer/__tests__/coordinates.test.ts
+++ b/frontend/pdf-viewer/__tests__/coordinates.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from 'vitest';
+import {projectPdfRectToCss} from '../core/coordinates';
+
+describe('projectPdfRectToCss', () => {
+  it('projects at scale=1 with Y-flip', () => {
+    // pageHeight=792, rect={x:100, y:200, width:150, height:50}
+    // expected: left=100, top=(792-200-50)*1=542, width=150, height=50
+    const result = projectPdfRectToCss({x: 100, y: 200, width: 150, height: 50}, 792, 1);
+    expect(result).toEqual({left: 100, top: 542, width: 150, height: 50});
+  });
+
+  it('projects at scale=1.5 with Y-flip', () => {
+    // scale=1.5: left=100*1.5=150, top=(792-200-50)*1.5=813, width=150*1.5=225, height=50*1.5=75
+    const result = projectPdfRectToCss({x: 100, y: 200, width: 150, height: 50}, 792, 1.5);
+    expect(result).toEqual({left: 150, top: 813, width: 225, height: 75});
+  });
+
+  it('projects at scale=2 with Y-flip', () => {
+    // rect at origin bottom: x=0, y=0, width=50, height=30
+    // top=(792-0-30)*2=1524, left=0, width=100, height=60
+    const result = projectPdfRectToCss({x: 0, y: 0, width: 50, height: 30}, 792, 2);
+    expect(result).toEqual({left: 0, top: 1524, width: 100, height: 60});
+  });
+
+  it('projects at scale=0.5', () => {
+    // left=10*0.5=5, top=(200-50-20)*0.5=65, width=100*0.5=50, height=20*0.5=10
+    const result = projectPdfRectToCss({x: 10, y: 50, width: 100, height: 20}, 200, 0.5);
+    expect(result).toEqual({left: 5, top: 65, width: 50, height: 10});
+  });
+
+  it('projects a rect at the top of the page (near pageHeight)', () => {
+    // rect near top: y=750, height=30 → top=(792-750-30)*1=12
+    const result = projectPdfRectToCss({x: 0, y: 750, width: 100, height: 30}, 792, 1);
+    expect(result).toEqual({left: 0, top: 12, width: 100, height: 30});
+  });
+});

--- a/frontend/pdf-viewer/__tests__/injected-store.test.tsx
+++ b/frontend/pdf-viewer/__tests__/injected-store.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Proves that PrumoPdfViewer (and Viewer.Root beneath it) use an injected
+ * store rather than creating a fresh internal one.
+ *
+ * The mechanism under test:
+ *   PrumoPdfViewer(store) → Viewer.Root(store) → ViewerProvider(store)
+ *   → React context → useViewerStore / useViewerStoreApi
+ *
+ * We dispatch an action directly on the externally-owned store and assert
+ * that components inside the viewer reflect the mutation — which would be
+ * impossible if the viewer had silently spun up its own second store.
+ */
+
+import {render, renderHook, screen, act} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import {ViewerProvider, useViewerStore, useViewerStoreApi} from '../core/context';
+import {createViewerStore} from '../core/store';
+import type {ViewerState} from '../core/state';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Mocks (same setup as primitives.test.tsx / scaffolding.test.ts)
+// pdfjs-dist uses browser APIs unavailable in jsdom; swap in the legacy Node
+// build so import resolution succeeds without crashing.
+import * as legacyPdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
+vi.mock('pdfjs-dist', () => legacyPdfjs);
+
+// articleFileSource (transitively imported by PrumoPdfViewer via adapters/)
+// reaches for the Supabase client. Stub it to a neutral no-op so the test
+// module graph resolves cleanly without real env vars.
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: () => ({select: () => ({eq: () => ({eq: () => ({maybeSingle: async () => ({data: null, error: null})})})})}),
+    storage: {from: () => ({createSignedUrl: async () => ({data: null, error: null})})},
+  },
+}));
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers — mirrors context.test.tsx
+
+function CurrentPage() {
+  const page = useViewerStore((s: ViewerState) => s.currentPage);
+  return <span data-testid="current-page">{page}</span>;
+}
+
+function CurrentScale() {
+  const scale = useViewerStore((s: ViewerState) => s.scale);
+  return <span data-testid="scale">{scale.toFixed(2)}</span>;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('injected store: ViewerProvider + Viewer.Root + PrumoPdfViewer', () => {
+  // ── 1. ViewerProvider with an external store ──────────────────────────────
+  it('ViewerProvider: external store is used (not replaced by an internal one)', () => {
+    const external = createViewerStore({scale: 2.5});
+    render(
+      <ViewerProvider store={external}>
+        <CurrentScale />
+      </ViewerProvider>,
+    );
+    // The custom initial scale is visible → the external store is in use.
+    expect(screen.getByTestId('scale').textContent).toBe('2.50');
+  });
+
+  it('ViewerProvider: action dispatched on external store is reflected inside', async () => {
+    const external = createViewerStore({scale: 1.0});
+    render(
+      <ViewerProvider store={external}>
+        <CurrentScale />
+      </ViewerProvider>,
+    );
+    expect(screen.getByTestId('scale').textContent).toBe('1.00');
+
+    await act(async () => {
+      external.getState().actions.setScale(3.0);
+    });
+
+    expect(screen.getByTestId('scale').textContent).toBe('3.00');
+  });
+
+  // ── 2. useViewerStoreApi returns the injected instance ────────────────────
+  it('useViewerStoreApi returns the exact same StoreApi that was injected', () => {
+    const external = createViewerStore();
+
+    // renderHook avoids the "captured =" pattern that the React Compiler
+    // rejects (mutation of outer-scope variable during render).
+    const {result} = renderHook(() => useViewerStoreApi(), {
+      wrapper: ({children}) => (
+        <ViewerProvider store={external}>{children}</ViewerProvider>
+      ),
+    });
+
+    // Object identity: the hook must return the same reference, not a copy.
+    expect(result.current).toBe(external);
+  });
+
+  // ── 3. Viewer.Root forwards store to ViewerProvider ───────────────────────
+  it('Viewer.Root: external store is used by child components', async () => {
+    const {Viewer} = await import('../primitives/Viewer');
+    const external = createViewerStore({currentPage: 7});
+
+    render(
+      <Viewer.Root source={null} store={external}>
+        <CurrentPage />
+      </Viewer.Root>,
+    );
+
+    // The custom initial currentPage is visible → Viewer.Root forwarded the store.
+    expect(screen.getByTestId('current-page').textContent).toBe('7');
+  });
+
+  it('Viewer.Root: action dispatched on external store is reflected inside', async () => {
+    const {Viewer} = await import('../primitives/Viewer');
+    const external = createViewerStore({currentPage: 1});
+
+    render(
+      <Viewer.Root source={null} store={external}>
+        <CurrentPage />
+      </Viewer.Root>,
+    );
+    expect(screen.getByTestId('current-page').textContent).toBe('1');
+
+    await act(async () => {
+      external.getState().actions.goToPage(5);
+    });
+
+    expect(screen.getByTestId('current-page').textContent).toBe('5');
+  });
+
+  // ── 4. PrumoPdfViewer forwards store end-to-end ───────────────────────────
+  it('PrumoPdfViewer: injected store is used (not a fresh internal one)', async () => {
+    const {PrumoPdfViewer} = await import('../PrumoPdfViewer');
+    const external = createViewerStore({scale: 1.75});
+
+    // We render PrumoPdfViewer with a sibling CurrentScale also wrapped in
+    // the same ViewerProvider so both components read from the same store.
+    // Without the injected store, PrumoPdfViewer would create its OWN
+    // ViewerProvider internally, making CurrentScale unreachable from it.
+    render(
+      <ViewerProvider store={external}>
+        {/* This component is in the OUTER ViewerProvider (the shared one). */}
+        <CurrentScale />
+        {/* PrumoPdfViewer receives the same store → Viewer.Root forwards it
+            → its internal ViewerProvider is the SAME context node. */}
+        <PrumoPdfViewer source={null} store={external} toolbar={false} />
+      </ViewerProvider>,
+    );
+
+    // Both CurrentScale (in outer provider) and the viewer use the same store.
+    expect(screen.getByTestId('scale').textContent).toBe('1.75');
+
+    // Mutate via the external store; the sibling component must update.
+    await act(async () => {
+      external.getState().actions.setScale(2.25);
+    });
+
+    expect(screen.getByTestId('scale').textContent).toBe('2.25');
+  });
+
+  it('PrumoPdfViewer: goToPage on injected store is reflected outside the viewer', async () => {
+    const {PrumoPdfViewer} = await import('../PrumoPdfViewer');
+    const external = createViewerStore({currentPage: 1});
+
+    render(
+      <ViewerProvider store={external}>
+        <CurrentPage />
+        <PrumoPdfViewer source={null} store={external} toolbar={false} />
+      </ViewerProvider>,
+    );
+    expect(screen.getByTestId('current-page').textContent).toBe('1');
+
+    await act(async () => {
+      external.getState().actions.goToPage(3);
+    });
+
+    // The CurrentPage component (outside the viewer) reflects the mutation —
+    // proving ONE store is shared, not two isolated ones.
+    expect(screen.getByTestId('current-page').textContent).toBe('3');
+  });
+});

--- a/frontend/pdf-viewer/core/context.tsx
+++ b/frontend/pdf-viewer/core/context.tsx
@@ -64,3 +64,14 @@ export function useViewerStoreApi(): StoreApi<ViewerState> {
   }
   return store;
 }
+
+/**
+ * Return the raw StoreApi for the nearest ViewerProvider's store, or `null`
+ * when called outside a Provider. Use this variant in components / hooks that
+ * may render in contexts where no ViewerProvider exists (e.g. QA screen).
+ *
+ * Unlike `useViewerStoreApi`, this never throws — callers must handle `null`.
+ */
+export function useViewerStoreApiOptional(): StoreApi<ViewerState> | null {
+  return useContext(ViewerStoreContext);
+}

--- a/frontend/pdf-viewer/core/coordinates.ts
+++ b/frontend/pdf-viewer/core/coordinates.ts
@@ -28,3 +28,39 @@ export interface PDFTextRange {
   charStart: number;
   charEnd: number;
 }
+
+/**
+ * CSS pixel rect (relative to the page canvas element) produced by projecting
+ * a PDFRect from PDF user space.
+ */
+export interface CSSRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Project a PDF user-space rect to CSS pixels, relative to the top-left of
+ * the rendered page canvas element.
+ *
+ * PDF user space has its origin at the bottom-left of the page; CSS has its
+ * origin at the top-left. The Y-flip formula is:
+ *   top = (pageHeightPts - rect.y - rect.height) * scale
+ *
+ * @param rect           Bounding box in PDF user space (points).
+ * @param pageHeightPts  Page height in PDF points (from PDFPageHandle.size.height).
+ * @param scale          Current viewer render scale (1.0 = 100%).
+ */
+export function projectPdfRectToCss(
+  rect: PDFRect,
+  pageHeightPts: number,
+  scale: number,
+): CSSRect {
+  return {
+    left: rect.x * scale,
+    top: (pageHeightPts - rect.y - rect.height) * scale,
+    width: rect.width * scale,
+    height: rect.height * scale,
+  };
+}

--- a/frontend/pdf-viewer/primitives/CitationLiveRegion.tsx
+++ b/frontend/pdf-viewer/primitives/CitationLiveRegion.tsx
@@ -1,0 +1,48 @@
+/**
+ * CitationLiveRegion — polite aria-live region that announces citation jumps.
+ *
+ * Subscribes to `activeCitationId` and the `citations` map in the viewer
+ * store.  When a citation becomes active it emits a screen-reader-only
+ * message: "Jumped to cited source on page N".
+ *
+ * Mount once inside a ViewerProvider (e.g. at the root of PrumoPdfViewer).
+ * Both canvas and reader modes benefit — the announcement fires regardless
+ * of the current viewer mode.
+ *
+ * React Compiler constraint: no try/finally, no throw inside try.
+ */
+import {useViewerStore} from '../core/context';
+import {t} from '@/lib/copy';
+
+export function CitationLiveRegion() {
+  const activeCitationId = useViewerStore((s) => s.activeCitationId);
+  const activeCitation = useViewerStore((s) =>
+    s.activeCitationId != null ? s.citations.get(s.activeCitationId) : undefined,
+  );
+
+  let announcement = '';
+
+  if (activeCitationId != null && activeCitation != null) {
+    const {anchor} = activeCitation;
+    const page =
+      anchor.kind === 'region'
+        ? anchor.page
+        : anchor.range.page;
+
+    announcement = t('extraction', 'citationJumpAnnouncement').replace(
+      '{{n}}',
+      String(page),
+    );
+  }
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+    >
+      {announcement}
+    </span>
+  );
+}

--- a/frontend/pdf-viewer/primitives/CitationOverlay.tsx
+++ b/frontend/pdf-viewer/primitives/CitationOverlay.tsx
@@ -1,0 +1,105 @@
+/**
+ * CitationOverlay — renders a single region/hybrid citation highlight box
+ * as a `position:absolute` child of the Viewer.Page div.
+ *
+ * Only renders in `canvas` mode: in `reader` mode there is no canvas surface
+ * and the region coordinates are meaningless in the DOM flow.
+ *
+ * Text-only anchors are handled by TextLayer search highlights; this component
+ * renders nothing for them.
+ *
+ * A11y:
+ *   - The active box is focusable (`tabIndex=-1`) and labelled so screen
+ *     readers can inspect it after the CitationLiveRegion announcement.
+ *   - `aria-hidden` is NOT set — a focusable element must never be
+ *     aria-hidden (WCAG 4.1.2 violation).
+ *   - A `useEffect` moves focus to the box on activation so keyboard users
+ *     land in the right place immediately after the jump.
+ *
+ * React Compiler constraint: no try/finally, no throw inside try.
+ */
+import {useEffect, useRef} from 'react';
+import {useViewerStore} from '../core/context';
+import {usePageHandle} from '../hooks/usePageHandle';
+import {projectPdfRectToCss} from '../core/coordinates';
+import type {RegionCitationAnchor, HybridCitationAnchor} from '../core/citation';
+import {t} from '@/lib/copy';
+
+export interface CitationOverlayProps {
+  pageNumber: number;
+}
+
+export function CitationOverlay({pageNumber}: CitationOverlayProps) {
+  const mode = useViewerStore((s) => s.mode);
+  const scale = useViewerStore((s) => s.scale);
+  const activeCitationId = useViewerStore((s) => s.activeCitationId);
+  const citation = useViewerStore((s) =>
+    s.activeCitationId != null ? s.citations.get(s.activeCitationId) : undefined,
+  );
+
+  const pageHandle = usePageHandle(pageNumber);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  // Derive whether the overlay should be shown for this page.
+  // Text-only anchors are rendered by TextLayer — skip here.
+  const anchor = citation?.anchor;
+  const isRegionOrHybrid =
+    anchor != null && anchor.kind !== 'text';
+
+  const anchorPage =
+    isRegionOrHybrid
+      ? anchor!.kind === 'region'
+        ? (anchor as RegionCitationAnchor).page
+        : (anchor as HybridCitationAnchor).range.page
+      : null;
+
+  const isActiveOnThisPage =
+    mode === 'canvas' &&
+    activeCitationId != null &&
+    isRegionOrHybrid &&
+    anchorPage === pageNumber &&
+    pageHandle != null;
+
+  // Move focus to the overlay box when it becomes the active highlight.
+  // useEffect is allowed by React Compiler all_errors — no try/finally.
+  useEffect(() => {
+    if (isActiveOnThisPage && boxRef.current) {
+      boxRef.current.focus();
+    }
+  }, [isActiveOnThisPage, activeCitationId]);
+
+  if (!isActiveOnThisPage) return null;
+
+  // anchor is region or hybrid at this point — both have a top-level `rect`.
+  const rect =
+    anchor!.kind === 'region'
+      ? (anchor as RegionCitationAnchor).rect
+      : (anchor as HybridCitationAnchor).rect;
+
+  const {left, top, width, height} = projectPdfRectToCss(
+    rect,
+    pageHandle!.size.height,
+    scale,
+  );
+
+  return (
+    <div
+      ref={boxRef}
+      tabIndex={-1}
+      aria-label={t('extraction', 'citationHighlightLabel')}
+      style={{
+        position: 'absolute',
+        left,
+        top,
+        width,
+        height,
+        pointerEvents: 'none',
+        // Subtle ring + translucent fill so the underlying content stays readable.
+        backgroundColor: 'rgba(250, 204, 21, 0.25)',
+        outline: '2px solid rgba(234, 179, 8, 0.8)',
+        borderRadius: '2px',
+        boxSizing: 'border-box',
+      }}
+    />
+  );
+}

--- a/frontend/pdf-viewer/primitives/Viewer.tsx
+++ b/frontend/pdf-viewer/primitives/Viewer.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useRef, type ReactNode} from 'react';
 import {ViewerProvider, useViewerStore, useViewerStoreApi} from '../core/context';
 import {useDocumentLoader} from '../hooks/useDocumentLoader';
+import {CitationOverlay} from './CitationOverlay';
 import type {PDFSource} from '../core/source';
 import type {StoreApi} from 'zustand';
 import type {ViewerState} from '../core/state';
@@ -180,6 +181,7 @@ function Page({
     // and colour the document author intended.
     <div data-page-number={pageNumber} className="relative shadow-md bg-white">
       {children}
+      <CitationOverlay pageNumber={pageNumber} />
     </div>
   );
 }

--- a/frontend/services/aiSuggestionService.ts
+++ b/frontend/services/aiSuggestionService.ts
@@ -1,21 +1,15 @@
 /**
- * AI suggestions service — reads ProposalRecord, persists accept/reject
- * as ReviewerDecisions on the active extraction run.
+ * AI suggestions service — reads AI proposals via the typed API client,
+ * persists accept/reject as ReviewerDecisions on the active extraction run.
  *
- * Post-migration off `ai_suggestions` AND `extracted_values`: the only
- * persistent state is now the HITL workflow tables. Specifically:
- *
- * - Source of truth for proposed values: `extraction_proposal_records`
- *   (filtered by `source='ai'` for the suggestions panel).
- * - "Accepted" status: there's a non-reject ReviewerDecision in the
- *   `reviewer_state` row for that (instance, field) pointing back at the
- *   proposal.
- * - "Rejected" persists as a ReviewerDecision with `decision='reject'`.
- *
- * Evidence (text + page_number) is loaded from `extraction_evidence`
- * rows linked to each proposal via `proposal_record_id`.
+ * The backend endpoints (/api/v1/articles/{id}/suggestions, /history,
+ * /instance-ids) replaced the former direct PostgREST reads from
+ * `extraction_proposal_records`, `extraction_evidence`,
+ * `extraction_reviewer_states`, and the auth-user reads.
+ * Caller-scoped status (accepted/rejected/pending) is now resolved
+ * server-side and returned in each AISuggestionItem.
  */
-import { supabase } from '@/integrations/supabase/client';
+import { apiClient } from '@/integrations/api';
 import { ExtractionValueService } from '@/services/extractionValueService';
 import type {
   AISuggestion,
@@ -24,72 +18,52 @@ import type {
 } from '@/types/ai-extraction';
 import { getSuggestionKey } from '@/types/ai-extraction';
 import { APIError } from '@/lib/ai-extraction/errors';
+import type { components } from '@/types/api/schema';
 
-interface ProposalRow {
-  id: string;
-  run_id: string;
-  instance_id: string;
-  field_id: string;
-  source: string;
-  proposed_value: { value: unknown } | unknown;
-  confidence_score: number | null;
-  rationale: string | null;
-  created_at: string;
-}
+type AISuggestionItem = components['schemas']['AISuggestionItem'];
+type AISuggestionHistoryItemServer = components['schemas']['AISuggestionHistoryItem'];
+type AISuggestionsResponse = components['schemas']['AISuggestionsResponse'];
 
-interface EvidenceRow {
-  proposal_record_id: string | null;
-  text_content: string | null;
-  page_number: number | null;
-}
-
-interface ReviewerStateKeyRow {
-  instance_id: string;
-  field_id: string;
-  reviewer_decision: { decision: string } | { decision: string }[] | null;
-}
-
-function unwrapValue(raw: ProposalRow['proposed_value']): unknown {
+function unwrapValue(raw: { [key: string]: unknown } | null | undefined): unknown {
   if (raw === null || raw === undefined) return '';
-  if (typeof raw === 'object' && raw !== null && 'value' in raw) {
-    return (raw as { value: unknown }).value ?? '';
-  }
+  if ('value' in raw) return raw['value'] ?? '';
   return raw;
 }
 
-function decisionFromState(state: ReviewerStateKeyRow): string | null {
-  if (!state.reviewer_decision) return null;
-  const dec = Array.isArray(state.reviewer_decision)
-    ? state.reviewer_decision[0]
-    : state.reviewer_decision;
-  return dec?.decision ?? null;
+function mapItemToSuggestion(item: AISuggestionItem): AISuggestion {
+  return {
+    id: item.id,
+    runId: item.run_id,
+    value: unwrapValue(item.proposed_value as { [key: string]: unknown }),
+    confidence: item.confidence_score ?? 0,
+    reasoning: item.rationale ?? '',
+    status: (item.status ?? 'pending') as AISuggestion['status'],
+    timestamp: new Date(item.created_at),
+    evidence: item.evidence?.text_content
+      ? {
+          text: item.evidence.text_content,
+          pageNumber: item.evidence.page_number ?? null,
+        }
+      : undefined,
+  };
 }
 
-function mapProposalToSuggestion(
-  row: ProposalRow,
-  evidenceByProposalId: Map<string, EvidenceRow>,
-  acceptedKeys: Set<string>,
-  rejectedKeys: Set<string>,
-): AISuggestion {
-  const key = getSuggestionKey(row.instance_id, row.field_id);
-  const status = acceptedKeys.has(key)
-    ? 'accepted'
-    : rejectedKeys.has(key)
-      ? 'rejected'
-      : 'pending';
-  const evidence = evidenceByProposalId.get(row.id);
+function mapHistoryItemToSuggestion(
+  item: AISuggestionHistoryItemServer,
+): AISuggestionHistoryItem {
   return {
-    id: row.id,
-    runId: row.run_id,
-    value: unwrapValue(row.proposed_value),
-    confidence: row.confidence_score ?? 0,
-    reasoning: row.rationale ?? '',
-    status,
-    timestamp: new Date(row.created_at),
-    evidence: evidence?.text_content
+    id: item.id,
+    runId: item.run_id,
+    value: unwrapValue(item.proposed_value as { [key: string]: unknown }),
+    confidence: item.confidence_score ?? 0,
+    reasoning: item.rationale ?? '',
+    // History items have no server-side status (raw proposal trail)
+    status: 'pending',
+    timestamp: new Date(item.created_at),
+    evidence: item.evidence?.text_content
       ? {
-          text: evidence.text_content,
-          pageNumber: evidence.page_number ?? null,
+          text: item.evidence.text_content,
+          pageNumber: item.evidence.page_number ?? null,
         }
       : undefined,
   };
@@ -97,7 +71,7 @@ function mapProposalToSuggestion(
 
 export class AISuggestionService {
   static async loadSuggestions(
-    _articleId: string,
+    articleId: string,
     instanceIds: string[],
     runId?: string,
   ): Promise<LoadSuggestionsResult> {
@@ -105,159 +79,51 @@ export class AISuggestionService {
       return { suggestions: {}, count: 0 };
     }
 
-    let proposalsQuery = supabase
-      .from('extraction_proposal_records')
-      .select(
-        'id, run_id, instance_id, field_id, source, proposed_value, confidence_score, rationale, created_at',
-      )
-      .in('instance_id', instanceIds)
-      .eq('source', 'ai')
-      .order('created_at', { ascending: false });
-    // Scope to a specific Run when one is provided so a Quality-Assessment
-    // run on the same article never bleeds AI proposals into the Data
-    // Extraction surface (or vice versa).
+    const params = new URLSearchParams();
+    for (const id of instanceIds) {
+      params.append('instance_ids', id);
+    }
     if (runId) {
-      proposalsQuery = proposalsQuery.eq('run_id', runId);
-    }
-    const proposalsRes = await proposalsQuery;
-    if (proposalsRes.error) {
-      throw new APIError(
-        `Failed to load proposals: ${proposalsRes.error.message}`,
-        undefined,
-        { error: proposalsRes.error },
-      );
-    }
-    const proposals = (proposalsRes.data ?? []) as ProposalRow[];
-
-    const proposalIds = proposals.map((p) => p.id);
-    const evidenceByProposalId = new Map<string, EvidenceRow>();
-    if (proposalIds.length > 0) {
-      const evidenceRes = await supabase
-        .from('extraction_evidence')
-        .select('proposal_record_id, text_content, page_number')
-        .in('proposal_record_id', proposalIds);
-      if (!evidenceRes.error) {
-        for (const ev of (evidenceRes.data ?? []) as EvidenceRow[]) {
-          if (ev.proposal_record_id) {
-            evidenceByProposalId.set(ev.proposal_record_id, ev);
-          }
-        }
-      }
+      params.append('run_id', runId);
     }
 
-    // Derive accepted/rejected status from the current user's
-    // reviewer_state for each (instance, field). We deliberately ignore
-    // other users' decisions — each user sees their own status.
-    // Surface auth errors (#49) and reviewer_states query errors (#73)
-    // instead of silently rendering every suggestion as 'pending'.
-    const userRes = await supabase.auth.getUser();
-    if (userRes.error) {
-      throw new APIError(
-        `Failed to load user: ${userRes.error.message}`,
-        undefined,
-        { error: userRes.error },
-      );
-    }
-    const user = userRes.data.user;
-    const acceptedKeys = new Set<string>();
-    const rejectedKeys = new Set<string>();
-    if (user) {
-      let statesQuery = supabase
-        .from('extraction_reviewer_states')
-        .select(
-          'instance_id, field_id, current_decision_id, reviewer_decision:extraction_reviewer_decisions!fk_extraction_reviewer_states_decision_run_match(decision)',
-        )
-        .in('instance_id', instanceIds)
-        .eq('reviewer_id', user.id);
-      if (runId) {
-        statesQuery = statesQuery.eq('run_id', runId);
-      }
-      const statesRes = await statesQuery;
-      if (statesRes.error) {
-        throw new APIError(
-          `Failed to load reviewer states: ${statesRes.error.message}`,
-          undefined,
-          { error: statesRes.error },
-        );
-      }
-      for (const state of (statesRes.data ?? []) as ReviewerStateKeyRow[]) {
-        const decision = decisionFromState(state);
-        if (!decision) continue;
-        const key = getSuggestionKey(state.instance_id, state.field_id);
-        if (decision === 'reject') {
-          rejectedKeys.add(key);
-        } else {
-          acceptedKeys.add(key);
-        }
-      }
-    }
+    const response = await apiClient<AISuggestionsResponse>(
+      `/api/v1/articles/${articleId}/suggestions?${params.toString()}`,
+    );
 
+    const items = response?.suggestions ?? [];
     const suggestionsMap: Record<string, AISuggestion> = {};
-    for (const row of proposals) {
-      const key = getSuggestionKey(row.instance_id, row.field_id);
+    for (const item of items) {
+      const key = getSuggestionKey(item.instance_id, item.field_id);
+      // First-wins guard: server already dedups to latest-per-coord,
+      // but keep this harmless if duplicates slip through.
       if (suggestionsMap[key]) continue;
-      suggestionsMap[key] = mapProposalToSuggestion(
-        row,
-        evidenceByProposalId,
-        acceptedKeys,
-        rejectedKeys,
-      );
+      suggestionsMap[key] = mapItemToSuggestion(item);
     }
 
     return {
       suggestions: suggestionsMap,
-      count: Object.keys(suggestionsMap).length,
+      count: response?.count ?? Object.keys(suggestionsMap).length,
     };
   }
 
   static async getHistory(
+    articleId: string,
     instanceId: string,
     fieldId: string,
     limit = 10,
   ): Promise<AISuggestionHistoryItem[]> {
-    const proposalsRes = await supabase
-      .from('extraction_proposal_records')
-      .select(
-        'id, run_id, instance_id, field_id, source, proposed_value, confidence_score, rationale, created_at',
-      )
-      .eq('instance_id', instanceId)
-      .eq('field_id', fieldId)
-      .eq('source', 'ai')
-      .order('created_at', { ascending: false })
-      .limit(limit);
-    if (proposalsRes.error) {
-      throw new APIError(
-        `Failed to load proposal history: ${proposalsRes.error.message}`,
-        undefined,
-        { error: proposalsRes.error },
-      );
-    }
-    const proposals = (proposalsRes.data ?? []) as ProposalRow[];
+    const params = new URLSearchParams({
+      instance_id: instanceId,
+      field_id: fieldId,
+      limit: String(limit),
+    });
 
-    const proposalIds = proposals.map((p) => p.id);
-    const evidenceByProposalId = new Map<string, EvidenceRow>();
-    if (proposalIds.length > 0) {
-      const evidenceRes = await supabase
-        .from('extraction_evidence')
-        .select('proposal_record_id, text_content, page_number')
-        .in('proposal_record_id', proposalIds);
-      if (!evidenceRes.error) {
-        for (const ev of (evidenceRes.data ?? []) as EvidenceRow[]) {
-          if (ev.proposal_record_id) {
-            evidenceByProposalId.set(ev.proposal_record_id, ev);
-          }
-        }
-      }
-    }
-
-    return proposals.map((row) =>
-      mapProposalToSuggestion(
-        row,
-        evidenceByProposalId,
-        /* acceptedKeys */ new Set(),
-        /* rejectedKeys */ new Set(),
-      ),
+    const items = await apiClient<AISuggestionHistoryItemServer[]>(
+      `/api/v1/articles/${articleId}/suggestions/history?${params.toString()}`,
     );
+
+    return items.map(mapHistoryItemToSuggestion);
   }
 
   /**
@@ -330,18 +196,6 @@ export class AISuggestionService {
   }
 
   static async getArticleInstanceIds(articleId: string): Promise<string[]> {
-    const { data, error } = await supabase
-      .from('extraction_instances')
-      .select('id')
-      .eq('article_id', articleId)
-      .not('article_id', 'is', null);
-    if (error) {
-      throw new APIError(
-        `Failed to load instances: ${error.message}`,
-        undefined,
-        { error },
-      );
-    }
-    return (data ?? []).map((i) => i.id);
+    return apiClient<string[]>(`/api/v1/articles/${articleId}/instance-ids`);
   }
 }

--- a/frontend/services/citationsService.ts
+++ b/frontend/services/citationsService.ts
@@ -1,0 +1,101 @@
+/**
+ * Citations service — fetches per-article citation anchors from the backend.
+ *
+ * Service-layer contract (zero-bailouts spec): exported functions never throw
+ * across the boundary; they return ErrorResult<T>. IO lives here; the React
+ * Compiler never sees try/catch inside a hook body.
+ */
+
+import {apiClient} from '@/integrations/api/client';
+import {toResult, type ErrorResult} from '@/lib/error-utils';
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ArticleCitationItem {
+  id: string;
+  verified: boolean;
+  anchorKind: 'text' | 'region' | 'hybrid' | null;
+  anchor: CitationAnchor | null;
+  metadata: {
+    pageNumber: number | null;
+    textContent: string | null;
+    source: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all citations for a given article.
+ * Returns an empty array when the article has no citations yet.
+ */
+export function fetchArticleCitations(
+  articleId: string,
+): Promise<ErrorResult<ArticleCitationItem[]>> {
+  return toResult(async () => {
+    const data = await apiClient<ArticleCitationItem[]>(
+      `/api/v1/articles/${articleId}/citations`,
+    );
+    return data ?? [];
+  }, 'citationsService.fetchArticleCitations');
+}
+
+// ---------------------------------------------------------------------------
+// Pure matcher — no IO, deterministic
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalizes a string for fuzzy comparison: trim, collapse whitespace,
+ * lowercase.
+ */
+function normalize(s: string): string {
+  return s.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+/**
+ * Attempts to match an AI evidence quote to a citation in the list.
+ *
+ * Matching strategy (in priority order):
+ *  1. Same page number AND (normalized textContent equals OR contains the
+ *     evidence text)
+ *  2. Text-only match (page is null/absent) — normalized textContent equals
+ *     or contains the evidence text
+ *
+ * Ties are broken by list order (earliest first).
+ * Returns null when no citation matches.
+ */
+export function matchEvidenceToCitation(
+  evidence: {text: string; pageNumber?: number | null},
+  citations: ArticleCitationItem[],
+): ArticleCitationItem | null {
+  const normalizedEvidence = normalize(evidence.text);
+  const hasPage =
+    evidence.pageNumber !== null && evidence.pageNumber !== undefined;
+
+  const textMatches = (item: ArticleCitationItem): boolean => {
+    const tc = item.metadata.textContent;
+    if (!tc) return false;
+    const normalizedTc = normalize(tc);
+    return (
+      normalizedTc === normalizedEvidence ||
+      normalizedTc.includes(normalizedEvidence)
+    );
+  };
+
+  // Pass 1: page + text match
+  if (hasPage) {
+    const pageAndText = citations.find(
+      (item) =>
+        item.metadata.pageNumber === evidence.pageNumber && textMatches(item),
+    );
+    if (pageAndText) return pageAndText;
+  }
+
+  // Pass 2: text-only match
+  return citations.find(textMatches) ?? null;
+}

--- a/frontend/services/extractionValueService.ts
+++ b/frontend/services/extractionValueService.ts
@@ -14,16 +14,8 @@
  * extraction now auto-advances to REVIEW after recording AI proposals,
  * so by the time the form opens, decisions can be written immediately.
  */
-import { supabase } from '@/integrations/supabase/client';
 import { apiClient } from '@/integrations/api';
-import { APIError } from '@/lib/ai-extraction/errors';
-
-const NON_TERMINAL_STAGES = [
-  'pending',
-  'proposal',
-  'review',
-  'consensus',
-] as const;
+import type { RunSummaryResponse, ArticleRunRef } from '@/hooks/runs/types';
 
 export interface RunRef {
   id: string;
@@ -56,23 +48,10 @@ export const ExtractionValueService = {
     articleId: string,
     projectTemplateId: string | null,
   ): Promise<RunRef | null> {
-    let query = supabase
-      .from('extraction_runs')
-      .select('id, stage, status, template_id, created_at')
-      .eq('article_id', articleId)
-      .eq('kind', 'extraction')
-      .in('stage', [...NON_TERMINAL_STAGES])
-      .order('created_at', { ascending: false })
-      .limit(1);
-    if (projectTemplateId) {
-      query = query.eq('template_id', projectTemplateId);
-    }
-    const { data, error } = await query.maybeSingle();
-    if (error) {
-      throw new APIError(`Failed to load active run: ${error.message}`, undefined, {
-        error,
-      });
-    }
+    const qs = projectTemplateId ? `?template_id=${projectTemplateId}` : '';
+    const data = await apiClient<RunSummaryResponse | null>(
+      `/api/v1/articles/${articleId}/active-run${qs}`,
+    );
     if (!data) return null;
     return {
       id: data.id,
@@ -95,25 +74,10 @@ export const ExtractionValueService = {
     articleId: string,
     projectTemplateId: string | null,
   ): Promise<RunRef | null> {
-    let query = supabase
-      .from('extraction_runs')
-      .select('id, stage, status, template_id, created_at')
-      .eq('article_id', articleId)
-      .eq('kind', 'extraction')
-      .eq('stage', 'finalized')
-      .order('created_at', { ascending: false })
-      .limit(1);
-    if (projectTemplateId) {
-      query = query.eq('template_id', projectTemplateId);
-    }
-    const { data, error } = await query.maybeSingle();
-    if (error) {
-      throw new APIError(
-        `Failed to load latest finalized run: ${error.message}`,
-        undefined,
-        { error },
-      );
-    }
+    const qs = projectTemplateId ? `?template_id=${projectTemplateId}` : '';
+    const data = await apiClient<RunSummaryResponse | null>(
+      `/api/v1/articles/${articleId}/finalized-run${qs}`,
+    );
     if (!data) return null;
     return {
       id: data.id,
@@ -140,46 +104,24 @@ export const ExtractionValueService = {
   async findFormRunsByArticle(
     articleIds: string[],
     projectTemplateId: string,
+    projectId: string,
   ): Promise<Map<string, string>> {
     const result = new Map<string, string>();
     if (articleIds.length === 0) return result;
 
-    const { data, error } = await supabase
-      .from('extraction_runs')
-      .select('id, article_id, stage, created_at')
-      .in('article_id', articleIds)
-      .eq('kind', 'extraction')
-      .eq('template_id', projectTemplateId)
-      .order('created_at', { ascending: false });
-    if (error) {
-      throw new APIError(
-        `Failed to load form runs by article: ${error.message}`,
-        undefined,
-        { error },
-      );
-    }
+    const refs = await apiClient<ArticleRunRef[]>('/api/v1/articles/form-runs', {
+      method: 'POST',
+      body: {
+        article_ids: articleIds,
+        template_id: projectTemplateId,
+        project_id: projectId,
+      },
+    });
 
-    type RunRow = {
-      id: string;
-      article_id: string;
-      stage: string;
-      created_at: string;
-    };
-    const nonTerminal = new Set<string>(NON_TERMINAL_STAGES);
-    // Latest-first sort means: for each article, scan rows in order and
-    // prefer a non-terminal hit; fall back to the first finalized seen.
-    const finalizedFallback = new Map<string, string>();
-    for (const row of (data ?? []) as RunRow[]) {
-      if (result.has(row.article_id)) continue;
-      if (nonTerminal.has(row.stage)) {
-        result.set(row.article_id, row.id);
-      } else if (row.stage === 'finalized' && !finalizedFallback.has(row.article_id)) {
-        finalizedFallback.set(row.article_id, row.id);
+    for (const ref of refs ?? []) {
+      if (ref.run_id != null) {
+        result.set(ref.article_id, ref.run_id);
       }
-      // cancelled is excluded by design.
-    }
-    for (const [articleId, runId] of finalizedFallback) {
-      if (!result.has(articleId)) result.set(articleId, runId);
     }
     return result;
   },
@@ -247,3 +189,4 @@ export const ExtractionValueService = {
     });
   },
 };
+

--- a/frontend/test/QualityAssessmentFullScreen.test.tsx
+++ b/frontend/test/QualityAssessmentFullScreen.test.tsx
@@ -195,6 +195,9 @@ vi.mock("@/integrations/api", () => ({
         current_values: [],
       };
     }
+    if (url.includes("/suggestions")) {
+      return { suggestions: [], count: 0 };
+    }
     return {};
   }),
 }));

--- a/frontend/test/hooks-runs.test.tsx
+++ b/frontend/test/hooks-runs.test.tsx
@@ -20,6 +20,7 @@ import {
   useRun,
   type RunDetailResponse,
 } from "@/hooks/runs";
+import { useRunReviewers } from "@/hooks/runs/useRunReviewers";
 
 vi.mock("@/integrations/api", () => ({
   apiClient: vi.fn(),
@@ -262,6 +263,79 @@ describe("useAdvanceRun", () => {
       body: { target_stage: "review" },
     });
     expect(mutationResult?.stage).toBe("review");
+  });
+});
+
+describe("runsKeys factory — disabled and reviewers keys", () => {
+  it("runsKeys.disabled produces ['runs', 'disabled']", () => {
+    expect(runsKeys.disabled).toEqual(["runs", "disabled"]);
+  });
+
+  it("runsKeys.noRunReviewers produces ['runs', 'no-run', 'reviewers']", () => {
+    expect(runsKeys.noRunReviewers).toEqual(["runs", "no-run", "reviewers"]);
+  });
+
+  it("runsKeys.reviewers(runId) produces ['runs', runId, 'reviewers']", () => {
+    expect(runsKeys.reviewers("run-42")).toEqual(["runs", "run-42", "reviewers"]);
+  });
+});
+
+describe("useRun disabled key", () => {
+  it("uses runsKeys.disabled as queryKey when runId is null", async () => {
+    const { wrapper, queryClient } = createWrapper();
+    renderHook(() => useRun(null), { wrapper });
+
+    // The cache entry should live under runsKeys.disabled, not some inline literal
+    const state = queryClient.getQueryState(runsKeys.disabled);
+    // Entry may be undefined (never fetched) but the key must exist if we seeded it
+    // The important check: no request was made
+    expect(apiClientMock).not.toHaveBeenCalled();
+    // And no entry under a rogue inline key
+    const rogueState = queryClient.getQueryState(["runs", "disabled"]);
+    // Both point to the same structural key — confirm runsKeys.disabled matches
+    expect(Array.from(runsKeys.disabled)).toEqual(["runs", "disabled"]);
+    void state;
+    void rogueState;
+  });
+});
+
+describe("useRunReviewers", () => {
+  it("fetches reviewers and returns derived maps", async () => {
+    apiClientMock.mockResolvedValueOnce({
+      reviewers: [
+        { id: "user-1", full_name: "Alice", avatar_url: "https://example.com/a.png" },
+        { id: "user-2", full_name: null, avatar_url: null },
+      ],
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRunReviewers("run-rev-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(apiClientMock).toHaveBeenCalledWith("/api/v1/runs/run-rev-1/reviewers");
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.labelById["user-1"]).toBe("Alice");
+    expect(result.current.labelById["user-2"]).toMatch(/^Reviewer user-2/);
+    expect(result.current.avatarById["user-1"]).toBe("https://example.com/a.png");
+    expect(result.current.avatarById["user-2"]).toBeNull();
+  });
+
+  it("uses runsKeys.reviewers(runId) as the queryKey — prefix-matches detail key", () => {
+    const reviewersKey = runsKeys.reviewers("run-rev-1");
+    const detailKey = runsKeys.detail("run-rev-1");
+    // reviewers key starts with the same prefix as detail key
+    expect(reviewersKey.slice(0, 2)).toEqual(detailKey);
+    expect(reviewersKey).toEqual(["runs", "run-rev-1", "reviewers"]);
+  });
+
+  it("does not fetch when runId is null and uses noRunReviewers key", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRunReviewers(null), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(apiClientMock).not.toHaveBeenCalled();
+    expect(runsKeys.noRunReviewers).toEqual(["runs", "no-run", "reviewers"]);
   });
 });
 

--- a/frontend/test/hooks/useAISuggestions.test.tsx
+++ b/frontend/test/hooks/useAISuggestions.test.tsx
@@ -473,7 +473,7 @@ describe('useAISuggestions — getSuggestionsHistory', () => {
     await act(async () => {
       history = await result.current.getSuggestionsHistory('inst-1', 'f-1');
     });
-    expect(AISuggestionService.getHistory).toHaveBeenCalledWith('inst-1', 'f-1', 10);
+    expect(AISuggestionService.getHistory).toHaveBeenCalledWith('art-1', 'inst-1', 'f-1', 10);
     expect(history).toHaveLength(1);
   });
 });

--- a/frontend/test/hooks/useArticleCitations.test.tsx
+++ b/frontend/test/hooks/useArticleCitations.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for useArticleCitations hook.
+ *
+ * Covers:
+ *  - Queries with the correct key (articleKeys.citations)
+ *  - Returns items when service succeeds
+ *  - Disabled when articleId is falsy
+ *  - Surfaces error via useQuery error state when service returns ok:false
+ */
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react';
+import type {ReactElement, ReactNode} from 'react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/services/citationsService', () => ({
+  fetchArticleCitations: vi.fn(),
+}));
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+import {fetchArticleCitations} from '@/services/citationsService';
+import {useArticleCitations} from '@/hooks/articles/useArticleCitations';
+import {articleKeys} from '@/lib/query-keys';
+import type {ArticleCitationItem} from '@/services/citationsService';
+
+const fetchMock = fetchArticleCitations as unknown as ReturnType<typeof vi.fn>;
+
+function createWrapper(): {
+  wrapper: (props: {children: ReactNode}) => ReactElement;
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {retry: false},
+    },
+  });
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return {wrapper, queryClient};
+}
+
+function makeItem(id: string): ArticleCitationItem {
+  return {
+    id,
+    verified: false,
+    anchorKind: 'text',
+    anchor: null,
+    metadata: {pageNumber: 1, textContent: 'Some text', source: 'ai'},
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useArticleCitations', () => {
+  it('returns items when service resolves ok:true', async () => {
+    const items = [makeItem('c-1'), makeItem('c-2')];
+    fetchMock.mockResolvedValueOnce({ok: true, data: items});
+
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(() => useArticleCitations('art-abc'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(items);
+    expect(fetchMock).toHaveBeenCalledWith('art-abc');
+  });
+
+  it('uses the correct query key (articleKeys.citations)', async () => {
+    fetchMock.mockResolvedValueOnce({ok: true, data: []});
+
+    const {wrapper, queryClient} = createWrapper();
+    const {result} = renderHook(() => useArticleCitations('art-xyz'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cached = queryClient.getQueryData(articleKeys.citations('art-xyz'));
+    expect(cached).toEqual([]);
+  });
+
+  it('is disabled when articleId is null', async () => {
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useArticleCitations(null),
+      {wrapper},
+    );
+
+    // Give async ticks a chance
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('is disabled when articleId is empty string', async () => {
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(
+      () => useArticleCitations(''),
+      {wrapper},
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('surfaces error when service returns ok:false', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      error: new Error('API failure'),
+    });
+
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(() => useArticleCitations('art-err'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe('API failure');
+  });
+});

--- a/frontend/test/hooks/useExtractionData.test.tsx
+++ b/frontend/test/hooks/useExtractionData.test.tsx
@@ -5,12 +5,11 @@
  *  - The active extraction template is picked DESC by ``created_at`` so
  *    Configuration and Extraction views converge on the same template
  *    (BUG #1 — split picker bug).
- *  - Entity_types are loaded scoped to the chosen template.
- *  - ``mergeInstancesById`` preserves stable references for unchanged
- *    rows so the form does not remount + scroll-reset on every refresh.
+ *  - The hook holds ZERO entity_type / instance reads — those now come
+ *    from the server RunView via ``runViewAdapters`` (consolidation).
  */
 
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/integrations/supabase/client', () => {
@@ -26,18 +25,7 @@ vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
 }));
 
-vi.mock('@/services/extractionInstanceService', () => ({
-  extractionInstanceService: {
-    // ``initializeArticleInstances`` was removed in 2026-05-19. The
-    // backend's ``hitl_session_service._ensure_instances`` is the sole
-    // creator of singleton instances on session open; the hook only
-    // reads via ``getInstances``.
-    getInstances: vi.fn(),
-  },
-}));
-
 import { supabase } from '@/integrations/supabase/client';
-import { extractionInstanceService } from '@/services/extractionInstanceService';
 import { useExtractionData } from '@/hooks/extraction/useExtractionData';
 
 interface Chain {
@@ -86,35 +74,30 @@ function primeSupabaseQueries(opts: {
   article?: any;
   project?: any;
   template?: any;
-  entityTypes?: any[];
   articles?: any[];
   templateChain?: Chain & Record<string, any>;
 }) {
   const articleChain = makeChain(opts.article ?? { id: ARTICLE_ID, project_id: PROJECT_ID });
   const projectChain = makeChain(opts.project ?? { id: PROJECT_ID, name: 'P1' });
   const templateChain = opts.templateChain ?? makeChain(opts.template ?? null);
-  const entityTypesChain = makeChain(opts.entityTypes ?? []);
   const articlesChain = makeChain(opts.articles ?? []);
 
-  // Call order mirrors loadData's two parallel phases:
-  //   Phase 1 (Promise.all): articles(by id), projects, templates, articles(list)
-  //   Phase 2 (Promise.all): extraction_entity_types
+  // Call order mirrors loadExtractionPhase1's parallel reads:
+  //   articles(by id), projects, templates, articles(list).
+  // No entity_types / instances reads fire from this hook anymore.
   (supabase.from as any)
     .mockReturnValueOnce(articleChain)
     .mockReturnValueOnce(projectChain)
     .mockReturnValueOnce(templateChain)
-    .mockReturnValueOnce(articlesChain)
-    .mockReturnValueOnce(entityTypesChain);
+    .mockReturnValueOnce(articlesChain);
 
-  return { articleChain, projectChain, templateChain, entityTypesChain, articlesChain };
+  return { articleChain, projectChain, templateChain, articlesChain };
 }
 
 describe('useExtractionData → active template picker', () => {
   it('orders project_extraction_templates DESC by created_at (newest active wins)', async () => {
     const tpl = { id: 'tpl-2', kind: 'extraction', is_active: true };
     const { templateChain } = primeSupabaseQueries({ template: tpl });
-
-    (extractionInstanceService.getInstances as any).mockResolvedValue([]);
 
     const { result } = renderHook(() =>
       useExtractionData({ projectId: PROJECT_ID, articleId: ARTICLE_ID }),
@@ -127,7 +110,6 @@ describe('useExtractionData → active template picker', () => {
   it('filters templates by project_id, kind=extraction, is_active=true', async () => {
     const tpl = { id: 'tpl-z', kind: 'extraction', is_active: true };
     const { templateChain } = primeSupabaseQueries({ template: tpl });
-    (extractionInstanceService.getInstances as any).mockResolvedValue([]);
 
     const { result } = renderHook(() =>
       useExtractionData({ projectId: PROJECT_ID, articleId: ARTICLE_ID }),
@@ -166,164 +148,25 @@ describe('useExtractionData → active template picker', () => {
   });
 });
 
-describe('useExtractionData → instance loading', () => {
-  it('reads existing instances on initial load (never writes — backend owns creation)', async () => {
+describe('useExtractionData → no direct entity/instance reads', () => {
+  it('does not expose entityTypes / instances / refreshInstances anymore', async () => {
     const tpl = { id: 'tpl-1', kind: 'extraction', is_active: true };
-    const entityTypes = [
-      { id: 'et-1', label: 'Section A', cardinality: 'one', fields: [] },
-    ];
-    primeSupabaseQueries({ template: tpl, entityTypes });
-
-    const seeded = [
-      { id: 'inst-1', entity_type_id: 'et-1', article_id: ARTICLE_ID, label: 'A', metadata: {} },
-    ];
-    (extractionInstanceService.getInstances as any).mockResolvedValue(seeded);
+    primeSupabaseQueries({ template: tpl });
 
     const { result } = renderHook(() =>
       useExtractionData({ projectId: PROJECT_ID, articleId: ARTICLE_ID }),
     );
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // Regression guard: ``initializeArticleInstances`` was removed; the
-    // backend's hitl_session_service._ensure_instances is the sole writer.
-    expect(
-      (extractionInstanceService as unknown as Record<string, unknown>).initializeArticleInstances,
-    ).toBeUndefined();
-    expect(extractionInstanceService.getInstances).toHaveBeenCalledWith({
-      articleId: ARTICLE_ID,
-      templateId: 'tpl-1',
-    });
-    expect(result.current.instances).toHaveLength(1);
-  });
-
-  it('refreshInstances calls extractionInstanceService.getInstances with the active template id', async () => {
-    const tpl = { id: 'tpl-X', kind: 'extraction', is_active: true };
-    primeSupabaseQueries({ template: tpl });
-    (extractionInstanceService.getInstances as any).mockResolvedValue([]);
-    (extractionInstanceService.getInstances as any).mockResolvedValue([]);
-
-    const { result } = renderHook(() =>
-      useExtractionData({ projectId: PROJECT_ID, articleId: ARTICLE_ID }),
-    );
-    await waitFor(() => expect(result.current.loading).toBe(false));
-
-    await act(async () => {
-      await result.current.refreshInstances();
-    });
-
-    expect(extractionInstanceService.getInstances).toHaveBeenCalledWith({
-      articleId: ARTICLE_ID,
-      templateId: 'tpl-X',
-    });
-  });
-});
-
-describe('useExtractionData → mergeInstancesById stable references', () => {
-  // The merge logic lives inline in the hook; we exercise it indirectly via
-  // refreshInstances + comparing reference identity of unchanged entries.
-  it('returns the same array reference when no instance changed', async () => {
-    const tpl = { id: 'tpl-merge', kind: 'extraction', is_active: true };
-    primeSupabaseQueries({ template: tpl });
-
-    const initial = [
-      {
-        id: 'inst-1',
-        entity_type_id: 'et-1',
-        article_id: ARTICLE_ID,
-        label: 'A',
-        sort_order: 0,
-        status: 'pending',
-        parent_instance_id: null,
-        metadata: {},
-      },
-    ];
-    // Initial load + first refresh both go through getInstances now;
-    // the test queues two sequential return values.
-    (extractionInstanceService.getInstances as any).mockResolvedValueOnce(initial);
-
-    const { result } = renderHook(() =>
-      useExtractionData({ projectId: PROJECT_ID, articleId: ARTICLE_ID }),
-    );
-    await waitFor(() => expect(result.current.instances).toHaveLength(1));
-    const beforeRef = result.current.instances;
-
-    (extractionInstanceService.getInstances as any).mockResolvedValueOnce(
-      // Same shape — merge must detect "no change" and reuse the array.
-      initial.map((i) => ({ ...i })),
-    );
-    await act(async () => {
-      await result.current.refreshInstances();
-    });
-    expect(result.current.instances).toBe(beforeRef);
-  });
-
-  it('produces a new array when an instance label changes', async () => {
-    const tpl = { id: 'tpl-merge2', kind: 'extraction', is_active: true };
-    primeSupabaseQueries({ template: tpl });
-
-    const initial = [
-      {
-        id: 'inst-1',
-        entity_type_id: 'et-1',
-        article_id: ARTICLE_ID,
-        label: 'A',
-        sort_order: 0,
-        status: 'pending',
-        parent_instance_id: null,
-        metadata: {},
-      },
-    ];
-    // Initial load + first refresh both go through getInstances now;
-    // the test queues two sequential return values.
-    (extractionInstanceService.getInstances as any).mockResolvedValueOnce(initial);
-
-    const { result } = renderHook(() =>
-      useExtractionData({ projectId: PROJECT_ID, articleId: ARTICLE_ID }),
-    );
-    await waitFor(() => expect(result.current.instances).toHaveLength(1));
-    const beforeRef = result.current.instances;
-
-    (extractionInstanceService.getInstances as any).mockResolvedValueOnce([
-      { ...initial[0], label: 'A renamed' },
-    ]);
-    await act(async () => {
-      await result.current.refreshInstances();
-    });
-    expect(result.current.instances).not.toBe(beforeRef);
-    expect(result.current.instances[0].label).toBe('A renamed');
-  });
-
-  it('produces a new array when an instance is removed upstream', async () => {
-    const tpl = { id: 'tpl-merge3', kind: 'extraction', is_active: true };
-    primeSupabaseQueries({ template: tpl });
-
-    const initial = [
-      {
-        id: 'inst-1',
-        entity_type_id: 'et-1',
-        article_id: ARTICLE_ID,
-        label: 'A',
-        sort_order: 0,
-        status: 'pending',
-        parent_instance_id: null,
-        metadata: {},
-      },
-    ];
-    // Initial load + first refresh both go through getInstances now;
-    // the test queues two sequential return values.
-    (extractionInstanceService.getInstances as any).mockResolvedValueOnce(initial);
-
-    const { result } = renderHook(() =>
-      useExtractionData({ projectId: PROJECT_ID, articleId: ARTICLE_ID }),
-    );
-    await waitFor(() => expect(result.current.instances).toHaveLength(1));
-    const beforeRef = result.current.instances;
-
-    (extractionInstanceService.getInstances as any).mockResolvedValueOnce([]);
-    await act(async () => {
-      await result.current.refreshInstances();
-    });
-    expect(result.current.instances).not.toBe(beforeRef);
-    expect(result.current.instances).toHaveLength(0);
+    const api = result.current as unknown as Record<string, unknown>;
+    expect(api.entityTypes).toBeUndefined();
+    expect(api.instances).toBeUndefined();
+    expect(api.refreshInstances).toBeUndefined();
+    // The bootstrap fields it still owns:
+    expect(result.current).toHaveProperty('article');
+    expect(result.current).toHaveProperty('project');
+    expect(result.current).toHaveProperty('template');
+    expect(result.current).toHaveProperty('articles');
+    expect(typeof result.current.refresh).toBe('function');
   });
 });

--- a/frontend/test/hooks/useExtractionSession.test.tsx
+++ b/frontend/test/hooks/useExtractionSession.test.tsx
@@ -70,6 +70,7 @@ const RUN_VIEW_FIXTURE: RunViewResponse = {
   published_states: [],
   entity_types: [],
   current_values: [],
+  instances: [],
 };
 
 beforeEach(() => {

--- a/frontend/test/hooks/useModelManagement.test.tsx
+++ b/frontend/test/hooks/useModelManagement.test.tsx
@@ -14,7 +14,7 @@
  *    surface failure to the user.
  */
 
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/contexts/AuthContext', () => ({
@@ -257,6 +257,48 @@ describe('useModelManagement → getModelProgress (RPC contract)', () => {
     });
 
     expect(progress).toEqual({ completed: 0, total: 0, percentage: 0 });
+  });
+});
+
+describe('useModelManagement → modelInstances prop (view-sourced)', () => {
+  // When the run-open page supplies the model-container instances derived
+  // from the server RunView, the hook must use them directly and NOT issue
+  // the ``loadModelInstances`` Supabase read. The progress RPC loop is
+  // still exercised per model.
+
+  it('derives models from the prop and skips loadModelInstances entirely', async () => {
+    // No mockLoadModelsToEmpty() — assert it is never called.
+    mockFetchModelProgress.mockResolvedValue({ completed: 2, total: 4, percentage: 50 });
+
+    const { result } = renderHook(() =>
+      useModelManagement({
+        ...baseProps,
+        modelInstances: [
+          { id: 'm-1', label: 'LogReg', sort_order: 0, created_at: '2026-01-01T00:00:00Z' },
+          { id: 'm-2', label: 'XGBoost', sort_order: 1, created_at: '2026-01-02T00:00:00Z' },
+        ],
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockLoadModelInstances).not.toHaveBeenCalled();
+    expect(result.current.models.map((m) => m.modelName)).toEqual(['LogReg', 'XGBoost']);
+    // Progress RPC still runs per supplied model.
+    expect(mockFetchModelProgress).toHaveBeenCalledWith('a-1', 'm-1');
+    expect(mockFetchModelProgress).toHaveBeenCalledWith('a-1', 'm-2');
+  });
+
+  it('renders zero models from an empty prop without touching the service', async () => {
+    const { result } = renderHook(() =>
+      useModelManagement({ ...baseProps, modelInstances: [] }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockLoadModelInstances).not.toHaveBeenCalled();
+    expect(result.current.models).toHaveLength(0);
+    expect(result.current.activeModelId).toBeNull();
   });
 });
 

--- a/frontend/test/lib/runViewAdapters.test.ts
+++ b/frontend/test/lib/runViewAdapters.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for runViewAdapters — pure functions that map a RunViewResponse
+ * onto the extraction form's types (ExtractionEntityTypeWithFields[] and
+ * ExtractionInstance[]).
+ *
+ * Step 1 (RED): module is absent — these tests should fail at import.
+ * Step 2 (GREEN): implement the adapters.
+ */
+import {describe, expect, it} from 'vitest';
+
+import type {RunViewResponse} from '@/hooks/runs/types';
+import {entityTypesFromRunView, instancesFromRunView} from '@/lib/extraction/runViewAdapters';
+
+// ---------------------------------------------------------------------------
+// Minimal fixture factory
+// ---------------------------------------------------------------------------
+
+function makeRunViewResponse(
+  overrides: Partial<RunViewResponse> = {},
+): RunViewResponse {
+  const run = {
+    id: 'run-1',
+    project_id: 'proj-1',
+    article_id: 'art-1',
+    template_id: 'tmpl-1',
+    kind: 'extraction',
+    version_id: 'ver-1',
+    stage: 'review',
+    status: 'in_progress',
+    hitl_config_snapshot: {},
+    parameters: {},
+    results: {},
+    created_at: '2024-01-01T00:00:00Z',
+    created_by: 'user-1',
+  };
+
+  const entityTypes = [
+    {
+      id: 'et-1',
+      name: 'study',
+      label: 'Study',
+      description: 'Top-level study entity',
+      parent_entity_type_id: null,
+      cardinality: 'one' as const,
+      role: 'study_section' as const,
+      sort_order: 0,
+      is_required: true,
+      fields: [
+        {
+          id: 'f-1',
+          name: 'title',
+          label: 'Title',
+          description: 'Article title',
+          field_type: 'text' as const,
+          is_required: true,
+          validation_schema: null,
+          allowed_values: null,
+          unit: null,
+          allowed_units: null,
+          sort_order: 0,
+          llm_description: null,
+          allow_other: false,
+          other_label: null,
+          other_placeholder: null,
+        },
+      ],
+    },
+  ];
+
+  const instances = [
+    {
+      id: 'inst-1',
+      entity_type_id: 'et-1',
+      parent_instance_id: null,
+      label: 'Main Study',
+      sort_order: 0,
+      status: 'pending' as const,
+      metadata: {},
+      project_id: 'proj-1',
+      article_id: null, // deliberately null to test fallback
+      template_id: 'tmpl-1',
+      created_by: 'user-1',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+  ];
+
+  return {
+    run,
+    proposals: [],
+    decisions: [],
+    consensus_decisions: [],
+    published_states: [],
+    entity_types: entityTypes,
+    current_values: [],
+    instances,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// entityTypesFromRunView
+// ---------------------------------------------------------------------------
+
+describe('entityTypesFromRunView', () => {
+  it('injects template_id from run onto each entity type', () => {
+    const view = makeRunViewResponse();
+    const [et] = entityTypesFromRunView(view);
+    expect(et.template_id).toBe('tmpl-1');
+  });
+
+  it('maps core entity type fields through correctly', () => {
+    const view = makeRunViewResponse();
+    const [et] = entityTypesFromRunView(view);
+    expect(et.id).toBe('et-1');
+    expect(et.name).toBe('study');
+    expect(et.label).toBe('Study');
+    expect(et.description).toBe('Top-level study entity');
+    expect(et.parent_entity_type_id).toBeNull();
+    expect(et.is_required).toBe(true);
+    expect(et.sort_order).toBe(0);
+  });
+
+  it('casts cardinality and role through', () => {
+    const view = makeRunViewResponse();
+    const [et] = entityTypesFromRunView(view);
+    expect(et.cardinality).toBe('one');
+    expect(et.role).toBe('study_section');
+  });
+
+  it('injects entity_type_id onto each field', () => {
+    const view = makeRunViewResponse();
+    const [et] = entityTypesFromRunView(view);
+    expect(et.fields).toHaveLength(1);
+    expect(et.fields[0].entity_type_id).toBe('et-1');
+  });
+
+  it('maps field properties correctly', () => {
+    const view = makeRunViewResponse();
+    const [et] = entityTypesFromRunView(view);
+    const f = et.fields[0];
+    expect(f.id).toBe('f-1');
+    expect(f.name).toBe('title');
+    expect(f.label).toBe('Title');
+    expect(f.field_type).toBe('text');
+    expect(f.is_required).toBe(true);
+    expect(f.sort_order).toBe(0);
+    expect(f.allow_other).toBe(false);
+    expect(f.other_label).toBeNull();
+    expect(f.other_placeholder).toBeNull();
+  });
+
+  it('sets created_at placeholder from run.created_at on entity type', () => {
+    const view = makeRunViewResponse();
+    const [et] = entityTypesFromRunView(view);
+    expect(et.created_at).toBe('2024-01-01T00:00:00Z');
+  });
+
+  it('sets created_at placeholder from run.created_at on fields', () => {
+    const view = makeRunViewResponse();
+    const [et] = entityTypesFromRunView(view);
+    expect(et.fields[0].created_at).toBe('2024-01-01T00:00:00Z');
+  });
+
+  it('returns empty array when entity_types is empty', () => {
+    const view = makeRunViewResponse({entity_types: []});
+    expect(entityTypesFromRunView(view)).toEqual([]);
+  });
+
+  it('handles multiple entity types', () => {
+    const view = makeRunViewResponse();
+    view.entity_types = [
+      ...view.entity_types,
+      {
+        id: 'et-2',
+        name: 'models',
+        label: 'Models',
+        description: null,
+        parent_entity_type_id: 'et-1',
+        cardinality: 'many',
+        role: 'model_container',
+        sort_order: 1,
+        is_required: false,
+        fields: [],
+      },
+    ];
+    const ets = entityTypesFromRunView(view);
+    expect(ets).toHaveLength(2);
+    expect(ets[1].template_id).toBe('tmpl-1');
+    expect(ets[1].cardinality).toBe('many');
+    expect(ets[1].role).toBe('model_container');
+    expect(ets[1].fields).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// instancesFromRunView
+// ---------------------------------------------------------------------------
+
+describe('instancesFromRunView', () => {
+  it('falls back to run.article_id when instance article_id is null', () => {
+    const view = makeRunViewResponse();
+    // fixture has article_id: null on the instance
+    const [inst] = instancesFromRunView(view);
+    expect(inst.article_id).toBe('art-1');
+  });
+
+  it('uses instance article_id when it is not null', () => {
+    const view = makeRunViewResponse();
+    view.instances[0] = {...view.instances[0], article_id: 'art-override'};
+    const [inst] = instancesFromRunView(view);
+    expect(inst.article_id).toBe('art-override');
+  });
+
+  it('maps label through (string)', () => {
+    const view = makeRunViewResponse();
+    const [inst] = instancesFromRunView(view);
+    expect(inst.label).toBe('Main Study');
+  });
+
+  it('uses empty string when label is not provided (null-like)', () => {
+    // RunViewInstanceResponse.label is string (not nullable in interface), but test the default
+    const view = makeRunViewResponse();
+    // Force a falsy label to confirm the ?? '' guard
+    (view.instances[0] as unknown as Record<string, unknown>).label = null;
+    const [inst] = instancesFromRunView(view);
+    expect(inst.label).toBe('');
+  });
+
+  it('passes status through as typed value', () => {
+    const view = makeRunViewResponse();
+    const [inst] = instancesFromRunView(view);
+    expect(inst.status).toBe('pending');
+  });
+
+  it('maps all remaining scalar fields 1:1', () => {
+    const view = makeRunViewResponse();
+    const [inst] = instancesFromRunView(view);
+    expect(inst.id).toBe('inst-1');
+    expect(inst.entity_type_id).toBe('et-1');
+    expect(inst.parent_instance_id).toBeNull();
+    expect(inst.sort_order).toBe(0);
+    expect(inst.project_id).toBe('proj-1');
+    expect(inst.template_id).toBe('tmpl-1');
+    expect(inst.created_by).toBe('user-1');
+    expect(inst.created_at).toBe('2024-01-01T00:00:00Z');
+    expect(inst.updated_at).toBe('2024-01-01T00:00:00Z');
+  });
+
+  it('returns empty array when instances is undefined', () => {
+    const view = makeRunViewResponse();
+    (view as unknown as Record<string, unknown>).instances = undefined;
+    expect(instancesFromRunView(view)).toEqual([]);
+  });
+
+  it('returns empty array when instances is empty', () => {
+    const view = makeRunViewResponse({instances: []});
+    expect(instancesFromRunView(view)).toEqual([]);
+  });
+});

--- a/frontend/test/services/aiSuggestionService.test.ts
+++ b/frontend/test/services/aiSuggestionService.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/integrations/supabase/client', () => {
-  const mock = { from: vi.fn(), auth: { getUser: vi.fn() } };
-  return { supabase: mock };
-});
+vi.mock('@/integrations/api', () => ({
+  apiClient: vi.fn(),
+}));
 
 vi.mock('@/services/extractionValueService', () => ({
   ExtractionValueService: {
@@ -15,68 +14,36 @@ vi.mock('@/services/extractionValueService', () => ({
 
 import { AISuggestionService } from '@/services/aiSuggestionService';
 import { ExtractionValueService } from '@/services/extractionValueService';
-import { supabase } from '@/integrations/supabase/client';
+import { apiClient } from '@/integrations/api';
 
-interface ChainCalls {
-  selects: string[];
-  eqs: Array<[string, unknown]>;
-  ins: Array<[string, unknown[]]>;
-  nots: Array<[string, string, unknown]>;
-  orders: Array<[string, { ascending?: boolean } | undefined]>;
-  limits: number[];
-}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-type AnyChain = Record<string, unknown> & {
-  data: unknown;
-  error: { message: string } | null;
-  __calls: ChainCalls;
-};
-
-function chain(payload: { data: unknown; error?: { message: string } | null }): AnyChain {
-  const result = { data: payload.data, error: payload.error ?? null };
-  const calls: ChainCalls = {
-    selects: [],
-    eqs: [],
-    ins: [],
-    nots: [],
-    orders: [],
-    limits: [],
+/** Minimal server AISuggestionItem fixture */
+function makeItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'p-1',
+    run_id: 'run-A',
+    instance_id: 'inst-1',
+    field_id: 'f-1',
+    proposed_value: { value: 'X' },
+    confidence_score: 0.8,
+    rationale: 'because',
+    created_at: '2026-04-28T10:00:00Z',
+    status: 'pending',
+    evidence: null,
+    ...overrides,
   };
-  const c: AnyChain = {
-    ...result,
-    __calls: calls,
-    select: vi.fn((cols?: string) => {
-      if (cols) calls.selects.push(cols);
-      return c;
-    }),
-    eq: vi.fn((col: string, val: unknown) => {
-      calls.eqs.push([col, val]);
-      return c;
-    }),
-    in: vi.fn((col: string, vals: unknown[]) => {
-      calls.ins.push([col, vals]);
-      return c;
-    }),
-    not: vi.fn((col: string, op: string, val: unknown) => {
-      calls.nots.push([col, op, val]);
-      return c;
-    }),
-    order: vi.fn((col: string, opts?: { ascending?: boolean }) => {
-      calls.orders.push([col, opts]);
-      return c;
-    }),
-    limit: vi.fn((n: number) => {
-      calls.limits.push(n);
-      return c;
-    }),
-    then: (cb: (r: typeof result) => unknown) => Promise.resolve(cb(result)),
-  };
-  return c;
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
+
+// ---------------------------------------------------------------------------
+// acceptSuggestion / rejectSuggestion — delegate to ExtractionValueService
+// ---------------------------------------------------------------------------
 
 describe('AISuggestionService.acceptSuggestion', () => {
   it('uses the provided runId without calling findActiveRun', async () => {
@@ -101,7 +68,7 @@ describe('AISuggestionService.acceptSuggestion', () => {
   });
 
   it('falls back to findActiveRun when no runId is supplied', async () => {
-    (ExtractionValueService.findActiveRun as any).mockResolvedValueOnce({
+    (ExtractionValueService.findActiveRun as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       id: 'run-fallback',
       stage: 'review',
       status: 'running',
@@ -117,391 +84,13 @@ describe('AISuggestionService.acceptSuggestion', () => {
       confidence: 0.9,
       reviewerId: 'user-1',
     });
-    expect(ExtractionValueService.findActiveRun).toHaveBeenCalledWith(
-      'art-1',
-      null,
-    );
+    expect(ExtractionValueService.findActiveRun).toHaveBeenCalledWith('art-1', null);
     expect(ExtractionValueService.acceptProposal).toHaveBeenCalledWith(
       'run-fallback',
       'inst-1',
       'field-1',
       'proposal-1',
     );
-  });
-});
-
-describe('AISuggestionService.loadSuggestions', () => {
-  it('short-circuits to empty when instanceIds is empty (no Supabase call)', async () => {
-    const result = await AISuggestionService.loadSuggestions('art-1', []);
-    expect(result).toEqual({ suggestions: {}, count: 0 });
-    expect(supabase.from).not.toHaveBeenCalled();
-  });
-
-  it("filters proposals by source='ai', orders by created_at desc, scopes by instance_id", async () => {
-    const proposalsChain = chain({ data: [] });
-    (supabase.from as any).mockReturnValueOnce(proposalsChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({ data: { user: null } });
-
-    await AISuggestionService.loadSuggestions('art-1', ['inst-1', 'inst-2']);
-
-    expect(proposalsChain.__calls.eqs).toContainEqual(['source', 'ai']);
-    expect(proposalsChain.__calls.ins).toContainEqual([
-      'instance_id',
-      ['inst-1', 'inst-2'],
-    ]);
-    expect(proposalsChain.__calls.orders).toContainEqual([
-      'created_at',
-      { ascending: false },
-    ]);
-  });
-
-  it('scopes proposals AND reviewer_states by run_id when one is provided', async () => {
-    const proposalsChain = chain({
-      data: [
-        {
-          id: 'p-1',
-          run_id: 'run-A',
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          source: 'ai',
-          proposed_value: { value: 'X' },
-          confidence_score: 0.8,
-          rationale: null,
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      ],
-    });
-    const evidenceChain = chain({ data: [] });
-    const statesChain = chain({ data: [] });
-    (supabase.from as any)
-      .mockReturnValueOnce(proposalsChain)
-      .mockReturnValueOnce(evidenceChain)
-      .mockReturnValueOnce(statesChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({
-      data: { user: { id: 'user-1' } },
-    });
-
-    await AISuggestionService.loadSuggestions('art-1', ['inst-1'], 'run-A');
-
-    expect(proposalsChain.__calls.eqs).toContainEqual(['run_id', 'run-A']);
-    expect(statesChain.__calls.eqs).toContainEqual(['run_id', 'run-A']);
-    expect(statesChain.__calls.eqs).toContainEqual(['reviewer_id', 'user-1']);
-  });
-
-  it('does NOT scope by run_id when none is provided', async () => {
-    const proposalsChain = chain({ data: [] });
-    (supabase.from as any).mockReturnValueOnce(proposalsChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({
-      data: { user: null },
-    });
-
-    await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
-
-    expect(
-      proposalsChain.__calls.eqs.find(([col]) => col === 'run_id'),
-    ).toBeUndefined();
-  });
-
-  it('joins evidence onto proposals via proposal_record_id', async () => {
-    const proposalsChain = chain({
-      data: [
-        {
-          id: 'p-1',
-          run_id: 'run-A',
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          source: 'ai',
-          proposed_value: { value: 'Y' },
-          confidence_score: 0.9,
-          rationale: 'because',
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      ],
-    });
-    const evidenceChain = chain({
-      data: [
-        {
-          proposal_record_id: 'p-1',
-          text_content: 'verbatim quote',
-          page_number: 3,
-        },
-      ],
-    });
-    (supabase.from as any)
-      .mockReturnValueOnce(proposalsChain)
-      .mockReturnValueOnce(evidenceChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({
-      data: { user: null },
-    });
-
-    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
-    expect(result.count).toBe(1);
-    const sug = result.suggestions['inst-1_f-1'];
-    expect(sug).toBeDefined();
-    expect(sug.evidence).toEqual({ text: 'verbatim quote', pageNumber: 3 });
-    expect(sug.value).toBe('Y');
-    expect(sug.runId).toBe('run-A');
-    // Status defaults to pending when there's no reviewer_state.
-    expect(sug.status).toBe('pending');
-  });
-
-  it("derives status='accepted' from a non-reject reviewer_state", async () => {
-    const proposalsChain = chain({
-      data: [
-        {
-          id: 'p-1',
-          run_id: 'run-A',
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          source: 'ai',
-          proposed_value: { value: 'V' },
-          confidence_score: 0.8,
-          rationale: null,
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      ],
-    });
-    const evidenceChain = chain({ data: [] });
-    const statesChain = chain({
-      data: [
-        {
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          reviewer_decision: { decision: 'accept_proposal' },
-        },
-      ],
-    });
-    (supabase.from as any)
-      .mockReturnValueOnce(proposalsChain)
-      .mockReturnValueOnce(evidenceChain)
-      .mockReturnValueOnce(statesChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({
-      data: { user: { id: 'user-1' } },
-    });
-
-    const result = await AISuggestionService.loadSuggestions(
-      'art-1',
-      ['inst-1'],
-    );
-    expect(result.suggestions['inst-1_f-1'].status).toBe('accepted');
-  });
-
-  it("derives status='rejected' from a reject reviewer_state", async () => {
-    const proposalsChain = chain({
-      data: [
-        {
-          id: 'p-1',
-          run_id: 'run-A',
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          source: 'ai',
-          proposed_value: { value: 'V' },
-          confidence_score: 0.8,
-          rationale: null,
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      ],
-    });
-    const evidenceChain = chain({ data: [] });
-    const statesChain = chain({
-      data: [
-        {
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          reviewer_decision: { decision: 'reject' },
-        },
-      ],
-    });
-    (supabase.from as any)
-      .mockReturnValueOnce(proposalsChain)
-      .mockReturnValueOnce(evidenceChain)
-      .mockReturnValueOnce(statesChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({
-      data: { user: { id: 'user-1' } },
-    });
-
-    const result = await AISuggestionService.loadSuggestions(
-      'art-1',
-      ['inst-1'],
-    );
-    expect(result.suggestions['inst-1_f-1'].status).toBe('rejected');
-  });
-
-  it('keeps only the newest proposal per (instance, field) — already ordered desc', async () => {
-    const proposalsChain = chain({
-      data: [
-        {
-          id: 'p-newest',
-          run_id: 'run-A',
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          source: 'ai',
-          proposed_value: { value: 'newer' },
-          confidence_score: 0.9,
-          rationale: null,
-          created_at: '2026-04-28T11:00:00Z',
-        },
-        {
-          id: 'p-older',
-          run_id: 'run-A',
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          source: 'ai',
-          proposed_value: { value: 'older' },
-          confidence_score: 0.5,
-          rationale: null,
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      ],
-    });
-    const evidenceChain = chain({ data: [] });
-    (supabase.from as any)
-      .mockReturnValueOnce(proposalsChain)
-      .mockReturnValueOnce(evidenceChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({ data: { user: null } });
-
-    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
-    expect(result.count).toBe(1);
-    expect(result.suggestions['inst-1_f-1'].id).toBe('p-newest');
-  });
-
-  it('throws APIError when proposals fetch fails', async () => {
-    const proposalsChain = chain({
-      data: null,
-      error: { message: 'proposals down' },
-    });
-    (supabase.from as any).mockReturnValueOnce(proposalsChain);
-
-    await expect(
-      AISuggestionService.loadSuggestions('art-1', ['inst-1']),
-    ).rejects.toThrow(/proposals down/);
-  });
-
-  it('throws when getUser reports an auth error (#49)', async () => {
-    const proposalsChain = chain({ data: [] });
-    (supabase.from as any).mockReturnValueOnce(proposalsChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({
-      data: { user: null },
-      error: { message: 'token expired' },
-    });
-
-    await expect(
-      AISuggestionService.loadSuggestions('art-1', ['inst-1']),
-    ).rejects.toThrow(/token expired/);
-  });
-
-  it('throws when the reviewer_states query fails (#73)', async () => {
-    const proposalsChain = chain({
-      data: [
-        {
-          id: 'p-1',
-          run_id: 'run-A',
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          source: 'ai',
-          proposed_value: { value: 'V' },
-          confidence_score: 0.9,
-          rationale: null,
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      ],
-    });
-    const evidenceChain = chain({ data: [] });
-    const statesChain = chain({
-      data: null,
-      error: { message: 'states down' },
-    });
-    (supabase.from as any)
-      .mockReturnValueOnce(proposalsChain)
-      .mockReturnValueOnce(evidenceChain)
-      .mockReturnValueOnce(statesChain);
-    (supabase.auth.getUser as any).mockResolvedValueOnce({
-      data: { user: { id: 'user-1' } },
-    });
-
-    await expect(
-      AISuggestionService.loadSuggestions('art-1', ['inst-1']),
-    ).rejects.toThrow(/states down/);
-  });
-});
-
-describe('AISuggestionService.getHistory', () => {
-  it('scopes by (instance, field) + source=ai, orders desc, applies limit', async () => {
-    const c = chain({ data: [] });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await AISuggestionService.getHistory('inst-1', 'f-1', 7);
-    expect(c.__calls.eqs).toContainEqual(['instance_id', 'inst-1']);
-    expect(c.__calls.eqs).toContainEqual(['field_id', 'f-1']);
-    expect(c.__calls.eqs).toContainEqual(['source', 'ai']);
-    expect(c.__calls.orders).toContainEqual(['created_at', { ascending: false }]);
-    expect(c.__calls.limits).toContain(7);
-  });
-
-  it('default limit is 10', async () => {
-    const c = chain({ data: [] });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await AISuggestionService.getHistory('inst-1', 'f-1');
-    expect(c.__calls.limits).toContain(10);
-  });
-
-  it('returns mapped suggestions with evidence joined', async () => {
-    const proposalsChain = chain({
-      data: [
-        {
-          id: 'p-1',
-          run_id: 'run-A',
-          instance_id: 'inst-1',
-          field_id: 'f-1',
-          source: 'ai',
-          proposed_value: { value: 'V' },
-          confidence_score: 0.8,
-          rationale: null,
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      ],
-    });
-    const evidenceChain = chain({
-      data: [
-        {
-          proposal_record_id: 'p-1',
-          text_content: 'quote',
-          page_number: 2,
-        },
-      ],
-    });
-    (supabase.from as any)
-      .mockReturnValueOnce(proposalsChain)
-      .mockReturnValueOnce(evidenceChain);
-
-    const result = await AISuggestionService.getHistory('inst-1', 'f-1');
-    expect(result).toHaveLength(1);
-    expect(result[0].evidence).toEqual({ text: 'quote', pageNumber: 2 });
-  });
-});
-
-describe('AISuggestionService.getArticleInstanceIds', () => {
-  it('returns only the ids array from the article instances query', async () => {
-    const c = chain({
-      data: [{ id: 'inst-1' }, { id: 'inst-2' }, { id: 'inst-3' }],
-    });
-    (supabase.from as any).mockReturnValueOnce(c);
-    const ids = await AISuggestionService.getArticleInstanceIds('art-1');
-    expect(ids).toEqual(['inst-1', 'inst-2', 'inst-3']);
-  });
-
-  it('throws APIError when the query fails', async () => {
-    (supabase.from as any).mockReturnValueOnce(
-      chain({ data: null, error: { message: 'instance fail' } }),
-    );
-    await expect(
-      AISuggestionService.getArticleInstanceIds('art-1'),
-    ).rejects.toThrow(/instance fail/);
-  });
-
-  it('handles empty data gracefully', async () => {
-    (supabase.from as any).mockReturnValueOnce(chain({ data: null }));
-    const ids = await AISuggestionService.getArticleInstanceIds('art-1');
-    expect(ids).toEqual([]);
   });
 });
 
@@ -525,7 +114,7 @@ describe('AISuggestionService.rejectSuggestion', () => {
   });
 
   it('falls back to findActiveRun when no runId is supplied', async () => {
-    (ExtractionValueService.findActiveRun as any).mockResolvedValueOnce({
+    (ExtractionValueService.findActiveRun as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       id: 'run-fallback',
       stage: 'review',
       status: 'running',
@@ -539,14 +128,219 @@ describe('AISuggestionService.rejectSuggestion', () => {
       projectId: 'proj-1',
       articleId: 'art-1',
     });
-    expect(ExtractionValueService.findActiveRun).toHaveBeenCalledWith(
-      'art-1',
-      null,
-    );
+    expect(ExtractionValueService.findActiveRun).toHaveBeenCalledWith('art-1', null);
     expect(ExtractionValueService.rejectValue).toHaveBeenCalledWith(
       'run-fallback',
       'inst-1',
       'field-1',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSuggestions
+// ---------------------------------------------------------------------------
+
+describe('AISuggestionService.loadSuggestions', () => {
+  it('short-circuits to empty when instanceIds is empty (no apiClient call)', async () => {
+    const result = await AISuggestionService.loadSuggestions('art-1', []);
+    expect(result).toEqual({ suggestions: {}, count: 0 });
+    expect(apiClient).not.toHaveBeenCalled();
+  });
+
+  it('calls the suggestions endpoint with repeated instance_ids params', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [],
+      count: 0,
+    });
+    await AISuggestionService.loadSuggestions('art-1', ['inst-1', 'inst-2']);
+    expect(apiClient).toHaveBeenCalledOnce();
+    const [path] = (apiClient as ReturnType<typeof vi.fn>).mock.calls[0] as [string, ...unknown[]];
+    expect(path).toContain('/api/v1/articles/art-1/suggestions');
+    expect(path).toContain('instance_ids=inst-1');
+    expect(path).toContain('instance_ids=inst-2');
+  });
+
+  it('appends run_id param when provided', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [],
+      count: 0,
+    });
+    await AISuggestionService.loadSuggestions('art-1', ['inst-1'], 'run-A');
+    const [path] = (apiClient as ReturnType<typeof vi.fn>).mock.calls[0] as [string, ...unknown[]];
+    expect(path).toContain('run_id=run-A');
+  });
+
+  it('does NOT append run_id when none is provided', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [],
+      count: 0,
+    });
+    await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    const [path] = (apiClient as ReturnType<typeof vi.fn>).mock.calls[0] as [string, ...unknown[]];
+    expect(path).not.toContain('run_id=');
+  });
+
+  it('maps server AISuggestionItem to AISuggestion keyed by instance_field', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [makeItem()],
+      count: 1,
+    });
+    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    expect(result.count).toBe(1);
+    const sug = result.suggestions['inst-1_f-1'];
+    expect(sug).toBeDefined();
+    expect(sug.id).toBe('p-1');
+    expect(sug.runId).toBe('run-A');
+    expect(sug.value).toBe('X'); // unwrapped from {value:'X'}
+    expect(sug.confidence).toBe(0.8);
+    expect(sug.reasoning).toBe('because');
+    expect(sug.status).toBe('pending');
+    expect(sug.timestamp).toBeInstanceOf(Date);
+    expect(sug.evidence).toBeUndefined(); // evidence=null → undefined
+  });
+
+  it('maps evidence when present', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [
+        makeItem({
+          evidence: {
+            text_content: 'verbatim quote',
+            page_number: 3,
+            proposal_record_id: 'p-1',
+          },
+        }),
+      ],
+      count: 1,
+    });
+    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    expect(result.suggestions['inst-1_f-1'].evidence).toEqual({
+      text: 'verbatim quote',
+      pageNumber: 3,
+    });
+  });
+
+  it("uses server-provided status='accepted'", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [makeItem({ status: 'accepted' })],
+      count: 1,
+    });
+    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    expect(result.suggestions['inst-1_f-1'].status).toBe('accepted');
+  });
+
+  it("uses server-provided status='rejected'", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [makeItem({ status: 'rejected' })],
+      count: 1,
+    });
+    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    expect(result.suggestions['inst-1_f-1'].status).toBe('rejected');
+  });
+
+  it('keeps only the first-wins entry per (instance, field) when server returns dupes', async () => {
+    // Server should deduplicate but the guard must be harmless
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [
+        makeItem({ id: 'p-first', proposed_value: { value: 'first' } }),
+        makeItem({ id: 'p-second', proposed_value: { value: 'second' } }),
+      ],
+      count: 2,
+    });
+    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    // first-wins guard keeps p-first
+    expect(result.suggestions['inst-1_f-1'].id).toBe('p-first');
+  });
+
+  it('throws when apiClient rejects', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('network down'),
+    );
+    await expect(
+      AISuggestionService.loadSuggestions('art-1', ['inst-1']),
+    ).rejects.toThrow(/network down/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getHistory
+// ---------------------------------------------------------------------------
+
+describe('AISuggestionService.getHistory', () => {
+  it('calls the history endpoint with instance_id, field_id, and limit', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    await AISuggestionService.getHistory('art-1', 'inst-1', 'f-1', 7);
+    const [path] = (apiClient as ReturnType<typeof vi.fn>).mock.calls[0] as [string, ...unknown[]];
+    expect(path).toContain('/api/v1/articles/art-1/suggestions/history');
+    expect(path).toContain('instance_id=inst-1');
+    expect(path).toContain('field_id=f-1');
+    expect(path).toContain('limit=7');
+  });
+
+  it('default limit is 10', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    await AISuggestionService.getHistory('art-1', 'inst-1', 'f-1');
+    const [path] = (apiClient as ReturnType<typeof vi.fn>).mock.calls[0] as [string, ...unknown[]];
+    expect(path).toContain('limit=10');
+  });
+
+  it('returns mapped history items with evidence', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: 'p-1',
+        run_id: 'run-A',
+        instance_id: 'inst-1',
+        field_id: 'f-1',
+        proposed_value: { value: 'V' },
+        confidence_score: 0.8,
+        rationale: null,
+        created_at: '2026-04-28T10:00:00Z',
+        evidence: {
+          text_content: 'quote',
+          page_number: 2,
+          proposal_record_id: 'p-1',
+        },
+      },
+    ]);
+    const result = await AISuggestionService.getHistory('art-1', 'inst-1', 'f-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].evidence).toEqual({ text: 'quote', pageNumber: 2 });
+    expect(result[0].value).toBe('V');
+    expect(result[0].runId).toBe('run-A');
+    // History items have no server status — default to 'pending'
+    expect(result[0].status).toBe('pending');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getArticleInstanceIds
+// ---------------------------------------------------------------------------
+
+describe('AISuggestionService.getArticleInstanceIds', () => {
+  it('calls the instance-ids endpoint and returns the array', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      'inst-1',
+      'inst-2',
+      'inst-3',
+    ]);
+    const ids = await AISuggestionService.getArticleInstanceIds('art-1');
+    expect(ids).toEqual(['inst-1', 'inst-2', 'inst-3']);
+    const [path] = (apiClient as ReturnType<typeof vi.fn>).mock.calls[0] as [string, ...unknown[]];
+    expect(path).toBe('/api/v1/articles/art-1/instance-ids');
+  });
+
+  it('returns empty array when server returns empty', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    const ids = await AISuggestionService.getArticleInstanceIds('art-1');
+    expect(ids).toEqual([]);
+  });
+
+  it('throws when apiClient rejects', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('instance fail'),
+    );
+    await expect(
+      AISuggestionService.getArticleInstanceIds('art-1'),
+    ).rejects.toThrow(/instance fail/);
   });
 });

--- a/frontend/test/services/citationsService.test.ts
+++ b/frontend/test/services/citationsService.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for citationsService.
+ *
+ * Covers:
+ *  - fetchArticleCitations: correct URL, data mapping, ErrorResult on failure
+ *  - matchEvidenceToCitation: page+text, whitespace/case normalisation,
+ *    page-null text-only fallback, no-match → null, tie → earliest
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/integrations/api/client', () => ({
+  apiClient: vi.fn(),
+}));
+
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {debug: vi.fn(), error: vi.fn(), warn: vi.fn()},
+}));
+
+import {apiClient} from '@/integrations/api/client';
+import {
+  fetchArticleCitations,
+  matchEvidenceToCitation,
+  type ArticleCitationItem,
+} from '@/services/citationsService';
+
+const apiClientMock = apiClient as unknown as ReturnType<typeof vi.fn>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeItem(
+  id: string,
+  textContent: string | null,
+  pageNumber: number | null,
+): ArticleCitationItem {
+  return {
+    id,
+    verified: false,
+    anchorKind: 'text',
+    anchor: null,
+    metadata: {pageNumber, textContent, source: 'ai'},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// fetchArticleCitations
+// ---------------------------------------------------------------------------
+
+describe('fetchArticleCitations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls the correct URL and returns ok:true with mapped data', async () => {
+    const items = [makeItem('c-1', 'Hello world', 1)];
+    apiClientMock.mockResolvedValueOnce(items);
+
+    const result = await fetchArticleCitations('art-123');
+
+    expect(apiClientMock).toHaveBeenCalledWith(
+      '/api/v1/articles/art-123/citations',
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual(items);
+    }
+  });
+
+  it('returns empty array when apiClient resolves to null/undefined', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
+
+    const result = await fetchArticleCitations('art-456');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it('returns ok:false when apiClient throws', async () => {
+    apiClientMock.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await fetchArticleCitations('art-789');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('Network error');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchEvidenceToCitation
+// ---------------------------------------------------------------------------
+
+describe('matchEvidenceToCitation', () => {
+  it('returns null for empty citation list', () => {
+    expect(
+      matchEvidenceToCitation({text: 'some text', pageNumber: 1}, []),
+    ).toBeNull();
+  });
+
+  it('matches by exact page + text content', () => {
+    const c1 = makeItem('c-1', 'The quick brown fox', 2);
+    const c2 = makeItem('c-2', 'Another sentence', 2);
+    expect(
+      matchEvidenceToCitation(
+        {text: 'The quick brown fox', pageNumber: 2},
+        [c1, c2],
+      ),
+    ).toBe(c1);
+  });
+
+  it('matches when textContent contains the evidence text', () => {
+    const c1 = makeItem('c-1', 'Prefix. The evidence text. Suffix.', 3);
+    expect(
+      matchEvidenceToCitation(
+        {text: 'The evidence text.', pageNumber: 3},
+        [c1],
+      ),
+    ).toBe(c1);
+  });
+
+  it('matches despite different whitespace and casing', () => {
+    const c1 = makeItem('c-1', 'Hello   World', 1);
+    expect(
+      matchEvidenceToCitation({text: '  hello world  ', pageNumber: 1}, [c1]),
+    ).toBe(c1);
+  });
+
+  it('falls back to text-only match when evidence pageNumber is null', () => {
+    const c1 = makeItem('c-1', 'Specific phrase', 5);
+    expect(
+      matchEvidenceToCitation({text: 'Specific phrase', pageNumber: null}, [c1]),
+    ).toBe(c1);
+  });
+
+  it('falls back to text-only match when evidence pageNumber is undefined', () => {
+    const c1 = makeItem('c-1', 'Another phrase', 7);
+    expect(
+      matchEvidenceToCitation({text: 'Another phrase'}, [c1]),
+    ).toBe(c1);
+  });
+
+  it('prefers page+text match over text-only match on a different page', () => {
+    const wrongPage = makeItem('c-wrong', 'Target text', 99);
+    const rightPage = makeItem('c-right', 'Target text', 4);
+    expect(
+      matchEvidenceToCitation(
+        {text: 'Target text', pageNumber: 4},
+        [wrongPage, rightPage],
+      ),
+    ).toBe(rightPage);
+  });
+
+  it('returns null when no citation matches', () => {
+    const c1 = makeItem('c-1', 'Completely different content', 1);
+    expect(
+      matchEvidenceToCitation({text: 'No match here', pageNumber: 1}, [c1]),
+    ).toBeNull();
+  });
+
+  it('breaks ties by list order — returns earliest match', () => {
+    const first = makeItem('c-first', 'Same text', 2);
+    const second = makeItem('c-second', 'Same text', 2);
+    expect(
+      matchEvidenceToCitation({text: 'Same text', pageNumber: 2}, [first, second]),
+    ).toBe(first);
+  });
+
+  it('returns null when textContent is null on all items', () => {
+    const c1 = makeItem('c-1', null, 1);
+    expect(
+      matchEvidenceToCitation({text: 'any text', pageNumber: 1}, [c1]),
+    ).toBeNull();
+  });
+});

--- a/frontend/test/services/extractionValueService.test.ts
+++ b/frontend/test/services/extractionValueService.test.ts
@@ -1,116 +1,45 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Mock @/integrations/api BEFORE importing the service under test
+vi.mock('@/integrations/api', () => ({ apiClient: vi.fn() }));
+
+import { apiClient } from '@/integrations/api';
 import { ExtractionValueService } from '@/services/extractionValueService';
 
-vi.mock('@/integrations/supabase/client', () => {
-  const mock = { from: vi.fn() };
-  return { supabase: mock };
-});
-
-vi.mock('@/integrations/api', () => ({
-  apiClient: vi.fn(async () => ({})),
-}));
-
-import { supabase } from '@/integrations/supabase/client';
-import { apiClient } from '@/integrations/api';
-
-interface ChainCalls {
-  table?: string;
-  selects: string[];
-  eqs: Array<[string, unknown]>;
-  ins: Array<[string, unknown[]]>;
-  neqs: Array<[string, unknown]>;
-  orders: Array<[string, { ascending?: boolean } | undefined]>;
-  limits: number[];
-  maybeSingleCalled: boolean;
-}
-
-type AnyChain = Record<string, unknown> & {
-  data: unknown;
-  error: { message: string } | null;
-  __calls: ChainCalls;
-};
-
-/**
- * Builds a chainable Supabase query mock that *records* every fluent
- * method call so tests can assert on the filters/ordering applied —
- * essential for catching kind/template/stage scoping regressions, the
- * source of the recent "decision posted to wrong run" bug.
- */
-function chain(payload: { data: unknown; error?: { message: string } | null }): AnyChain {
-  const result = { data: payload.data, error: payload.error ?? null };
-  const calls: ChainCalls = {
-    selects: [],
-    eqs: [],
-    ins: [],
-    neqs: [],
-    orders: [],
-    limits: [],
-    maybeSingleCalled: false,
-  };
-  const c: AnyChain = {
-    ...result,
-    __calls: calls,
-    select: vi.fn((cols?: string) => {
-      if (cols) calls.selects.push(cols);
-      return c;
-    }),
-    eq: vi.fn((col: string, val: unknown) => {
-      calls.eqs.push([col, val]);
-      return c;
-    }),
-    in: vi.fn((col: string, vals: unknown[]) => {
-      calls.ins.push([col, vals]);
-      return c;
-    }),
-    neq: vi.fn((col: string, val: unknown) => {
-      calls.neqs.push([col, val]);
-      return c;
-    }),
-    order: vi.fn((col: string, opts?: { ascending?: boolean }) => {
-      calls.orders.push([col, opts]);
-      return c;
-    }),
-    limit: vi.fn((n: number) => {
-      calls.limits.push(n);
-      return c;
-    }),
-    maybeSingle: vi.fn(() => {
-      calls.maybeSingleCalled = true;
-      return Promise.resolve(result);
-    }),
-    then: (cb: (r: typeof result) => unknown) => Promise.resolve(cb(result)),
-  };
-  return c;
-}
+const apiClientMock = apiClient as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  // Default ``supabase.from`` to an empty chain so any query a test
-  // doesn't explicitly stub falls through harmlessly. Individual tests
-  // override the relevant call(s) with ``mockReturnValueOnce``.
-  (supabase.from as any).mockReturnValue(chain({ data: [] }));
+  apiClientMock.mockReset();
+  // Default: return null (no active run)
+  apiClientMock.mockResolvedValue(null);
 });
 
+// ---------------------------------------------------------------------------
+// findActiveRun
+// ---------------------------------------------------------------------------
 describe('ExtractionValueService.findActiveRun', () => {
-  it('returns null when no run exists', async () => {
-    (supabase.from as any).mockReturnValueOnce(chain({ data: null }));
+  it('returns null when the API returns null', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
     const result = await ExtractionValueService.findActiveRun('article-1', 'tpl-1');
     expect(result).toBeNull();
   });
 
-  it('returns the most recent non-finalized run', async () => {
-    (supabase.from as any).mockReturnValueOnce(
-      chain({
-        data: {
-          id: 'run-1',
-          stage: 'review',
-          status: 'running',
-          template_id: 'tpl-1',
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      }),
-    );
+  it('returns mapped RunRef when the API returns a RunSummaryResponse', async () => {
+    apiClientMock.mockResolvedValueOnce({
+      id: 'run-1',
+      stage: 'review',
+      status: 'running',
+      template_id: 'tpl-1',
+      project_id: 'proj-1',
+      article_id: 'article-1',
+      kind: 'extraction',
+      version_id: 'v1',
+      hitl_config_snapshot: {},
+      parameters: {},
+      results: {},
+      created_at: '2026-04-28T10:00:00Z',
+      created_by: 'user-1',
+    });
     const result = await ExtractionValueService.findActiveRun('article-1', 'tpl-1');
     expect(result).toEqual({
       id: 'run-1',
@@ -120,162 +49,57 @@ describe('ExtractionValueService.findActiveRun', () => {
     });
   });
 
-  it("scopes the query to kind='extraction' so QA runs cannot leak in", async () => {
-    const c = chain({ data: null });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await ExtractionValueService.findActiveRun('article-1', 'tpl-1');
-    expect(c.__calls.eqs).toContainEqual(['kind', 'extraction']);
-  });
-
-  it('scopes the query to article_id', async () => {
-    const c = chain({ data: null });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await ExtractionValueService.findActiveRun('art-42', 'tpl-1');
-    expect(c.__calls.eqs).toContainEqual(['article_id', 'art-42']);
-  });
-
-  it('restricts stages to pending/proposal/review/consensus', async () => {
-    const c = chain({ data: null });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await ExtractionValueService.findActiveRun('article-1', null);
-    const stageFilter = c.__calls.ins.find(([col]) => col === 'stage');
-    expect(stageFilter).toBeDefined();
-    expect(new Set(stageFilter![1])).toEqual(
-      new Set(['pending', 'proposal', 'review', 'consensus']),
+  it('calls apiClient with the correct path (with template_id)', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
+    await ExtractionValueService.findActiveRun('article-42', 'tpl-7');
+    expect(apiClientMock).toHaveBeenCalledWith(
+      '/api/v1/articles/article-42/active-run?template_id=tpl-7',
     );
   });
 
-  it('orders by created_at DESC and picks one row — the latest run wins', async () => {
-    const c = chain({ data: null });
-    (supabase.from as any).mockReturnValueOnce(c);
+  it('calls apiClient with path without query param when template_id is null', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
+    await ExtractionValueService.findActiveRun('article-42', null);
+    expect(apiClientMock).toHaveBeenCalledWith('/api/v1/articles/article-42/active-run');
+  });
+
+  it('does NOT touch supabase', async () => {
+    // If supabase were imported and called, the test environment would error
+    // because we never mock it here. This test simply verifies apiClient is
+    // the sole transport by confirming the call lands on it.
+    apiClientMock.mockResolvedValueOnce(null);
     await ExtractionValueService.findActiveRun('article-1', null);
-    expect(c.__calls.orders).toContainEqual(['created_at', { ascending: false }]);
-    expect(c.__calls.limits).toContain(1);
-    expect(c.__calls.maybeSingleCalled).toBe(true);
-  });
-
-  it('applies template_id filter when provided', async () => {
-    const c = chain({ data: null });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await ExtractionValueService.findActiveRun('article-1', 'tpl-7');
-    expect(c.__calls.eqs).toContainEqual(['template_id', 'tpl-7']);
-  });
-
-  it('does NOT apply template_id filter when null', async () => {
-    const c = chain({ data: null });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await ExtractionValueService.findActiveRun('article-1', null);
-    expect(c.__calls.eqs.find(([col]) => col === 'template_id')).toBeUndefined();
-  });
-
-  it('throws APIError when Supabase reports an error', async () => {
-    (supabase.from as any).mockReturnValueOnce(
-      chain({ data: null, error: { message: 'boom' } }),
-    );
-    await expect(
-      ExtractionValueService.findActiveRun('article-1', null),
-    ).rejects.toThrow(/boom/);
+    expect(apiClientMock).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('ExtractionValueService.findFormRunsByArticle', () => {
-  it('returns the latest non-terminal run per article (H4)', async () => {
-    // Two articles, both with a non-terminal run. The latest per article
-    // wins. Cancelled and finalized rows are ignored when a non-terminal
-    // row exists.
-    (supabase.from as any).mockReturnValueOnce(
-      chain({
-        data: [
-          // article-A: non-terminal latest
-          {
-            id: 'run-A-new',
-            article_id: 'article-A',
-            stage: 'review',
-            created_at: '2026-05-26T10:00:00Z',
-          },
-          {
-            id: 'run-A-old',
-            article_id: 'article-A',
-            stage: 'finalized',
-            created_at: '2026-05-25T10:00:00Z',
-          },
-          // article-B: only finalized
-          {
-            id: 'run-B-final',
-            article_id: 'article-B',
-            stage: 'finalized',
-            created_at: '2026-05-26T09:00:00Z',
-          },
-          // article-C: cancelled only — must be excluded
-          {
-            id: 'run-C-cancel',
-            article_id: 'article-C',
-            stage: 'cancelled',
-            created_at: '2026-05-26T08:00:00Z',
-          },
-        ],
-      }),
-    );
-
-    const result = await ExtractionValueService.findFormRunsByArticle(
-      ['article-A', 'article-B', 'article-C'],
-      'tpl-1',
-    );
-
-    // article-A: non-terminal preferred over older finalized
-    expect(result.get('article-A')).toBe('run-A-new');
-    // article-B: only finalized available — fallback
-    expect(result.get('article-B')).toBe('run-B-final');
-    // article-C: cancelled excluded
-    expect(result.has('article-C')).toBe(false);
-  });
-
-  it('scopes the query to kind=extraction + template_id (H4)', async () => {
-    const c = chain({ data: [] });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await ExtractionValueService.findFormRunsByArticle(['article-A'], 'tpl-1');
-    expect(c.__calls.eqs).toContainEqual(['kind', 'extraction']);
-    expect(c.__calls.eqs).toContainEqual(['template_id', 'tpl-1']);
-    const articleFilter = c.__calls.ins.find(([col]) => col === 'article_id');
-    expect(articleFilter?.[1]).toEqual(['article-A']);
-  });
-
-  it('returns empty map when articleIds is empty (no round trip)', async () => {
-    const result = await ExtractionValueService.findFormRunsByArticle([], 'tpl-1');
-    expect(result.size).toBe(0);
-    // Crucially: no .from() call was issued — short-circuit.
-    expect((supabase.from as any).mock.calls.length).toBe(0);
-  });
-});
-
+// ---------------------------------------------------------------------------
+// findLatestFinalizedRun
+// ---------------------------------------------------------------------------
 describe('ExtractionValueService.findLatestFinalizedRun', () => {
-  it("scopes the query to kind='extraction' and stage='finalized'", async () => {
-    const c = chain({ data: null });
-    (supabase.from as any).mockReturnValueOnce(c);
-    await ExtractionValueService.findLatestFinalizedRun('article-1', 'tpl-1');
-    expect(c.__calls.eqs).toContainEqual(['kind', 'extraction']);
-    expect(c.__calls.eqs).toContainEqual(['stage', 'finalized']);
-    expect(c.__calls.eqs).toContainEqual(['template_id', 'tpl-1']);
-    expect(c.__calls.orders).toContainEqual(['created_at', { ascending: false }]);
-    expect(c.__calls.limits).toContain(1);
+  it('returns null when the API returns null', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
+    const result = await ExtractionValueService.findLatestFinalizedRun('article-1', null);
+    expect(result).toBeNull();
   });
 
-  it('returns the row when one exists', async () => {
-    (supabase.from as any).mockReturnValueOnce(
-      chain({
-        data: {
-          id: 'run-final',
-          stage: 'finalized',
-          status: 'completed',
-          template_id: 'tpl-1',
-          created_at: '2026-04-28T10:00:00Z',
-        },
-      }),
-    );
-    const result = await ExtractionValueService.findLatestFinalizedRun(
-      'article-1',
-      'tpl-1',
-    );
+  it('returns mapped RunRef when the API returns a RunSummaryResponse', async () => {
+    apiClientMock.mockResolvedValueOnce({
+      id: 'run-final',
+      stage: 'finalized',
+      status: 'completed',
+      template_id: 'tpl-1',
+      project_id: 'proj-1',
+      article_id: 'article-1',
+      kind: 'extraction',
+      version_id: 'v1',
+      hitl_config_snapshot: {},
+      parameters: {},
+      results: {},
+      created_at: '2026-04-28T10:00:00Z',
+      created_by: 'user-1',
+    });
+    const result = await ExtractionValueService.findLatestFinalizedRun('article-1', 'tpl-1');
     expect(result).toEqual({
       id: 'run-final',
       stage: 'finalized',
@@ -284,36 +108,102 @@ describe('ExtractionValueService.findLatestFinalizedRun', () => {
     });
   });
 
-  it('returns null when no finalized run exists', async () => {
-    (supabase.from as any).mockReturnValueOnce(chain({ data: null }));
-    const result = await ExtractionValueService.findLatestFinalizedRun(
-      'article-1',
-      null,
+  it('calls apiClient with the correct path (with template_id)', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
+    await ExtractionValueService.findLatestFinalizedRun('article-42', 'tpl-7');
+    expect(apiClientMock).toHaveBeenCalledWith(
+      '/api/v1/articles/article-42/finalized-run?template_id=tpl-7',
     );
-    expect(result).toBeNull();
   });
 
-  it('throws APIError when Supabase reports an error', async () => {
-    (supabase.from as any).mockReturnValueOnce(
-      chain({ data: null, error: { message: 'fnz fail' } }),
-    );
-    await expect(
-      ExtractionValueService.findLatestFinalizedRun('article-1', null),
-    ).rejects.toThrow(/fnz fail/);
+  it('calls apiClient with path without query param when template_id is null', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
+    await ExtractionValueService.findLatestFinalizedRun('article-42', null);
+    expect(apiClientMock).toHaveBeenCalledWith('/api/v1/articles/article-42/finalized-run');
   });
 
-  it('does NOT apply template_id filter when null', async () => {
-    const c = chain({ data: null });
-    (supabase.from as any).mockReturnValueOnce(c);
+  it('does NOT touch supabase', async () => {
+    apiClientMock.mockResolvedValueOnce(null);
     await ExtractionValueService.findLatestFinalizedRun('article-1', null);
-    expect(c.__calls.eqs.find(([col]) => col === 'template_id')).toBeUndefined();
+    expect(apiClientMock).toHaveBeenCalledTimes(1);
   });
 });
 
+// ---------------------------------------------------------------------------
+// findFormRunsByArticle
+// ---------------------------------------------------------------------------
+describe('ExtractionValueService.findFormRunsByArticle', () => {
+  it('returns empty Map without calling apiClient when articleIds is empty', async () => {
+    const result = await ExtractionValueService.findFormRunsByArticle([], 'tpl-1', 'proj-1');
+    expect(result.size).toBe(0);
+    expect(apiClientMock).not.toHaveBeenCalled();
+  });
+
+  it('calls apiClient with POST body containing article_ids, template_id, project_id', async () => {
+    apiClientMock.mockResolvedValueOnce([
+      { article_id: 'article-A', run_id: 'run-A' },
+      { article_id: 'article-B', run_id: 'run-B' },
+    ]);
+    await ExtractionValueService.findFormRunsByArticle(
+      ['article-A', 'article-B'],
+      'tpl-1',
+      'proj-1',
+    );
+    expect(apiClientMock).toHaveBeenCalledWith('/api/v1/articles/form-runs', {
+      method: 'POST',
+      body: {
+        article_ids: ['article-A', 'article-B'],
+        template_id: 'tpl-1',
+        project_id: 'proj-1',
+      },
+    });
+  });
+
+  it('builds Map<article_id, run_id> from ArticleRunRef[] response', async () => {
+    apiClientMock.mockResolvedValueOnce([
+      { article_id: 'article-A', run_id: 'run-A' },
+      { article_id: 'article-B', run_id: 'run-B' },
+    ]);
+    const result = await ExtractionValueService.findFormRunsByArticle(
+      ['article-A', 'article-B'],
+      'tpl-1',
+      'proj-1',
+    );
+    expect(result.get('article-A')).toBe('run-A');
+    expect(result.get('article-B')).toBe('run-B');
+    expect(result.size).toBe(2);
+  });
+
+  it('excludes entries where run_id is null', async () => {
+    apiClientMock.mockResolvedValueOnce([
+      { article_id: 'article-A', run_id: 'run-A' },
+      { article_id: 'article-B', run_id: null },
+    ]);
+    const result = await ExtractionValueService.findFormRunsByArticle(
+      ['article-A', 'article-B'],
+      'tpl-1',
+      'proj-1',
+    );
+    expect(result.get('article-A')).toBe('run-A');
+    expect(result.has('article-B')).toBe(false);
+    expect(result.size).toBe(1);
+  });
+
+  it('does NOT touch supabase', async () => {
+    apiClientMock.mockResolvedValueOnce([]);
+    await ExtractionValueService.findFormRunsByArticle(['article-A'], 'tpl-1', 'proj-1');
+    expect(apiClientMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Write paths (saveValue / acceptProposal / rejectValue) — unchanged
+// ---------------------------------------------------------------------------
 describe('ExtractionValueService write paths', () => {
   it('saveValue posts an edit decision with wrapped value', async () => {
+    apiClientMock.mockResolvedValueOnce({});
     await ExtractionValueService.saveValue('run-1', 'inst-1', 'field-1', 42);
-    expect(apiClient).toHaveBeenCalledWith('/api/v1/runs/run-1/decisions', {
+    expect(apiClientMock).toHaveBeenCalledWith('/api/v1/runs/run-1/decisions', {
       method: 'POST',
       body: {
         instance_id: 'inst-1',
@@ -326,20 +216,17 @@ describe('ExtractionValueService write paths', () => {
   });
 
   it('saveValue forwards rationale when provided', async () => {
+    apiClientMock.mockResolvedValueOnce({});
     await ExtractionValueService.saveValue('run-1', 'inst-1', 'field-1', null, 'because');
-    const lastCall = (apiClient as any).mock.calls.at(-1);
+    const lastCall = apiClientMock.mock.calls.at(-1)!;
     expect(lastCall[1].body.rationale).toBe('because');
     expect(lastCall[1].body.value).toEqual({ value: null });
   });
 
   it('acceptProposal posts decision=accept_proposal with proposal_record_id', async () => {
-    await ExtractionValueService.acceptProposal(
-      'run-1',
-      'inst-1',
-      'field-1',
-      'proposal-1',
-    );
-    expect(apiClient).toHaveBeenCalledWith('/api/v1/runs/run-1/decisions', {
+    apiClientMock.mockResolvedValueOnce({});
+    await ExtractionValueService.acceptProposal('run-1', 'inst-1', 'field-1', 'proposal-1');
+    expect(apiClientMock).toHaveBeenCalledWith('/api/v1/runs/run-1/decisions', {
       method: 'POST',
       body: {
         instance_id: 'inst-1',
@@ -351,8 +238,9 @@ describe('ExtractionValueService write paths', () => {
   });
 
   it('rejectValue posts a reject decision with no value', async () => {
+    apiClientMock.mockResolvedValueOnce({});
     await ExtractionValueService.rejectValue('run-1', 'inst-1', 'field-1');
-    expect(apiClient).toHaveBeenCalledWith('/api/v1/runs/run-1/decisions', {
+    expect(apiClientMock).toHaveBeenCalledWith('/api/v1/runs/run-1/decisions', {
       method: 'POST',
       body: {
         instance_id: 'inst-1',
@@ -363,20 +251,12 @@ describe('ExtractionValueService write paths', () => {
   });
 
   it('writes always target the runId passed in (no implicit findActiveRun)', async () => {
-    // Regression cover for the bug where an upstream layer was
-    // re-resolving the active run via findActiveRun and silently
-    // posting to a stale PENDING run. The service must not consult
-    // ``findActiveRun`` — it must use what the caller hands it.
-    (apiClient as any).mockClear();
+    apiClientMock.mockResolvedValue({});
+    apiClientMock.mockClear();
     await ExtractionValueService.saveValue('explicit-run', 'inst-1', 'field-1', 1);
-    await ExtractionValueService.acceptProposal(
-      'explicit-run',
-      'inst-1',
-      'field-1',
-      'p-1',
-    );
+    await ExtractionValueService.acceptProposal('explicit-run', 'inst-1', 'field-1', 'p-1');
     await ExtractionValueService.rejectValue('explicit-run', 'inst-1', 'field-1');
-    for (const call of (apiClient as any).mock.calls) {
+    for (const call of apiClientMock.mock.calls) {
       expect(call[0]).toBe('/api/v1/runs/explicit-run/decisions');
     }
   });

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -1,6 +1,193 @@
 {
   "components": {
     "schemas": {
+      "AISuggestionHistoryItem": {
+        "description": "One entry in the proposal history for a single (instance, field) coord.\n\nSame shape as AISuggestionItem minus `status` \u2014 history is proposal trail only.",
+        "properties": {
+          "confidence_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Score"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "evidence": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EvidenceResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "field_id": {
+            "format": "uuid",
+            "title": "Field Id",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "instance_id": {
+            "format": "uuid",
+            "title": "Instance Id",
+            "type": "string"
+          },
+          "proposed_value": {
+            "additionalProperties": true,
+            "title": "Proposed Value",
+            "type": "object"
+          },
+          "rationale": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rationale"
+          },
+          "run_id": {
+            "format": "uuid",
+            "title": "Run Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "run_id",
+          "instance_id",
+          "field_id",
+          "proposed_value",
+          "confidence_score",
+          "rationale",
+          "created_at",
+          "evidence"
+        ],
+        "title": "AISuggestionHistoryItem",
+        "type": "object"
+      },
+      "AISuggestionItem": {
+        "description": "A single AI suggestion (latest proposal per coord) with caller-scoped status.",
+        "properties": {
+          "confidence_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Score"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "evidence": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EvidenceResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "field_id": {
+            "format": "uuid",
+            "title": "Field Id",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "instance_id": {
+            "format": "uuid",
+            "title": "Instance Id",
+            "type": "string"
+          },
+          "proposed_value": {
+            "additionalProperties": true,
+            "title": "Proposed Value",
+            "type": "object"
+          },
+          "rationale": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rationale"
+          },
+          "run_id": {
+            "format": "uuid",
+            "title": "Run Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "run_id",
+          "instance_id",
+          "field_id",
+          "proposed_value",
+          "confidence_score",
+          "rationale",
+          "created_at",
+          "evidence",
+          "status"
+        ],
+        "title": "AISuggestionItem",
+        "type": "object"
+      },
+      "AISuggestionsResponse": {
+        "description": "Response for the suggestions endpoint.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "suggestions": {
+            "items": {
+              "$ref": "#/components/schemas/AISuggestionItem"
+            },
+            "title": "Suggestions",
+            "type": "array"
+          }
+        },
+        "required": [
+          "suggestions",
+          "count"
+        ],
+        "title": "AISuggestionsResponse",
+        "type": "object"
+      },
       "APIKeyResponse": {
         "description": "Resposta with data de uma API key (sem a key em si).",
         "properties": {
@@ -143,6 +330,54 @@
           "ok"
         ],
         "title": "ApiResponse",
+        "type": "object"
+      },
+      "ApiResponse_AISuggestionsResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AISuggestionsResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dados da resposta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details"
+          },
+          "ok": {
+            "description": "Indica se a operacao foi bem-sucedida",
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "rastreamento",
+            "title": "Trace Id"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "ApiResponse[AISuggestionsResponse]",
         "type": "object"
       },
       "ApiResponse_Annotated_Union_SingleSectionResult__BatchSectionResult___FieldInfo_annotation_NoneType__required_True__discriminator__mode____": {
@@ -1264,6 +1499,54 @@
         "title": "ApiResponse[RunViewResponse]",
         "type": "object"
       },
+      "ApiResponse_Union_RunSummaryResponse__NoneType__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RunSummaryResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dados da resposta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details"
+          },
+          "ok": {
+            "description": "Indica se a operacao foi bem-sucedida",
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "rastreamento",
+            "title": "Trace Id"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "ApiResponse[Union[RunSummaryResponse, NoneType]]",
+        "type": "object"
+      },
       "ApiResponse_Union_SaveCredentialsResponse__TestConnectionResponse__ListCollectionsResponse__FetchItemsResponse__FetchAttachmentsResponse__DownloadAttachmentResponse__SyncCollectionResponse__SyncStatusResponse__SyncRetryFailedResponse__SyncItemResultsResponse__": {
         "properties": {
           "data": {
@@ -1436,6 +1719,163 @@
         "title": "ApiResponse[UpdateTemplateActiveResponse]",
         "type": "object"
       },
+      "ApiResponse_list_AISuggestionHistoryItem__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AISuggestionHistoryItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dados da resposta",
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details"
+          },
+          "ok": {
+            "description": "Indica se a operacao foi bem-sucedida",
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "rastreamento",
+            "title": "Trace Id"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "ApiResponse[list[AISuggestionHistoryItem]]",
+        "type": "object"
+      },
+      "ApiResponse_list_ArticleRunRef__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ArticleRunRef"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dados da resposta",
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details"
+          },
+          "ok": {
+            "description": "Indica se a operacao foi bem-sucedida",
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "rastreamento",
+            "title": "Trace Id"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "ApiResponse[list[ArticleRunRef]]",
+        "type": "object"
+      },
+      "ApiResponse_list_UUID__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dados da resposta",
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details"
+          },
+          "ok": {
+            "description": "Indica se a operacao foi bem-sucedida",
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "rastreamento",
+            "title": "Trace Id"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "ApiResponse[list[UUID]]",
+        "type": "object"
+      },
       "ApiResponse_list_dict_str__Any___": {
         "properties": {
           "data": {
@@ -1487,6 +1927,34 @@
           "ok"
         ],
         "title": "ApiResponse[list[dict[str, Any]]]",
+        "type": "object"
+      },
+      "ArticleRunRef": {
+        "description": "Per-article run reference returned by POST /articles/form-runs.\n\n``run_id`` is None when the article has no matching run.",
+        "properties": {
+          "article_id": {
+            "format": "uuid",
+            "title": "Article Id",
+            "type": "string"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          }
+        },
+        "required": [
+          "article_id",
+          "run_id"
+        ],
+        "title": "ArticleRunRef",
         "type": "object"
       },
       "BatchSectionResult": {
@@ -2230,6 +2698,52 @@
         "title": "ErrorDetail",
         "type": "object"
       },
+      "EvidenceResponse": {
+        "description": "Evidence snippet attached to a proposal record.",
+        "properties": {
+          "page_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page Number"
+          },
+          "proposal_record_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Proposal Record Id"
+          },
+          "text_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text Content"
+          }
+        },
+        "required": [
+          "proposal_record_id",
+          "text_content",
+          "page_number"
+        ],
+        "title": "EvidenceResponse",
+        "type": "object"
+      },
       "ExportCancelResponse": {
         "description": "Response do cancelamento do job.",
         "properties": {
@@ -2811,6 +3325,36 @@
           "items"
         ],
         "title": "FetchItemsResponse",
+        "type": "object"
+      },
+      "FormRunsRequest": {
+        "description": "Request body for POST /api/v1/articles/form-runs.\n\nResolves the latest relevant run for each article_id in the batch.\n``project_id`` is used for BOLA enforcement.",
+        "properties": {
+          "article_ids": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "title": "Article Ids",
+            "type": "array"
+          },
+          "project_id": {
+            "format": "uuid",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "template_id": {
+            "format": "uuid",
+            "title": "Template Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "article_ids",
+          "template_id",
+          "project_id"
+        ],
+        "title": "FormRunsRequest",
         "type": "object"
       },
       "HTTPValidationError": {
@@ -3973,8 +4517,106 @@
         "title": "RunViewField",
         "type": "object"
       },
+      "RunViewInstance": {
+        "description": "A single extraction instance, sourced from extraction_instances and scoped\nto the run's (article_id, template_id) pair. The ``metadata`` ORM column maps\nto ``metadata_`` on the ORM object; ``validation_alias`` ensures\n``model_validate(orm_obj)`` reads the right attribute while the JSON output\nkey stays ``metadata``.",
+        "properties": {
+          "article_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Article Id"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "format": "uuid",
+            "title": "Created By",
+            "type": "string"
+          },
+          "entity_type_id": {
+            "format": "uuid",
+            "title": "Entity Type Id",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          },
+          "parent_instance_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Instance Id"
+          },
+          "project_id": {
+            "format": "uuid",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "sort_order": {
+            "title": "Sort Order",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "template_id": {
+            "format": "uuid",
+            "title": "Template Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "entity_type_id",
+          "parent_instance_id",
+          "label",
+          "sort_order",
+          "status",
+          "metadata",
+          "project_id",
+          "article_id",
+          "template_id",
+          "created_by",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "RunViewInstance",
+        "type": "object"
+      },
       "RunViewResponse": {
-        "description": "``RunDetailResponse`` (run + blind-filtered workflow rows) plus the two\npieces the run-open form needs server-side: the frozen entity_types tree and\nthe caller's current_values. (``instances`` is added in Task 12.)",
+        "description": "``RunDetailResponse`` (run + blind-filtered workflow rows) plus the three\npieces the run-open form needs server-side: the frozen entity_types tree,\nthe caller's current_values, and the instances for the run's\n(article_id, template_id) scope.",
         "properties": {
           "consensus_decisions": {
             "items": {
@@ -4004,6 +4646,13 @@
             "title": "Entity Types",
             "type": "array"
           },
+          "instances": {
+            "items": {
+              "$ref": "#/components/schemas/RunViewInstance"
+            },
+            "title": "Instances",
+            "type": "array"
+          },
           "proposals": {
             "items": {
               "$ref": "#/components/schemas/ProposalRecordResponse"
@@ -4029,7 +4678,8 @@
           "consensus_decisions",
           "published_states",
           "entity_types",
-          "current_values"
+          "current_values",
+          "instances"
         ],
         "title": "RunViewResponse",
         "type": "object"
@@ -5028,6 +5678,119 @@
         ]
       }
     },
+    "/api/v1/articles/form-runs": {
+      "post": {
+        "description": "Resolve the latest relevant run per article for the extraction form.\n\nPer article: returns the latest non-terminal run; falls back to the\nlatest finalized run; returns run_id=null when no run exists.\nCancelled runs are excluded. BOLA-gated via project_id in the body.",
+        "operationId": "post_form_runs_api_v1_articles_form_runs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FormRunsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_ArticleRunRef__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Post Form Runs",
+        "tags": [
+          "articles"
+        ]
+      }
+    },
+    "/api/v1/articles/{article_id}/active-run": {
+      "get": {
+        "description": "Return the latest non-terminal extraction run for the article.\n\nReturns null (data: null) when no active run exists. 404 when the\narticle is not found; 403 when the caller is not a project member.",
+        "operationId": "get_active_run_api_v1_articles__article_id__active_run_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "article_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "template_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Template Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_Union_RunSummaryResponse__NoneType__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Get Active Run",
+        "tags": [
+          "articles"
+        ]
+      }
+    },
     "/api/v1/articles/{article_id}/citations": {
       "get": {
         "description": "Return all v1-shape citations attached to ``article_id``.\n\nUnanchored rows (hallucinated or pre-ingestion) are included with\n``verified=False``; anchored rows carry ``verified=True`` + ``anchorKind``.",
@@ -5074,6 +5837,282 @@
         "summary": "List Article Citations Endpoint",
         "tags": [
           "citations"
+        ]
+      }
+    },
+    "/api/v1/articles/{article_id}/finalized-run": {
+      "get": {
+        "description": "Return the latest finalized extraction run for the article.\n\nReturns null (data: null) when no finalized run exists. 404 when the\narticle is not found; 403 when the caller is not a project member.",
+        "operationId": "get_finalized_run_api_v1_articles__article_id__finalized_run_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "article_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "template_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Template Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_Union_RunSummaryResponse__NoneType__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Get Finalized Run",
+        "tags": [
+          "articles"
+        ]
+      }
+    },
+    "/api/v1/articles/{article_id}/instance-ids": {
+      "get": {
+        "description": "Return all extraction_instance ids for the article.\n\n404 when article is not found; 403 when caller is not a project member.",
+        "operationId": "get_instance_ids_api_v1_articles__article_id__instance_ids_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "article_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_UUID__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Get Instance Ids",
+        "tags": [
+          "articles"
+        ]
+      }
+    },
+    "/api/v1/articles/{article_id}/suggestions": {
+      "get": {
+        "description": "Return latest AI proposals per (instance, field) with caller-scoped status.\n\nStatus is derived exclusively from the caller's own reviewer_state rows \u2014\nnever another reviewer's (blind boundary, Constraint 3).\n404 when article is not found; 403 when caller is not a project member.",
+        "operationId": "get_suggestions_api_v1_articles__article_id__suggestions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "article_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "instance_ids",
+            "required": false,
+            "schema": {
+              "default": [],
+              "items": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "title": "Instance Ids",
+              "type": "array"
+            }
+          },
+          {
+            "in": "query",
+            "name": "run_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Run Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_AISuggestionsResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Get Suggestions",
+        "tags": [
+          "articles"
+        ]
+      }
+    },
+    "/api/v1/articles/{article_id}/suggestions/history": {
+      "get": {
+        "description": "Return AI proposal history for a single (instance, field) coord.\n\nNewest-first; no status (history is the raw proposal trail).\n404 when article is not found; 403 when caller is not a project member.",
+        "operationId": "get_suggestions_history_api_v1_articles__article_id__suggestions_history_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "article_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Instance Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "field_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Field Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_AISuggestionHistoryItem__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Get Suggestions History",
+        "tags": [
+          "articles"
         ]
       }
     },

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -5030,7 +5030,7 @@
     },
     "/api/v1/articles/{article_id}/citations": {
       "get": {
-        "description": "Return all v1-shape citations attached to ``article_id``.",
+        "description": "Return all v1-shape citations attached to ``article_id``.\n\nUnanchored rows (hallucinated or pre-ingestion) are included with\n``verified=False``; anchored rows carry ``verified=True`` + ``anchorKind``.",
         "operationId": "list_article_citations_endpoint_api_v1_articles__article_id__citations_get",
         "parameters": [
           {

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -121,6 +121,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/articles/form-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Post Form Runs
+         * @description Resolve the latest relevant run per article for the extraction form.
+         *
+         *     Per article: returns the latest non-terminal run; falls back to the
+         *     latest finalized run; returns run_id=null when no run exists.
+         *     Cancelled runs are excluded. BOLA-gated via project_id in the body.
+         */
+        post: operations["post_form_runs_api_v1_articles_form_runs_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/articles/{article_id}/active-run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Active Run
+         * @description Return the latest non-terminal extraction run for the article.
+         *
+         *     Returns null (data: null) when no active run exists. 404 when the
+         *     article is not found; 403 when the caller is not a project member.
+         */
+        get: operations["get_active_run_api_v1_articles__article_id__active_run_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/articles/{article_id}/citations": {
         parameters: {
             query?: never;
@@ -136,6 +183,98 @@ export interface paths {
          *     ``verified=False``; anchored rows carry ``verified=True`` + ``anchorKind``.
          */
         get: operations["list_article_citations_endpoint_api_v1_articles__article_id__citations_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/articles/{article_id}/finalized-run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Finalized Run
+         * @description Return the latest finalized extraction run for the article.
+         *
+         *     Returns null (data: null) when no finalized run exists. 404 when the
+         *     article is not found; 403 when the caller is not a project member.
+         */
+        get: operations["get_finalized_run_api_v1_articles__article_id__finalized_run_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/articles/{article_id}/instance-ids": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Instance Ids
+         * @description Return all extraction_instance ids for the article.
+         *
+         *     404 when article is not found; 403 when caller is not a project member.
+         */
+        get: operations["get_instance_ids_api_v1_articles__article_id__instance_ids_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/articles/{article_id}/suggestions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Suggestions
+         * @description Return latest AI proposals per (instance, field) with caller-scoped status.
+         *
+         *     Status is derived exclusively from the caller's own reviewer_state rows —
+         *     never another reviewer's (blind boundary, Constraint 3).
+         *     404 when article is not found; 403 when caller is not a project member.
+         */
+        get: operations["get_suggestions_api_v1_articles__article_id__suggestions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/articles/{article_id}/suggestions/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Suggestions History
+         * @description Return AI proposal history for a single (instance, field) coord.
+         *
+         *     Newest-first; no status (history is the raw proposal trail).
+         *     404 when article is not found; 403 when caller is not a project member.
+         */
+        get: operations["get_suggestions_history_api_v1_articles__article_id__suggestions_history_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -770,6 +909,100 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /**
+         * AISuggestionHistoryItem
+         * @description One entry in the proposal history for a single (instance, field) coord.
+         *
+         *     Same shape as AISuggestionItem minus `status` — history is proposal trail only.
+         */
+        AISuggestionHistoryItem: {
+            /** Confidence Score */
+            confidence_score: number | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            evidence: components["schemas"]["EvidenceResponse"] | null;
+            /**
+             * Field Id
+             * Format: uuid
+             */
+            field_id: string;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Instance Id
+             * Format: uuid
+             */
+            instance_id: string;
+            /** Proposed Value */
+            proposed_value: {
+                [key: string]: unknown;
+            };
+            /** Rationale */
+            rationale: string | null;
+            /**
+             * Run Id
+             * Format: uuid
+             */
+            run_id: string;
+        };
+        /**
+         * AISuggestionItem
+         * @description A single AI suggestion (latest proposal per coord) with caller-scoped status.
+         */
+        AISuggestionItem: {
+            /** Confidence Score */
+            confidence_score: number | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            evidence: components["schemas"]["EvidenceResponse"] | null;
+            /**
+             * Field Id
+             * Format: uuid
+             */
+            field_id: string;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Instance Id
+             * Format: uuid
+             */
+            instance_id: string;
+            /** Proposed Value */
+            proposed_value: {
+                [key: string]: unknown;
+            };
+            /** Rationale */
+            rationale: string | null;
+            /**
+             * Run Id
+             * Format: uuid
+             */
+            run_id: string;
+            /** Status */
+            status: string;
+        };
+        /**
+         * AISuggestionsResponse
+         * @description Response for the suggestions endpoint.
+         */
+        AISuggestionsResponse: {
+            /** Count */
+            count: number;
+            /** Suggestions */
+            suggestions: components["schemas"]["AISuggestionItem"][];
+        };
+        /**
          * APIKeyResponse
          * @description Resposta with data de uma API key (sem a key em si).
          */
@@ -813,6 +1046,23 @@ export interface components {
              * @description Dados da resposta
              */
             data?: unknown | null;
+            /** @description Error details */
+            error?: components["schemas"]["ErrorDetail"] | null;
+            /**
+             * Ok
+             * @description Indica se a operacao foi bem-sucedida
+             */
+            ok: boolean;
+            /**
+             * Trace Id
+             * @description rastreamento
+             */
+            trace_id?: string | null;
+        };
+        /** ApiResponse[AISuggestionsResponse] */
+        ApiResponse_AISuggestionsResponse_: {
+            /** @description Dados da resposta */
+            data?: components["schemas"]["AISuggestionsResponse"] | null;
             /** @description Error details */
             error?: components["schemas"]["ErrorDetail"] | null;
             /**
@@ -1220,6 +1470,23 @@ export interface components {
              */
             trace_id?: string | null;
         };
+        /** ApiResponse[Union[RunSummaryResponse, NoneType]] */
+        ApiResponse_Union_RunSummaryResponse__NoneType__: {
+            /** @description Dados da resposta */
+            data?: components["schemas"]["RunSummaryResponse"] | null;
+            /** @description Error details */
+            error?: components["schemas"]["ErrorDetail"] | null;
+            /**
+             * Ok
+             * @description Indica se a operacao foi bem-sucedida
+             */
+            ok: boolean;
+            /**
+             * Trace Id
+             * @description rastreamento
+             */
+            trace_id?: string | null;
+        };
         /** ApiResponse[Union[SaveCredentialsResponse, TestConnectionResponse, ListCollectionsResponse, FetchItemsResponse, FetchAttachmentsResponse, DownloadAttachmentResponse, SyncCollectionResponse, SyncStatusResponse, SyncRetryFailedResponse, SyncItemResultsResponse]] */
         ApiResponse_Union_SaveCredentialsResponse__TestConnectionResponse__ListCollectionsResponse__FetchItemsResponse__FetchAttachmentsResponse__DownloadAttachmentResponse__SyncCollectionResponse__SyncStatusResponse__SyncRetryFailedResponse__SyncItemResultsResponse__: {
             /**
@@ -1274,6 +1541,66 @@ export interface components {
              */
             trace_id?: string | null;
         };
+        /** ApiResponse[list[AISuggestionHistoryItem]] */
+        ApiResponse_list_AISuggestionHistoryItem__: {
+            /**
+             * Data
+             * @description Dados da resposta
+             */
+            data?: components["schemas"]["AISuggestionHistoryItem"][] | null;
+            /** @description Error details */
+            error?: components["schemas"]["ErrorDetail"] | null;
+            /**
+             * Ok
+             * @description Indica se a operacao foi bem-sucedida
+             */
+            ok: boolean;
+            /**
+             * Trace Id
+             * @description rastreamento
+             */
+            trace_id?: string | null;
+        };
+        /** ApiResponse[list[ArticleRunRef]] */
+        ApiResponse_list_ArticleRunRef__: {
+            /**
+             * Data
+             * @description Dados da resposta
+             */
+            data?: components["schemas"]["ArticleRunRef"][] | null;
+            /** @description Error details */
+            error?: components["schemas"]["ErrorDetail"] | null;
+            /**
+             * Ok
+             * @description Indica se a operacao foi bem-sucedida
+             */
+            ok: boolean;
+            /**
+             * Trace Id
+             * @description rastreamento
+             */
+            trace_id?: string | null;
+        };
+        /** ApiResponse[list[UUID]] */
+        ApiResponse_list_UUID__: {
+            /**
+             * Data
+             * @description Dados da resposta
+             */
+            data?: string[] | null;
+            /** @description Error details */
+            error?: components["schemas"]["ErrorDetail"] | null;
+            /**
+             * Ok
+             * @description Indica se a operacao foi bem-sucedida
+             */
+            ok: boolean;
+            /**
+             * Trace Id
+             * @description rastreamento
+             */
+            trace_id?: string | null;
+        };
         /** ApiResponse[list[dict[str, Any]]] */
         ApiResponse_list_dict_str__Any___: {
             /**
@@ -1295,6 +1622,21 @@ export interface components {
              * @description rastreamento
              */
             trace_id?: string | null;
+        };
+        /**
+         * ArticleRunRef
+         * @description Per-article run reference returned by POST /articles/form-runs.
+         *
+         *     ``run_id`` is None when the article has no matching run.
+         */
+        ArticleRunRef: {
+            /**
+             * Article Id
+             * Format: uuid
+             */
+            article_id: string;
+            /** Run Id */
+            run_id: string | null;
         };
         /**
          * BatchSectionResult
@@ -1657,6 +1999,18 @@ export interface components {
             message: string;
         };
         /**
+         * EvidenceResponse
+         * @description Evidence snippet attached to a proposal record.
+         */
+        EvidenceResponse: {
+            /** Page Number */
+            page_number: number | null;
+            /** Proposal Record Id */
+            proposal_record_id: string | null;
+            /** Text Content */
+            text_content: string | null;
+        };
+        /**
          * ExportCancelResponse
          * @description Response do cancelamento do job.
          */
@@ -1912,6 +2266,27 @@ export interface components {
             }[];
             /** Total Results */
             total_results?: number | null;
+        };
+        /**
+         * FormRunsRequest
+         * @description Request body for POST /api/v1/articles/form-runs.
+         *
+         *     Resolves the latest relevant run for each article_id in the batch.
+         *     ``project_id`` is used for BOLA enforcement.
+         */
+        FormRunsRequest: {
+            /** Article Ids */
+            article_ids: string[];
+            /**
+             * Project Id
+             * Format: uuid
+             */
+            project_id: string;
+            /**
+             * Template Id
+             * Format: uuid
+             */
+            template_id: string;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -2495,10 +2870,70 @@ export interface components {
             validation_schema?: unknown | null;
         };
         /**
+         * RunViewInstance
+         * @description A single extraction instance, sourced from extraction_instances and scoped
+         *     to the run's (article_id, template_id) pair. The ``metadata`` ORM column maps
+         *     to ``metadata_`` on the ORM object; ``validation_alias`` ensures
+         *     ``model_validate(orm_obj)`` reads the right attribute while the JSON output
+         *     key stays ``metadata``.
+         */
+        RunViewInstance: {
+            /** Article Id */
+            article_id: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Created By
+             * Format: uuid
+             */
+            created_by: string;
+            /**
+             * Entity Type Id
+             * Format: uuid
+             */
+            entity_type_id: string;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Label */
+            label: string;
+            /** Metadata */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Parent Instance Id */
+            parent_instance_id: string | null;
+            /**
+             * Project Id
+             * Format: uuid
+             */
+            project_id: string;
+            /** Sort Order */
+            sort_order: number;
+            /** Status */
+            status: string;
+            /**
+             * Template Id
+             * Format: uuid
+             */
+            template_id: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /**
          * RunViewResponse
-         * @description ``RunDetailResponse`` (run + blind-filtered workflow rows) plus the two
-         *     pieces the run-open form needs server-side: the frozen entity_types tree and
-         *     the caller's current_values. (``instances`` is added in Task 12.)
+         * @description ``RunDetailResponse`` (run + blind-filtered workflow rows) plus the three
+         *     pieces the run-open form needs server-side: the frozen entity_types tree,
+         *     the caller's current_values, and the instances for the run's
+         *     (article_id, template_id) scope.
          */
         RunViewResponse: {
             /** Consensus Decisions */
@@ -2509,6 +2944,8 @@ export interface components {
             decisions: components["schemas"]["ReviewerDecisionResponse"][];
             /** Entity Types */
             entity_types: components["schemas"]["RunViewEntityType"][];
+            /** Instances */
+            instances: components["schemas"]["RunViewInstance"][];
             /** Proposals */
             proposals: components["schemas"]["ProposalRecordResponse"][];
             /** Published States */
@@ -3006,6 +3443,72 @@ export interface operations {
             };
         };
     };
+    post_form_runs_api_v1_articles_form_runs_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FormRunsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_list_ArticleRunRef__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_active_run_api_v1_articles__article_id__active_run_get: {
+        parameters: {
+            query?: {
+                template_id?: string | null;
+            };
+            header?: never;
+            path: {
+                article_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_Union_RunSummaryResponse__NoneType__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_article_citations_endpoint_api_v1_articles__article_id__citations_get: {
         parameters: {
             query?: never;
@@ -3024,6 +3527,139 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiResponse_list_dict_str__Any___"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_finalized_run_api_v1_articles__article_id__finalized_run_get: {
+        parameters: {
+            query?: {
+                template_id?: string | null;
+            };
+            header?: never;
+            path: {
+                article_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_Union_RunSummaryResponse__NoneType__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_instance_ids_api_v1_articles__article_id__instance_ids_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                article_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_list_UUID__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_suggestions_api_v1_articles__article_id__suggestions_get: {
+        parameters: {
+            query?: {
+                instance_ids?: string[];
+                run_id?: string | null;
+            };
+            header?: never;
+            path: {
+                article_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_AISuggestionsResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_suggestions_history_api_v1_articles__article_id__suggestions_history_get: {
+        parameters: {
+            query: {
+                instance_id: string;
+                field_id: string;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                article_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_list_AISuggestionHistoryItem__"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -131,6 +131,9 @@ export interface paths {
         /**
          * List Article Citations Endpoint
          * @description Return all v1-shape citations attached to ``article_id``.
+         *
+         *     Unanchored rows (hallucinated or pre-ingestion) are included with
+         *     ``verified=False``; anchored rows carry ``verified=True`` + ``anchorKind``.
          */
         get: operations["list_article_citations_endpoint_api_v1_articles__article_id__citations_get"];
         put?: never;


### PR DESCRIPTION
Promote dev → main (production deploy).

Promotes 3 commits accumulated on dev:

- **#324** feat(extraction): finish data-path consolidation — run-resolution + AI-suggestion endpoints, RunView instances, run-key factory (extraction run-open path now zero Supabase reads)
- **#325** feat(extraction): grounded-extraction backbone + reviewer click-to-highlight (dark until parser ships)
- **#326** fix(tests): self-provision sibling coordinate in cross-coordinate consensus test

All 8 required checks green on dev@024285f. Backend pytest 1818/1818 locally after sync; consensus test fix confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)