### PR TITLE
fix(extraction): green the Frontend E2E job after RunHeader migration

### DIFF
--- a/frontend/components/runs/header/Breadcrumb.tsx
+++ b/frontend/components/runs/header/Breadcrumb.tsx
@@ -14,11 +14,11 @@ interface BreadcrumbProps {
 
 export function Breadcrumb({ onBack, crumbs }: BreadcrumbProps) {
   return (
-    <nav className="flex min-w-0 items-center gap-1" aria-label="breadcrumb">
+    <nav className="flex shrink-0 items-center gap-1" aria-label="breadcrumb">
       <Button
         variant="ghost"
         size="sm"
-        className="h-8 w-8 p-0"
+        className="h-8 w-8 p-0 shrink-0"
         aria-label={t('common', 'back')}
         onClick={onBack}
       >

--- a/frontend/e2e/_fixtures/ensure-fixtures.ts
+++ b/frontend/e2e/_fixtures/ensure-fixtures.ts
@@ -152,6 +152,8 @@ export async function ensureFixtures(): Promise<void> {
   await ensureArticleText(F.PROJECT_ID, F.QA_CONSENSUS_ARTICLE_ID);
   await ensureArticle(F.QA_BLIND_REVIEW_ARTICLE_ID, F.PROJECT_ID, "E2E QA Article Two");
   await ensureArticleText(F.PROJECT_ID, F.QA_BLIND_REVIEW_ARTICLE_ID);
+  await ensureArticle(F.QA_REOPEN_ARTICLE_ID, F.PROJECT_ID, "E2E QA Article Three");
+  await ensureArticleText(F.PROJECT_ID, F.QA_REOPEN_ARTICLE_ID);
   const ownerToken = await login(F.OWNER_EMAIL, F.FIXTURE_PASSWORD);
   await ensureCharmsImported(F.PROJECT_ID, ownerToken);
 

--- a/frontend/e2e/_fixtures/fixture-ids.ts
+++ b/frontend/e2e/_fixtures/fixture-ids.ts
@@ -25,6 +25,15 @@ export const ARTICLE_ID = "f00dc63a-6b47-42c3-8a93-af69eb28a1c0";
 export const QA_CONSENSUS_ARTICLE_ID = "f00dc63a-6b47-42c3-8a93-af69eb28a1c1";
 export const QA_BLIND_REVIEW_ARTICLE_ID = "f00dc63a-6b47-42c3-8a93-af69eb28a1c2";
 
+/**
+ * Dedicated article for the QA reopen UI flow. The reopen test finalizes a QA
+ * run; sharing {@link ARTICLE_ID} with `qa-flow` let a prior finalize make
+ * session-open resume an already-finalized (terminal) run, so the test's
+ * advance→consensus seeding returned 400. Its own article keeps the resumed
+ * run non-terminal regardless of sibling test order.
+ */
+export const QA_REOPEN_ARTICLE_ID = "f00dc63a-6b47-42c3-8a93-af69eb28a1c3";
+
 /** Dedicated project for the template-import test — intentionally CHARMS-free. */
 export const IMPORT_PROJECT_ID = "e2e00001-0000-4000-8000-000000000001";
 

--- a/frontend/e2e/flows/extraction-export.e2e.ts
+++ b/frontend/e2e/flows/extraction-export.e2e.ts
@@ -22,11 +22,30 @@
  *   * E2E_ARTICLE_ID  — at least one finalized article
  */
 
-import { APIRequestContext, expect, test } from "@playwright/test";
+import { APIRequestContext, Locator, Page, expect, test } from "@playwright/test";
 
 import { authHeaders, parseEnvelope } from "../_fixtures/api";
 import { loginViaUi } from "../_fixtures/auth";
 import { createTraceId, loadE2EEnv, missingEnvKeys } from "../_fixtures/env";
+
+/**
+ * Log in, open the Data Extraction tab, and return the (visible) export toolbar
+ * button. The cold first load must resolve the project's active template before
+ * the toolbar — and this button — renders; on the ephemeral CI stack that can
+ * exceed Playwright's default 5s actionability timeout, so wait generously here
+ * instead of letting each case race it. (The describe is already `serial` to
+ * dodge the parallel-login auth rate limit.)
+ */
+async function openExportTab(
+  page: Page,
+  env: ReturnType<typeof loadE2EEnv>,
+): Promise<Locator> {
+  await loginViaUi(page);
+  await page.goto(`${env.frontendUrl}/projects/${env.projectId}?tab=extraction`);
+  const exportBtn = page.getByTestId("extraction-export-button");
+  await expect(exportBtn).toBeVisible({ timeout: 20000 });
+  return exportBtn;
+}
 
 const XLSX_MIME =
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
@@ -283,16 +302,10 @@ test.describe("Extraction export — UI flow", () => {
     page,
   }) => {
     const env = loadE2EEnv();
-    await loginViaUi(page);
-    await page.goto(
-      `${env.frontendUrl}/projects/${env.projectId}?tab=extraction`,
-    );
-
     // The consolidated entry point is the toolbar export button (the legacy
     // "Export Data" More-menu item was removed; that source-level guard lives
     // in the HeaderMoreMenu component test).
-    const exportBtn = page.getByTestId("extraction-export-button");
-    await expect(exportBtn).toBeVisible();
+    const exportBtn = await openExportTab(page, env);
     // No legacy "Export Data" affordance is reachable on this view.
     await expect(
       page.getByRole("menuitem", { name: /Export Data/i }),
@@ -305,13 +318,7 @@ test.describe("Extraction export — UI flow", () => {
 
   test("dialog opens with defaults and shows live preview", async ({ page }) => {
     const env = loadE2EEnv();
-    await loginViaUi(page);
-    await page.goto(
-      `${env.frontendUrl}/projects/${env.projectId}?tab=extraction`,
-    );
-
-    const exportBtn = page.getByTestId("extraction-export-button");
-    await expect(exportBtn).toBeVisible();
+    const exportBtn = await openExportTab(page, env);
     await exportBtn.click();
 
     // Dialog opens.
@@ -333,12 +340,8 @@ test.describe("Extraction export — UI flow", () => {
 
   test("Single-user mode reveals the reviewer control", async ({ page }) => {
     const env = loadE2EEnv();
-    await loginViaUi(page);
-    await page.goto(
-      `${env.frontendUrl}/projects/${env.projectId}?tab=extraction`,
-    );
-
-    await page.getByTestId("extraction-export-button").click();
+    const exportBtn = await openExportTab(page, env);
+    await exportBtn.click();
     await page.getByLabel(/Single user/i).check();
 
     // Single-user mode resolves to exactly one of three mutually exclusive
@@ -357,12 +360,8 @@ test.describe("Extraction export — UI flow", () => {
 
   test("All-users mode reveals the anonymize-reviewer toggle for managers", async ({ page }) => {
     const env = loadE2EEnv();
-    await loginViaUi(page);
-    await page.goto(
-      `${env.frontendUrl}/projects/${env.projectId}?tab=extraction`,
-    );
-
-    await page.getByTestId("extraction-export-button").click();
+    const exportBtn = await openExportTab(page, env);
+    await exportBtn.click();
     const allUsers = page.getByLabel(/All users/i);
     // Non-managers see it disabled; managers can tick it.
     const disabled = await allUsers.isDisabled();
@@ -381,12 +380,8 @@ test.describe("Extraction export — UI flow", () => {
 
   test("Cancel button closes the dialog without dispatching", async ({ page }) => {
     const env = loadE2EEnv();
-    await loginViaUi(page);
-    await page.goto(
-      `${env.frontendUrl}/projects/${env.projectId}?tab=extraction`,
-    );
-
-    await page.getByTestId("extraction-export-button").click();
+    const exportBtn = await openExportTab(page, env);
+    await exportBtn.click();
     await expect(page.getByText(/Export extraction data/i)).toBeVisible();
     await page.getByRole("button", { name: /Cancel/i }).click();
     await expect(page.getByText(/Export extraction data/i)).not.toBeVisible();
@@ -394,12 +389,8 @@ test.describe("Extraction export — UI flow", () => {
 
   test("Empty-scope guard: Selected only is disabled when nothing is ticked", async ({ page }) => {
     const env = loadE2EEnv();
-    await loginViaUi(page);
-    await page.goto(
-      `${env.frontendUrl}/projects/${env.projectId}?tab=extraction`,
-    );
-
-    await page.getByTestId("extraction-export-button").click();
+    const exportBtn = await openExportTab(page, env);
+    await exportBtn.click();
     const selected = page.getByLabel(/Selected only/i);
     // When no articles ticked, the radio is disabled per FR-005.
     await expect(selected).toBeDisabled();

--- a/frontend/e2e/flows/extraction-navigation.ui.e2e.ts
+++ b/frontend/e2e/flows/extraction-navigation.ui.e2e.ts
@@ -46,12 +46,18 @@ test.describe("Extraction page navigation", () => {
     await page.goto(`${env.frontendUrl}/projects/${env.projectId}/extraction/${env.articleId}`);
 
     await waitForBackButton(page);
-    // Breadcrumb shows the project name as a clickable link on viewports >= md.
+    // The RunHeader breadcrumb renders only once the extraction view reaches
+    // its `ready` state; the loading/error fallbacks render their own Back
+    // button (which is what waitForBackButton matches). Gate on the ready-state
+    // anchor before probing the breadcrumb so we never assert against a
+    // transient pre-ready render where the nav is mounted-but-hidden.
+    await expect(page.locator('[data-scroll-container="extraction-form"]')).toBeVisible({
+      timeout: 15000,
+    });
     // The breadcrumb is rendered inside a navigation landmark with role="navigation" name "breadcrumb".
     const breadcrumb = page.getByRole("navigation", { name: /breadcrumb/i });
-    await expect(breadcrumb).toBeVisible({ timeout: 5000 });
     const projectLink = breadcrumb.getByText("E2E Test Project").first();
-    await expect(projectLink).toBeVisible();
+    await expect(projectLink).toBeVisible({ timeout: 5000 });
 
     await projectLink.click();
     await page.waitForURL(new RegExp(`/projects/${env.projectId}(?!/extraction)`), { timeout: 10000 });

--- a/frontend/e2e/flows/qa-reopen.ui.e2e.ts
+++ b/frontend/e2e/flows/qa-reopen.ui.e2e.ts
@@ -22,6 +22,7 @@ import { expect, test } from "@playwright/test";
 import { authHeaders, parseEnvelope } from "../_fixtures/api";
 import { loginViaUi, resolveAuthToken } from "../_fixtures/auth";
 import { createTraceId, loadE2EEnv, missingEnvKeys } from "../_fixtures/env";
+import { QA_REOPEN_ARTICLE_ID } from "../_fixtures/fixture-ids";
 import { adminSelect } from "../_fixtures/supabase-admin";
 
 interface OpenSessionResponse {
@@ -64,12 +65,15 @@ test.describe("HITL reopen flow (Option C)", () => {
       "E2E_USER_EMAIL",
       "E2E_USER_PASSWORD",
       "E2E_PROJECT_ID",
-      "E2E_ARTICLE_ID",
       "E2E_QA_GLOBAL_TEMPLATE_ID",
     ]);
     test.skip(required.length > 0, `Missing required env: ${required.join(", ")}`);
 
     const env = loadE2EEnv();
+    // Dedicated article (not the shared E2E_ARTICLE_ID): this test finalizes
+    // its QA run, and a finalized run on a shared article makes session-open
+    // resume a terminal run, breaking the advance→consensus seeding below.
+    const articleId = QA_REOPEN_ARTICLE_ID;
     const qaTemplateId = process.env.E2E_QA_GLOBAL_TEMPLATE_ID!;
 
     await loginViaUi(page);
@@ -82,7 +86,7 @@ test.describe("HITL reopen flow (Option C)", () => {
       data: {
         kind: "quality_assessment",
         project_id: env.projectId,
-        article_id: env.articleId,
+        article_id: articleId,
         global_template_id: qaTemplateId,
       },
       timeout: 30000,
@@ -215,7 +219,7 @@ test.describe("HITL reopen flow (Option C)", () => {
     // 6. UI surface — the QA page now shows the "Revision" tag in the
     //    StageRail (nav[aria-label="Run stage"]) for the new (latest) run.
     await page.goto(
-      `${env.frontendUrl}/projects/${env.projectId}/articles/${env.articleId}/quality-assessment/${qaTemplateId}`,
+      `${env.frontendUrl}/projects/${env.projectId}/articles/${articleId}/quality-assessment/${qaTemplateId}`,
     );
     await expect(
       page.getByRole("navigation", { name: /run stage/i }),


### PR DESCRIPTION
Follow-up to #338. The RunHeader migration left the (non-required) **Frontend E2E (ephemeral stack)** job red on three flows. Only the breadcrumb is a genuine regression from #338; the other two are pre-existing shared-stack flakes (intermittently red on dev too) hardened here so the job is green in every scenario.

## Fixes
- **breadcrumb (regression)** — new RunHeader breadcrumb renders only in the `ready` view-state, but `extraction-navigation`'s `waitForBackButton` also matches the fallback-state Back button, so it asserted the breadcrumb before `ready` (mounted-but-hidden nav). Gate on the ready-state anchor (`[data-scroll-container="extraction-form"]`); keep the back button + nav `shrink-0`.
- **qa-reopen (pre-existing)** — test finalizes its QA run on the **shared** fixture article, so a prior `qa-flow` finalize made session-open resume a terminal run and advance→consensus 400'd. Dedicated `QA_REOPEN_ARTICLE_ID` (mirrors the `qa-multi-reviewer` pattern).
- **export (pre-existing)** — cold first-load resolves the active template before the toolbar button renders, exceeding the default 5s on a cold stack. All UI-flow cases now route through an `openExportTab()` helper that waits generously.

## Verification (local, against the running stack)
- All 3 flows pass with `--retries=0` (breadcrumb, qa-reopen, full export UI flow)
- 729/729 unit · typecheck clean · lint clean · 0 compiler bailouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)