### PR TITLE
feat(parsing): activate parse-to-markdown pipeline (PR-B — ingest enqueue + durable parse_failed + re-parse)

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -16,6 +16,7 @@ docs/superpowers/plans/2026-06-20-dual-path-parse-at-ingest.md
 docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md
 docs/superpowers/plans/2026-06-20-extraction-header-refinement.md
 docs/superpowers/plans/2026-06-20-table-view-ux-consolidation.md
+docs/superpowers/plans/2026-06-20-parse-pipeline-activation-prb.md
 
 # Design specs — likewise snapshots
 docs/superpowers/specs/2026-*-design.md

--- a/backend/app/api/v1/endpoints/article_files.py
+++ b/backend/app/api/v1/endpoints/article_files.py
@@ -1,10 +1,9 @@
 """Article-file ingest + recovery endpoints.
 
-Every code path that creates an ArticleFile MUST enqueue a parse (the
-single sanctioned hook is ArticleFileIngestService). The browser uploads
-the bytes to Supabase Storage under its own JWT; this endpoint creates the
-DB row server-side so membership is enforced and the parse is scheduled —
-the direct PostgREST insert that bypassed parsing is retired.
+The browser uploads the bytes to Supabase Storage under its own JWT; these
+endpoints create/recover the DB row server-side (via ArticleFileService) so
+membership is enforced and the parse is scheduled — the direct PostgREST
+insert that bypassed parsing is retired.
 """
 
 from __future__ import annotations
@@ -15,19 +14,18 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.api.deps.security import ensure_project_member, get_current_user_sub
 from app.core.deps import DbSession
-from app.core.logging import get_logger
 from app.schemas.article import ArticleFileResponse, ConfirmUploadRequest
 from app.schemas.common import ApiResponse
-from app.services.article_file_ingest_service import ArticleFileIngestService
-from app.services.article_file_service import ArticleFileService
+from app.services.article_file_service import ArticleFileService, ParseEnqueueError
 from app.services.article_text_block_read_service import (
     ArticleFileNotFoundError,
     get_article_file_project_id,
 )
 from app.services.citation_read_service import ArticleNotFoundError, get_article_project_id
 
-logger = get_logger(__name__)
 router = APIRouter(tags=["article-files"])
+
+_ENQUEUE_FAILED_DETAIL = "Failed to schedule parsing; please retry"
 
 
 def _trace(request: Request) -> str | None:
@@ -58,38 +56,20 @@ async def confirm_article_file_upload(
     if not body.storage_key.startswith(expected_prefix):
         raise HTTPException(status_code=400, detail="storage_key outside article path")
 
-    service = ArticleFileService(db)
-    article_file = await service.create_uploaded_file(
-        project_id=project_id,
-        article_id=article_id,
-        storage_key=body.storage_key,
-        file_type=body.content_type,
-        original_filename=body.original_filename,
-        bytes_=body.bytes,
-        file_role=body.file_role,
-    )
-    # Commit BEFORE enqueue: the Celery task loads the row in its own session.
-    await db.commit()
-
     try:
-        ArticleFileIngestService().enqueue_parse_at_ingest(
-            article_file_id=article_file.id,
+        article_file = await ArticleFileService(db).register_uploaded_file(
             project_id=project_id,
+            article_id=article_id,
+            storage_key=body.storage_key,
+            file_type=body.content_type,
+            original_filename=body.original_filename,
+            bytes_=body.bytes,
+            file_role=body.file_role,
             user_id=str(current_user_sub),
             trace_id=trace_id,
         )
-    except Exception as exc:  # do NOT swallow — surface so the user can retry
-        logger.warning(
-            "article_file_enqueue_failed",
-            trace_id=trace_id,
-            article_file_id=str(article_file.id),
-            error=str(exc),
-        )
-        service.mark_parse_failed(article_file, f"enqueue failed: {exc}")
-        await db.commit()
-        raise HTTPException(
-            status_code=503, detail="Failed to schedule parsing; please retry"
-        ) from exc
+    except ParseEnqueueError as e:
+        raise HTTPException(status_code=503, detail=_ENQUEUE_FAILED_DETAIL) from e
 
     return ApiResponse.success(ArticleFileResponse.model_validate(article_file), trace_id=trace_id)
 
@@ -109,32 +89,16 @@ async def reparse_article_file(
         raise HTTPException(status_code=404, detail=str(e)) from e
     await ensure_project_member(db, project_id, current_user_sub)
 
-    service = ArticleFileService(db)
-    article_file = await service.get_by_id(article_file_id)
-    if article_file is None:  # defensive — gate already resolved the project
-        raise HTTPException(status_code=404, detail="Article file not found")
-    service.reset_for_reparse(article_file)
-    await db.commit()
-    await db.refresh(article_file)
-
     try:
-        ArticleFileIngestService().enqueue_parse_at_ingest(
-            article_file_id=article_file.id,
+        article_file = await ArticleFileService(db).reparse(
+            article_file_id=article_file_id,
             project_id=project_id,
             user_id=str(current_user_sub),
             trace_id=trace_id,
         )
-    except Exception as exc:
-        logger.warning(
-            "article_file_reparse_enqueue_failed",
-            trace_id=trace_id,
-            article_file_id=str(article_file.id),
-            error=str(exc),
-        )
-        service.mark_parse_failed(article_file, f"enqueue failed: {exc}")
-        await db.commit()
-        raise HTTPException(
-            status_code=503, detail="Failed to schedule parsing; please retry"
-        ) from exc
+    except ParseEnqueueError as e:
+        raise HTTPException(status_code=503, detail=_ENQUEUE_FAILED_DETAIL) from e
+    if article_file is None:  # defensive — gate already resolved the project
+        raise HTTPException(status_code=404, detail="Article file not found")
 
     return ApiResponse.success(ArticleFileResponse.model_validate(article_file), trace_id=trace_id)

--- a/backend/app/api/v1/endpoints/article_files.py
+++ b/backend/app/api/v1/endpoints/article_files.py
@@ -21,6 +21,10 @@ from app.repositories.article_repository import ArticleFileRepository
 from app.schemas.article import ArticleFileResponse, ConfirmUploadRequest
 from app.schemas.common import ApiResponse
 from app.services.article_file_ingest_service import ArticleFileIngestService
+from app.services.article_text_block_read_service import (
+    ArticleFileNotFoundError,
+    get_article_file_project_id,
+)
 from app.services.citation_read_service import ArticleNotFoundError, get_article_project_id
 
 logger = get_logger(__name__)
@@ -78,6 +82,53 @@ async def confirm_article_file_upload(
     except Exception as exc:  # do NOT swallow — surface so the user can retry
         logger.warning(
             "article_file_enqueue_failed",
+            trace_id=trace_id,
+            article_file_id=str(article_file.id),
+            error=str(exc),
+        )
+        article_file.extraction_status = "parse_failed"
+        article_file.extraction_error = f"enqueue failed: {exc}"[:500]
+        await db.commit()
+        raise HTTPException(
+            status_code=503, detail="Failed to schedule parsing; please retry"
+        ) from exc
+
+    return ApiResponse.success(ArticleFileResponse.model_validate(article_file), trace_id=trace_id)
+
+
+@router.post("/article-files/{article_file_id}/reparse")
+async def reparse_article_file(
+    article_file_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse[ArticleFileResponse]:
+    """Re-enqueue a parse for an existing ArticleFile (recovery)."""
+    trace_id = _trace(request)
+    try:
+        project_id = await get_article_file_project_id(db, article_file_id)
+    except ArticleFileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    await ensure_project_member(db, project_id, current_user_sub)
+
+    article_file = await ArticleFileRepository(db).get_by_id(article_file_id)
+    if article_file is None:  # defensive — gate already resolved the project
+        raise HTTPException(status_code=404, detail="Article file not found")
+    article_file.extraction_status = "pending"
+    article_file.extraction_error = None
+    await db.commit()
+    await db.refresh(article_file)
+
+    try:
+        ArticleFileIngestService().enqueue_parse_at_ingest(
+            article_file_id=article_file.id,
+            project_id=project_id,
+            user_id=str(current_user_sub),
+            trace_id=trace_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "article_file_reparse_enqueue_failed",
             trace_id=trace_id,
             article_file_id=str(article_file.id),
             error=str(exc),

--- a/backend/app/api/v1/endpoints/article_files.py
+++ b/backend/app/api/v1/endpoints/article_files.py
@@ -16,11 +16,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from app.api.deps.security import ensure_project_member, get_current_user_sub
 from app.core.deps import DbSession
 from app.core.logging import get_logger
-from app.models.article import ArticleFile
-from app.repositories.article_repository import ArticleFileRepository
 from app.schemas.article import ArticleFileResponse, ConfirmUploadRequest
 from app.schemas.common import ApiResponse
 from app.services.article_file_ingest_service import ArticleFileIngestService
+from app.services.article_file_service import ArticleFileService
 from app.services.article_text_block_read_service import (
     ArticleFileNotFoundError,
     get_article_file_project_id,
@@ -59,16 +58,16 @@ async def confirm_article_file_upload(
     if not body.storage_key.startswith(expected_prefix):
         raise HTTPException(status_code=400, detail="storage_key outside article path")
 
-    article_file = ArticleFile(
+    service = ArticleFileService(db)
+    article_file = await service.create_uploaded_file(
         project_id=project_id,
         article_id=article_id,
-        file_type=body.content_type,
         storage_key=body.storage_key,
+        file_type=body.content_type,
         original_filename=body.original_filename,
-        bytes=body.bytes,
+        bytes_=body.bytes,
         file_role=body.file_role,
     )
-    article_file = await ArticleFileRepository(db).create(article_file)
     # Commit BEFORE enqueue: the Celery task loads the row in its own session.
     await db.commit()
 
@@ -86,8 +85,7 @@ async def confirm_article_file_upload(
             article_file_id=str(article_file.id),
             error=str(exc),
         )
-        article_file.extraction_status = "parse_failed"
-        article_file.extraction_error = f"enqueue failed: {exc}"[:500]
+        service.mark_parse_failed(article_file, f"enqueue failed: {exc}")
         await db.commit()
         raise HTTPException(
             status_code=503, detail="Failed to schedule parsing; please retry"
@@ -111,11 +109,11 @@ async def reparse_article_file(
         raise HTTPException(status_code=404, detail=str(e)) from e
     await ensure_project_member(db, project_id, current_user_sub)
 
-    article_file = await ArticleFileRepository(db).get_by_id(article_file_id)
+    service = ArticleFileService(db)
+    article_file = await service.get_by_id(article_file_id)
     if article_file is None:  # defensive — gate already resolved the project
         raise HTTPException(status_code=404, detail="Article file not found")
-    article_file.extraction_status = "pending"
-    article_file.extraction_error = None
+    service.reset_for_reparse(article_file)
     await db.commit()
     await db.refresh(article_file)
 
@@ -133,8 +131,7 @@ async def reparse_article_file(
             article_file_id=str(article_file.id),
             error=str(exc),
         )
-        article_file.extraction_status = "parse_failed"
-        article_file.extraction_error = f"enqueue failed: {exc}"[:500]
+        service.mark_parse_failed(article_file, f"enqueue failed: {exc}")
         await db.commit()
         raise HTTPException(
             status_code=503, detail="Failed to schedule parsing; please retry"

--- a/backend/app/api/v1/endpoints/article_files.py
+++ b/backend/app/api/v1/endpoints/article_files.py
@@ -1,0 +1,92 @@
+"""Article-file ingest + recovery endpoints.
+
+Every code path that creates an ArticleFile MUST enqueue a parse (the
+single sanctioned hook is ArticleFileIngestService). The browser uploads
+the bytes to Supabase Storage under its own JWT; this endpoint creates the
+DB row server-side so membership is enforced and the parse is scheduled —
+the direct PostgREST insert that bypassed parsing is retired.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from app.api.deps.security import ensure_project_member, get_current_user_sub
+from app.core.deps import DbSession
+from app.core.logging import get_logger
+from app.models.article import ArticleFile
+from app.repositories.article_repository import ArticleFileRepository
+from app.schemas.article import ArticleFileResponse, ConfirmUploadRequest
+from app.schemas.common import ApiResponse
+from app.services.article_file_ingest_service import ArticleFileIngestService
+from app.services.citation_read_service import ArticleNotFoundError, get_article_project_id
+
+logger = get_logger(__name__)
+router = APIRouter(tags=["article-files"])
+
+
+def _trace(request: Request) -> str | None:
+    return getattr(request.state, "trace_id", None)
+
+
+@router.post("/articles/{article_id}/files", status_code=status.HTTP_201_CREATED)
+async def confirm_article_file_upload(
+    article_id: UUID,
+    body: ConfirmUploadRequest,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse[ArticleFileResponse]:
+    """Register an already-uploaded object and enqueue its parse."""
+    trace_id = _trace(request)
+    if body.article_id != article_id:
+        raise HTTPException(status_code=400, detail="article_id mismatch")
+    try:
+        project_id = await get_article_project_id(db, article_id)
+    except ArticleNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    await ensure_project_member(db, project_id, current_user_sub)
+
+    # The service role bypasses RLS, so the storage key must be proven to
+    # live under the resolved project/article prefix (not a client claim).
+    expected_prefix = f"{project_id}/{article_id}/"
+    if not body.storage_key.startswith(expected_prefix):
+        raise HTTPException(status_code=400, detail="storage_key outside article path")
+
+    article_file = ArticleFile(
+        project_id=project_id,
+        article_id=article_id,
+        file_type=body.content_type,
+        storage_key=body.storage_key,
+        original_filename=body.original_filename,
+        bytes=body.bytes,
+        file_role=body.file_role,
+    )
+    article_file = await ArticleFileRepository(db).create(article_file)
+    # Commit BEFORE enqueue: the Celery task loads the row in its own session.
+    await db.commit()
+
+    try:
+        ArticleFileIngestService().enqueue_parse_at_ingest(
+            article_file_id=article_file.id,
+            project_id=project_id,
+            user_id=str(current_user_sub),
+            trace_id=trace_id,
+        )
+    except Exception as exc:  # do NOT swallow — surface so the user can retry
+        logger.warning(
+            "article_file_enqueue_failed",
+            trace_id=trace_id,
+            article_file_id=str(article_file.id),
+            error=str(exc),
+        )
+        article_file.extraction_status = "parse_failed"
+        article_file.extraction_error = f"enqueue failed: {exc}"[:500]
+        await db.commit()
+        raise HTTPException(
+            status_code=503, detail="Failed to schedule parsing; please retry"
+        ) from exc
+
+    return ApiResponse.success(ArticleFileResponse.model_validate(article_file), trace_id=trace_id)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -7,6 +7,7 @@ Agrega todas as rotas da API v1.
 from fastapi import APIRouter
 
 from app.api.v1.endpoints import (
+    article_files,
     article_text_blocks,
     articles,
     articles_export,
@@ -105,6 +106,8 @@ api_router.include_router(
     prefix="/articles",
     tags=["articles"],
 )
+
+api_router.include_router(article_files.router)
 
 api_router.include_router(
     article_text_blocks.router,

--- a/backend/app/services/article_file_service.py
+++ b/backend/app/services/article_file_service.py
@@ -1,0 +1,60 @@
+"""Service layer for ``article_files`` CRUD.
+
+Keeps the API layer off models and repositories (layered-architecture
+fitness: ``api -> services -> repositories -> models``). The endpoints
+resolve membership and own the transaction boundary (commit); this service
+constructs/loads rows and applies status transitions, flushing only.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.article import ArticleFile
+from app.repositories.article_repository import ArticleFileRepository
+
+
+class ArticleFileService:
+    """CRUD + parse-status transitions for ``article_files``."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._repo = ArticleFileRepository(db)
+
+    async def create_uploaded_file(
+        self,
+        *,
+        project_id: UUID,
+        article_id: UUID,
+        storage_key: str,
+        file_type: str,
+        original_filename: str | None,
+        bytes_: int | None,
+        file_role: str,
+    ) -> ArticleFile:
+        """Create the ``article_files`` row (flush only; caller commits)."""
+        article_file = ArticleFile(
+            project_id=project_id,
+            article_id=article_id,
+            file_type=file_type,
+            storage_key=storage_key,
+            original_filename=original_filename,
+            bytes=bytes_,
+            file_role=file_role,
+        )
+        return await self._repo.create(article_file)
+
+    async def get_by_id(self, article_file_id: UUID) -> ArticleFile | None:
+        """Load an ``ArticleFile`` by id, or ``None`` if it does not exist."""
+        return await self._repo.get_by_id(article_file_id)
+
+    def mark_parse_failed(self, article_file: ArticleFile, error: str) -> None:
+        """Mark the row as parse-failed with a truncated error (caller commits)."""
+        article_file.extraction_status = "parse_failed"
+        article_file.extraction_error = error[:500]
+
+    def reset_for_reparse(self, article_file: ArticleFile) -> None:
+        """Reset the row to pending so a re-parse can run (caller commits)."""
+        article_file.extraction_status = "pending"
+        article_file.extraction_error = None

--- a/backend/app/services/article_file_service.py
+++ b/backend/app/services/article_file_service.py
@@ -1,9 +1,11 @@
-"""Service layer for ``article_files`` CRUD.
+"""Service layer for ``article_files`` ingest + recovery.
 
 Keeps the API layer off models and repositories (layered-architecture
-fitness: ``api -> services -> repositories -> models``). The endpoints
-resolve membership and own the transaction boundary (commit); this service
-constructs/loads rows and applies status transitions, flushing only.
+fitness: ``api -> services -> repositories -> models``) AND co-locates
+ArticleFile creation with the parse-at-ingest hook (every create site must
+enqueue — see ``tests/fitness/test_article_file_create_uses_hook.py``). The
+endpoint owns membership + HTTP mapping; this service owns the DB work and
+scheduling.
 """
 
 from __future__ import annotations
@@ -12,17 +14,30 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.logging import get_logger
 from app.models.article import ArticleFile
 from app.repositories.article_repository import ArticleFileRepository
+from app.services.article_file_ingest_service import ArticleFileIngestService
+
+logger = get_logger(__name__)
+
+
+class ParseEnqueueError(Exception):
+    """Raised when scheduling the parse fails after the row was persisted.
+
+    The row is left as ``parse_failed`` (committed) so the caller can map
+    this to a retryable HTTP error without losing the failure state.
+    """
 
 
 class ArticleFileService:
-    """CRUD + parse-status transitions for ``article_files``."""
+    """CRUD + parse scheduling for ``article_files``."""
 
     def __init__(self, db: AsyncSession) -> None:
+        self._db = db
         self._repo = ArticleFileRepository(db)
 
-    async def create_uploaded_file(
+    async def register_uploaded_file(
         self,
         *,
         project_id: UUID,
@@ -32,8 +47,13 @@ class ArticleFileService:
         original_filename: str | None,
         bytes_: int | None,
         file_role: str,
+        user_id: str,
+        trace_id: str | None,
     ) -> ArticleFile:
-        """Create the ``article_files`` row (flush only; caller commits)."""
+        """Create the ``article_files`` row and enqueue its parse.
+
+        Raises ``ParseEnqueueError`` if the parse could not be scheduled.
+        """
         article_file = ArticleFile(
             project_id=project_id,
             article_id=article_id,
@@ -43,18 +63,63 @@ class ArticleFileService:
             bytes=bytes_,
             file_role=file_role,
         )
-        return await self._repo.create(article_file)
+        await self._repo.create(article_file)
+        # Commit BEFORE enqueue: the Celery task loads the row in its own session.
+        await self._db.commit()
+        await self._db.refresh(article_file)
+        await self._enqueue_or_fail(
+            article_file, project_id=project_id, user_id=user_id, trace_id=trace_id
+        )
+        return article_file
 
-    async def get_by_id(self, article_file_id: UUID) -> ArticleFile | None:
-        """Load an ``ArticleFile`` by id, or ``None`` if it does not exist."""
-        return await self._repo.get_by_id(article_file_id)
+    async def reparse(
+        self,
+        *,
+        article_file_id: UUID,
+        project_id: UUID,
+        user_id: str,
+        trace_id: str | None,
+    ) -> ArticleFile | None:
+        """Reset an existing file to pending and re-enqueue its parse.
 
-    def mark_parse_failed(self, article_file: ArticleFile, error: str) -> None:
-        """Mark the row as parse-failed with a truncated error (caller commits)."""
-        article_file.extraction_status = "parse_failed"
-        article_file.extraction_error = error[:500]
-
-    def reset_for_reparse(self, article_file: ArticleFile) -> None:
-        """Reset the row to pending so a re-parse can run (caller commits)."""
+        Returns ``None`` if the file does not exist. Raises
+        ``ParseEnqueueError`` if the parse could not be scheduled.
+        """
+        article_file = await self._repo.get_by_id(article_file_id)
+        if article_file is None:
+            return None
         article_file.extraction_status = "pending"
         article_file.extraction_error = None
+        await self._db.commit()
+        await self._db.refresh(article_file)
+        await self._enqueue_or_fail(
+            article_file, project_id=project_id, user_id=user_id, trace_id=trace_id
+        )
+        return article_file
+
+    async def _enqueue_or_fail(
+        self,
+        article_file: ArticleFile,
+        *,
+        project_id: UUID,
+        user_id: str,
+        trace_id: str | None,
+    ) -> None:
+        try:
+            ArticleFileIngestService().enqueue_parse_at_ingest(
+                article_file_id=article_file.id,
+                project_id=project_id,
+                user_id=user_id,
+                trace_id=trace_id,
+            )
+        except Exception as exc:  # do NOT swallow — persist failure + signal caller
+            logger.warning(
+                "article_file_enqueue_failed",
+                trace_id=trace_id,
+                article_file_id=str(article_file.id),
+                error=str(exc),
+            )
+            article_file.extraction_status = "parse_failed"
+            article_file.extraction_error = f"enqueue failed: {exc}"[:500]
+            await self._db.commit()
+            raise ParseEnqueueError(str(exc)) from exc

--- a/backend/app/worker/tasks/parsing_tasks.py
+++ b/backend/app/worker/tasks/parsing_tasks.py
@@ -89,6 +89,32 @@ async def _run_parse(
             raise
 
 
+async def _mark_parse_failed(article_file_id: str, error_message: str) -> None:
+    """Persist a terminal parse failure in its own committed transaction.
+
+    The main worker_session() rolls back on parser error (discarding any
+    in-session status flush), so the failure is recorded out-of-band in a
+    fresh session that commits independently. Covers parser errors AND
+    pre-parse failures (e.g. storage download) the service never marks.
+    """
+    from sqlalchemy import select
+
+    from app.models.article import ArticleFile
+    from app.worker._session import worker_session
+
+    async with worker_session() as session:
+        article_file = (
+            await session.execute(
+                select(ArticleFile).where(ArticleFile.id == UUID(article_file_id))
+            )
+        ).scalar_one_or_none()
+        if article_file is None:
+            return
+        article_file.extraction_status = "parse_failed"
+        article_file.extraction_error = error_message[:500]
+        await session.commit()
+
+
 @celery_app.task(
     bind=True,
     max_retries=3,
@@ -109,4 +135,11 @@ def parse_article_file_task(
             lambda: _run_parse(article_file_id, project_id, user_id, trace_id or self.request.id)
         )
     except Exception as exc:
-        self.retry(exc=exc)
+        if self.request.retries >= self.max_retries:
+            # Terminal: the main session already rolled back, so persist the
+            # failure durably in its own transaction before the task dies.
+            # Capture error_message now — `exc` is deleted after the except block.
+            error_message = str(exc)
+            run_task(lambda: _mark_parse_failed(article_file_id, error_message))
+            raise
+        raise self.retry(exc=exc)

--- a/backend/tests/fitness/test_article_file_create_uses_hook.py
+++ b/backend/tests/fitness/test_article_file_create_uses_hook.py
@@ -15,6 +15,7 @@ _APP = Path(__file__).parent.parent.parent / "app"
 _ALLOWED = {
     "services/zotero_import_service.py",
     "services/article_file_ingest_service.py",
+    "services/article_file_service.py",
     "repositories/unit_of_work.py",
 }
 

--- a/backend/tests/integration/test_article_files_endpoints.py
+++ b/backend/tests/integration/test_article_files_endpoints.py
@@ -59,7 +59,7 @@ async def test_confirm_creates_row_and_enqueues(
 ) -> None:
     project_id, _, article_id = member_article
     with patch(
-        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        "app.services.article_file_service.ArticleFileIngestService.enqueue_parse_at_ingest",
         return_value="task-123",
     ) as enq:
         res = await db_client.post(
@@ -102,7 +102,7 @@ async def test_confirm_does_not_swallow_enqueue_failure(
 ) -> None:
     project_id, _, article_id = member_article
     with patch(
-        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        "app.services.article_file_service.ArticleFileIngestService.enqueue_parse_at_ingest",
         side_effect=RuntimeError("broker down"),
     ):
         res = await db_client.post(
@@ -133,7 +133,7 @@ async def test_reparse_resets_status_and_enqueues(
     await db_session.commit()
 
     with patch(
-        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        "app.services.article_file_service.ArticleFileIngestService.enqueue_parse_at_ingest",
         return_value="task-9",
     ) as enq:
         res = await db_client.post(f"/api/v1/article-files/{file.id}/reparse")

--- a/backend/tests/integration/test_article_files_endpoints.py
+++ b/backend/tests/integration/test_article_files_endpoints.py
@@ -114,3 +114,38 @@ async def test_confirm_does_not_swallow_enqueue_failure(
     ).scalar_one()
     await db_session.refresh(row)
     assert row.extraction_status == "parse_failed"
+
+
+@pytest.mark.asyncio
+async def test_reparse_resets_status_and_enqueues(
+    db_client: AsyncClient, db_session: AsyncSession, member_article
+) -> None:
+    project_id, _, article_id = member_article
+    file = ArticleFile(
+        project_id=project_id,
+        article_id=article_id,
+        file_type="PDF",
+        storage_key=f"{project_id}/{article_id}/old.pdf",
+        extraction_status="parse_failed",
+        extraction_error="boom",
+    )
+    db_session.add(file)
+    await db_session.commit()
+
+    with patch(
+        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        return_value="task-9",
+    ) as enq:
+        res = await db_client.post(f"/api/v1/article-files/{file.id}/reparse")
+    assert res.status_code == 200, res.text
+    assert res.json()["data"]["extractionStatus"] == "pending"
+    enq.assert_called_once()
+    await db_session.refresh(file)
+    assert file.extraction_status == "pending"
+    assert file.extraction_error is None
+
+
+@pytest.mark.asyncio
+async def test_reparse_missing_file_404(db_client: AsyncClient) -> None:
+    res = await db_client.post(f"/api/v1/article-files/{uuid4()}/reparse")
+    assert res.status_code == 404, res.text

--- a/backend/tests/integration/test_article_files_endpoints.py
+++ b/backend/tests/integration/test_article_files_endpoints.py
@@ -1,0 +1,116 @@
+"""Integration tests for the article-file ingest/recovery endpoints."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from app.models.article import Article, ArticleFile
+
+
+@pytest_asyncio.fixture
+async def member_article(
+    db_session: AsyncSession,
+) -> AsyncGenerator[tuple[UUID, UUID, UUID], None]:
+    """Yield (project_id, member_user_id, article_id); JWT override = member."""
+    row = (
+        await db_session.execute(
+            text("SELECT pm.project_id, pm.user_id FROM public.project_members pm LIMIT 1")
+        )
+    ).first()
+    if row is None:
+        pytest.skip("Need a seeded project member")
+    project_id, member_id = UUID(str(row[0])), UUID(str(row[1]))
+    article = Article(project_id=project_id, title="confirm-upload-test")
+    db_session.add(article)
+    await db_session.commit()
+
+    async def _override() -> TokenPayload:
+        return TokenPayload(sub=str(member_id), email="m@x.com", role="authenticated", aal="aal1")
+
+    app.dependency_overrides[get_current_user] = _override
+    try:
+        yield project_id, member_id, article.id
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def _body(project_id: UUID, article_id: UUID, key: str | None = None) -> dict:
+    return {
+        "articleId": str(article_id),
+        "storageKey": key or f"{project_id}/{article_id}/doc.pdf",
+        "originalFilename": "doc.pdf",
+        "contentType": "PDF",
+        "bytes": 1234,
+        "fileRole": "MAIN",
+    }
+
+
+@pytest.mark.asyncio
+async def test_confirm_creates_row_and_enqueues(
+    db_client: AsyncClient, db_session: AsyncSession, member_article
+) -> None:
+    project_id, _, article_id = member_article
+    with patch(
+        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        return_value="task-123",
+    ) as enq:
+        res = await db_client.post(
+            f"/api/v1/articles/{article_id}/files", json=_body(project_id, article_id)
+        )
+    assert res.status_code == 201, res.text
+    assert res.json()["data"]["extractionStatus"] == "pending"
+    enq.assert_called_once()
+    row = (
+        await db_session.execute(select(ArticleFile).where(ArticleFile.article_id == article_id))
+    ).scalar_one()
+    assert row.storage_key == f"{project_id}/{article_id}/doc.pdf"
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_non_member(db_client: AsyncClient, member_article) -> None:
+    project_id, _, article_id = member_article
+
+    async def _outsider() -> TokenPayload:
+        return TokenPayload(sub=str(uuid4()), email="o@x.com", role="authenticated", aal="aal1")
+
+    app.dependency_overrides[get_current_user] = _outsider
+    res = await db_client.post(
+        f"/api/v1/articles/{article_id}/files", json=_body(project_id, article_id)
+    )
+    assert res.status_code == 403, res.text
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_foreign_storage_key(db_client: AsyncClient, member_article) -> None:
+    project_id, _, article_id = member_article
+    bad = _body(project_id, article_id, key=f"{uuid4()}/{uuid4()}/evil.pdf")
+    res = await db_client.post(f"/api/v1/articles/{article_id}/files", json=bad)
+    assert res.status_code == 400, res.text
+
+
+@pytest.mark.asyncio
+async def test_confirm_does_not_swallow_enqueue_failure(
+    db_client: AsyncClient, db_session: AsyncSession, member_article
+) -> None:
+    project_id, _, article_id = member_article
+    with patch(
+        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        side_effect=RuntimeError("broker down"),
+    ):
+        res = await db_client.post(
+            f"/api/v1/articles/{article_id}/files", json=_body(project_id, article_id)
+        )
+    assert res.status_code == 503, res.text
+    row = (
+        await db_session.execute(select(ArticleFile).where(ArticleFile.article_id == article_id))
+    ).scalar_one()
+    await db_session.refresh(row)
+    assert row.extraction_status == "parse_failed"

--- a/backend/tests/integration/test_parsing_tasks_durable_failure.py
+++ b/backend/tests/integration/test_parsing_tasks_durable_failure.py
@@ -1,0 +1,50 @@
+"""Durable parse_failed: a terminal failure must survive in its own txn."""
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.article import Article, ArticleFile
+from app.worker._session import worker_session
+from app.worker.tasks.parsing_tasks import _mark_parse_failed
+
+
+async def _seed_pending_file(db: AsyncSession) -> UUID:
+    """Insert an article + a pending PDF file under a seeded project."""
+    project_id = (
+        await db.execute(text("SELECT id FROM public.projects LIMIT 1"))
+    ).scalar_one_or_none()
+    if project_id is None:
+        pytest.skip("Need at least one seeded project")
+    article = Article(project_id=project_id, title="durable-fail-test")
+    db.add(article)
+    await db.flush()
+    file = ArticleFile(
+        project_id=project_id,
+        article_id=article.id,
+        file_type="PDF",
+        storage_key=f"{project_id}/{article.id}/x.pdf",
+        extraction_status="pending",
+    )
+    db.add(file)
+    await db.commit()
+    return file.id
+
+
+@pytest.mark.asyncio
+async def test_mark_parse_failed_persists_in_its_own_transaction(
+    db_session_real: AsyncSession,
+) -> None:
+    file_id = await _seed_pending_file(db_session_real)
+
+    await _mark_parse_failed(str(file_id), "boom: parser exploded")
+
+    # Read back via a brand-new session to prove the write was committed.
+    async with worker_session() as verify:
+        row = (
+            await verify.execute(select(ArticleFile).where(ArticleFile.id == file_id))
+        ).scalar_one()
+        assert row.extraction_status == "parse_failed"
+        assert "boom" in (row.extraction_error or "")

--- a/backend/tests/unit/test_article_files_unit.py
+++ b/backend/tests/unit/test_article_files_unit.py
@@ -1,0 +1,316 @@
+"""Unit tests for ArticleFileService + the article-file endpoint handlers.
+
+These call the service methods and the endpoint coroutines directly (with
+mocked collaborators) so every branch — including the error paths the
+integration tests cannot exercise through the ASGI transport — is covered.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.endpoints.article_files import (
+    confirm_article_file_upload,
+    reparse_article_file,
+)
+from app.models.article import ArticleFile
+from app.schemas.article import ConfirmUploadRequest
+from app.services.article_file_service import ArticleFileService, ParseEnqueueError
+from app.services.article_text_block_read_service import ArticleFileNotFoundError
+from app.services.citation_read_service import ArticleNotFoundError
+
+_INGEST = "app.services.article_file_service.ArticleFileIngestService"
+_EP = "app.api.v1.endpoints.article_files"
+
+
+def _fake_article_file(article_id, project_id, *, status="pending"):
+    af = ArticleFile(
+        project_id=project_id,
+        article_id=article_id,
+        file_type="PDF",
+        storage_key=f"{project_id}/{article_id}/f.pdf",
+        original_filename="f.pdf",
+        bytes=1,
+        file_role="MAIN",
+    )
+    af.id = uuid4()
+    af.extraction_status = status
+    af.extraction_error = None
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    af.created_at = now
+    af.updated_at = now
+    return af
+
+
+def _make_service():
+    db = AsyncMock()
+    svc = ArticleFileService(db)
+    svc._repo = AsyncMock()
+    return svc, db
+
+
+# --------------------------------------------------------------------------
+# ArticleFileService
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_uploaded_file_commits_before_enqueue() -> None:
+    svc, db = _make_service()
+    with patch(_INGEST) as ingest:
+        result = await svc.register_uploaded_file(
+            project_id=uuid4(),
+            article_id=uuid4(),
+            storage_key="p/a/f.pdf",
+            file_type="PDF",
+            original_filename="f.pdf",
+            bytes_=1,
+            file_role="MAIN",
+            user_id="u",
+            trace_id=None,
+        )
+    assert isinstance(result, ArticleFile)
+    svc._repo.create.assert_awaited_once()
+    db.commit.assert_awaited()
+    db.refresh.assert_awaited_with(result)
+    ingest.return_value.enqueue_parse_at_ingest.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_register_uploaded_file_enqueue_failure_marks_parse_failed() -> None:
+    svc, db = _make_service()
+    with patch(_INGEST) as ingest:
+        ingest.return_value.enqueue_parse_at_ingest.side_effect = RuntimeError("broker down")
+        with pytest.raises(ParseEnqueueError):
+            await svc.register_uploaded_file(
+                project_id=uuid4(),
+                article_id=uuid4(),
+                storage_key="p/a/f.pdf",
+                file_type="PDF",
+                original_filename="f.pdf",
+                bytes_=1,
+                file_role="MAIN",
+                user_id="u",
+                trace_id="t",
+            )
+    # commit happened twice: once before enqueue, once after marking parse_failed
+    assert db.commit.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reparse_resets_and_enqueues() -> None:
+    svc, db = _make_service()
+    af = _fake_article_file(uuid4(), uuid4(), status="parse_failed")
+    af.extraction_error = "boom"
+    svc._repo.get_by_id = AsyncMock(return_value=af)
+    with patch(_INGEST) as ingest:
+        result = await svc.reparse(
+            article_file_id=af.id, project_id=uuid4(), user_id="u", trace_id=None
+        )
+    assert result is af
+    assert af.extraction_status == "pending"
+    assert af.extraction_error is None
+    ingest.return_value.enqueue_parse_at_ingest.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reparse_returns_none_when_missing() -> None:
+    svc, _ = _make_service()
+    svc._repo.get_by_id = AsyncMock(return_value=None)
+    result = await svc.reparse(
+        article_file_id=uuid4(), project_id=uuid4(), user_id="u", trace_id=None
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_reparse_enqueue_failure_raises() -> None:
+    svc, _ = _make_service()
+    af = _fake_article_file(uuid4(), uuid4())
+    svc._repo.get_by_id = AsyncMock(return_value=af)
+    with patch(_INGEST) as ingest:
+        ingest.return_value.enqueue_parse_at_ingest.side_effect = RuntimeError("x")
+        with pytest.raises(ParseEnqueueError):
+            await svc.reparse(article_file_id=af.id, project_id=uuid4(), user_id="u", trace_id="t")
+    assert af.extraction_status == "parse_failed"
+
+
+# --------------------------------------------------------------------------
+# confirm_article_file_upload endpoint
+# --------------------------------------------------------------------------
+
+
+def _confirm_body(article_id, project_id, *, key=None):
+    return ConfirmUploadRequest(
+        article_id=article_id,
+        storage_key=key or f"{project_id}/{article_id}/f.pdf",
+        original_filename="f.pdf",
+        content_type="PDF",
+        bytes=1,
+        file_role="MAIN",
+    )
+
+
+def _request():
+    req = MagicMock()
+    req.state.trace_id = "trace"
+    return req
+
+
+@pytest.mark.asyncio
+async def test_confirm_endpoint_rejects_article_id_mismatch() -> None:
+    aid, pid = uuid4(), uuid4()
+    body = _confirm_body(uuid4(), pid)  # body.article_id != path aid
+    with pytest.raises(HTTPException) as exc:
+        await confirm_article_file_upload(
+            article_id=aid, body=body, request=_request(), db=AsyncMock(), current_user_sub=uuid4()
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_confirm_endpoint_404_when_article_missing() -> None:
+    aid, pid = uuid4(), uuid4()
+    body = _confirm_body(aid, pid)
+    with patch(
+        f"{_EP}.get_article_project_id", AsyncMock(side_effect=ArticleNotFoundError("nope"))
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await confirm_article_file_upload(
+                article_id=aid,
+                body=body,
+                request=_request(),
+                db=AsyncMock(),
+                current_user_sub=uuid4(),
+            )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_confirm_endpoint_rejects_foreign_storage_key() -> None:
+    aid, pid = uuid4(), uuid4()
+    body = _confirm_body(aid, pid, key=f"{uuid4()}/{uuid4()}/evil.pdf")
+    with (
+        patch(f"{_EP}.get_article_project_id", AsyncMock(return_value=pid)),
+        patch(f"{_EP}.ensure_project_member", AsyncMock()),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await confirm_article_file_upload(
+            article_id=aid, body=body, request=_request(), db=AsyncMock(), current_user_sub=uuid4()
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_confirm_endpoint_success_returns_envelope() -> None:
+    aid, pid = uuid4(), uuid4()
+    body = _confirm_body(aid, pid)
+    af = _fake_article_file(aid, pid)
+    with (
+        patch(f"{_EP}.get_article_project_id", AsyncMock(return_value=pid)),
+        patch(f"{_EP}.ensure_project_member", AsyncMock()),
+        patch(f"{_EP}.ArticleFileService") as svc,
+    ):
+        svc.return_value.register_uploaded_file = AsyncMock(return_value=af)
+        resp = await confirm_article_file_upload(
+            article_id=aid, body=body, request=_request(), db=AsyncMock(), current_user_sub=uuid4()
+        )
+    assert resp.ok is True
+    assert resp.data.extraction_status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_confirm_endpoint_maps_enqueue_failure_to_503() -> None:
+    aid, pid = uuid4(), uuid4()
+    body = _confirm_body(aid, pid)
+    with (
+        patch(f"{_EP}.get_article_project_id", AsyncMock(return_value=pid)),
+        patch(f"{_EP}.ensure_project_member", AsyncMock()),
+        patch(f"{_EP}.ArticleFileService") as svc,
+    ):
+        svc.return_value.register_uploaded_file = AsyncMock(side_effect=ParseEnqueueError("x"))
+        with pytest.raises(HTTPException) as exc:
+            await confirm_article_file_upload(
+                article_id=aid,
+                body=body,
+                request=_request(),
+                db=AsyncMock(),
+                current_user_sub=uuid4(),
+            )
+    assert exc.value.status_code == 503
+
+
+# --------------------------------------------------------------------------
+# reparse_article_file endpoint
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reparse_endpoint_404_when_file_missing() -> None:
+    with (
+        patch(
+            f"{_EP}.get_article_file_project_id",
+            AsyncMock(side_effect=ArticleFileNotFoundError("nope")),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await reparse_article_file(
+            article_file_id=uuid4(), request=_request(), db=AsyncMock(), current_user_sub=uuid4()
+        )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reparse_endpoint_success_returns_envelope() -> None:
+    aid, pid = uuid4(), uuid4()
+    af = _fake_article_file(aid, pid)
+    with (
+        patch(f"{_EP}.get_article_file_project_id", AsyncMock(return_value=pid)),
+        patch(f"{_EP}.ensure_project_member", AsyncMock()),
+        patch(f"{_EP}.ArticleFileService") as svc,
+    ):
+        svc.return_value.reparse = AsyncMock(return_value=af)
+        resp = await reparse_article_file(
+            article_file_id=af.id, request=_request(), db=AsyncMock(), current_user_sub=uuid4()
+        )
+    assert resp.ok is True
+    assert resp.data.extraction_status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_reparse_endpoint_maps_enqueue_failure_to_503() -> None:
+    with (
+        patch(f"{_EP}.get_article_file_project_id", AsyncMock(return_value=uuid4())),
+        patch(f"{_EP}.ensure_project_member", AsyncMock()),
+        patch(f"{_EP}.ArticleFileService") as svc,
+    ):
+        svc.return_value.reparse = AsyncMock(side_effect=ParseEnqueueError("x"))
+        with pytest.raises(HTTPException) as exc:
+            await reparse_article_file(
+                article_file_id=uuid4(),
+                request=_request(),
+                db=AsyncMock(),
+                current_user_sub=uuid4(),
+            )
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_reparse_endpoint_defensive_404_when_service_returns_none() -> None:
+    with (
+        patch(f"{_EP}.get_article_file_project_id", AsyncMock(return_value=uuid4())),
+        patch(f"{_EP}.ensure_project_member", AsyncMock()),
+        patch(f"{_EP}.ArticleFileService") as svc,
+    ):
+        svc.return_value.reparse = AsyncMock(return_value=None)
+        with pytest.raises(HTTPException) as exc:
+            await reparse_article_file(
+                article_file_id=uuid4(),
+                request=_request(),
+                db=AsyncMock(),
+                current_user_sub=uuid4(),
+            )
+    assert exc.value.status_code == 404

--- a/backend/tests/unit/test_article_files_unit.py
+++ b/backend/tests/unit/test_article_files_unit.py
@@ -175,17 +175,17 @@ async def test_confirm_endpoint_rejects_article_id_mismatch() -> None:
 async def test_confirm_endpoint_404_when_article_missing() -> None:
     aid, pid = uuid4(), uuid4()
     body = _confirm_body(aid, pid)
-    with patch(
-        f"{_EP}.get_article_project_id", AsyncMock(side_effect=ArticleNotFoundError("nope"))
+    with (
+        patch(f"{_EP}.get_article_project_id", AsyncMock(side_effect=ArticleNotFoundError("nope"))),
+        pytest.raises(HTTPException) as exc,
     ):
-        with pytest.raises(HTTPException) as exc:
-            await confirm_article_file_upload(
-                article_id=aid,
-                body=body,
-                request=_request(),
-                db=AsyncMock(),
-                current_user_sub=uuid4(),
-            )
+        await confirm_article_file_upload(
+            article_id=aid,
+            body=body,
+            request=_request(),
+            db=AsyncMock(),
+            current_user_sub=uuid4(),
+        )
     assert exc.value.status_code == 404
 
 

--- a/docs/superpowers/plans/2026-06-20-parse-pipeline-activation-prb.md
+++ b/docs/superpowers/plans/2026-06-20-parse-pipeline-activation-prb.md
@@ -1,0 +1,997 @@
+---
+status: draft
+last_reviewed: 2026-06-20
+owner: '@raphaelfh'
+---
+
+# PR-B — Make every ingest path enqueue parse, durably — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a manually-uploaded article PDF actually get parsed
+(today it never does), and make a parse failure durably visible.
+
+**Architecture:** The browser keeps uploading PDF bytes directly to
+Supabase Storage under the user JWT, but the `article_files` row is now
+created by a new backend endpoint that (a) enforces project membership,
+(b) validates the storage key against the server-resolved project/article,
+and (c) calls the existing `enqueue_parse_at_ingest` hook — without
+swallowing enqueue failures. A second endpoint re-enqueues a parse for an
+existing file (recovery). Separately, the Celery task records a terminal
+`parse_failed` status in its own committed transaction so the status
+survives the worker's rollback.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 async, Celery, Pydantic v2,
+structlog (backend); React 19 + TS strict, TanStack, Vitest (frontend);
+pytest (backend tests). Design spec:
+[`2026-06-20-parse-to-markdown-end-to-end-design.md`](../specs/2026-06-20-parse-to-markdown-end-to-end-design.md).
+
+## Global Constraints
+
+- English only for code, comments, commits, docs, copy keys.
+- Conventional Commits; PR targets `dev`, squash-merged.
+- Backend membership gate: every endpoint touching project data calls
+  `ensure_project_member(db, project_id, user_sub)` BEFORE access;
+  resolve `project_id` server-side from `article_id`/`article_file_id`,
+  never trust the request body.
+- API responses use the `ApiResponse` envelope: return
+  `-> ApiResponse[X]` and `ApiResponse.success(payload, trace_id=...)`
+  (no `response_model=`). Frontend single-unwraps via `apiClient<T>`.
+- New frontend backend calls go through `apiClient` (no new
+  `supabase.from(...)` writes). Import request/response shapes from the
+  generated `frontend/types/api/schema.d.ts` (run
+  `npm run generate:api-types`); never hand-mirror enums.
+- Alembic revision ids ≤ 32 chars (not used in this PR — no migration).
+- `extraction_status` real values are `pending | parsed | parse_failed`.
+
+---
+
+## File Structure
+
+- **Create** `backend/app/api/v1/endpoints/article_files.py` — new router
+  hosting `POST /api/v1/articles/{article_id}/files` (confirm upload →
+  create row → enqueue) and `POST /api/v1/article-files/{article_file_id}/reparse`
+  (re-enqueue). One responsibility: article-file ingest/recovery HTTP.
+- **Modify** `backend/app/api/v1/router.py` — register the new module.
+- **Modify** `backend/app/worker/tasks/parsing_tasks.py` — add
+  `_mark_parse_failed` + durable terminal-failure handling in the task.
+- **Modify** `backend/app/services/document_parsing_service.py` — also set
+  `extraction_error` on the in-session `parse_failed` flush (so the
+  success-path/last-attempt error is captured; durable write is in the
+  task). *(small, optional — see Task 1 note.)*
+- **Modify** `frontend/services/articlesService.ts` — add
+  `confirmArticleFileUpload` + `reparseArticleFile`; route `addArticle`
+  and `uploadArticleFile` through the confirm endpoint instead of the
+  direct `supabase.from('article_files').insert`.
+- **Modify** `frontend/components/articles/ArticleDetailDialog.tsx` — a
+  per-file "Re-parse" button calling `reparseArticleFile`.
+- **Regenerate** `frontend/types/api/{openapi.json,schema.d.ts}`.
+- **Tests:** `backend/tests/integration/test_parsing_tasks_durable_failure.py`,
+  `backend/tests/integration/test_article_files_endpoints.py`,
+  `frontend/test/services/articlesService.test.ts` (extend).
+
+---
+
+### Task 1: Durable `parse_failed` in the Celery task
+
+A terminal parse failure must persist. Today the worker's
+`session.rollback()` (`parsing_tasks.py:88`) discards the service's
+`parse_failed` flush, so a failed file stays `pending` forever.
+
+**Files:**
+- Modify: `backend/app/worker/tasks/parsing_tasks.py` (add helper at end of
+  module; change the task's `except` at `:107-112`)
+- Test: `backend/tests/integration/test_parsing_tasks_durable_failure.py`
+
+**Interfaces:**
+- Produces: `async def _mark_parse_failed(article_file_id: str, error_message: str) -> None`
+  — opens a fresh `worker_session()`, sets
+  `extraction_status="parse_failed"` + `extraction_error=error_message[:500]`,
+  commits. No-ops if the row is gone.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/integration/test_parsing_tasks_durable_failure.py`:
+
+```python
+"""Durable parse_failed: a terminal failure must survive in its own txn."""
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.article import Article, ArticleFile
+from app.worker._session import worker_session
+from app.worker.tasks.parsing_tasks import _mark_parse_failed
+
+
+async def _seed_pending_file(db: AsyncSession) -> UUID:
+    """Insert an article + a pending PDF file under a seeded project."""
+    project_id = (
+        await db.execute(text("SELECT id FROM public.projects LIMIT 1"))
+    ).scalar_one_or_none()
+    if project_id is None:
+        pytest.skip("Need at least one seeded project")
+    article = Article(project_id=project_id, title="durable-fail-test")
+    db.add(article)
+    await db.flush()
+    file = ArticleFile(
+        project_id=project_id,
+        article_id=article.id,
+        file_type="PDF",
+        storage_key=f"{project_id}/{article.id}/x.pdf",
+        extraction_status="pending",
+    )
+    db.add(file)
+    await db.commit()
+    return file.id
+
+
+@pytest.mark.asyncio
+async def test_mark_parse_failed_persists_in_its_own_transaction(
+    db_session: AsyncSession,
+) -> None:
+    file_id = await _seed_pending_file(db_session)
+
+    await _mark_parse_failed(str(file_id), "boom: parser exploded")
+
+    # Read back via a brand-new session to prove the write was committed.
+    async with worker_session() as verify:
+        row = (
+            await verify.execute(select(ArticleFile).where(ArticleFile.id == file_id))
+        ).scalar_one()
+        assert row.extraction_status == "parse_failed"
+        assert "boom" in (row.extraction_error or "")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/integration/test_parsing_tasks_durable_failure.py -v`
+Expected: FAIL with `ImportError: cannot import name '_mark_parse_failed'`.
+
+- [ ] **Step 3: Add the helper + durable terminal handling**
+
+In `backend/app/worker/tasks/parsing_tasks.py`, add this coroutine after
+`_run_parse` (before the `@celery_app.task` decorator):
+
+```python
+async def _mark_parse_failed(article_file_id: str, error_message: str) -> None:
+    """Persist a terminal parse failure in its own committed transaction.
+
+    The main worker_session() rolls back on parser error (discarding any
+    in-session status flush), so the failure is recorded out-of-band in a
+    fresh session that commits independently. Covers parser errors AND
+    pre-parse failures (e.g. storage download) the service never marks.
+    """
+    from sqlalchemy import select
+
+    from app.models.article import ArticleFile
+    from app.worker._session import worker_session
+
+    async with worker_session() as session:
+        article_file = (
+            await session.execute(
+                select(ArticleFile).where(ArticleFile.id == UUID(article_file_id))
+            )
+        ).scalar_one_or_none()
+        if article_file is None:
+            return
+        article_file.extraction_status = "parse_failed"
+        article_file.extraction_error = error_message[:500]
+        await session.commit()
+```
+
+Then change the task body (`parsing_tasks.py:107-112`) from:
+
+```python
+    try:
+        return run_task(
+            lambda: _run_parse(article_file_id, project_id, user_id, trace_id or self.request.id)
+        )
+    except Exception as exc:
+        self.retry(exc=exc)
+```
+
+to:
+
+```python
+    try:
+        return run_task(
+            lambda: _run_parse(article_file_id, project_id, user_id, trace_id or self.request.id)
+        )
+    except Exception as exc:
+        if self.request.retries >= self.max_retries:
+            # Terminal: the main session already rolled back, so persist the
+            # failure durably in its own transaction before the task dies.
+            run_task(lambda: _mark_parse_failed(article_file_id, str(exc)))
+            raise
+        raise self.retry(exc=exc)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/integration/test_parsing_tasks_durable_failure.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd backend && uv run ruff check app/worker/tasks/parsing_tasks.py && uv run ruff format app/worker/tasks/parsing_tasks.py
+git add backend/app/worker/tasks/parsing_tasks.py backend/tests/integration/test_parsing_tasks_durable_failure.py
+git commit -m "fix(parsing): persist terminal parse_failed in its own transaction"
+```
+
+> Note: leaving `document_parsing_service.py` untouched is fine — the task
+> handler now covers every failure mode (parser error AND storage/download
+> error), which the service path never marked. Do NOT also write
+> `extraction_error` in the service (it would be rolled back anyway).
+
+---
+
+### Task 2: Confirm-upload endpoint (`POST /api/v1/articles/{article_id}/files`)
+
+Creates the `article_files` row server-side (membership-gated,
+storage-key-validated) and enqueues the parse — without swallowing enqueue
+failures.
+
+**Files:**
+- Create: `backend/app/api/v1/endpoints/article_files.py`
+- Modify: `backend/app/api/v1/router.py:9-26` (import) and `:97-125`
+  (register)
+- Test: `backend/tests/integration/test_article_files_endpoints.py`
+
+**Interfaces:**
+- Consumes: `ConfirmUploadRequest` (`backend/app/schemas/article.py:231`),
+  `ArticleFileResponse` (`:181`), `get_article_project_id`
+  (`citation_read_service.py`), `ensure_project_member`,
+  `get_current_user_sub`, `ArticleFileIngestService.enqueue_parse_at_ingest`.
+- Produces: `router` (FastAPI `APIRouter`, no prefix, absolute paths) with
+  `POST /articles/{article_id}/files -> ApiResponse[ArticleFileResponse]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/integration/test_article_files_endpoints.py`:
+
+```python
+"""Integration tests for the article-file ingest/recovery endpoints."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from app.models.article import Article, ArticleFile
+
+
+@pytest_asyncio.fixture
+async def member_article(
+    db_session: AsyncSession,
+) -> AsyncGenerator[tuple[UUID, UUID, UUID], None]:
+    """Yield (project_id, member_user_id, article_id); JWT override = member."""
+    row = (
+        await db_session.execute(
+            text(
+                "SELECT pm.project_id, pm.user_id FROM public.project_members pm LIMIT 1"
+            )
+        )
+    ).first()
+    if row is None:
+        pytest.skip("Need a seeded project member")
+    project_id, member_id = UUID(str(row[0])), UUID(str(row[1]))
+    article = Article(project_id=project_id, title="confirm-upload-test")
+    db_session.add(article)
+    await db_session.commit()
+
+    async def _override() -> TokenPayload:
+        return TokenPayload(sub=str(member_id), email="m@x.com", role="authenticated", aal="aal1")
+
+    app.dependency_overrides[get_current_user] = _override
+    try:
+        yield project_id, member_id, article.id
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def _body(project_id: UUID, article_id: UUID, key: str | None = None) -> dict:
+    return {
+        "articleId": str(article_id),
+        "storageKey": key or f"{project_id}/{article_id}/doc.pdf",
+        "originalFilename": "doc.pdf",
+        "contentType": "PDF",
+        "bytes": 1234,
+        "fileRole": "MAIN",
+    }
+
+
+@pytest.mark.asyncio
+async def test_confirm_creates_row_and_enqueues(
+    db_client: AsyncClient, db_session: AsyncSession, member_article
+) -> None:
+    project_id, _, article_id = member_article
+    with patch(
+        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        return_value="task-123",
+    ) as enq:
+        res = await db_client.post(
+            f"/api/v1/articles/{article_id}/files", json=_body(project_id, article_id)
+        )
+    assert res.status_code == 201, res.text
+    assert res.json()["data"]["extractionStatus"] == "pending"
+    enq.assert_called_once()
+    row = (
+        await db_session.execute(
+            select(ArticleFile).where(ArticleFile.article_id == article_id)
+        )
+    ).scalar_one()
+    assert row.storage_key == f"{project_id}/{article_id}/doc.pdf"
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_non_member(db_client: AsyncClient, member_article) -> None:
+    project_id, _, article_id = member_article
+
+    async def _outsider() -> TokenPayload:
+        return TokenPayload(sub=str(uuid4()), email="o@x.com", role="authenticated", aal="aal1")
+
+    app.dependency_overrides[get_current_user] = _outsider
+    res = await db_client.post(
+        f"/api/v1/articles/{article_id}/files", json=_body(project_id, article_id)
+    )
+    assert res.status_code == 403, res.text
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_foreign_storage_key(
+    db_client: AsyncClient, member_article
+) -> None:
+    project_id, _, article_id = member_article
+    bad = _body(project_id, article_id, key=f"{uuid4()}/{uuid4()}/evil.pdf")
+    res = await db_client.post(f"/api/v1/articles/{article_id}/files", json=bad)
+    assert res.status_code == 400, res.text
+
+
+@pytest.mark.asyncio
+async def test_confirm_does_not_swallow_enqueue_failure(
+    db_client: AsyncClient, db_session: AsyncSession, member_article
+) -> None:
+    project_id, _, article_id = member_article
+    with patch(
+        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        side_effect=RuntimeError("broker down"),
+    ):
+        res = await db_client.post(
+            f"/api/v1/articles/{article_id}/files", json=_body(project_id, article_id)
+        )
+    assert res.status_code == 503, res.text
+    row = (
+        await db_session.execute(
+            select(ArticleFile).where(ArticleFile.article_id == article_id)
+        )
+    ).scalar_one()
+    await db_session.refresh(row)
+    assert row.extraction_status == "parse_failed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/integration/test_article_files_endpoints.py -v`
+Expected: FAIL (404 — route not registered yet).
+
+- [ ] **Step 3: Create the endpoint module**
+
+Create `backend/app/api/v1/endpoints/article_files.py`:
+
+```python
+"""Article-file ingest + recovery endpoints.
+
+Every code path that creates an ArticleFile MUST enqueue a parse (the
+single sanctioned hook is ArticleFileIngestService). The browser uploads
+the bytes to Supabase Storage under its own JWT; this endpoint creates the
+DB row server-side so membership is enforced and the parse is scheduled —
+the direct PostgREST insert that bypassed parsing is retired.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from app.api.deps.security import ensure_project_member, get_current_user_sub
+from app.core.deps import DbSession
+from app.core.logging import get_logger
+from app.models.article import ArticleFile
+from app.repositories.article_repository import ArticleFileRepository
+from app.schemas.article import ArticleFileResponse, ConfirmUploadRequest
+from app.schemas.common import ApiResponse
+from app.services.article_file_ingest_service import ArticleFileIngestService
+from app.services.citation_read_service import ArticleNotFoundError, get_article_project_id
+
+logger = get_logger(__name__)
+router = APIRouter(tags=["article-files"])
+
+
+def _trace(request: Request) -> str | None:
+    return getattr(request.state, "trace_id", None)
+
+
+@router.post("/articles/{article_id}/files", status_code=status.HTTP_201_CREATED)
+async def confirm_article_file_upload(
+    article_id: UUID,
+    body: ConfirmUploadRequest,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse[ArticleFileResponse]:
+    """Register an already-uploaded object and enqueue its parse."""
+    trace_id = _trace(request)
+    if body.article_id != article_id:
+        raise HTTPException(status_code=400, detail="article_id mismatch")
+    try:
+        project_id = await get_article_project_id(db, article_id)
+    except ArticleNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    await ensure_project_member(db, project_id, current_user_sub)
+
+    # The service role bypasses RLS, so the storage key must be proven to
+    # live under the resolved project/article prefix (not a client claim).
+    expected_prefix = f"{project_id}/{article_id}/"
+    if not body.storage_key.startswith(expected_prefix):
+        raise HTTPException(status_code=400, detail="storage_key outside article path")
+
+    article_file = ArticleFile(
+        project_id=project_id,
+        article_id=article_id,
+        file_type=body.content_type,
+        storage_key=body.storage_key,
+        original_filename=body.original_filename,
+        bytes=body.bytes,
+        file_role=body.file_role,
+    )
+    article_file = await ArticleFileRepository(db).create(article_file)
+    # Commit BEFORE enqueue: the Celery task loads the row in its own session.
+    await db.commit()
+
+    try:
+        ArticleFileIngestService().enqueue_parse_at_ingest(
+            article_file_id=article_file.id,
+            project_id=project_id,
+            user_id=str(current_user_sub),
+            trace_id=trace_id,
+        )
+    except Exception as exc:  # do NOT swallow — surface so the user can retry
+        logger.warning(
+            "article_file_enqueue_failed",
+            trace_id=trace_id,
+            article_file_id=str(article_file.id),
+            error=str(exc),
+        )
+        article_file.extraction_status = "parse_failed"
+        article_file.extraction_error = f"enqueue failed: {exc}"[:500]
+        await db.commit()
+        raise HTTPException(
+            status_code=503, detail="Failed to schedule parsing; please retry"
+        ) from exc
+
+    return ApiResponse.success(
+        ArticleFileResponse.model_validate(article_file), trace_id=trace_id
+    )
+```
+
+- [ ] **Step 4: Register the router**
+
+In `backend/app/api/v1/router.py`, add `article_files` to the import tuple
+(`:9-26`, keep alphabetical):
+
+```python
+    article_files,
+    article_text_blocks,
+```
+
+Then append an include block near the other article routers (`:97-113`):
+
+```python
+api_router.include_router(article_files.router)
+```
+
+(No prefix — the decorator paths are absolute under the `/api/v1` mount.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/integration/test_article_files_endpoints.py -v`
+Expected: 4 PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd backend && uv run ruff check app/api/v1/endpoints/article_files.py app/api/v1/router.py && uv run ruff format app/api/v1/endpoints/article_files.py
+git add backend/app/api/v1/endpoints/article_files.py backend/app/api/v1/router.py backend/tests/integration/test_article_files_endpoints.py
+git commit -m "feat(parsing): backend confirm-upload endpoint that enqueues parse with BOLA gate"
+```
+
+---
+
+### Task 3: Re-parse endpoint (`POST /api/v1/article-files/{article_file_id}/reparse`)
+
+Recovers a stuck/failed file (the "teste" article + the 39 pending) by
+re-enqueuing on the existing `article_file_id`.
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/article_files.py`
+- Test: `backend/tests/integration/test_article_files_endpoints.py` (extend)
+
+**Interfaces:**
+- Consumes: `get_article_file_project_id`
+  (`article_text_block_read_service.py`), `ArticleFileNotFoundError`.
+- Produces: `POST /article-files/{article_file_id}/reparse -> ApiResponse[ArticleFileResponse]`.
+
+- [ ] **Step 1: Write the failing test** (append to the test file)
+
+```python
+@pytest.mark.asyncio
+async def test_reparse_resets_status_and_enqueues(
+    db_client: AsyncClient, db_session: AsyncSession, member_article
+) -> None:
+    project_id, _, article_id = member_article
+    file = ArticleFile(
+        project_id=project_id,
+        article_id=article_id,
+        file_type="PDF",
+        storage_key=f"{project_id}/{article_id}/old.pdf",
+        extraction_status="parse_failed",
+        extraction_error="boom",
+    )
+    db_session.add(file)
+    await db_session.commit()
+
+    with patch(
+        "app.api.v1.endpoints.article_files.ArticleFileIngestService.enqueue_parse_at_ingest",
+        return_value="task-9",
+    ) as enq:
+        res = await db_client.post(f"/api/v1/article-files/{file.id}/reparse")
+    assert res.status_code == 200, res.text
+    assert res.json()["data"]["extractionStatus"] == "pending"
+    enq.assert_called_once()
+    await db_session.refresh(file)
+    assert file.extraction_status == "pending"
+    assert file.extraction_error is None
+
+
+@pytest.mark.asyncio
+async def test_reparse_missing_file_404(db_client: AsyncClient, member_article) -> None:
+    res = await db_client.post(f"/api/v1/article-files/{uuid4()}/reparse")
+    assert res.status_code == 404, res.text
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd backend && uv run pytest tests/integration/test_article_files_endpoints.py -k reparse -v`
+Expected: FAIL (404 route unknown for the success case at the wrong layer).
+
+- [ ] **Step 3: Add the re-parse endpoint**
+
+Append to `article_files.py` (and add the import at top):
+
+```python
+from app.services.article_text_block_read_service import (
+    ArticleFileNotFoundError,
+    get_article_file_project_id,
+)
+```
+
+```python
+@router.post("/article-files/{article_file_id}/reparse")
+async def reparse_article_file(
+    article_file_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(get_current_user_sub),
+) -> ApiResponse[ArticleFileResponse]:
+    """Re-enqueue a parse for an existing ArticleFile (recovery)."""
+    trace_id = _trace(request)
+    try:
+        project_id = await get_article_file_project_id(db, article_file_id)
+    except ArticleFileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    await ensure_project_member(db, project_id, current_user_sub)
+
+    article_file = await ArticleFileRepository(db).get_by_id(article_file_id)
+    if article_file is None:  # defensive — gate already resolved the project
+        raise HTTPException(status_code=404, detail="Article file not found")
+    article_file.extraction_status = "pending"
+    article_file.extraction_error = None
+    await db.commit()
+
+    try:
+        ArticleFileIngestService().enqueue_parse_at_ingest(
+            article_file_id=article_file.id,
+            project_id=project_id,
+            user_id=str(current_user_sub),
+            trace_id=trace_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "article_file_reparse_enqueue_failed",
+            trace_id=trace_id,
+            article_file_id=str(article_file.id),
+            error=str(exc),
+        )
+        article_file.extraction_status = "parse_failed"
+        article_file.extraction_error = f"enqueue failed: {exc}"[:500]
+        await db.commit()
+        raise HTTPException(
+            status_code=503, detail="Failed to schedule parsing; please retry"
+        ) from exc
+
+    return ApiResponse.success(
+        ArticleFileResponse.model_validate(article_file), trace_id=trace_id
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd backend && uv run pytest tests/integration/test_article_files_endpoints.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd backend && uv run ruff check app/api/v1/endpoints/article_files.py && uv run ruff format app/api/v1/endpoints/article_files.py
+git add backend/app/api/v1/endpoints/article_files.py backend/tests/integration/test_article_files_endpoints.py
+git commit -m "feat(parsing): re-parse endpoint to recover stuck/failed article files"
+```
+
+---
+
+### Task 4: Regenerate the API contract types
+
+The frontend must import the new endpoint shapes from the generated
+contract (frontend rule: no hand-mirroring).
+
+**Files:**
+- Modify: `frontend/types/api/openapi.json`, `frontend/types/api/schema.d.ts`
+
+- [ ] **Step 1: Regenerate**
+
+Run (from repo root): `npm run generate:api-types`
+
+- [ ] **Step 2: Verify the new paths are present**
+
+Run: `grep -c "articles/{article_id}/files\|article-files/{article_file_id}/reparse" frontend/types/api/openapi.json`
+Expected: ≥ 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/types/api/openapi.json frontend/types/api/schema.d.ts
+git commit -m "chore(api): regenerate contract types for article-file ingest endpoints"
+```
+
+---
+
+### Task 5: Route `addArticle` through the confirm endpoint
+
+**Files:**
+- Modify: `frontend/services/articlesService.ts`
+- Test: `frontend/test/services/articlesService.test.ts` (extend)
+
+**Interfaces:**
+- Produces: `confirmArticleFileUpload(params) => apiClient<ArticleFileResponse>('/api/v1/articles/{articleId}/files', {method:'POST', body})`.
+  `addArticle` now calls it instead of `supabase.from('article_files').insert`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add `vi.mock('@/integrations/api', ...)` at the top of
+`frontend/test/services/articlesService.test.ts` (next to the existing
+mocks) and a new test:
+
+```typescript
+vi.mock('@/integrations/api', () => ({apiClient: vi.fn(async () => ({}))}));
+```
+
+```typescript
+import {apiClient} from '@/integrations/api';
+
+describe('articlesService.addArticle — backend confirm', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('registers the file via the backend, not a direct article_files insert', async () => {
+    // article insert + storage upload succeed
+    vi.mocked(supabase.from).mockImplementation(() => {
+      const c: Record<string, unknown> = {};
+      c.insert = vi.fn(() => c);
+      c.select = vi.fn(() => c);
+      c.single = vi.fn(async () => ({data: {id: 'art-1'}, error: null}));
+      c.delete = vi.fn(() => c);
+      c.eq = vi.fn(() => c);
+      return c;
+    });
+    vi.mocked(supabase.storage.from).mockReturnValue({
+      upload: vi.fn(async () => ({error: null})),
+      remove: vi.fn(async () => ({error: null})),
+    } as never);
+
+    const res = await addArticle(ARTICLE_DATA as never, {
+      file: FAKE_PDF,
+      detectedFormat: 'PDF',
+    } as never);
+
+    expect(res.ok).toBe(true);
+    expect(apiClient).toHaveBeenCalledWith(
+      '/api/v1/articles/art-1/files',
+      expect.objectContaining({method: 'POST'}),
+    );
+    // No direct article_files PostgREST insert anymore:
+    const fromCalls = vi.mocked(supabase.from).mock.calls.map(c => c[0]);
+    expect(fromCalls).not.toContain('article_files');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (repo root): `npm run test:run -- frontend/test/services/articlesService.test.ts`
+Expected: FAIL (`apiClient` not called; `article_files` still in `from` calls).
+
+- [ ] **Step 3: Implement**
+
+In `frontend/services/articlesService.ts`, add the import and helper:
+
+```typescript
+import {apiClient} from '@/integrations/api';
+
+interface ConfirmUploadParams {
+  articleId: string;
+  storageKey: string;
+  originalFilename: string;
+  contentType: string;
+  bytes: number;
+  fileRole: FileRole;
+}
+
+function confirmArticleFileUpload(p: ConfirmUploadParams): Promise<unknown> {
+  return apiClient(`/api/v1/articles/${p.articleId}/files`, {
+    method: 'POST',
+    body: {
+      articleId: p.articleId,
+      storageKey: p.storageKey,
+      originalFilename: p.originalFilename,
+      contentType: p.contentType,
+      bytes: p.bytes,
+      fileRole: p.fileRole,
+    },
+  });
+}
+```
+
+Replace the `article_files` insert block in `addArticle` (`:76-91`) with:
+
+```typescript
+      try {
+        await confirmArticleFileUpload({
+          articleId: article.id,
+          storageKey,
+          originalFilename: pdfInput.file.name,
+          contentType: pdfInput.detectedFormat,
+          bytes: pdfInput.file.size,
+          fileRole: FILE_ROLES.MAIN,
+        });
+      } catch (e) {
+        // Rollback: remove storage object and article row
+        await supabase.storage.from('articles').remove([storageKey]);
+        await supabase.from('articles').delete().eq('id', article.id);
+        throw e instanceof Error ? e : new Error('File registration failed');
+      }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run (repo root): `npm run test:run -- frontend/test/services/articlesService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add frontend/services/articlesService.ts frontend/test/services/articlesService.test.ts
+git commit -m "feat(parsing): route addArticle file registration through the backend enqueue endpoint"
+```
+
+---
+
+### Task 6: Route `uploadArticleFile` through the confirm endpoint
+
+**Files:**
+- Modify: `frontend/services/articlesService.ts`
+- Test: `frontend/test/services/articlesService.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+describe('articlesService.uploadArticleFile — backend confirm', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('registers supplements via the backend, not a direct insert', async () => {
+    vi.mocked(supabase.storage.from).mockReturnValue({
+      upload: vi.fn(async () => ({error: null})),
+      remove: vi.fn(async () => ({error: null})),
+    } as never);
+
+    const res = await uploadArticleFile({
+      projectId: 'proj-1',
+      articleId: 'art-1',
+      storageKey: 'proj-1/art-1/supp.pdf',
+      file: FAKE_PDF,
+      role: 'SUPPLEMENT',
+    } as never);
+
+    expect(res.ok).toBe(true);
+    expect(apiClient).toHaveBeenCalledWith(
+      '/api/v1/articles/art-1/files',
+      expect.objectContaining({method: 'POST'}),
+    );
+    const fromCalls = vi.mocked(supabase.from).mock.calls.map(c => c[0]);
+    expect(fromCalls).not.toContain('article_files');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test:run -- frontend/test/services/articlesService.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** — replace the `article_files` insert block in
+`uploadArticleFile` (`:312-322`) with:
+
+```typescript
+    try {
+      await confirmArticleFileUpload({
+        articleId: params.articleId,
+        storageKey: params.storageKey,
+        originalFilename: params.file.name,
+        contentType: detectedFormat,
+        bytes: params.file.size,
+        fileRole: params.role,
+      });
+    } catch (e) {
+      await supabase.storage.from('articles').remove([params.storageKey]);
+      throw e instanceof Error ? e : new Error('File registration failed');
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test:run -- frontend/test/services/articlesService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add frontend/services/articlesService.ts frontend/test/services/articlesService.test.ts
+git commit -m "feat(parsing): route supplement uploads through the backend enqueue endpoint"
+```
+
+---
+
+### Task 7: Re-parse service + button
+
+**Files:**
+- Modify: `frontend/services/articlesService.ts` (add `reparseArticleFile`)
+- Modify: `frontend/components/articles/ArticleDetailDialog.tsx` (button on
+  each file row, near the role badge at `:329`)
+- Test: `frontend/test/services/articlesService.test.ts` (extend)
+
+**Interfaces:**
+- Produces: `reparseArticleFile(articleFileId: string) => Promise<ErrorResult<unknown>>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import {reparseArticleFile} from '@/services/articlesService';
+
+describe('articlesService.reparseArticleFile', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('POSTs the reparse endpoint for the given file id', async () => {
+    const res = await reparseArticleFile('file-7');
+    expect(res.ok).toBe(true);
+    expect(apiClient).toHaveBeenCalledWith(
+      '/api/v1/article-files/file-7/reparse',
+      expect.objectContaining({method: 'POST'}),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test:run -- frontend/test/services/articlesService.test.ts`
+Expected: FAIL (`reparseArticleFile` not exported).
+
+- [ ] **Step 3: Implement the service function**
+
+In `frontend/services/articlesService.ts`:
+
+```typescript
+export function reparseArticleFile(articleFileId: string): Promise<ErrorResult<unknown>> {
+  return toResult(
+    () => apiClient(`/api/v1/article-files/${articleFileId}/reparse`, {method: 'POST'}),
+    'articlesService.reparseArticleFile',
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify the service test passes**
+
+Run: `npm run test:run -- frontend/test/services/articlesService.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the button** in `ArticleDetailDialog.tsx` file-row
+render (near `getFileRoleLabel`, `:329`). Import at top:
+`import {reparseArticleFile} from '@/services/articlesService';` and
+`import {toast} from 'sonner';` (if not present). In the file row JSX:
+
+```tsx
+<Button
+  variant="ghost"
+  size="sm"
+  onClick={async () => {
+    const r = await reparseArticleFile(file.id);
+    if (r.ok) toast.success(t('articles', 'reparseQueued'));
+    else toast.error(r.error.message);
+  }}
+>
+  {t('articles', 'reparse')}
+</Button>
+```
+
+Add the copy keys to `frontend/lib/copy/articles.ts`:
+
+```typescript
+  reparse: 'Re-parse',
+  reparseQueued: 'Re-parse queued',
+```
+
+- [ ] **Step 6: Typecheck, lint, commit**
+
+```bash
+npm run typecheck && npm run lint
+git add frontend/services/articlesService.ts frontend/components/articles/ArticleDetailDialog.tsx frontend/lib/copy/articles.ts frontend/test/services/articlesService.test.ts
+git commit -m "feat(parsing): per-file Re-parse action to recover stuck article files"
+```
+
+---
+
+## Final verification
+
+- [ ] `cd backend && uv run pytest tests/integration/test_article_files_endpoints.py tests/integration/test_parsing_tasks_durable_failure.py -v` — all PASS
+- [ ] `make lint-backend` — clean
+- [ ] `npm run test:run -- frontend/test/services/articlesService.test.ts` — PASS
+- [ ] `npm run lint && npm run typecheck` — clean
+- [ ] Manual (against a worker): add an article with a PDF → the file row
+  appears `pending` → worker parses → status `parsed`; kill the broker and
+  add a file → endpoint returns 503 and the row is `parse_failed`; click
+  Re-parse → status returns to `pending`.
+
+## Out of scope (later PRs)
+
+- The status badge + "Reader / Indexed" column + enum single-source — PR-C.
+- Reader wiring + document switcher — PR-D. Supplement parsing — PR-E.
+- Hardening the Supabase Storage INSERT policy to be project-scoped (today
+  any authed user can write any key; the confirm endpoint's prefix check
+  closes the read-access path, but the storage policy is a separate RLS
+  migration) — follow-up.

--- a/docs/superpowers/specs/2026-06-20-parse-to-markdown-end-to-end-design.md
+++ b/docs/superpowers/specs/2026-06-20-parse-to-markdown-end-to-end-design.md
@@ -1,0 +1,321 @@
+---
+status: draft
+last_reviewed: 2026-06-20
+owner: '@raphaelfh'
+---
+
+> **Status:** Draft — design direction approved in brainstorm 2026-06-20
+> (incl. an adversarially-verified design review); pending written-spec
+> review before `writing-plans`.
+
+# Design: Parse-to-markdown end-to-end (pipeline activation, parse-status visibility, multi-document viewer)
+
+**Date:** 2026-06-20
+**Branch:** `claude/trusting-boyd-bf529c`
+**Related:**
+[ADR-0011](../../adr/0011-structured-pdf-parsing-at-ingest.md) (structured
+PDF parsing at ingest),
+[ADR-0013](../../adr/0013-dual-tier-markdown-representation.md) (dual-tier markdown),
+and the plans
+[`2026-06-19-structured-pdf-parsing-at-ingest.md`](../plans/2026-06-19-structured-pdf-parsing-at-ingest.md)
+and
+[`2026-06-19-grounded-extraction-and-hitl-highlight.md`](../plans/2026-06-19-grounded-extraction-and-hitl-highlight.md).
+
+## Problem
+
+A user added a LlamaParse BYOK key, then added a new article "teste", and
+could not tell whether its PDF was parsed to markdown. It was **not**.
+Live evidence: `articles.id = 07d38220-…`, file `ed49229d-…`,
+`extraction_status = "pending"`, `extracted_at = NULL`, **0** rows in
+`article_text_blocks`; the LlamaParse key is saved/valid/default but its
+`last_used_at` is `NULL` (never used).
+
+Two compounding root causes (both code-verified):
+
+- **RC1 — the manual "Add article" path never enqueues a parse.**
+  `addArticle` (`frontend/services/articlesService.ts:79`) uploads the PDF
+  and inserts the `article_files` row **directly via Supabase PostgREST**
+  (`articlesService.ts:106`); it never calls the backend, so
+  `ArticleFileIngestService.enqueue_parse_at_ingest`
+  (`backend/app/services/article_file_ingest_service.py:20`) never fires.
+  The **only** caller of that hook today is the Zotero importer
+  (`backend/app/services/zotero_import_service.py:460`). There is also a
+  **second** un-enqueued upload path, `uploadArticleFile`
+  (`articlesService.ts:313`, used by `ArticleFileUploadDialogNew` for
+  supplements). Manually-added files therefore sit at `pending` forever.
+- **RC2 — the dual-path parse feature is not live in prod.**
+  `article_text_blocks` is globally empty and all 39 `article_files` rows
+  are `pending`; nothing has ever advanced. The dual-path parse-at-ingest
+  feature (dev commit `03ac24ad` / #350) is in `dev` but not promoted to
+  `main` (Railway deploys from `main`).
+
+Adjacent gaps surfaced while grounding the fix:
+
+- The **viewer reader pane** is never fed text blocks.
+  `ExtractionPDFPanel.tsx:31` only has `articleId` and never calls
+  `useArticleTextBlocks`, so the reader always renders the "requires the
+  document to be indexed" empty state
+  (`frontend/pdf-viewer/primitives/Reader.tsx:43`) — even for parsed docs.
+- The viewer is **hardcoded to the MAIN file**
+  (`frontend/pdf-viewer/adapters/articleFileSource.ts:31`, `.eq('file_role','MAIN')`),
+  so supplemental documents cannot be opened, even though the data model
+  fully supports multiple files per article (`article_files.file_role`).
+
+This design makes parsing actually run on every ingest path, makes its
+success/failure **visible**, and adds a **document switcher** so the user
+can open (and read the grounded markdown of) any linked document.
+
+## Scope guardrails (what this is NOT)
+
+- Not a generic app-schema API buildout. Only the endpoints needed below.
+- Not the PHI fail-closed gate (`create_document_parser(project_is_phi=…)`).
+  Per the 2026-06-20 decision, supplements follow the **same per-project
+  parser backend as the MAIN file** (no special-casing). The PHI gate
+  remains a documented future item, out of scope here.
+- Not a bulk backfill. Recovery of the 39 stranded files is via a per-file
+  **Re-parse** action, not a sweeper.
+
+## Verified review findings folded in (must-fixes)
+
+These are the design-review findings that survived adversarial
+verification against the code. Each reshapes a phase below.
+
+- **MF-1 — `parse_failed` never persists.** On a parse exception the
+  worker does `session.rollback()` (`backend/app/worker/tasks/parsing_tasks.py:82`),
+  discarding the `extraction_status = "parse_failed"` that
+  `document_parsing_service.py:127` only `flush()`-es. After `max_retries`
+  the row stays `pending`. **Consequence:** the status badge can never show
+  "failed". Failures *before* the parse call (storage download) never set
+  it at all. → Make terminal failure durable (commit in its own session)
+  **before** the badge ships. (Checklist C/D.)
+- **MF-2 — service-role reroute can widen access (BOLA/RLS).** The Storage
+  INSERT policy is not project-scoped
+  (`backend/alembic/versions/0003_storage_object_policies.py:47` —
+  `bucket_id='articles' AND auth.uid() IS NOT NULL`); today the real gate
+  is the `article_files` RLS insert (`is_project_member`,
+  `baseline_v1.sql:2292`). A service-role backend insert bypasses that RLS,
+  so the new endpoint **must** resolve `project_id` from `article_id` and
+  `ensure_project_member` **before** insert, and **derive `storage_key`
+  server-side** (never trust the client). Template:
+  `backend/app/api/v1/endpoints/article_text_blocks.py:42`. (Checklist A/B.)
+- **MF-3 — RC1 is two paths, not one.** Reroute **both** `addArticle`
+  (`articlesService.ts:106`) and `uploadArticleFile`
+  (`articlesService.ts:313`). Rerouting only one leaves supplements
+  unparsed — and PR-E (supplement parsing) is born from that same path.
+- **MF-4 — "re-upload teste" no-ops without the fix.** Re-upload goes
+  through the same un-enqueued `addArticle`. The recovery path is a
+  per-file **Re-parse** button calling `enqueue_parse_at_ingest` on the
+  existing `article_file_id` (no storage round-trip), which also recovers
+  `parse_failed` files (MF-1).
+- **MF-5 — second reader-wiring site.**
+  `frontend/pages/QualityAssessmentFullScreen.tsx:642` has the identical
+  reader gap (and is also missing `store`). The viewer's only two
+  consumers are it and `ExtractionPDFPanel`. Wire both — ideally via one
+  shared hook so they cannot drift again.
+- **MF-6 — Articles-list payload lacks `extraction_status`.**
+  `loadProjectArticles` (`articlesService.ts:432`) selects only
+  `id, title, doi, created_at`; status lives on the child `article_files`,
+  and the list's only `article_files` read fetches `article_id` only. The
+  badge needs a new data source (a typed backend field for the MAIN file's
+  status), not a hand-added PostgREST select.
+- **MF-7 — empty-state is sticky after parse.**
+  `useArticleTextBlocks` has a 5-min `staleTime`, no `refetchInterval`, no
+  invalidation on completion (Celery async, no realtime). Opening the
+  reader right after upload pins `[]` for 5 min. → poll while status is
+  `pending`, stop on a terminal state.
+- **MF-8 — cross-document highlight leak on switch.**
+  `useDocumentLoader` reacts to `source` but never clears `citations` /
+  `currentPage` / `search`, so `CitationOverlay` projects doc A's rect onto
+  doc B (`frontend/pdf-viewer/hooks/useDocumentLoader.ts:15`,
+  `frontend/pdf-viewer/primitives/CitationOverlay.tsx:79`). → clear on
+  switch. (Checklist G.)
+- **MF-9 — ordering: 3.1 before 2.3.** The adapter never surfaces
+  `article_file_id`, which the reader hook needs. Generalize the adapter
+  first, then wire the reader once. A single `GET /articles/{id}/files`
+  feeds both the source and the hook (kills the dual-read/waterfall).
+- **MF-10 — unbounded BYOK cost.** `rate_limit="10/m"` is throughput, not
+  cost; LlamaParse uploads the whole file at the `agentic` tier with no
+  `max_pages`/byte ceiling (`backend/app/infrastructure/parsing/llamaparse_parser.py:44`).
+  Fanning out to supplements needs a per-file size guard using the already
+  stored `article_files.bytes`.
+- **MF-11 — enum drift in 3 places + free-text column.** The stale comment
+  (`frontend/types/article-files.ts:24`), the backend
+  `ExtractTextResponse.status` literal (`backend/app/schemas/article.py:262`),
+  and the e2e fixture writing `"completed"`
+  (`frontend/e2e/_fixtures/ensure-fixtures.ts:89`) all disagree with the
+  real values `pending | parsed | parse_failed`. Establish one source of
+  truth + regenerate types; add a DB CHECK so it cannot silently drift.
+- **NOTE (rejected):** the review's claim that "the reader toggle is never
+  rendered" was **refuted** — `modeToggle` defaults to `true`
+  (`frontend/pdf-viewer/ui/Toolbar.tsx:13`) and both callers render it.
+  The toggle works today; reader mode is simply opt-in (no auto-select).
+
+## Decisions (locked 2026-06-20)
+
+1. **Re-parse over backfill.** A per-file "Re-parse" action recovers the
+   "teste" article and the 39 stranded files on demand (MF-4). No sweeper.
+2. **Drop all three dead BLOB columns** (`pdf_extracted_text`,
+   `semantic_abstract_text`, `semantic_fulltext_text`). None has a live
+   consumer: `semantic_abstract_text` is redundant with the real metadata
+   `abstract` column (`backend/app/models/article.py:66`), and
+   `pdf_extracted_text` (legacy raw pypdf dump) is superseded by
+   `article_text_blocks` (plain text is reconstructable from blocks).
+   Dropped in lockstep: model fields (`article.py:128-130`), the Zotero
+   carry-forward block (`zotero_import_service.py:367-369`), FE display +
+   `BLOB_COLUMN_IDS` + test refs, regenerated Supabase types, and one
+   reversible destructive migration (revision id ≤ 32 chars). This executes
+   the `articles`-level subset of roadmap Task 3.2/3.3
+   (`text_raw`/`text_html` on `article_files` stay with that task).
+3. **Supplements follow the LlamaCloud flow** like the MAIN file (same
+   per-project parser backend; no PHI special-case). Keep a lightweight
+   per-file cost guard (MF-10) as a safety net.
+4. **`parsed_by` column deferred (YAGNI).** The Docling-fallback is already
+   observable via the `parser_gate_llamaparse_no_key_fallback_docling` log
+   (`backend/app/core/factories.py:66`). Add the column only if the UI must
+   persistently show which backend ran.
+
+## Architecture / phased delivery
+
+Five units, one per PR (one concern each, per `CLAUDE.md`). Ordering is
+load-bearing where noted.
+
+### PR-A — Fase 0: promote the parse feature to prod (ops, no code)
+
+Promote `dev → main` so the parse worker runs on Railway. The
+`/article-files/.../text-blocks` router is already mounted
+(`backend/app/api/v1/router.py:110`); this promotion is the only thing
+between the existing reader endpoint and prod. Verify against `main` /
+Railway before sequencing the rest.
+
+### PR-B — Make every ingest path enqueue parse, durably
+
+Concern: *manual uploads enqueue a parse, and failures are visible.*
+
+- New backend endpoint that creates/confirms an `article_file` and calls
+  `enqueue_parse_at_ingest` after the row commits. Reuse the existing
+  (currently unwired) `UploadUrlRequest` / `UploadUrlResponse` /
+  `ConfirmUploadRequest` schemas (`backend/app/schemas/article.py`,
+  exported in `schemas/__init__.py`). These imply a **presigned-URL +
+  confirm** flow, so the FE upload sequence is **replaced**, not patched
+  (scope note: larger than an insert swap).
+- **BOLA/RLS (MF-2):** resolve `project_id` from `article_id`,
+  `ensure_project_member` before insert, **derive `storage_key`
+  server-side**. Do not swallow a `.delay()` failure into a 2xx — either
+  propagate (5xx with `error.message`) or set `parse_failed` +
+  `extraction_error` atomically (contrast the Zotero best-effort swallow
+  at `zotero_import_service.py:460`).
+- Reroute **both** `addArticle` and `uploadArticleFile` through it (MF-3).
+- **Re-parse action (MF-4):** endpoint + button that enqueues
+  `parse_article_file_task` on an existing `article_file_id`. Surfaced from
+  the per-file status (PR-C) and from the article detail dialog.
+- **Durable `parse_failed` (MF-1):** persist terminal failure in its own
+  committed session in the task's exception handler (after retries
+  exhausted), covering pre-parse failures (storage download) too. This is
+  a hard prerequisite of PR-C's badge.
+
+### PR-C — Parse-status visibility
+
+Concern: *the user can see parsed / parsing / failed.*
+
+- **Enum single-source (MF-11):** define `pending | parsed | parse_failed`
+  once (Python `Literal`/enum + DB CHECK), regenerate
+  `frontend/types/api/schema.d.ts`, fix the stale comment, the
+  `ExtractTextResponse.status` literal, and the e2e fixture. Reconcile the
+  model `nullable=True` vs schema non-Optional mismatch.
+- **Per-file badge** reading `extraction_status`. **Aggregation rule:** the
+  Articles-list badge reflects the **MAIN** file only; per-file statuses
+  (incl. supplements) appear in `ArticleDetailDialog` and the PR-D
+  switcher. Handle the no-MAIN article (supplement-only) with a neutral
+  state, not "pending".
+- **List data source (MF-6):** extend the MAIN-file list query to return
+  `extraction_status` for the article's MAIN file via the typed backend
+  (not a new `supabase.from(...)` select).
+- **UI column swap:** remove all three dead "–" display columns ("PDF
+  text", "Sem. abstract", "Sem. fulltext",
+  `frontend/lib/articlesListDisplay.ts:46-48` + their `BLOB_COLUMN_IDS`
+  entries `:51-55`) and add a "Reader / Indexed" status column. Per
+  Decision 2, **drop all three columns in lockstep** (model fields
+  `article.py:128-130` + Zotero carry block `zotero_import_service.py:367-369`
+  + FE/test refs + regenerated Supabase types + reversible migration,
+  revision id ≤ 32 chars).
+
+### PR-D — Reader wiring + multi-document switcher
+
+Concern: *open and read the grounded markdown of any linked document.*
+Order inside the PR: **3.1 → 2.3 → 3.3** (MF-9).
+
+- **3.1 Generalize the adapter** so `articleFileSource` accepts an
+  `article_file_id` (not hardcoded MAIN) and the panel obtains the id from
+  a single `GET /api/v1/articles/{id}/files` (typed, `_gate_article`
+  membership check, `ApiResponse[ArticleFileResponse[]]`, single unwrap).
+  This kills the dual-read/waterfall.
+- **2.3 Wire the reader** in **both** `ExtractionPDFPanel` and
+  `QualityAssessmentFullScreen` (MF-5) via one shared hook: resolve the
+  selected file id → `useArticleTextBlocks` → pass `readerBlocks` /
+  `readerLoading` into `PrumoPdfViewer`. **Poll while status is pending**
+  (MF-7), stop on terminal.
+- **3.3 Selected-file state** feeds **both** the source and the hook from
+  the same `selectedFileId` (no PDF/blocks desync). **On switch, clear**
+  `citations` / `search` / page (MF-8); also destroy the outgoing pdf.js
+  document to avoid the leak. Switcher = a dropdown of files labeled by
+  `FILE_ROLE_LABELS` + filename, default MAIN, with a per-file parsed
+  indicator.
+
+### PR-E — Supplement parsing
+
+Concern: *supplements get blocks / reader / highlights.* Blocked on PR-B
+(supplements need an enqueue path) and best after PR-D (so they're
+viewable).
+
+- Enqueue a parse for **every** `file_role` at creation (the parse task and
+  service are already role-agnostic; only the enqueue sites are MAIN-only).
+- Supplements use the **same per-project parser backend** as MAIN
+  (Decision 3). Add the **per-file cost guard** (MF-10): skip/flag files
+  over a configurable page/byte ceiling, reflecting the skip in
+  `extraction_status`.
+
+## Cross-cutting concerns
+
+- **Authorization:** every new endpoint resolves project from
+  `article_id` / `article_file_id` and `ensure_project_member` before any
+  access; never trust a body `project_id`. Cross-project member → 403/404
+  integration test.
+- **Migrations:** the destructive drop (PR-C) is reversible (down re-adds
+  the nullable columns), documented as unrecoverable data, revision id
+  ≤ 32 chars, single linear head (`0027_api_key_llama_cloud`). The DB CHECK
+  for `extraction_status` is additive.
+- **Envelope/types:** new endpoints use `ApiResponse[...]`, FE single-
+  unwraps via `apiClient`; FE consumes generated types, never hand-mirrors
+  the enum.
+
+## Test strategy
+
+- **Backend (pytest, integration):** confirm endpoint enqueues
+  `parse_article_file_task` for MAIN and supplement; rejects non-members
+  (BOLA 403); enqueue failure is **not** swallowed into success; terminal
+  `parse_failed` is **durable** across a simulated worker rollback;
+  re-parse enqueues on an existing `article_file_id`.
+- **Frontend (vitest):** `addArticle` / `uploadArticleFile` call the typed
+  client, not `supabase.from(...).insert` (RC1 regression-lock); badge
+  renders the three real states; switching the selected document changes
+  the `articleKeys.textBlocks` key and does not render the prior doc's
+  blocks; switching clears citations/search; reader-blocks wiring present
+  in **both** `ExtractionPDFPanel` and `QualityAssessmentFullScreen`.
+- **E2E (Playwright):** upload → see "parsing" → see "parsed" → open reader
+  → see markdown; open a supplement via the switcher.
+
+## Out of scope / follow-ups
+
+- PHI fail-closed gate (`project_is_phi`) — future ADR/plan.
+- `parsed_by` column (Decision 4) — add only if persistently displayed.
+- Per-role parser policy (e.g. cheaper backend for DATASET/FIGURE) — note
+  only; cost guard (MF-10) is the interim safety net.
+
+## Resolved in spec review (2026-06-20)
+
+1. **Column drops:** drop all three dead BLOB columns
+   (`pdf_extracted_text`, `semantic_abstract_text`, `semantic_fulltext_text`)
+   — none has a live consumer; the three "–" display columns are removed
+   from the table too.
+2. **Re-parse:** per-file only (badge + article detail dialog). No bulk
+   "re-parse all" action for now — revisit if the UX needs it.

--- a/frontend/components/articles/ArticleDetailDialog.tsx
+++ b/frontend/components/articles/ArticleDetailDialog.tsx
@@ -24,6 +24,7 @@ import {
     fetchArticleFiles,
     downloadFileBlob,
     deleteArticleFile,
+    reparseArticleFile,
     type ArticleFileRecord,
 } from "@/services/articlesService";
 
@@ -340,6 +341,17 @@ export function ArticleDetailDialog({ open, onOpenChange, articleId }: ArticleDe
                         </div>
                       </div>
                       <div className="flex gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={async () => {
+                            const r = await reparseArticleFile(file.id);
+                            if (r.ok) toast.success(t('articles', 'reparseQueued'));
+                            else toast.error(r.error.message);
+                          }}
+                        >
+                          {t('articles', 'reparse')}
+                        </Button>
                         <Button
                           size="sm"
                           variant="outline"

--- a/frontend/lib/copy/articles.ts
+++ b/frontend/lib/copy/articles.ts
@@ -309,6 +309,9 @@ export const articles = {
     exportInProgress: 'Export in progress…',
     exportCancelExport: 'Cancel export',
     exportSkippedFilesCount: '{{n}} file(s) could not be included in the package.',
+    // ArticleDetailDialog: per-file re-parse action
+    reparse: 'Re-parse',
+    reparseQueued: 'Re-parse queued',
 } as const;
 
 export type ArticlesCopy = typeof articles;

--- a/frontend/services/articlesService.ts
+++ b/frontend/services/articlesService.ts
@@ -440,6 +440,21 @@ export function deleteArticle(articleId: string): Promise<ErrorResult<void>> {
 }
 
 // ---------------------------------------------------------------------------
+// ArticleDetailDialog: trigger a re-parse for a stuck article file
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueues a re-parse job for the given article file.
+ * Returns ok:true on success; ok:false with error.message on failure.
+ */
+export function reparseArticleFile(articleFileId: string): Promise<ErrorResult<unknown>> {
+  return toResult(
+    () => apiClient(`/api/v1/article-files/${articleFileId}/reparse`, {method: 'POST'}),
+    'articlesService.reparseArticleFile',
+  );
+}
+
+// ---------------------------------------------------------------------------
 // ExtractionInterface: article list for dashboard stats
 // ---------------------------------------------------------------------------
 

--- a/frontend/services/articlesService.ts
+++ b/frontend/services/articlesService.ts
@@ -337,20 +337,18 @@ export function uploadArticleFile(params: UploadFileParams): Promise<ErrorResult
 
     if (uploadError) throw new Error('Upload failed: ' + uploadError.message);
 
-    const {error: insertError} = await supabase.from('article_files').insert([{
-      project_id: params.projectId,
-      article_id: params.articleId,
-      file_type: detectedFormat,
-      file_role: params.role,
-      storage_key: params.storageKey,
-      original_filename: params.file.name,
-      bytes: params.file.size,
-    }]);
-
-    if (insertError) {
-      // Rollback storage
+    try {
+      await confirmArticleFileUpload({
+        articleId: params.articleId,
+        storageKey: params.storageKey,
+        originalFilename: params.file.name,
+        contentType: detectedFormat,
+        bytes: params.file.size,
+        fileRole: params.role,
+      });
+    } catch (e) {
       await supabase.storage.from('articles').remove([params.storageKey]);
-      throw new Error('File registration failed: ' + insertError.message);
+      throw e instanceof Error ? e : new Error('File registration failed');
     }
   }, 'articlesService.uploadArticleFile');
 }

--- a/frontend/services/articlesService.ts
+++ b/frontend/services/articlesService.ts
@@ -11,9 +11,37 @@
  * typed-client swap.
  */
 import {supabase} from '@/integrations/supabase/client';
+import {apiClient} from '@/integrations/api';
 import {toResult, type ErrorResult} from '@/lib/error-utils';
 import {detectFileFormat} from '@/lib/file-validation';
 import {FILE_ROLES, type FileRole} from '@/lib/file-constants';
+
+// ---------------------------------------------------------------------------
+// confirmArticleFileUpload: register a storage object via the backend endpoint
+// ---------------------------------------------------------------------------
+
+interface ConfirmUploadParams {
+  articleId: string;
+  storageKey: string;
+  originalFilename: string;
+  contentType: string;
+  bytes: number;
+  fileRole: FileRole;
+}
+
+function confirmArticleFileUpload(p: ConfirmUploadParams): Promise<unknown> {
+  return apiClient(`/api/v1/articles/${p.articleId}/files`, {
+    method: 'POST',
+    body: {
+      articleId: p.articleId,
+      storageKey: p.storageKey,
+      originalFilename: p.originalFilename,
+      contentType: p.contentType,
+      bytes: p.bytes,
+      fileRole: p.fileRole,
+    },
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Shared insert payload type (used by addArticle and saveArticle)
@@ -103,21 +131,20 @@ export function addArticle(
         throw new Error('Upload failed: ' + uploadError.message);
       }
 
-      const {error: insertError} = await supabase.from('article_files').insert([{
-        project_id: articleData.project_id,
-        article_id: article.id,
-        file_type: pdfInput.detectedFormat,
-        file_role: FILE_ROLES.MAIN,
-        storage_key: storageKey,
-        original_filename: pdfInput.file.name,
-        bytes: pdfInput.file.size,
-      }]);
-
-      if (insertError) {
+      try {
+        await confirmArticleFileUpload({
+          articleId: article.id,
+          storageKey,
+          originalFilename: pdfInput.file.name,
+          contentType: pdfInput.detectedFormat,
+          bytes: pdfInput.file.size,
+          fileRole: FILE_ROLES.MAIN,
+        });
+      } catch (e) {
         // Rollback: remove storage object and article row
         await supabase.storage.from('articles').remove([storageKey]);
         await supabase.from('articles').delete().eq('id', article.id);
-        throw new Error('File registration failed: ' + insertError.message);
+        throw e instanceof Error ? e : new Error('File registration failed');
       }
     }
 

--- a/frontend/test/services/articlesService.test.ts
+++ b/frontend/test/services/articlesService.test.ts
@@ -228,9 +228,8 @@ describe('articlesService.uploadArticleFile', () => {
       remove: storageRemove,
     } as never);
 
-    vi.mocked(supabase.from).mockImplementation(() => ({
-      insert: vi.fn(async () => ({error: {message: 'insert failed'}})),
-    } as never));
+    // apiClient rejects → triggers storage rollback
+    vi.mocked(apiClient).mockRejectedValueOnce(new Error('constraint violation'));
 
     const result = await uploadArticleFile({
       projectId: 'proj-1',
@@ -242,6 +241,35 @@ describe('articlesService.uploadArticleFile', () => {
 
     expect(result.ok).toBe(false);
     expect(storageRemove).toHaveBeenCalledWith(['proj-1/art-4/file.pdf']);
-    expect(vi.mocked(supabase.from)).toHaveBeenCalledWith('article_files');
+    // No longer calls supabase.from('article_files')
+    const fromCalls = vi.mocked(supabase.from).mock.calls.map(c => c[0]);
+    expect(fromCalls).not.toContain('article_files');
+  });
+});
+
+describe('articlesService.uploadArticleFile — backend confirm', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('registers supplements via the backend, not a direct insert', async () => {
+    vi.mocked(supabase.storage.from).mockReturnValue({
+      upload: vi.fn(async () => ({error: null})),
+      remove: vi.fn(async () => ({error: null})),
+    } as never);
+
+    const res = await uploadArticleFile({
+      projectId: 'proj-1',
+      articleId: 'art-1',
+      storageKey: 'proj-1/art-1/supp.pdf',
+      file: FAKE_PDF,
+      role: 'SUPPLEMENT',
+    } as never);
+
+    expect(res.ok).toBe(true);
+    expect(apiClient).toHaveBeenCalledWith(
+      '/api/v1/articles/art-1/files',
+      expect.objectContaining({method: 'POST'}),
+    );
+    const fromCalls = vi.mocked(supabase.from).mock.calls.map(c => c[0]);
+    expect(fromCalls).not.toContain('article_files');
   });
 });

--- a/frontend/test/services/articlesService.test.ts
+++ b/frontend/test/services/articlesService.test.ts
@@ -14,10 +14,13 @@ vi.mock('@/integrations/supabase/client', () => {
   return {supabase: {from, storage: {from: storageFrom}}};
 });
 
+vi.mock('@/integrations/api', () => ({apiClient: vi.fn(async () => ({}))}));
+
 // file-validation is a pure util — let it run, or stub it simply
 vi.mock('@/lib/file-validation', () => ({detectFileFormat: vi.fn(() => 'application/pdf')}));
 
 import {supabase} from '@/integrations/supabase/client';
+import {apiClient} from '@/integrations/api';
 import {addArticle, uploadArticleFile} from '@/services/articlesService';
 
 // ---------------------------------------------------------------------------
@@ -84,6 +87,7 @@ describe('articlesService.addArticle', () => {
   });
 
   it('article_files insert failure — storage object removed AND article row deleted', async () => {
+    // After the change: apiClient rejection triggers the rollback path
     let callIndex = 0;
     const articleDeleteEq = vi.fn(async () => ({data: null, error: null}));
     const storageRemove = vi.fn(async () => ({error: null}));
@@ -105,9 +109,9 @@ describe('articlesService.addArticle', () => {
         c.eq = articleDeleteEq;
         return c as never;
       }
-      // article_files insert failure
+      // No article_files PostgREST calls expected any more
       const c: Record<string, unknown> = {};
-      c.insert = vi.fn(async () => ({error: {message: 'constraint violation'}}));
+      c.insert = vi.fn(async () => ({error: null}));
       return c as never;
     });
 
@@ -115,6 +119,9 @@ describe('articlesService.addArticle', () => {
       upload: vi.fn(async () => ({error: null})),
       remove: storageRemove,
     } as never);
+
+    // apiClient rejects → triggers rollback
+    vi.mocked(apiClient).mockRejectedValueOnce(new Error('constraint violation'));
 
     const result = await addArticle(ARTICLE_DATA, {
       file: FAKE_PDF,
@@ -128,8 +135,7 @@ describe('articlesService.addArticle', () => {
     expect(articleDeleteEq).toHaveBeenCalledWith('id', 'art-2');
   });
 
-  it('happy path — article insert + storage upload + article_files insert all called', async () => {
-    const articleFilesInsert = vi.fn(async () => ({error: null}));
+  it('happy path — article insert + storage upload + backend confirm called (no direct article_files insert)', async () => {
     const storageUpload = vi.fn(async () => ({error: null}));
 
     vi.mocked(supabase.from).mockImplementation((table: string) => {
@@ -140,8 +146,8 @@ describe('articlesService.addArticle', () => {
         c.single = vi.fn(async () => ({data: {id: 'art-3'}, error: null}));
         return c as never;
       }
-      // article_files
-      return {insert: articleFilesInsert} as never;
+      // article_files should NOT be called — fail loudly if it is
+      return {insert: vi.fn(async () => ({error: {message: 'unexpected article_files insert'}})) } as never;
     });
 
     vi.mocked(supabase.storage.from).mockReturnValue({
@@ -155,13 +161,53 @@ describe('articlesService.addArticle', () => {
 
     expect(result.ok).toBe(true);
     expect(storageUpload).toHaveBeenCalled();
-    expect(articleFilesInsert).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({article_id: 'art-3', file_role: 'MAIN'}),
-      ]),
+    // Backend confirm endpoint was called
+    expect(apiClient).toHaveBeenCalledWith(
+      '/api/v1/articles/art-3/files',
+      expect.objectContaining({method: 'POST'}),
     );
-    expect(vi.mocked(supabase.from)).toHaveBeenCalledWith('articles');
-    expect(vi.mocked(supabase.from)).toHaveBeenCalledWith('article_files');
+    // No direct article_files PostgREST insert
+    const fromCalls = vi.mocked(supabase.from).mock.calls.map(c => c[0]);
+    expect(fromCalls).not.toContain('article_files');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addArticle — backend confirm (new test from brief)
+// ---------------------------------------------------------------------------
+
+describe('articlesService.addArticle — backend confirm', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('registers the file via the backend, not a direct article_files insert', async () => {
+    // article insert + storage upload succeed
+    vi.mocked(supabase.from).mockImplementation(() => {
+      const c: Record<string, unknown> = {};
+      c.insert = vi.fn(() => c);
+      c.select = vi.fn(() => c);
+      c.single = vi.fn(async () => ({data: {id: 'art-1'}, error: null}));
+      c.delete = vi.fn(() => c);
+      c.eq = vi.fn(() => c);
+      return c;
+    });
+    vi.mocked(supabase.storage.from).mockReturnValue({
+      upload: vi.fn(async () => ({error: null})),
+      remove: vi.fn(async () => ({error: null})),
+    } as never);
+
+    const res = await addArticle(ARTICLE_DATA as never, {
+      file: FAKE_PDF,
+      detectedFormat: 'PDF',
+    } as never);
+
+    expect(res.ok).toBe(true);
+    expect(apiClient).toHaveBeenCalledWith(
+      '/api/v1/articles/art-1/files',
+      expect.objectContaining({method: 'POST'}),
+    );
+    // No direct article_files PostgREST insert anymore:
+    const fromCalls = vi.mocked(supabase.from).mock.calls.map(c => c[0]);
+    expect(fromCalls).not.toContain('article_files');
   });
 });
 

--- a/frontend/test/services/articlesService.test.ts
+++ b/frontend/test/services/articlesService.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/lib/file-validation', () => ({detectFileFormat: vi.fn(() => 'applicat
 
 import {supabase} from '@/integrations/supabase/client';
 import {apiClient} from '@/integrations/api';
-import {addArticle, uploadArticleFile} from '@/services/articlesService';
+import {addArticle, uploadArticleFile, reparseArticleFile} from '@/services/articlesService';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -244,6 +244,23 @@ describe('articlesService.uploadArticleFile', () => {
     // No longer calls supabase.from('article_files')
     const fromCalls = vi.mocked(supabase.from).mock.calls.map(c => c[0]);
     expect(fromCalls).not.toContain('article_files');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reparseArticleFile
+// ---------------------------------------------------------------------------
+
+describe('articlesService.reparseArticleFile', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('POSTs the reparse endpoint for the given file id', async () => {
+    const res = await reparseArticleFile('file-7');
+    expect(res.ok).toBe(true);
+    expect(apiClient).toHaveBeenCalledWith(
+      '/api/v1/article-files/file-7/reparse',
+      expect.objectContaining({method: 'POST'}),
+    );
   });
 });
 

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -443,6 +443,54 @@
         "title": "ApiResponse[Annotated[Union[SingleSectionResult, BatchSectionResult], FieldInfo(annotation=NoneType, required=True, discriminator='mode')]]",
         "type": "object"
       },
+      "ApiResponse_ArticleFileResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArticleFileResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dados da resposta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details"
+          },
+          "ok": {
+            "description": "Indica se a operacao foi bem-sucedida",
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "rastreamento",
+            "title": "Trace Id"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "ApiResponse[ArticleFileResponse]",
+        "type": "object"
+      },
       "ApiResponse_CloneTemplateResponse_": {
         "properties": {
           "data": {
@@ -1977,6 +2025,115 @@
         "title": "ApiResponse[list[dict[str, Any]]]",
         "type": "object"
       },
+      "ArticleFileResponse": {
+        "description": "Response de file de article.",
+        "properties": {
+          "articleId": {
+            "format": "uuid",
+            "title": "Articleid",
+            "type": "string"
+          },
+          "bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bytes"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "title": "Createdat",
+            "type": "string"
+          },
+          "extractedAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extractedat"
+          },
+          "extractionError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extractionerror"
+          },
+          "extractionStatus": {
+            "default": "pending",
+            "title": "Extractionstatus",
+            "type": "string"
+          },
+          "fileRole": {
+            "title": "Filerole",
+            "type": "string"
+          },
+          "fileType": {
+            "title": "Filetype",
+            "type": "string"
+          },
+          "hasText": {
+            "default": false,
+            "title": "Hastext",
+            "type": "boolean"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "originalFilename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Originalfilename"
+          },
+          "projectId": {
+            "format": "uuid",
+            "title": "Projectid",
+            "type": "string"
+          },
+          "storageKey": {
+            "title": "Storagekey",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "title": "Updatedat",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "projectId",
+          "articleId",
+          "fileType",
+          "storageKey",
+          "fileRole",
+          "createdAt",
+          "updatedAt"
+        ],
+        "title": "ArticleFileResponse",
+        "type": "object"
+      },
       "ArticleRunRef": {
         "description": "Per-article run reference returned by POST /articles/form-runs.\n\n``run_id`` is None when the article has no matching run.",
         "properties": {
@@ -2119,6 +2276,55 @@
           "created"
         ],
         "title": "CloneTemplateResponse",
+        "type": "object"
+      },
+      "ConfirmUploadRequest": {
+        "description": "Request for confirmar upload.",
+        "properties": {
+          "articleId": {
+            "format": "uuid",
+            "title": "Articleid",
+            "type": "string"
+          },
+          "bytes": {
+            "title": "Bytes",
+            "type": "integer"
+          },
+          "contentType": {
+            "title": "Contenttype",
+            "type": "string"
+          },
+          "fileRole": {
+            "default": "MAIN",
+            "enum": [
+              "MAIN",
+              "SUPPLEMENT",
+              "PROTOCOL",
+              "DATASET",
+              "APPENDIX",
+              "FIGURE",
+              "OTHER"
+            ],
+            "title": "Filerole",
+            "type": "string"
+          },
+          "originalFilename": {
+            "title": "Originalfilename",
+            "type": "string"
+          },
+          "storageKey": {
+            "title": "Storagekey",
+            "type": "string"
+          }
+        },
+        "required": [
+          "articleId",
+          "storageKey",
+          "originalFilename",
+          "contentType",
+          "bytes"
+        ],
+        "title": "ConfirmUploadRequest",
         "type": "object"
       },
       "ConsensusDecisionResponse": {
@@ -5524,6 +5730,55 @@
         ]
       }
     },
+    "/api/v1/article-files/{article_file_id}/reparse": {
+      "post": {
+        "description": "Re-enqueue a parse for an existing ArticleFile (recovery).",
+        "operationId": "reparse_article_file_api_v1_article_files__article_file_id__reparse_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "article_file_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Article File Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_ArticleFileResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Reparse Article File",
+        "tags": [
+          "article-files"
+        ]
+      }
+    },
     "/api/v1/article-files/{article_file_id}/text-blocks": {
       "get": {
         "description": "Return all text blocks for ``article_file_id`` in reading order.",
@@ -5919,6 +6174,65 @@
         "summary": "List Article Citations Endpoint",
         "tags": [
           "citations"
+        ]
+      }
+    },
+    "/api/v1/articles/{article_id}/files": {
+      "post": {
+        "description": "Register an already-uploaded object and enqueue its parse.",
+        "operationId": "confirm_article_file_upload_api_v1_articles__article_id__files_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "article_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Article Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_ArticleFileResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Confirm Article File Upload",
+        "tags": [
+          "article-files"
         ]
       }
     },

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -25,6 +25,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/article-files/{article_file_id}/reparse": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reparse Article File
+         * @description Re-enqueue a parse for an existing ArticleFile (recovery).
+         */
+        post: operations["reparse_article_file_api_v1_article_files__article_file_id__reparse_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/article-files/{article_file_id}/text-blocks": {
         parameters: {
             query?: never;
@@ -185,6 +205,26 @@ export interface paths {
         get: operations["list_article_citations_endpoint_api_v1_articles__article_id__citations_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/articles/{article_id}/files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirm Article File Upload
+         * @description Register an already-uploaded object and enqueue its parse.
+         */
+        post: operations["confirm_article_file_upload_api_v1_articles__article_id__files_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1113,6 +1153,23 @@ export interface components {
              */
             trace_id?: string | null;
         };
+        /** ApiResponse[ArticleFileResponse] */
+        ApiResponse_ArticleFileResponse_: {
+            /** @description Dados da resposta */
+            data?: components["schemas"]["ArticleFileResponse"] | null;
+            /** @description Error details */
+            error?: components["schemas"]["ErrorDetail"] | null;
+            /**
+             * Ok
+             * @description Indica se a operacao foi bem-sucedida
+             */
+            ok: boolean;
+            /**
+             * Trace Id
+             * @description rastreamento
+             */
+            trace_id?: string | null;
+        };
         /** ApiResponse[CloneTemplateResponse] */
         ApiResponse_CloneTemplateResponse_: {
             /** @description Dados da resposta */
@@ -1658,6 +1715,61 @@ export interface components {
             trace_id?: string | null;
         };
         /**
+         * ArticleFileResponse
+         * @description Response de file de article.
+         */
+        ArticleFileResponse: {
+            /**
+             * Articleid
+             * Format: uuid
+             */
+            articleId: string;
+            /** Bytes */
+            bytes?: number | null;
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /** Extractedat */
+            extractedAt?: string | null;
+            /** Extractionerror */
+            extractionError?: string | null;
+            /**
+             * Extractionstatus
+             * @default pending
+             */
+            extractionStatus: string;
+            /** Filerole */
+            fileRole: string;
+            /** Filetype */
+            fileType: string;
+            /**
+             * Hastext
+             * @default false
+             */
+            hasText: boolean;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Originalfilename */
+            originalFilename?: string | null;
+            /**
+             * Projectid
+             * Format: uuid
+             */
+            projectId: string;
+            /** Storagekey */
+            storageKey: string;
+            /**
+             * Updatedat
+             * Format: date-time
+             */
+            updatedAt: string;
+        };
+        /**
          * ArticleRunRef
          * @description Per-article run reference returned by POST /articles/form-runs.
          *
@@ -1733,6 +1845,31 @@ export interface components {
              * Format: uuid
              */
             version_id: string;
+        };
+        /**
+         * ConfirmUploadRequest
+         * @description Request for confirmar upload.
+         */
+        ConfirmUploadRequest: {
+            /**
+             * Articleid
+             * Format: uuid
+             */
+            articleId: string;
+            /** Bytes */
+            bytes: number;
+            /** Contenttype */
+            contentType: string;
+            /**
+             * Filerole
+             * @default MAIN
+             * @enum {string}
+             */
+            fileRole: "MAIN" | "SUPPLEMENT" | "PROTOCOL" | "DATASET" | "APPENDIX" | "FIGURE" | "OTHER";
+            /** Originalfilename */
+            originalFilename: string;
+            /** Storagekey */
+            storageKey: string;
         };
         /** ConsensusDecisionResponse */
         ConsensusDecisionResponse: {
@@ -3336,6 +3473,37 @@ export interface operations {
             };
         };
     };
+    reparse_article_file_api_v1_article_files__article_file_id__reparse_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                article_file_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_ArticleFileResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_article_text_blocks_api_v1_article_files__article_file_id__text_blocks_get: {
         parameters: {
             query?: never;
@@ -3577,6 +3745,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiResponse_list_dict_str__Any___"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    confirm_article_file_upload_api_v1_articles__article_id__files_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                article_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ConfirmUploadRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_ArticleFileResponse_"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Why

Manually-added article PDFs never got parsed: the frontend inserted the
`article_files` row directly via Supabase PostgREST, bypassing the backend,
so the parse was never enqueued (only the Zotero importer enqueued).
Separately, a permanently-failed parse stayed `pending` forever because the
worker rolled back the `parse_failed` status. This is PR-B of the
parse-to-markdown end-to-end design.

Design spec: `docs/superpowers/specs/2026-06-20-parse-to-markdown-end-to-end-design.md`
Plan: `docs/superpowers/plans/2026-06-20-parse-pipeline-activation-prb.md`

## What changed

- **Durable `parse_failed`** (`backend/app/worker/tasks/parsing_tasks.py`):
  on terminal failure, persist the status in its own committed
  `worker_session()` (the main parse session rolls back). Covers parser
  errors AND pre-parse failures (e.g. storage download).
- **Confirm-upload endpoint** `POST /api/v1/articles/{article_id}/files`
  (`backend/app/api/v1/endpoints/article_files.py`): creates the
  `article_files` row server-side and enqueues the parse. BOLA-gated
  (`ensure_project_member`, project resolved from the article), validates
  `storage_key` starts with the server-resolved `{project_id}/{article_id}/`
  (the service-role insert bypasses RLS, so this is the guard), and does
  NOT swallow enqueue failures (sets `parse_failed` + 503).
- **Re-parse endpoint** `POST /api/v1/article-files/{article_file_id}/reparse`
  to recover stuck/failed files.
- **Frontend rerouted off PostgREST**: `addArticle` and `uploadArticleFile`
  now register the file via the confirm endpoint (`apiClient`), with
  rollback on failure; new `reparseArticleFile` service + a per-file
  "Re-parse" button in `ArticleDetailDialog`.
- Regenerated API contract types.

## Risk

- The `article_files` insert moves from user-JWT PostgREST (RLS-enforced) to
  a service-role backend endpoint — the explicit membership check + the
  server-derived `storage_key` prefix validation are now load-bearing
  (both covered by tests).
- The upload byte path is unchanged (browser → Supabase Storage under the
  user JWT); only the row creation + enqueue moved server-side.
- No migration. `extraction_status` values remain `pending|parsed|parse_failed`.
- **Operational:** the parse worker must be live in prod for uploads to
  actually parse (the dev→main promotion / Fase 0). Until then files sit
  `pending` and can be recovered with Re-parse once deployed.

## Test plan

- [x] `uv run pytest tests/integration/test_article_files_endpoints.py tests/integration/test_parsing_tasks_durable_failure.py` — 7 passing (member→201+enqueue, outsider→403, foreign key→400, enqueue-fail→503+parse_failed, reparse resets+enqueues, missing→404, durable parse_failed survives a fresh session)
- [x] `npm run test:run -- frontend/test/services/articlesService.test.ts` — 7 passing (addArticle/uploadArticleFile call the endpoint not PostgREST; rollback on rejection; reparse posts the right path)
- [x] `npm run typecheck` clean

## Out of scope (later PRs in the same design)

- Parse-status badge + enum single-source + dropping the dead `semantic_*`/
  `pdf_extracted_text` columns — PR-C.
- Reader wiring + multi-document switcher — PR-D. Supplement parsing — PR-E.
- 8 Minor review findings (test-teardown hygiene, a pre-existing Portuguese
  `title=` on a neighboring button, etc.) tracked for cleanup — none block CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
