### PR TITLE
docs(governance): single-source root indices + relocate observability (WS-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,7 @@ For manual setup (without `make`), see [`.github/CONTRIBUTING.md`](.github/CONTR
 
 ## Documentation
 
-- 📖 [Documentation index](docs/README.md) — Diátaxis-organised site map.
-- 🚀 [Deployment reference](docs/reference/deployment.md) — Railway + Vercel topology, env vars, rollback.
-- 🧱 [Extraction + HITL architecture](docs/reference/extraction-hitl-architecture.md) — canonical schema, run lifecycle.
-- 🛢️ [Migration strategy](docs/reference/migrations.md) — Alembic vs Supabase split, squash recipe.
-- ✅ [Test strategy](docs/reference/test-strategy.md) — load-bearing tests.
+- 📖 [Documentation index](docs/README.md) — the Diátaxis-organised site map (deployment, migrations, architecture, test strategy, and more).
 - 🧭 [ADRs](docs/adr/) — recorded architecture decisions.
 - 🗺️ [Roadmap](docs/ROADMAP.md) — milestones + link to GitHub Projects.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,6 @@ tutorial lives here.*
 | Guide | When to read |
 | --- | --- |
 | [Seed the database](./how-to/seed-database.md) | After `make reset-db` or when bootstrapping a new env |
-| [Extraction E2E observability](./how-to/observability-extraction.md) | Debugging extraction latency / errors across browser → API → DB |
 
 ## Reference — *information lookup*
 
@@ -35,6 +34,7 @@ tutorial lives here.*
 | [Constitution](./reference/constitution.md) | Non-negotiable architectural principles (layering, typed everything, split migration ownership) |
 | [Extraction + HITL architecture](./reference/extraction-hitl-architecture.md) | Canonical schema, run lifecycle, RLS posture |
 | [Test strategy](./reference/test-strategy.md) | Load-bearing tests, pyramid layout |
+| [Extraction observability](./reference/observability-extraction.md) | Metrics + structured events; debugging extraction latency/errors (browser → API → DB) |
 | [CHARMS template (v1.1)](./reference/templates/charms-v1.1-complete.md) | Field-by-field spec of the global CHARMS template |
 | [CHARMS visual hierarchy](./reference/templates/charms-v1.1-hierarchy.md) | Tree view of CHARMS entities |
 
@@ -49,8 +49,8 @@ tutorial lives here.*
 
 | Path | Purpose |
 | --- | --- |
-| [`docs/superpowers/specs/`](./superpowers/specs/) | Active design specs |
-| [`docs/superpowers/plans/`](./superpowers/plans/) | Active implementation plans |
+| [`docs/superpowers/specs/`](./superpowers/specs/) | Design specs (lifecycle in each file's frontmatter; shipped → `specs/archive/`) |
+| [`docs/superpowers/plans/`](./superpowers/plans/) | Implementation plans (lifecycle in each file's frontmatter; shipped → `plans/archive/`) |
 | [`docs/superpowers/quality-runs/`](./superpowers/quality-runs/) | Outputs of the architectural quality autoloop |
 | [`docs/superpowers/design-system/`](./superpowers/design-system/) | Component design briefs |
 | [`docs/design-references/`](./design-references/) | Visual references (Linear UX) |
@@ -66,7 +66,7 @@ tutorial lives here.*
 
 ## Doc conventions
 
-- Every file under `docs/` carries YAML frontmatter (`status`, `last_reviewed`, `owner`) and a visible status line at the top.
+- Every file under `docs/` carries YAML frontmatter (`status`, `last_reviewed`, `owner`) — the **single source of truth** (the staleness gate reads frontmatter). A visible status line in the body is optional and must not restate `last_reviewed` (the duplicated date drifts).
 - Status values: `stable` · `draft` · `deprecated` · `shipped` · `frozen` · `in_progress`.
 - CI (`.github/workflows/docs-ci.yml`) enforces markdownlint, cspell, link check, and frontmatter presence on every PR that touches `**/*.md`.
 - Docs older than 180 days trigger a `staleness` warning (set `STALENESS_FAIL=1` in CI to harden later).

--- a/docs/reference/migrations.md
+++ b/docs/reference/migrations.md
@@ -4,7 +4,7 @@ last_reviewed: 2026-06-10
 owner: '@raphaelfh'
 ---
 
-> **Status:** Stable · Last reviewed: 2026-05-24 · Owner: @raphaelfh
+> **Status:** Stable · Last reviewed: 2026-06-10 · Owner: @raphaelfh
 
 # Database migration strategy
 

--- a/docs/reference/observability-extraction.md
+++ b/docs/reference/observability-extraction.md
@@ -1,12 +1,18 @@
 ---
 status: stable
-last_reviewed: 2026-05-24
+last_reviewed: 2026-06-20
 owner: '@raphaelfh'
 ---
 
-> **Status:** Stable · Last reviewed: 2026-05-24 · Owner: @raphaelfh
+> **Status:** Stable · Last reviewed: 2026-06-20 · Owner: @raphaelfh
 
-# Unified Evaluation Observability
+# Extraction Observability
+
+> Metrics and structured events for the extraction stack. The `evaluation_*`
+> names below are the **pre-rename vocabulary** (the evaluation stack was unified
+> into extraction); they are retained for historical dashboards, while new
+> emitters use `extraction_*`. Glossary:
+> [extraction-hitl-architecture.md](./extraction-hitl-architecture.md).
 
 ## Core metrics
 
@@ -33,7 +39,7 @@ owner: '@raphaelfh'
   - filter `evaluation_queue_backlog_scale_alert`
   - group by `project_id`
 
-# Extraction E2E and Database Observability
+## Extraction E2E and database observability
 
 ## Goal
 

--- a/llms.txt
+++ b/llms.txt
@@ -33,8 +33,9 @@ Hosting: Railway (backend + worker + Redis) + Vercel (frontend) + Supabase
 - playwright-report/
 - test-results/
 
-## Documentation conventions
+## Conventions
 
-- Every doc carries `status`, `last_reviewed`, `owner` frontmatter.
-- Conventional commits (`feat:`, `fix:`, `docs:`, `chore:`, `test:`, `ci:`, `refactor:`).
-- English only for code, comments, commits, and documentation.
+Hard rules (English-only; conventional commits; `status`/`last_reviewed`/`owner`
+frontmatter; layering; typed everything) live in [CLAUDE.md](CLAUDE.md) and
+[docs/reference/constitution.md](docs/reference/constitution.md) — the single
+source, not restated here. Full doc map: [docs/README.md](docs/README.md).


### PR DESCRIPTION
## What

**WS-5 of the governance cleanup** — single-sources the root indices and fixes
the dual-maintained metadata that had drifted. Off `dev`, isolated.

## Changes

- **D2 — relocate the misfiled observability doc**: `observability-extraction.md` moves `how-to/ → reference/` (it's a metrics + event catalog, not a task recipe). Collapses its **two H1s into one** and reconciles the legacy `evaluation_*` vocabulary (a pre-rename note pointing at the extraction glossary). Index quadrant updated (how-to → reference table).
- **D1 — stop re-listing the same facts in N places**:
  - `README.md` no longer re-lists the reference docs — it points at the [doc index](docs/README.md) (the single source for the site map).
  - `llms.txt` drops the duplicated hard-rules block (English-only / conventional commits / frontmatter) and points at `CLAUDE.md` + the constitution.
- **D4 — frontmatter is the single source for `last_reviewed`**: fixes the drifted `migrations.md` body date (was `2026-05-24` vs frontmatter `2026-06-10`); the convention now says the optional visible status line must not restate the date.
- **D6 — `docs/README` no longer labels the spec/plan dirs "Active"** (lifecycle lives in each file's frontmatter; shipped → `*/archive/`).

## Verification

- `markdownlint` — 0 · `cspell` — 0 · `check-frontmatter.sh` — pass
- relocated doc has a **single H1**; **zero** lingering links to the old `how-to/` path; `migrations.md` frontmatter/body dates now match.

## Findings resolved

D1, D2, D4, D6. (G6 + most of F6 were already resolved in WS-4; G7 is moot post-archive.)

## Note

The `README.md` ↔ `CLAUDE.md` tech-stack sections are kept as **two
audience-appropriate views** (public vs agent) rather than merged — they don't
contradict, so per the audit's conservative-on-redundancy guidance they're left
as intentional. The only remaining WS is **WS-6** (dead-link repairs, frozen-spec
graduation to `docs/explanation/`, llms.txt frontmatter, arch-doc ConsensusRule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
