### PR TITLE
fix(tables): resize only the dragged column (drop push-pull neighbour adjustment)

### DIFF
--- a/frontend/components/articles/ArticlesList.tsx
+++ b/frontend/components/articles/ArticlesList.tsx
@@ -335,14 +335,10 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
         }
         return {...DEFAULT_COLUMN_WIDTHS};
     });
-    const renderedResizableColumns = TABLE_COLUMNS
-        .filter((col) => col.visibleKey == null || visibleColumns[col.visibleKey] === true)
-        .map((col) => col.id);
-    const {registerHeaderRef, startResize} = useResizableTableColumns({
+    const {startResize} = useResizableTableColumns({
         columnWidths,
         setColumnWidths,
         defaultColumnWidths: DEFAULT_COLUMN_WIDTHS,
-        orderedColumns: renderedResizableColumns,
         storageKey: COLUMN_WIDTHS_KEY,
     });
 
@@ -788,7 +784,6 @@ export const ArticlesList = forwardRef<ArticlesListHandle, ArticlesListProps>(fu
                               ).map((col) => (
                                   <TableHead
                                       key={col.id}
-                                      ref={(el) => registerHeaderRef(col.id, el)}
                                       className={`relative h-8 text-xs font-medium text-muted-foreground group/head ${TABLE_CELL_CLASS} ${colVisibilityClass(col.breakpoint)}`}
                                       style={getColumnStyle(col.id)}
                                   >

--- a/frontend/components/extraction/ArticleExtractionTable.tsx
+++ b/frontend/components/extraction/ArticleExtractionTable.tsx
@@ -146,7 +146,6 @@ const EXTRACTION_DEFAULT_COLUMN_WIDTHS: Record<string, number> = {
     status: 96,
     actions: 96,
 };
-const RESIZABLE_COLUMN_ORDER = ['title', 'authors', 'year', 'status', 'actions'] as const;
 // Header checkbox component with indeterminate support.
 function HeaderCheckbox({
   checked,
@@ -207,11 +206,10 @@ export function ArticleExtractionTable({ projectId, templateId, toolbarActions }
             return {...EXTRACTION_DEFAULT_COLUMN_WIDTHS};
         }
     });
-    const {registerHeaderRef, startResize} = useResizableTableColumns({
+    const {startResize} = useResizableTableColumns({
         columnWidths,
         setColumnWidths,
         defaultColumnWidths: EXTRACTION_DEFAULT_COLUMN_WIDTHS,
-        orderedColumns: [...RESIZABLE_COLUMN_ORDER],
         storageKey: EXTRACTION_COLUMN_WIDTHS_KEY,
     });
 
@@ -799,7 +797,6 @@ export function ArticleExtractionTable({ projectId, templateId, toolbarActions }
                 </TooltipProvider>
               </TableHead>
                           <TableHead
-                              ref={(el) => registerHeaderRef('title', el)}
                               className={`relative ${TABLE_CELL_CLASS}`} style={getColumnStyle('title')}>
                               <div className="pr-4 min-w-0">
                                   <SortIconHeader
@@ -819,7 +816,6 @@ export function ArticleExtractionTable({ projectId, templateId, toolbarActions }
                               />
               </TableHead>
                           <TableHead
-                              ref={(el) => registerHeaderRef('authors', el)}
                               className={`relative hidden md:table-cell ${TABLE_CELL_CLASS}`} style={getColumnStyle('authors')}>
                               <span
                                   className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">{t('extraction', 'tableColumnAuthors')}</span>
@@ -834,7 +830,6 @@ export function ArticleExtractionTable({ projectId, templateId, toolbarActions }
                               />
               </TableHead>
                           <TableHead
-                              ref={(el) => registerHeaderRef('year', el)}
                               className={`relative hidden md:table-cell ${TABLE_CELL_CLASS}`} style={getColumnStyle('year')}>
                               <SortIconHeader
                                   label={t('extraction', 'tableColumnYear')}
@@ -852,7 +847,6 @@ export function ArticleExtractionTable({ projectId, templateId, toolbarActions }
                               />
               </TableHead>
                           <TableHead
-                              ref={(el) => registerHeaderRef('status', el)}
                               className={`relative ${TABLE_CELL_CLASS} text-center`} style={getColumnStyle('status')}>
                               <div className="flex items-center justify-center gap-1">
                                   <SortIconHeader
@@ -901,7 +895,6 @@ export function ArticleExtractionTable({ projectId, templateId, toolbarActions }
                               />
               </TableHead>
                           <TableHead
-                              ref={(el) => registerHeaderRef('actions', el)}
                               className={`relative ${TABLE_CELL_CLASS} text-center`} style={getColumnStyle('actions')}>
                               {t('extraction', 'tableActions')}
                               <div

--- a/frontend/components/shared/list/useResizableTableColumns.test.ts
+++ b/frontend/components/shared/list/useResizableTableColumns.test.ts
@@ -1,0 +1,84 @@
+import {act, renderHook} from '@testing-library/react';
+import {useState} from 'react';
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {useResizableTableColumns} from '@/components/shared/list/useResizableTableColumns';
+
+const DEFAULTS = {title: 320, authors: 150, year: 100};
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+function useHarness() {
+    const [columnWidths, setColumnWidths] = useState<Record<string, number>>({...DEFAULTS});
+    const api = useResizableTableColumns({
+        columnWidths,
+        setColumnWidths,
+        defaultColumnWidths: DEFAULTS,
+        storageKey: 'test-resize-widths',
+    });
+    return {columnWidths, ...api};
+}
+
+function drag(toX: number) {
+    act(() => {
+        window.dispatchEvent(new MouseEvent('mousemove', {clientX: toX}));
+    });
+}
+
+// Ends the gesture: detaches the hook's window listeners and persists, so each
+// test is self-contained rather than leaning on global afterEach teardown.
+function release() {
+    act(() => {
+        window.dispatchEvent(new MouseEvent('mouseup'));
+    });
+}
+
+describe('useResizableTableColumns', () => {
+    it('resizing one column changes ONLY that column, never a neighbour', () => {
+        const {result} = renderHook(() => useHarness());
+
+        act(() => {
+            result.current.startResize('title', 100);
+        });
+        drag(150);
+
+        expect(result.current.columnWidths.title).toBe(370);
+        // The invariant this fix establishes: a single-column drag must never
+        // move a sibling. The removed push-pull model shrank the next column.
+        expect(result.current.columnWidths.authors).toBe(150);
+        expect(result.current.columnWidths.year).toBe(100);
+
+        release();
+    });
+
+    it('clamps to the minimum width when dragging left past the floor', () => {
+        const {result} = renderHook(() => useHarness());
+
+        act(() => {
+            result.current.startResize('title', 500);
+        });
+        // 320 - 500 = -180 below the 80 floor; clamp to 80.
+        drag(0);
+
+        expect(result.current.columnWidths.title).toBe(80);
+        expect(result.current.columnWidths.authors).toBe(150);
+
+        release();
+    });
+
+    it('persists widths to localStorage on mouseup', () => {
+        const {result} = renderHook(() => useHarness());
+
+        act(() => {
+            result.current.startResize('year', 100);
+        });
+        drag(140);
+        release();
+
+        const stored = JSON.parse(localStorage.getItem('test-resize-widths') ?? '{}');
+        expect(stored.year).toBe(140);
+        expect(stored.title).toBe(320);
+    });
+});

--- a/frontend/components/shared/list/useResizableTableColumns.ts
+++ b/frontend/components/shared/list/useResizableTableColumns.ts
@@ -6,17 +6,25 @@ interface UseResizableTableColumnsParams {
     columnWidths: WidthMap;
     setColumnWidths: React.Dispatch<React.SetStateAction<WidthMap>>;
     defaultColumnWidths: WidthMap;
-    orderedColumns: string[];
     storageKey: string;
     minWidth?: number;
     maxWidth?: number;
 }
 
+/**
+ * Drag-to-resize for `table-fixed w-max` list headers (extraction, articles,
+ * and any future table of the same shape).
+ *
+ * Resizing only ever changes the dragged column's width. The table width is the
+ * sum of its column widths (`w-max`) inside a horizontally scrollable container,
+ * so the surrounding columns reflow naturally — there is no neighbour to "steal"
+ * width from. An earlier version inversely resized the adjacent column, which
+ * made dragging one column visibly shrink another; that push-pull model is gone.
+ */
 export function useResizableTableColumns({
     columnWidths,
     setColumnWidths,
     defaultColumnWidths,
-    orderedColumns,
     storageKey,
     minWidth = 80,
     maxWidth = 600,
@@ -24,9 +32,6 @@ export function useResizableTableColumns({
     const [resizingColumn, setResizingColumn] = useState<string | null>(null);
     const [resizeStartX, setResizeStartX] = useState(0);
     const [resizeStartWidth, setResizeStartWidth] = useState(0);
-    const [resizeAdjacentColumn, setResizeAdjacentColumn] = useState<string | null>(null);
-    const [resizeAdjacentStartWidth, setResizeAdjacentStartWidth] = useState(0);
-    const headerRefs = useRef<Record<string, HTMLTableCellElement | null>>({});
     // Latest-value mirror so the mouseup handler can persist without
     // re-subscribing; written in an effect (refs must not be written in render).
     const columnWidthsRef = useRef(columnWidths);
@@ -34,40 +39,11 @@ export function useResizableTableColumns({
         columnWidthsRef.current = columnWidths;
     }, [columnWidths]);
 
-    const registerHeaderRef = (columnId: string, el: HTMLTableCellElement | null) => {
-        headerRefs.current[columnId] = el;
-    };
-
     const startResize = (columnId: string, clientX: number) => {
-        const isVisibleColumn = (key: string) => {
-            const el = headerRefs.current[key];
-            if (!el) return false;
-            const rect = el.getBoundingClientRect();
-            return rect.width > 0 && rect.height > 0;
-        };
-
-        const currentIndex = orderedColumns.indexOf(columnId);
-        let adjacentColumn: string | null = null;
-        if (currentIndex >= 0) {
-            for (let i = currentIndex + 1; i < orderedColumns.length; i += 1) {
-                const candidate = orderedColumns[i];
-                if (isVisibleColumn(candidate)) {
-                    adjacentColumn = candidate;
-                    break;
-                }
-            }
-        }
-
         const initialWidth = columnWidths[columnId] ?? defaultColumnWidths[columnId] ?? minWidth;
-        const adjacentStartWidth = adjacentColumn
-            ? (columnWidths[adjacentColumn] ?? defaultColumnWidths[adjacentColumn] ?? minWidth)
-            : 0;
-
         setResizingColumn(columnId);
         setResizeStartX(clientX);
         setResizeStartWidth(initialWidth);
-        setResizeAdjacentColumn(adjacentColumn);
-        setResizeAdjacentStartWidth(adjacentStartWidth);
     };
 
     useEffect(() => {
@@ -75,34 +51,8 @@ export function useResizableTableColumns({
 
         const onMove = (e: MouseEvent) => {
             const deltaFromStart = e.clientX - resizeStartX;
-            const baseWidth = resizeStartWidth;
-            const adjacentBaseWidth = resizeAdjacentStartWidth;
-            const hasAdjacent = !!resizeAdjacentColumn && adjacentBaseWidth > 0;
-
-            const minDeltaByActive = minWidth - baseWidth;
-            const maxDeltaByActive = maxWidth - baseWidth;
-            const minDeltaByAdjacent = hasAdjacent ? -(maxWidth - adjacentBaseWidth) : Number.NEGATIVE_INFINITY;
-            const maxDeltaByAdjacent = hasAdjacent ? adjacentBaseWidth - minWidth : Number.POSITIVE_INFINITY;
-            const clampedDelta = Math.min(
-                Math.min(maxDeltaByActive, maxDeltaByAdjacent),
-                Math.max(Math.max(minDeltaByActive, minDeltaByAdjacent), deltaFromStart)
-            );
-
-            const nextWidth = Math.min(maxWidth, Math.max(minWidth, baseWidth + clampedDelta));
-            const nextAdjacentWidth = hasAdjacent
-                ? Math.min(maxWidth, Math.max(minWidth, adjacentBaseWidth - clampedDelta))
-                : null;
-
-            setColumnWidths((prev) => {
-                if (resizeAdjacentColumn && nextAdjacentWidth != null) {
-                    return {
-                        ...prev,
-                        [resizingColumn]: nextWidth,
-                        [resizeAdjacentColumn]: nextAdjacentWidth,
-                    };
-                }
-                return {...prev, [resizingColumn]: nextWidth};
-            });
+            const nextWidth = Math.min(maxWidth, Math.max(minWidth, resizeStartWidth + deltaFromStart));
+            setColumnWidths((prev) => ({...prev, [resizingColumn]: nextWidth}));
         };
 
         const onUp = () => {
@@ -113,8 +63,6 @@ export function useResizableTableColumns({
             }
 
             setResizingColumn(null);
-            setResizeAdjacentColumn(null);
-            setResizeAdjacentStartWidth(0);
         };
 
         window.addEventListener('mousemove', onMove);
@@ -126,8 +74,6 @@ export function useResizableTableColumns({
     }, [
         maxWidth,
         minWidth,
-        resizeAdjacentColumn,
-        resizeAdjacentStartWidth,
         resizeStartWidth,
         resizeStartX,
         resizingColumn,
@@ -151,7 +97,6 @@ export function useResizableTableColumns({
 
     return {
         resizingColumn,
-        registerHeaderRef,
         startResize,
     };
 }


### PR DESCRIPTION
## Problem

Dragging a column's resize handle visibly changed a **neighbouring** column's width — not the one being dragged. The shared `useResizableTableColumns` hook used a *push-pull* model: it found the next visible column and resized it inversely (one grows, the other shrinks). This affected every table sharing the hook (**extraction**, **articles**).

## Fix

The list tables render as `table-fixed w-max min-w-full` inside an `overflow-auto` container, so the table width is just the **sum** of its column widths and the container scrolls — there is no fixed budget, so compensating a neighbour was never necessary (and was the bug).

Resize now changes **only the dragged column**. Done in the shared hook so all current and future tables of this shape are fixed in one place.

### Also removed (dead code the bug relied on)
- `orderedColumns` param (only used by the adjacent-column scan) + the `RESIZABLE_COLUMN_ORDER` / `renderedResizableColumns` consts at the two call sites.
- The now-unread `registerHeaderRef` / `headerRefs` API and its `ref={…}` attributes — the old neighbour-visibility check (`getBoundingClientRect`) was its only reader.

Hook public surface is now `{ resizingColumn, startResize }`. Net **+14 / −81**.

## Tests
New hook unit test (`useResizableTableColumns.test.ts`): single-column invariant (dragging `title` leaves `authors`/`year` untouched), min-width clamp, and localStorage persistence.

## Verification
- New hook test ✅ · `tsc --noEmit` ✅ · `eslint` (changed files) ✅
- Full env-less `vitest run`: **125 files / 767 tests** ✅ (mirrors CI's env-less Frontend Tests)
- `npm run build` ✅ — both consumers compile under React Compiler (`panicThreshold: all_errors`)
- Adversarial multi-lens review (correctness / completeness / conventions / test-adequacy) → **0 confirmed blockers**; zero dangling references to any removed symbol.

QA's `HITLArticleTable` uses fixed Tailwind widths (no resizable columns), so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)