### PR TITLE
fix(extraction): PDF-right split, hide empty run-header kebab, header+view responsiveness

### DIFF
--- a/frontend/components/extraction/ExtractionFormPanel.tsx
+++ b/frontend/components/extraction/ExtractionFormPanel.tsx
@@ -47,7 +47,7 @@ export function ExtractionFormPanel({
     // because radix ScrollArea renders the actual scroll node beneath.
     <div data-scroll-container="extraction-form" className="h-full">
       <ScrollArea className="h-full bg-muted/30">
-        <div className="@container p-8 space-y-4">
+        <div className="@container min-w-0 p-4 @md:p-6 @lg:p-8 space-y-4">
           {viewMode === 'extract' && formViewProps ? (
             <ExtractionFormView {...formViewProps} showPDF={showPDF} />
           ) : viewMode === 'compare' && compareViewProps ? (

--- a/frontend/components/extraction/ExtractionHeader.tsx
+++ b/frontend/components/extraction/ExtractionHeader.tsx
@@ -295,8 +295,10 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
               onOpenSuggestions={props.onAISuggestionsClick}
             />
             <RunHeader.PrimaryAction />
-            <span className="mx-1 h-5 w-px bg-border/60" aria-hidden="true" />
-            <RunHeader.Help />
+            <span className="mx-1 hidden h-5 w-px bg-border/60 @[40rem]/headerbar:block" aria-hidden="true" />
+            <span className="hidden @[40rem]/headerbar:inline-flex">
+              <RunHeader.Help />
+            </span>
             <RunHeader.Menu>
               {hasComparison && (
                 <RunHeader.MenuItem onSelect={() => onViewModeChange(viewMode === 'compare' ? 'extract' : 'compare')}>

--- a/frontend/components/extraction/ExtractionPDFPanel.tsx
+++ b/frontend/components/extraction/ExtractionPDFPanel.tsx
@@ -34,18 +34,20 @@ function ExtractionPDFPanelComponent({
     return null;
   }
 
+  // PDF lives on the RIGHT (order 2). The form panel is order 1, so the single
+  // resize handle sits BETWEEN them — i.e. before this panel, not after it.
   return (
     <>
+      <ResizableHandle withHandle />
       <ResizablePanel
         id="extraction-pdf"
-        order={1}
+        order={2}
         defaultSize={50}
         minSize={30}
         maxSize={70}
       >
         <PrumoPdfViewer source={source} store={store} className="h-full" />
       </ResizablePanel>
-      <ResizableHandle withHandle />
     </>
   );
 }

--- a/frontend/components/extraction/__tests__/ExtractionHeader.exports.test.tsx
+++ b/frontend/components/extraction/__tests__/ExtractionHeader.exports.test.tsx
@@ -25,8 +25,16 @@ const base = {
 };
 
 describe('ExtractionHeader (post legacy-cascade)', () => {
-  it('renders the More menu without an Export Data item', async () => {
+  it('hides the More menu entirely when it would have no items', () => {
+    // base has hasComparison:false and no canReopen, so the only two menu
+    // items are both gated off. An empty kebab is a dead affordance — it must
+    // not render at all (regression: it used to open to an empty dropdown).
     render(<MemoryRouter><ExtractionHeader {...base} /></MemoryRouter>);
+    expect(screen.queryByRole('button', { name: /more/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the More menu (without an Export Data item) when it has items', async () => {
+    render(<MemoryRouter><ExtractionHeader {...base} hasComparison /></MemoryRouter>);
     await userEvent.click(screen.getByRole('button', { name: /more/i }));
     expect(screen.queryByText(/Export Data/i)).not.toBeInTheDocument();
   });

--- a/frontend/components/runs/header/AIActions.tsx
+++ b/frontend/components/runs/header/AIActions.tsx
@@ -12,17 +12,20 @@ interface AIActionsProps {
 
 export function AIActions({ pendingCount, canExtract, extracting, onExtract, onOpenSuggestions }: AIActionsProps) {
   if (canExtract) {
+    const label = extracting ? t('runs', 'extractingWithAI') : t('runs', 'extractWithAI');
     return (
-      <Button size="sm" variant="secondary" onClick={onExtract} disabled={extracting} className="gap-1.5">
+      // Label collapses to the icon below 40rem; aria-label keeps the
+      // accessible name since the Sparkles icon is aria-hidden.
+      <Button size="sm" variant="secondary" onClick={onExtract} disabled={extracting} aria-label={label} className="shrink-0 gap-1.5 whitespace-nowrap">
         <Sparkles className="h-4 w-4 text-ai" aria-hidden="true" />
-        {extracting ? t('runs', 'extractingWithAI') : t('runs', 'extractWithAI')}
+        <span className="hidden @[40rem]/headerbar:inline">{label}</span>
       </Button>
     );
   }
   if (pendingCount <= 0) return null;
   return (
-    <button type="button" onClick={() => onOpenSuggestions?.()} className="flex items-center gap-1.5 rounded-md border border-ai/40 bg-ai/10 px-2.5 py-0.5 text-[11px] text-ai focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-      <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />AI · {pendingCount}
+    <button type="button" onClick={() => onOpenSuggestions?.()} className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-ai/40 bg-ai/10 px-2.5 py-0.5 text-[11px] text-ai focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+      <Sparkles className="h-3.5 w-3.5" aria-hidden="true" /><span className="hidden @[48rem]/headerbar:inline">AI · </span>{pendingCount}
     </button>
   );
 }

--- a/frontend/components/runs/header/Breadcrumb.tsx
+++ b/frontend/components/runs/header/Breadcrumb.tsx
@@ -15,7 +15,7 @@ interface BreadcrumbProps {
 
 export function Breadcrumb({ onBack, crumbs }: BreadcrumbProps) {
   return (
-    <nav className="flex shrink-0 items-center gap-1" aria-label="breadcrumb">
+    <nav className="flex min-w-0 items-center gap-1" aria-label="breadcrumb">
       <Button
         variant="ghost"
         size="sm"
@@ -34,9 +34,12 @@ export function Breadcrumb({ onBack, crumbs }: BreadcrumbProps) {
                 <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
               )}
               {crumb.onClick ? (
+                // min-w-0 + truncate so the non-final crumb shrinks WITH its
+                // li under flex pressure instead of overflowing it and painting
+                // over the next crumb (the narrow-width overlap).
                 <button
                   type="button"
-                  className="whitespace-nowrap rounded text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="min-w-0 max-w-[180px] truncate rounded text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   onClick={crumb.onClick}
                 >
                   {crumb.label}
@@ -44,7 +47,7 @@ export function Breadcrumb({ onBack, crumbs }: BreadcrumbProps) {
               ) : isLast ? (
                 <TruncatedText text={crumb.label} className="max-w-[220px] text-sm font-medium text-foreground" />
               ) : (
-                <span className="whitespace-nowrap text-sm text-muted-foreground">{crumb.label}</span>
+                <span className="block min-w-0 max-w-[180px] truncate text-sm text-muted-foreground">{crumb.label}</span>
               )}
             </li>
           );

--- a/frontend/components/runs/header/Menu.tsx
+++ b/frontend/components/runs/header/Menu.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { Children, type ReactNode } from 'react';
 import { MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -14,6 +14,14 @@ interface MenuProps {
 }
 
 export function Menu({ children }: MenuProps) {
+  // Conditional MenuItems collapse to `false`/`null` when their gate is off
+  // (e.g. extraction with no comparison + cannot reopen). An always-mounted
+  // trigger over an empty content set is a dead affordance — the kebab opened
+  // to nothing. Children.toArray drops booleans/null, so when nothing survives
+  // we render no trigger at all rather than an empty dropdown.
+  if (Children.toArray(children).length === 0) {
+    return null;
+  }
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/frontend/components/runs/header/PrimaryAction.tsx
+++ b/frontend/components/runs/header/PrimaryAction.tsx
@@ -31,7 +31,10 @@ export function PrimaryAction() {
   );
   return (
     <div className="flex items-center gap-2">
-      {helper && <span id={helperId} className="whitespace-nowrap text-[11px] text-muted-foreground">{helper}</span>}
+      {/* sr-only (not `hidden`) below 52rem so the node stays in the a11y tree
+          and the button's aria-describedby keeps resolving; revealed visually
+          where the row has room. */}
+      {helper && <span id={helperId} className="sr-only text-[11px] text-muted-foreground @[52rem]/headerbar:not-sr-only @[52rem]/headerbar:whitespace-nowrap">{helper}</span>}
       {transition.tooltip ? (
         <Tooltip>
           <TooltipTrigger asChild>{button}</TooltipTrigger>

--- a/frontend/components/runs/header/Reviewers.tsx
+++ b/frontend/components/runs/header/Reviewers.tsx
@@ -11,7 +11,7 @@ export function Reviewers() {
   const shown = Math.min(reviewers.count, 3);
   return (
     <div className="flex items-center gap-2" data-testid="run-reviewers">
-      <div className="flex -space-x-2" title={`${reviewers.count}/${reviewers.required}`}>
+      <div className="flex shrink-0 -space-x-2" title={`${reviewers.count}/${reviewers.required}`}>
         {Array.from({ length: shown }).map((_, i) => (
           <span key={i} className={cn('h-[18px] w-[18px] rounded-full border-2 border-background', AVATAR[i % AVATAR.length])} aria-hidden="true" />
         ))}

--- a/frontend/components/runs/header/RoleChip.tsx
+++ b/frontend/components/runs/header/RoleChip.tsx
@@ -24,20 +24,23 @@ export function RoleChip() {
     <>
       {t('common', roleKeys[role])}
       {suffixKey && (
-        <>
+        // Collapse the role qualifier on narrow headers (mirrors the StageRail
+        // label reveal at the same breakpoint) so the chip shrinks to just the
+        // role word before Center starts clipping.
+        <span className="hidden @[48rem]/headerbar:inline">
           <span className="text-muted-foreground" aria-hidden="true">{' · '}</span>
           <span className="text-muted-foreground">{t('runs', suffixKey)}</span>
-        </>
+        </span>
       )}
     </>
   );
   if (!canReveal) {
-    return <span className="rounded-md bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">{text}</span>;
+    return <span className="whitespace-nowrap rounded-md bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">{text}</span>;
   }
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground">
+        <Button variant="ghost" size="sm" className="h-7 gap-1 whitespace-nowrap px-2 text-[11px] text-muted-foreground hover:text-foreground">
           {text}
           <ChevronDown className="h-3 w-3" aria-hidden="true" />
         </Button>

--- a/frontend/components/runs/header/RunHeader.tsx
+++ b/frontend/components/runs/header/RunHeader.tsx
@@ -17,13 +17,21 @@ import { Worklist } from './Worklist';
 import { CommandPalette } from './CommandPalette';
 
 function Left({ children }: { children: ReactNode }) {
-  return <div className={cn('flex min-w-0 flex-1 items-center gap-3')}>{children}</div>;
+  // overflow-hidden is the backstop: even after the shrinkable children
+  // (Breadcrumb truncates, StageRail clips) compress, content can never paint
+  // out of this track onto the Center slot — the narrow-width overlap bug.
+  return <div className={cn('flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden @[48rem]/headerbar:gap-3')}>{children}</div>;
 }
 function Center({ children }: { children: ReactNode }) {
-  return <div className={cn('flex shrink-0 items-center gap-2')}>{children}</div>;
+  // Mid-priority (reviewers + role chip). Allowed to shrink/clip so it yields
+  // room to Left instead of forcing overflow; its leaves collapse their labels
+  // via @container queries before any clipping engages.
+  return <div className={cn('flex min-w-0 shrink items-center gap-2 overflow-hidden')}>{children}</div>;
 }
 function Right({ children }: { children: ReactNode }) {
-  return <div className={cn('flex shrink-0 items-center gap-2')}>{children}</div>;
+  // Stays shrink-0 so the PrimaryAction is never clipped; only the inter-item
+  // gap tightens at narrow widths.
+  return <div className={cn('flex shrink-0 items-center gap-1 @[48rem]/headerbar:gap-2')}>{children}</div>;
 }
 
 function RunHeaderRoot({ value, children }: { value: RunHeaderValue; children: ReactNode }) {
@@ -31,7 +39,7 @@ function RunHeaderRoot({ value, children }: { value: RunHeaderValue; children: R
     <RunHeaderProvider value={value}>
       <TooltipProvider delayDuration={200}>
         <header className="relative z-10 border-b border-border/40 bg-background/80 backdrop-blur-md">
-          <div className="flex h-12 items-center gap-4 px-6">{children}</div>
+          <div className="flex h-12 items-center gap-2 px-3 @[40rem]/headerbar:gap-4 @[40rem]/headerbar:px-6">{children}</div>
         </header>
       </TooltipProvider>
     </RunHeaderProvider>

--- a/frontend/components/runs/header/StageRail.tsx
+++ b/frontend/components/runs/header/StageRail.tsx
@@ -28,9 +28,9 @@ export function StageRail() {
   const { stage, isRevision } = useRunHeader();
   const nodes = stageNodeStates(stage);
   return (
-    <nav className="flex items-center gap-1.5" aria-label="Run stage">
+    <nav className="flex min-w-0 shrink items-center gap-1.5 overflow-hidden" aria-label="Run stage">
       {isRevision && (
-        <span className="mr-1 whitespace-nowrap rounded-md bg-ai/10 px-2 py-0.5 text-[11px] font-medium text-ai">
+        <span className="mr-1 hidden @[48rem]/headerbar:inline-flex whitespace-nowrap rounded-md bg-ai/10 px-2 py-0.5 text-[11px] font-medium text-ai">
           {t('runs', 'revision')}
         </span>
       )}

--- a/frontend/components/runs/header/__tests__/Breadcrumb.test.tsx
+++ b/frontend/components/runs/header/__tests__/Breadcrumb.test.tsx
@@ -46,7 +46,10 @@ describe('RunHeader.Breadcrumb', () => {
     expect(screen.getByText('My Run')).toBeInTheDocument();
   });
 
-  it('applies truncate class to the last crumb only', () => {
+  it('truncates every crumb so a non-final crumb cannot overflow into the next', () => {
+    // Non-final crumbs must also truncate (min-w-0 + truncate): a whitespace-nowrap
+    // crumb overflows its shrunk <li> at narrow widths and paints over the next
+    // crumb. Both the final title and the non-final crumbs carry the truncate class.
     render(
       <RunHeader value={base}>
         <RunHeader.Left>
@@ -57,10 +60,8 @@ describe('RunHeader.Breadcrumb', () => {
         </RunHeader.Left>
       </RunHeader>,
     );
-    const lastCrumb = screen.getByText('My Run');
-    expect(lastCrumb.className).toMatch(/truncate/);
-    const firstCrumb = screen.getByText('Projects');
-    expect(firstCrumb.className).not.toMatch(/truncate/);
+    expect(screen.getByText('My Run').className).toMatch(/truncate/);
+    expect(screen.getByText('Projects').className).toMatch(/truncate/);
   });
 
   it('renders clickable crumbs as buttons and non-clickable as spans', async () => {

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -1322,18 +1322,10 @@ export default function ExtractionFullScreen() {
       <div className="flex-1 overflow-hidden">
         <ViewerProvider store={viewerStore}>
         <ResizablePanelGroup direction="horizontal">
-            {/* PDF Viewer (optional) - Extracted to isolated component */}
-          <ExtractionPDFPanel
-            articleId={articleId || ''}
-            projectId={projectId || ''}
-            showPDF={showPDF}
-            store={viewerStore}
-          />
-
-            {/* Extraction form - Extracted to isolated component */}
+            {/* Extraction form (left) - Extracted to isolated component */}
           <ResizablePanel
             id="extraction-form"
-            order={2}
+            order={1}
             defaultSize={showPDF ? 50 : 100}
             minSize={30}
           >
@@ -1379,6 +1371,14 @@ export default function ExtractionFullScreen() {
               }}
             />
           </ResizablePanel>
+
+            {/* PDF Viewer (right, optional) - renders the handle + panel */}
+          <ExtractionPDFPanel
+            articleId={articleId || ''}
+            projectId={projectId || ''}
+            showPDF={showPDF}
+            store={viewerStore}
+          />
         </ResizablePanelGroup>
         </ViewerProvider>
       </div>

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -605,8 +605,10 @@ export default function QualityAssessmentFullScreen() {
             onExtract={onExtractWithAI}
           />
           <RunHeader.PrimaryAction />
-          <span className="mx-1 h-5 w-px bg-border/60" aria-hidden="true" />
-          <RunHeader.Help />
+          <span className="mx-1 hidden h-5 w-px bg-border/60 @[40rem]/headerbar:block" aria-hidden="true" />
+          <span className="hidden @[40rem]/headerbar:inline-flex">
+            <RunHeader.Help />
+          </span>
           <RunHeader.Menu>
             {canCompare && (
               <RunHeader.MenuItem

--- a/frontend/pdf-viewer/PrumoPdfViewer.tsx
+++ b/frontend/pdf-viewer/PrumoPdfViewer.tsx
@@ -73,8 +73,8 @@ export function PrumoPdfViewer({
   }, []);
 
   return (
-    <div ref={rootRef} className={`flex flex-col h-full ${className ?? ''}`} tabIndex={-1}>
-      <Viewer.Root source={source} store={store} className="flex flex-col flex-1 min-h-0">
+    <div ref={rootRef} className={`flex flex-col h-full min-w-0 overflow-hidden ${className ?? ''}`} tabIndex={-1}>
+      <Viewer.Root source={source} store={store} className="flex flex-col flex-1 min-h-0 min-w-0">
         {toolbar && <Toolbar onSearchToggle={() => setSearchOpen((v) => !v)} />}
         <SearchBar open={searchOpen} onClose={() => setSearchOpen(false)} />
         {/* aria-live region: announces citation jumps to screen readers (canvas + reader mode) */}

--- a/frontend/pdf-viewer/ui/SearchBar.tsx
+++ b/frontend/pdf-viewer/ui/SearchBar.tsx
@@ -84,7 +84,7 @@ export function SearchBar({open, onClose}: SearchBarProps) {
 
   return (
     <div
-      className="flex items-center gap-1 px-2 py-1 border-b bg-background"
+      className="flex min-w-0 items-center gap-1 px-2 py-1 border-b bg-background"
       role="search"
       data-testid="pdf-search-bar"
     >
@@ -95,7 +95,7 @@ export function SearchBar({open, onClose}: SearchBarProps) {
         onChange={(e) => actions.setSearchQuery(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="Find in document"
-        className="h-8 w-64 text-sm"
+        className="h-8 w-full min-w-0 max-w-64 text-sm"
         aria-label="Search query"
       />
       <span className="text-xs text-muted-foreground min-w-[68px] text-center">

--- a/frontend/pdf-viewer/ui/Toolbar.tsx
+++ b/frontend/pdf-viewer/ui/Toolbar.tsx
@@ -29,9 +29,9 @@ export function Toolbar({
 
   return (
     <div
-      className={`flex items-center justify-between gap-2 px-3 py-2 border-b bg-background ${className ?? ''}`}
+      className={`flex flex-wrap items-center justify-between gap-x-2 gap-y-1 px-3 py-2 border-b bg-background ${className ?? ''}`}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         {leading}
         {modeToggle && (
           <Button
@@ -54,7 +54,7 @@ export function Toolbar({
         )}
         <NavigationControls />
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         <ZoomControls />
         {onSearchToggle && (
           <Button


### PR DESCRIPTION
## What

Fixes three reported defects in the extraction run view (`/projects/:projectId/extraction/:articleId`).

### 1. PDF panel opens on the RIGHT
`ExtractionPDFPanel` now renders the resize handle **before** its panel (`order={2}`); `ExtractionFullScreen` places the form panel first (`order={1}`, left). Result: form left / PDF right, single handle between them.

### 2. Empty kebab ("...") no longer opens to nothing
Guarded at the shared `Menu` component — `Children.toArray(children).length === 0 → return null` — so the dead affordance disappears when all its items are gated off. Also fixes the same latent empty-menu in the **QA** header.

### 3. Header + view responsiveness pass
Root cause (measured): the header row had no overflow containment and Center/Right were `shrink-0` while Left's children couldn't shrink → content painted over neighbours at narrow widths.
- `RunHeader` Left clips (`overflow-hidden`) + responsive gaps/padding; Center shrinkable.
- `Breadcrumb`: **every** crumb gets `min-w-0 truncate` (a non-final `whitespace-nowrap` crumb was overflowing its shrunk `<li>` and painting over the next crumb).
- `StageRail`, `RoleChip` (`· blind`), `AIActions` (`AI ·` / Extract label), `PrimaryAction` helper (`sr-only`, a11y preserved), divider + Help collapse via `@container/headerbar` queries.
- View: PDF `Toolbar` wraps, `SearchBar`/`PrumoPdfViewer`/`ExtractionFormPanel` gain `min-w-0` + responsive padding.
- **Wide-width layout unchanged** — collapses engage only at narrow widths.

## Verification
- `npm run typecheck` clean, `eslint` clean on all changed files.
- 171 vitest tests pass (updated 2 stale contract tests: empty-kebab guard + breadcrumb truncate).
- Visually verified across 1280 / 900 / 700 / 560 px: zero slot/crumb overlap, zero horizontal row scroll, all critical actions (Mark ready, kebab, toggles) present; wide view identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)