### PR TITLE
fix(e2e): unblock QA suite in CI + de-flake export/consensus/blind-review

### DIFF
--- a/frontend/e2e/_fixtures/ensure-fixtures.ts
+++ b/frontend/e2e/_fixtures/ensure-fixtures.ts
@@ -142,6 +142,16 @@ export async function ensureFixtures(): Promise<void> {
   await ensureMembership(F.PROJECT_ID, reviewerCId, "reviewer");
   await ensureArticle(F.ARTICLE_ID, F.PROJECT_ID, "E2E Fixture Article");
   await ensureArticleText(F.PROJECT_ID, F.ARTICLE_ID);
+
+  // Dedicated articles for the QA API suites that hard-reset runs, so their
+  // parallel `resetQaRuns` calls can never delete each other's in-flight run.
+  // Names are intentionally neutral: these rows show up in the project's
+  // extraction list, and a substring like "Consensus"/"Single user" would
+  // collide with the export dialog's getByLabel() locators.
+  await ensureArticle(F.QA_CONSENSUS_ARTICLE_ID, F.PROJECT_ID, "E2E QA Article One");
+  await ensureArticleText(F.PROJECT_ID, F.QA_CONSENSUS_ARTICLE_ID);
+  await ensureArticle(F.QA_BLIND_REVIEW_ARTICLE_ID, F.PROJECT_ID, "E2E QA Article Two");
+  await ensureArticleText(F.PROJECT_ID, F.QA_BLIND_REVIEW_ARTICLE_ID);
   const ownerToken = await login(F.OWNER_EMAIL, F.FIXTURE_PASSWORD);
   await ensureCharmsImported(F.PROJECT_ID, ownerToken);
 

--- a/frontend/e2e/_fixtures/fixture-ids.ts
+++ b/frontend/e2e/_fixtures/fixture-ids.ts
@@ -15,6 +15,16 @@ export const REVIEWER_C_EMAIL = "e2e-reviewer-c@prumo.test";
 export const PROJECT_ID = "5b9d8976-6da5-45e4-84a5-380a40fdbb0b";
 export const ARTICLE_ID = "f00dc63a-6b47-42c3-8a93-af69eb28a1c0";
 
+/**
+ * Dedicated articles for the two API suites that hard-reset QA runs
+ * (`prepareCleanQaRun` → `resetQaRuns` deletes every quality_assessment run for
+ * a (project, article) pair). They share the same project but MUST NOT share an
+ * article, or running them in parallel lets one suite delete the other's
+ * in-flight run mid-decision. One article per resetting suite = no collision.
+ */
+export const QA_CONSENSUS_ARTICLE_ID = "f00dc63a-6b47-42c3-8a93-af69eb28a1c1";
+export const QA_BLIND_REVIEW_ARTICLE_ID = "f00dc63a-6b47-42c3-8a93-af69eb28a1c2";
+
 /** Dedicated project for the template-import test — intentionally CHARMS-free. */
 export const IMPORT_PROJECT_ID = "e2e00001-0000-4000-8000-000000000001";
 

--- a/frontend/e2e/_fixtures/hitl.ts
+++ b/frontend/e2e/_fixtures/hitl.ts
@@ -136,19 +136,21 @@ export async function prepareCleanQaRun(
   }
 
   if (targetStage === "review") {
-    // /hitl/sessions can return a run already at `review` (the service
-    // opens at review for QA kind). Only advance when we still need to.
-    const detailRes = await opts.request.get(
-      `${opts.apiUrl}/api/v1/runs/${session.run_id}`,
-      {
-        headers: authHeaders(opts.token, opts.traceId),
-        timeout: 15000,
-      },
-    );
-    await expectOk(detailRes, "fetch run detail");
-    const detail = (await parseEnvelope<{ run: { stage: string } }>(detailRes))
-      .data;
-    if (detail.run.stage !== "review") {
+    // /hitl/sessions can return a run already at `review` (the service opens at
+    // review for QA kind), and sibling QA suites that share this (project,
+    // article) fixture can advance it concurrently. The contract here is only
+    // "leave the run at review", so treat "already at review" as success — the
+    // check→advance window must not flake on a review→review transition.
+    const stageOf = async (): Promise<string> => {
+      const detailRes = await opts.request.get(
+        `${opts.apiUrl}/api/v1/runs/${session.run_id}`,
+        { headers: authHeaders(opts.token, opts.traceId), timeout: 15000 },
+      );
+      await expectOk(detailRes, "fetch run detail");
+      return (await parseEnvelope<{ run: { stage: string } }>(detailRes)).data
+        .run.stage;
+    };
+    if ((await stageOf()) !== "review") {
       const advanceRes = await opts.request.post(
         `${opts.apiUrl}/api/v1/runs/${session.run_id}/advance`,
         {
@@ -157,7 +159,12 @@ export async function prepareCleanQaRun(
           timeout: 15000,
         },
       );
-      await expectOk(advanceRes, "advance proposal → review");
+      // A concurrent prepare on the shared fixture may have moved the run to
+      // review between our read and this write; that's the desired end state,
+      // so only fail if it is genuinely not at review afterwards.
+      if (!advanceRes.ok() && (await stageOf()) !== "review") {
+        await expectOk(advanceRes, "advance proposal → review");
+      }
     }
   }
 

--- a/frontend/e2e/flows/blind-review-manager.api.e2e.ts
+++ b/frontend/e2e/flows/blind-review-manager.api.e2e.ts
@@ -26,6 +26,7 @@ import { expect, test } from "@playwright/test";
 import { authHeaders, parseEnvelope } from "../_fixtures/api";
 import { loginViaUi, resolveAuthToken } from "../_fixtures/auth";
 import { createTraceId, loadE2EEnv, missingEnvKeys } from "../_fixtures/env";
+import { QA_BLIND_REVIEW_ARTICLE_ID } from "../_fixtures/fixture-ids";
 import { prepareCleanQaRun } from "../_fixtures/hitl";
 import type { ReviewKind } from "../../lib/comparison/permissions";
 
@@ -138,7 +139,7 @@ test.describe("Manager blind-review + per-kind reveal", () => {
       apiUrl: env.apiUrl,
       token: managerToken,
       projectId: env.projectId!,
-      articleId: env.articleId!,
+      articleId: QA_BLIND_REVIEW_ARTICLE_ID,
       qaTemplateId,
       traceId,
     });
@@ -197,7 +198,7 @@ test.describe("Manager blind-review + per-kind reveal", () => {
       apiUrl: env.apiUrl,
       token: managerToken,
       projectId: env.projectId!,
-      articleId: env.articleId!,
+      articleId: QA_BLIND_REVIEW_ARTICLE_ID,
       qaTemplateId,
       traceId,
     });
@@ -247,7 +248,7 @@ test.describe("Manager blind-review + per-kind reveal", () => {
       apiUrl: env.apiUrl,
       token: managerToken,
       projectId: env.projectId!,
-      articleId: env.articleId!,
+      articleId: QA_BLIND_REVIEW_ARTICLE_ID,
       qaTemplateId,
       traceId,
     });

--- a/frontend/e2e/flows/extraction-export.e2e.ts
+++ b/frontend/e2e/flows/extraction-export.e2e.ts
@@ -261,6 +261,12 @@ test.describe("Extraction export — API surface", () => {
 // ---------------------------------------------------------------------
 
 test.describe("Extraction export — UI flow", () => {
+  // Serial: every case logs the same owner in via the UI. Run in parallel and
+  // the concurrent password-grant logins trip Supabase's local auth rate limit,
+  // leaving a blank page where the export toolbar should be (matches the serial
+  // guard on extraction-navigation for the same reason).
+  test.describe.configure({ mode: "serial" });
+
   test.beforeEach(async () => {
     const required = missingEnvKeys([
       "E2E_USER_EMAIL",

--- a/frontend/e2e/flows/qa-multi-reviewer-consensus.api.e2e.ts
+++ b/frontend/e2e/flows/qa-multi-reviewer-consensus.api.e2e.ts
@@ -12,6 +12,7 @@ import { expect, test } from "@playwright/test";
 import { authHeaders, parseEnvelope } from "../_fixtures/api";
 import { loginViaUi, resolveAuthToken } from "../_fixtures/auth";
 import { createTraceId, loadE2EEnv, missingEnvKeys } from "../_fixtures/env";
+import { QA_CONSENSUS_ARTICLE_ID } from "../_fixtures/fixture-ids";
 import { prepareCleanQaRun } from "../_fixtures/hitl";
 
 interface DecisionResponse {
@@ -92,7 +93,7 @@ test.describe("HITL multi-reviewer consensus", () => {
       apiUrl: env.apiUrl,
       token: userAToken,
       projectId: env.projectId!,
-      articleId: env.articleId!,
+      articleId: QA_CONSENSUS_ARTICLE_ID,
       qaTemplateId,
       traceId,
     });
@@ -191,7 +192,7 @@ test.describe("HITL multi-reviewer consensus", () => {
       apiUrl: env.apiUrl,
       token: userAToken,
       projectId: env.projectId!,
-      articleId: env.articleId!,
+      articleId: QA_CONSENSUS_ARTICLE_ID,
       qaTemplateId,
       traceId,
     });
@@ -228,6 +229,25 @@ test.describe("HITL multi-reviewer consensus", () => {
       timeout: 15000,
     });
 
+    // Blind-review: by default a manager is blinded to peer reviewer decisions
+    // (settings.managers_see_reviewers[kind] = false) and the run-detail read
+    // returns only their own row until the per-kind reveal is on or the run is
+    // finalized. An arbitrator reveals QA to inspect the divergence in the
+    // shared compare view before resolving — model that here so the read below
+    // reflects what the arbitrator actually sees. See blind-review-manager.api.
+    const setQaVisibility = async (value: boolean): Promise<void> => {
+      const res = await request.put(
+        `${env.apiUrl}/api/v1/projects/${env.projectId}/manager-review-visibility`,
+        {
+          headers: authHeaders(userAToken, traceId),
+          data: { kind: "quality_assessment", managers_see_reviewers: value },
+          timeout: 15000,
+        },
+      );
+      expect(res.ok(), `reveal QA=${value}`).toBeTruthy();
+    };
+    await setQaVisibility(true);
+
     const detailRes = await request.get(`${env.apiUrl}/api/v1/runs/${runId}`, {
       headers: authHeaders(userAToken, traceId),
       timeout: 15000,
@@ -240,6 +260,10 @@ test.describe("HITL multi-reviewer consensus", () => {
     expect(coord.length).toBe(3);
     const reviewers = new Set(coord.map((d) => d.reviewer_id));
     expect(reviewers.size).toBe(3);
+
+    // Restore the blinded default so the shared project setting does not leak
+    // into sibling serial cases.
+    await setQaVisibility(false);
 
     const consensusRes = await request.post(
       `${env.apiUrl}/api/v1/runs/${runId}/consensus`,
@@ -308,7 +332,7 @@ test.describe("HITL multi-reviewer consensus", () => {
       apiUrl: env.apiUrl,
       token: userAToken,
       projectId: env.projectId!,
-      articleId: env.articleId!,
+      articleId: QA_CONSENSUS_ARTICLE_ID,
       qaTemplateId,
       traceId,
     });
@@ -403,7 +427,7 @@ test.describe("HITL multi-reviewer consensus", () => {
       apiUrl: env.apiUrl,
       token: userAToken,
       projectId: env.projectId!,
-      articleId: env.articleId!,
+      articleId: QA_CONSENSUS_ARTICLE_ID,
       qaTemplateId,
       traceId,
     });
@@ -506,7 +530,7 @@ test.describe("HITL multi-reviewer consensus", () => {
       apiUrl: env.apiUrl,
       token: userAToken,
       projectId: env.projectId!,
-      articleId: env.articleId!,
+      articleId: QA_CONSENSUS_ARTICLE_ID,
       qaTemplateId,
       traceId,
     });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,6 +44,11 @@ process.env.E2E_REVIEWER_C_PASSWORD ??= FixtureIds.FIXTURE_PASSWORD;
 process.env.E2E_PROJECT_ID ??= FixtureIds.PROJECT_ID;
 process.env.E2E_ARTICLE_ID ??= FixtureIds.ARTICLE_ID;
 process.env.E2E_IMPORT_PROJECT_ID ??= FixtureIds.IMPORT_PROJECT_ID;
+// PROBAST is the seeded quality_assessment global template the QA/consensus/
+// blind-review suites import. Without this zero-config default the whole QA
+// suite silently skips wherever .env doesn't set it (notably CI), so the
+// multi-reviewer consensus + blind-review contracts never actually run there.
+process.env.E2E_QA_GLOBAL_TEMPLATE_ID ??= FixtureIds.PROBAST_GLOBAL_TEMPLATE_ID;
 
 const baseURL = process.env.E2E_FRONTEND_URL || "http://127.0.0.1:8080";
 


### PR DESCRIPTION
## What

Test-infrastructure only (no product/backend code). Makes the QA / multi-reviewer-consensus / blind-review e2e suite actually run in CI and de-flakes it.

## Why

While verifying all flows post-deploy, the local e2e suite failed 3 tests that are **green in CI** — because CI silently **skips** the whole QA suite: `E2E_QA_GLOBAL_TEMPLATE_ID` had no zero-config default, so the consensus + blind-review contracts only ran on warm local environments, where they then flaked or asserted stale behavior. Root causes, each fixed at the right layer:

1. **CI silent-skip coverage hole** — default `E2E_QA_GLOBAL_TEMPLATE_ID` to the seeded PROBAST global id in `playwright.config.ts`, mirroring the other zero-config fixture defaults. The QA/consensus/blind-review tests now run in CI.
2. **Stale 3-way consensus expectation** — under blind-review (#318) a manager is blinded to peer reviewer decisions in the `consensus` stage by design; the backend returning only the caller row is **correct**. The test now performs the manager **reveal** (`PUT /manager-review-visibility`, QA=true) before reading the divergence, matching the real arbitration flow and `blind-review-manager.api`.
3. **Cross-file fixture race** — the two suites that hard-reset QA runs (`resetQaRuns` deletes every QA run for a (project, article) pair) shared one article, so in parallel one suite deleted the other`\s in-flight run mid-decision. Each now uses its own dedicated fixture article (neutral names to avoid colliding with the export dialog`\s `getByLabel` locators).
4. **prepareCleanQaRun** advance-to-review made idempotent (tolerate a concurrent `review->review`).
5. **export UI-flow** made serial so parallel same-account logins don`\t trip the local Supabase auth rate limit.

## Verification

- Full local `test:e2e:local`: **54 passed / 0 failed** (was 49 / 3 failed).
- consensus + blind-review **3x stress** at `--retries=0`, full parallelism: green (previously 2/3 failed).
- eslint on changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)