### PR TITLE
fix(navigation): give focus-mode phone users a working project-nav drawer

### DIFF
--- a/frontend/components/extraction/ExtractionHeader.tsx
+++ b/frontend/components/extraction/ExtractionHeader.tsx
@@ -31,9 +31,11 @@ export interface ExtractionHeaderProps {
   articleTitle: string;
   onBack: () => void;
 
-  // App sidebar collapse state + toggle (focus-shell wiring for ⌘B).
+  // App sidebar collapse state + toggle (focus-shell wiring for ⌘B). Below `lg`
+  // the desktop sidebar is hidden, so onOpenMobileNav opens the drawer instead.
   sidebarCollapsed?: boolean;
   onToggleSidebar?: () => void;
+  onOpenMobileNav?: () => void;
 
   // Article navigation
   articles: Article[];
@@ -128,6 +130,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
     onBack,
     sidebarCollapsed,
     onToggleSidebar,
+    onOpenMobileNav,
     articles,
     currentArticleId,
     onNavigateToArticle,
@@ -264,6 +267,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
       <div className="@container/headerbar">
         <RunHeader value={headerValue}>
           <RunHeader.Left>
+            <RunHeader.MobileNav onOpen={onOpenMobileNav} />
             <RunHeader.SidebarToggle pressed={!sidebarCollapsed} onToggle={onToggleSidebar} />
             <RunHeader.Breadcrumb onBack={onBack} crumbs={[{ label: projectName, onClick: () => navigate(`/projects/${props.projectId}`) }, { label: articleTitle }]} />
             {articles.length > 1 && (

--- a/frontend/components/runs/RunWorkspaceShell.tsx
+++ b/frontend/components/runs/RunWorkspaceShell.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SidebarProvider, useSidebar } from '@/contexts/SidebarContext';
 import { ProjectSidebar } from '@/components/layout/ProjectSidebar';
+import { MobileSidebar } from '@/components/layout/MobileSidebar';
 import { useKeyboardShortcuts, type Binding } from '@/hooks/useKeyboardShortcuts';
 import type { SidebarTabId } from '@/components/layout/sidebarConfig';
 
@@ -13,13 +14,17 @@ interface RunWorkspaceShellProps {
 
 function ShellInner({ projectId, activeTab, children }: RunWorkspaceShellProps) {
   const navigate = useNavigate();
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, mobileOpen, setMobileOpen } = useSidebar();
   const [switcherOpen, setSwitcherOpen] = useState(false);
 
   // Focus shell only wires ⌘B (sidebar). G-nav is out of scope here so the
   // sidebar nav items navigate OUT of focus mode to the project tab.
   const bindings: Binding[] = [{ type: 'chord', key: 'b', mod: true, handler: toggleSidebar }];
   useKeyboardShortcuts({ bindings, enabled: true });
+
+  // Both the desktop ProjectSidebar and the mobile drawer navigate OUT of focus
+  // mode to the chosen project tab.
+  const goToTab = (tab: SidebarTabId) => navigate(`/projects/${projectId}?tab=${tab}`);
 
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-background">
@@ -30,9 +35,18 @@ function ShellInner({ projectId, activeTab, children }: RunWorkspaceShellProps) 
             would be wasted work in the common collapsed case. */}
         <ProjectSidebar
           activeTab={activeTab}
-          onTabChange={(tab) => navigate(`/projects/${projectId}?tab=${tab}`)}
+          onTabChange={goToTab}
           switcherOpen={switcherOpen}
           onSwitcherOpenChange={setSwitcherOpen}
+        />
+        {/* Below `lg` the ProjectSidebar is display:none; this overlay is how
+            phone/tablet users in focus mode reach project navigation. Opened by
+            the RunHeader.MobileNav hamburger via shared SidebarContext state. */}
+        <MobileSidebar
+          open={mobileOpen}
+          onOpenChange={setMobileOpen}
+          activeTab={activeTab}
+          onTabChange={goToTab}
         />
         <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{children}</main>
       </div>

--- a/frontend/components/runs/header/MobileNav.tsx
+++ b/frontend/components/runs/header/MobileNav.tsx
@@ -1,0 +1,26 @@
+import { Menu } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { t } from '@/lib/copy';
+
+/**
+ * Compact-tier app-navigation trigger for the focus shell. Visible only below
+ * `lg`, where the desktop ProjectSidebar is `display:none` and its collapse
+ * toggle (SidebarToggle) is a no-op; opens the MobileSidebar drawer instead.
+ * Mirrors Topbar's hamburger (`lg:hidden` + toggleMobile). Prop-driven and
+ * renders nothing without a handler, so the shared header lib stays decoupled
+ * from SidebarContext.
+ */
+export function MobileNav({ onOpen }: { onOpen?: () => void }) {
+  if (!onOpen) return null;
+  return (
+    <Button
+      size="icon"
+      variant="ghost"
+      onClick={onOpen}
+      aria-label={t('navigation', 'ariaOpenMenu')}
+      className="flex h-8 w-8 shrink-0 p-0 text-muted-foreground transition-colors duration-75 hover:bg-muted/50 lg:hidden"
+    >
+      <Menu className="h-4 w-4" aria-hidden="true" />
+    </Button>
+  );
+}

--- a/frontend/components/runs/header/RunHeader.tsx
+++ b/frontend/components/runs/header/RunHeader.tsx
@@ -6,6 +6,7 @@ import { StageRail } from './StageRail';
 import { PrimaryAction } from './PrimaryAction';
 import { PanelToggle } from './PanelToggle';
 import { SidebarToggle } from './SidebarToggle';
+import { MobileNav } from './MobileNav';
 import { Help } from './Help';
 import { RoleChip } from './RoleChip';
 import { Reviewers } from './Reviewers';
@@ -46,4 +47,4 @@ function RunHeaderRoot({ value, children }: { value: RunHeaderValue; children: R
   );
 }
 
-export const RunHeader = Object.assign(RunHeaderRoot, { Left, Center, Right, StageRail, PrimaryAction, PanelToggle, SidebarToggle, Help, RoleChip, Reviewers, Save: SaveSlot, AIActions, Breadcrumb, Menu, MenuItem, Worklist, CommandPalette });
+export const RunHeader = Object.assign(RunHeaderRoot, { Left, Center, Right, StageRail, PrimaryAction, PanelToggle, SidebarToggle, MobileNav, Help, RoleChip, Reviewers, Save: SaveSlot, AIActions, Breadcrumb, Menu, MenuItem, Worklist, CommandPalette });

--- a/frontend/components/runs/header/SidebarToggle.tsx
+++ b/frontend/components/runs/header/SidebarToggle.tsx
@@ -8,6 +8,10 @@ import { t } from '@/lib/copy';
  * from SidebarContext; renders nothing when no handler is wired. Mirrors the
  * right-hand PanelToggle (Meta+B ↔ "\") to bracket the bar.
  *
+ * Gated to `lg+` to match the desktop ProjectSidebar (`hidden lg:block`): below
+ * `lg` the sidebar is `display:none`, so collapsing/expanding it is a no-op.
+ * The RunHeader.MobileNav hamburger covers the sub-`lg` tier (opens a drawer).
+ *
  * `pressed` = sidebar OPEN; PanelLeftClose shows when open (matches Topbar.tsx).
  */
 export function SidebarToggle({ pressed, onToggle }: { pressed?: boolean; onToggle?: () => void }) {
@@ -20,7 +24,7 @@ export function SidebarToggle({ pressed, onToggle }: { pressed?: boolean; onTogg
       aria-pressed={pressed}
       aria-keyshortcuts="Meta+B"
       aria-label={t('runs', 'sidebarToggle')}
-      className="relative h-8 w-8 shrink-0 p-0 text-muted-foreground transition-colors duration-75 hover:bg-muted/50"
+      className="relative hidden h-8 w-8 shrink-0 p-0 text-muted-foreground transition-colors duration-75 hover:bg-muted/50 lg:inline-flex"
     >
       <span className="relative block h-4 w-4">
         <PanelLeftClose

--- a/frontend/components/runs/header/__tests__/Toggles.test.tsx
+++ b/frontend/components/runs/header/__tests__/Toggles.test.tsx
@@ -28,6 +28,33 @@ describe('RunHeader.SidebarToggle', () => {
     await userEvent.click(btn);
     expect(onToggle).toHaveBeenCalledOnce();
   });
+  it('is gated to lg+ (the desktop sidebar is display:none below lg, so its collapse toggle would be a no-op there)', () => {
+    render(
+      <RunHeader value={base}><RunHeader.Left><RunHeader.SidebarToggle pressed onToggle={() => {}} /></RunHeader.Left></RunHeader>,
+    );
+    const btn = screen.getByRole('button', { name: 'sidebarToggle' });
+    expect(btn.className).toContain('hidden');
+    expect(btn.className).toContain('lg:inline-flex');
+  });
+});
+
+describe('RunHeader.MobileNav', () => {
+  it('renders nothing without onOpen', () => {
+    const { container } = render(
+      <RunHeader value={base}><RunHeader.Left><RunHeader.MobileNav /></RunHeader.Left></RunHeader>,
+    );
+    expect(container.querySelector('button')).toBeNull();
+  });
+  it('is a hamburger gated to below lg that opens the drawer', async () => {
+    const onOpen = vi.fn();
+    render(
+      <RunHeader value={base}><RunHeader.Left><RunHeader.MobileNav onOpen={onOpen} /></RunHeader.Left></RunHeader>,
+    );
+    const btn = screen.getByRole('button', { name: 'ariaOpenMenu' });
+    expect(btn.className).toContain('lg:hidden');
+    await userEvent.click(btn);
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
 });
 
 describe('RunHeader.PanelToggle (mirror)', () => {

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -85,9 +85,9 @@ const SCROLL_CONTAINERS_TO_PRESERVE = [
 export default function ExtractionFullScreen() {
   const { projectId, articleId } = useParams();
   const navigate = useNavigate();
-  // App navigation sidebar (provided by RunWorkspaceShell) — wired to the
-  // RunHeader.SidebarToggle + ⌘B.
-  const { sidebarCollapsed, toggleSidebar } = useSidebar();
+  // App navigation sidebar (provided by RunWorkspaceShell). SidebarToggle + ⌘B
+  // collapse the desktop sidebar (lg+); toggleMobile opens the drawer below lg.
+  const { sidebarCollapsed, toggleSidebar, toggleMobile } = useSidebar();
 
   // ONE stable viewer store shared between the PDF panel and the form panel.
   // useState lazy initializer creates the store exactly once per mount —
@@ -1196,6 +1196,7 @@ export default function ExtractionFullScreen() {
         onBack={handleBack}
         sidebarCollapsed={sidebarCollapsed}
         onToggleSidebar={toggleSidebar}
+        onOpenMobileNav={toggleMobile}
         articles={articles}
         currentArticleId={articleId || ''}
         onNavigateToArticle={handleNavigateToArticle}

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -305,9 +305,9 @@ export default function QualityAssessmentFullScreen() {
   // PDF panel state — lifted so RunHeader.PanelToggle can share the same toggle.
   const pdfPanelState = usePdfPanel({ initialOpen: false });
 
-  // App navigation sidebar (provided by RunWorkspaceShell) — wired to the
-  // RunHeader.SidebarToggle + ⌘B.
-  const { sidebarCollapsed, toggleSidebar } = useSidebar();
+  // App navigation sidebar (provided by RunWorkspaceShell). SidebarToggle + ⌘B
+  // collapse the desktop sidebar (lg+); toggleMobile opens the drawer below lg.
+  const { sidebarCollapsed, toggleSidebar, toggleMobile } = useSidebar();
 
   // "\" toggles the source (PDF) panel. No J/K — QA has a single article.
   // ``usePdfPanel`` returns a fresh object each render, so hold the toggle in a
@@ -562,6 +562,7 @@ export default function QualityAssessmentFullScreen() {
         }}
       >
         <RunHeader.Left>
+          <RunHeader.MobileNav onOpen={toggleMobile} />
           <RunHeader.SidebarToggle pressed={!sidebarCollapsed} onToggle={toggleSidebar} />
           <RunHeader.Breadcrumb
             onBack={() => navigate(`/projects/${projectId}`)}

--- a/frontend/test/RunWorkspaceShell.test.tsx
+++ b/frontend/test/RunWorkspaceShell.test.tsx
@@ -1,13 +1,42 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { RunWorkspaceShell } from '@/components/runs/RunWorkspaceShell';
+import { RunHeader } from '@/components/runs/header';
+import { useSidebar } from '@/contexts/SidebarContext';
 
 vi.mock('@/lib/copy', () => ({ t: (_n: string, k: string) => k }));
 vi.mock('@/components/layout/ProjectSidebar', () => ({
   ProjectSidebar: ({ activeTab }: { activeTab: string }) => <aside data-testid="project-sidebar">{activeTab}</aside>,
 }));
+// The footer pulls in the authed user menu; not under test here.
+vi.mock('@/components/layout/SidebarFooter', () => ({ SidebarFooter: () => null }));
 vi.mock('@/hooks/useProjectsList', () => ({ useProjectsList: () => ({ projects: [], loading: false }) }));
+
+const headerValue = {
+  kind: 'extraction' as const,
+  stage: 'review' as const,
+  isRevision: false,
+  isBlind: false,
+  canReveal: false,
+  progress: { completed: 0, total: 0, pct: 0 },
+  reviewers: { count: 0, required: 0, divergent: 0 },
+  transition: null,
+};
+
+// Reproduces the focus-page wiring: the compact hamburger lives in the header
+// and opens the drawer the shell mounts, via shared SidebarContext state.
+function HeaderHarness() {
+  const { toggleMobile } = useSidebar();
+  return (
+    <RunHeader value={headerValue}>
+      <RunHeader.Left>
+        <RunHeader.MobileNav onOpen={toggleMobile} />
+      </RunHeader.Left>
+    </RunHeader>
+  );
+}
 
 describe('RunWorkspaceShell', () => {
   it('renders the app sidebar (with the active tab) around its children', () => {
@@ -20,5 +49,26 @@ describe('RunWorkspaceShell', () => {
     );
     expect(screen.getByTestId('project-sidebar')).toHaveTextContent('extraction');
     expect(screen.getByTestId('page-body')).toBeInTheDocument();
+  });
+
+  it('reveals reachable project nav through a mobile drawer when the compact hamburger is tapped', async () => {
+    render(
+      <MemoryRouter initialEntries={['/projects/p1/extraction/a1']}>
+        <RunWorkspaceShell projectId="p1" activeTab="extraction">
+          <HeaderHarness />
+        </RunWorkspaceShell>
+      </MemoryRouter>,
+    );
+
+    // Drawer closed: project nav items are not reachable (the desktop sidebar is
+    // mocked, and the mobile drawer is unmounted while closed).
+    expect(screen.queryByRole('button', { name: 'navArticles' })).not.toBeInTheDocument();
+
+    // Tap the compact-tier hamburger.
+    await userEvent.click(screen.getByRole('button', { name: 'ariaOpenMenu' }));
+
+    // Drawer open: project nav items are now reachable.
+    expect(await screen.findByRole('button', { name: 'navArticles' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'navQualityAssessment' })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- **Focus-mode run pages (Extraction + QA) had no way to reach project navigation below `lg` (1024px).** The RunHeader sidebar toggle was wired to `toggleSidebar`, which only flips `ProjectSidebar`'s *collapsed* state — but `ProjectSidebar` is `hidden lg:block`, so below `lg` it is `display:none` regardless, and `RunWorkspaceShell` never mounted a mobile drawer. Net: the toggle was a no-op on phones/tablets.
- **Fix (option b — reuse the app's proven pattern):** add `RunHeader.MobileNav`, an `lg:hidden` hamburger that opens `MobileSidebar` via the existing `toggleMobile`/`mobileOpen` `SidebarContext` state — the same mechanism `ProjectLayout`/`Topbar` already use. `RunWorkspaceShell` now mounts `MobileSidebar`; both desktop and mobile nav share one `goToTab` that routes out of focus mode.
- **Gate `RunHeader.SidebarToggle` to `lg+`** (`hidden lg:inline-flex`) so the desktop collapse control is no longer a no-op duplicate on phones — the two controls are now complementary across `lg`, exactly like Topbar. No new copy keys (reuses `navigation.ariaOpenMenu`), no new state model.

## Linked issues / specs

Implements decision D3 ("give phone users in focus mode a way to reach project navigation") from the header-system responsive design intent. No schema/contract changes.

## How to verify

1. Open a focus-mode run page: `/projects/:projectId/extraction/:articleId` or `/projects/:projectId/articles/:articleId/quality-assessment/:templateId` (test account `teste@prumo.local`).
2. At a phone width (≤1023px): a hamburger (☰) shows at the left of the RunHeader; the desktop panel-toggle is hidden. Tap it → a left drawer overlays the page with the full project nav (Overview, Configuration, Articles, Screening, Data extraction, Quality assessment, PRISMA report); selecting one navigates out to that project tab.
3. At ≥1024px: the hamburger is hidden and the desktop sidebar toggle (⌘B) is shown — unchanged behavior.

Verified visually via a throwaway DEV-only harness at 320 / 480 / 1280 (removed before commit): hamburger `display:flex` + desktop toggle `display:none` below `lg`, inverse at `lg+`, drawer reveals the full reachable nav.

## Test plan

- [x] Frontend: `npm run test:run` passes (92/92 across runs + extraction + shell; new `RunWorkspaceShell` drawer-reveal test + `Toggles` breakpoint-gating assertions)
- [x] Typecheck: `tsc --noEmit` clean
- [x] Lints: `npm run lint` clean on touched files
- [ ] Backend: n/a (frontend-only)
- [ ] E2E: not run locally; behavior covered by the new component/integration tests

## Docs

- n/a — no doc surface changed (UI behavior + tests only).

## Screenshots (UI changes only)

| Phone (320/480px) | Desktop (1280px) |
|---|---|
| Hamburger visible; tapping reveals full project-nav drawer overlay (Data extraction active). | Hamburger hidden; desktop sidebar + ⌘B toggle unchanged. |