### PR TITLE
feat(sidebar): hover-peek mini-rail (collapsed 56px → 256px overlay peek)

### DIFF
--- a/docs/superpowers/design-system/sidebar-and-panels.md
+++ b/docs/superpowers/design-system/sidebar-and-panels.md
@@ -14,7 +14,15 @@ This document is the **single source of truth** for any side panel in Prumo: the
 
 ## 1. Behavior model
 
-- **Show / hide is binary.** A panel is fully visible OR fully hidden (`display: none`). No mini icon-only state.
+- **Show / hide is binary for the persisted preference.** The saved state is just
+  open/closed. The **main sidebar** additionally renders, while collapsed, a
+  **56 px mini-rail with a hover/focus peek** that overlays content at the full
+  256 px width. The peek is **transient** — never persisted, never cross-tab
+  synced — and is rendered by a separate `SidebarRail` sibling, not by
+  `ResizablePanel` (whose collapsed state stays a true unmount,
+  `display:none`-equivalent). Pinning open (⌘B) is the normal expand; it pushes
+  content, the peek only overlays. Secondary panels and the per-article focus
+  shell stay strictly binary — the shell collapses to width 0 for max canvas.
 - **Resizable with limits.** Every persistent panel exposes a 4 px drag handle on its outer edge.
   - **Click** → toggle collapse.
   - **Drag** → resize within `[minWidth, maxWidth]`.
@@ -36,6 +44,10 @@ This document is the **single source of truth** for any side panel in Prumo: the
 
 Anything new must declare these four values explicitly in its `<ResizablePanel>` props.
 
+The main sidebar's collapsed **mini-rail is 56 px** (`w-14`); its hover/focus
+**peek overlays at 256 px** (`w-64`). These are not `ResizablePanel` widths — the
+rail is a separate `SidebarRail` component (see §1, §4).
+
 ## 3. Visual tokens
 
 | Aspect | Token / value |
@@ -45,6 +57,7 @@ Anything new must declare these four values explicitly in its `<ResizablePanel>`
 | Header height | `h-12` (48 px) with `border-b border-border/40` |
 | Footer | `border-t border-border/40`, padding `p-2` |
 | Panel motion | Symmetric on **both** expand and collapse — the same motion in reverse. Width leads on the `aside` (`transition-[width] duration-200 ease-out`); the content fades on the inner wrapper (`duration-150 delay-75` on expand so it trails the width, `duration-100` on collapse so it leads). The inner content keeps a fixed width (= open width) and is clipped by `overflow-hidden`, so rows slide/clip cleanly instead of squishing. `motion-reduce:duration-0` both ways; no entry animation on first mount. |
+| Mini-rail / peek | Rail 56 px (`w-14`); peek 256 px (`w-64`) overlay with `shadow-elev-popover`, `transition-[width,box-shadow] duration-[180ms] ease-out`. The 56 px aside clips a fixed 256 px inner (`overflow-hidden`) so rows never reflow; labels/titles reveal via `group-data-[peek=closed]/rail:opacity-0` on the shared content. Hover-in 120 ms, hover-out grace 250 ms; `motion-reduce:duration-0`. |
 
 ## 4. Nav item rules
 
@@ -60,6 +73,12 @@ Anything new must declare these four values explicitly in its `<ResizablePanel>`
 | Inactive | `text-muted-foreground/80 hover:bg-muted/50 hover:text-foreground` |
 | Hover transition | `duration-75` |
 | Active state aria | `aria-current="page"` |
+
+**Collapsed mini-rail variant:** the same nav rows render icon-only at 56 px —
+icon at the left gutter; label, shortcut chip, and section titles hidden via
+`group-data-[peek=closed]/rail:opacity-0` and revealed on peek. It reuses the
+shared `SidebarContent` (one set of focusable buttons — the peek does not
+duplicate the nav), so active-state, copy, and shortcut wiring never drift.
 
 ## 5. Section title rules
 
@@ -104,6 +123,11 @@ All shortcut handlers MUST use the shared `useKeyboardShortcuts` hook so input-f
 - Drag handle: `role="separator" aria-orientation="vertical" aria-controls={panelId} aria-valuemin aria-valuemax aria-valuenow`. Arrow keys adjust ±16 px when focused; Enter/Space toggles collapse.
 - Focus management: collapsing via shortcut returns focus to the topbar toggle; expanding moves focus to the first nav item.
 - Reduced motion: when `prefers-reduced-motion: reduce`, all transitions become `duration-0`.
+- Mini-rail peek (WCAG 1.4.13): keyboard **focus** within the rail opens the peek
+  (focus parity — never hover-only); **Esc** dismisses it without moving the
+  pointer (Dismissable); the 250 ms hover-out grace lets the cursor travel from
+  the rail into the floating panel without it vanishing (Hoverable/Persistent).
+  Collapsed rail glyphs keep `aria-current` and `aria-keyshortcuts`.
 
 ## 9. When you build a new panel
 

--- a/docs/superpowers/specs/2026-06-21-sidebar-sota-polish-design.md
+++ b/docs/superpowers/specs/2026-06-21-sidebar-sota-polish-design.md
@@ -181,8 +181,39 @@ across `SidebarNavItem`, `UserMenu`, `SidebarHeader`.
 
 ## Out of scope
 
-- Mini/icon-rail "hover-peek" collapsed mode (SOTA P2) — natural next
-  step after this ships.
+- Mini/icon-rail "hover-peek" collapsed mode (SOTA P2) — delivered as a
+  follow-up, see below.
 - Re-baselining the run-page `SectionNavRail` active idiom (only
   required if Direction C were chosen; A leaves it alone).
 - Any backend / data-path change.
+
+## Follow-up: hover-peek mini-rail (approved 2026-06-21)
+
+Approved decisions (mockup + selection): **transient overlay** (not a
+state-model change), **main sidebar only**, **explicit ⌘B/click pin**.
+
+- **State model.** `sidebarCollapsed` stays binary; the rail is a third
+  *visual* state shown only while collapsed. No tri-state enum, no storage
+  migration — the persist invariant (and the focus-shell width-0 path)
+  are untouched.
+- **Components.** `SidebarRail` (56 px in-flow slot + an absolute overlay
+  that widens to 256 px on peek, clipping a fixed-256 inner) hosts the
+  shared `SidebarContent` (extracted from `ProjectSidebar`). `useSidebarPeek`
+  owns the hover-in (120 ms) / hover-out grace (250 ms) + focus + Esc.
+  Rail-aware classes (`group-data-[peek=closed]/rail:opacity-0`) on the
+  content's label/chip/title degrade it to icon-only when collapsed and are
+  inert in the full sidebar.
+- **Surfaces.** `ProjectSidebar` gains a `rail` prop; `ProjectLayout` sets it,
+  `RunWorkspaceShell` does not (focus shell keeps width-0).
+- **Pin.** ⌘B / the topbar toggle flips `sidebarCollapsed` (rail ⇆ full,
+  pushing content); hover/focus peek never writes the preference.
+- **A11y.** Focus opens the peek, Esc dismisses, 250 ms grace makes it
+  Hoverable (WCAG 1.4.13); `aria-keyshortcuts`/`aria-current` preserved.
+- **Spec.** Amended `sidebar-and-panels.md` §1 (mini-rail allowed, peek
+  transient), §2 (56/256), §3 (peek motion), §4 (icon-rail variant), §8
+  (WCAG 1.4.13).
+- **Tests.** `useSidebarPeek` (timers/focus/Esc), `SidebarRail`
+  (collapsed default, focus-opens/Esc-closes, hover-in delay).
+
+Out of scope for this follow-up: animating the rail⇆full *pin* width (it is
+an instant swap; only the peek animates).

--- a/frontend/components/layout/AppLayout.tsx
+++ b/frontend/components/layout/AppLayout.tsx
@@ -64,6 +64,7 @@ export const ProjectLayout: React.FC<AppLayoutProps> = ({children, className}) =
 
       <div className="flex flex-1 overflow-hidden">
         <ProjectSidebar
+          rail
           activeTab={activeTab}
           onTabChange={changeTab}
           projectName={project?.name}

--- a/frontend/components/layout/ProjectSidebar.tsx
+++ b/frontend/components/layout/ProjectSidebar.tsx
@@ -5,11 +5,9 @@
  */
 import React from 'react';
 import {ResizablePanel} from '@/components/ui/resizable-panel';
-import {SidebarHeader} from './SidebarHeader';
-import {SidebarSection} from './SidebarSection';
-import {SidebarNavItem} from './SidebarNavItem';
-import {SidebarFooter} from './SidebarFooter';
-import {sidebarSections, type SidebarTabId} from './sidebarConfig';
+import {SidebarContent} from './SidebarContent';
+import {SidebarRail} from './SidebarRail';
+import {type SidebarTabId} from './sidebarConfig';
 import {useSidebar} from '@/contexts/SidebarContext';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
@@ -21,6 +19,12 @@ interface ProjectSidebarProps {
   switcherOpen?: boolean;
   onSwitcherOpenChange?: (open: boolean) => void;
   className?: string;
+  /**
+   * Enable the collapsed mini-rail + hover-peek (main sidebar only). When off
+   * (the per-article focus shell), collapse stays a true width-0 unmount for
+   * max canvas. See docs/superpowers/design-system/sidebar-and-panels.md §1.
+   */
+  rail?: boolean;
 }
 
 export const ProjectSidebar: React.FC<ProjectSidebarProps> = ({
@@ -30,8 +34,26 @@ export const ProjectSidebar: React.FC<ProjectSidebarProps> = ({
   switcherOpen,
   onSwitcherOpenChange,
   className,
+  rail,
 }) => {
   const {sidebarCollapsed, toggleSidebar} = useSidebar();
+
+  const content = (
+    <SidebarContent
+      activeTab={activeTab}
+      onTabChange={onTabChange}
+      projectName={projectName}
+      switcherOpen={switcherOpen}
+      onSwitcherOpenChange={onSwitcherOpenChange}
+    />
+  );
+
+  // Rail mode: collapsed shows the 56px mini-rail with hover-peek; expanded is
+  // the normal resizable panel (pin via ⌘B). Without `rail`, collapse remains a
+  // true width-0 unmount (the focus shell).
+  if (rail && sidebarCollapsed) {
+    return <SidebarRail>{content}</SidebarRail>;
+  }
 
   return (
     <ResizablePanel
@@ -41,7 +63,7 @@ export const ProjectSidebar: React.FC<ProjectSidebarProps> = ({
       minWidth={240}
       maxWidth={400}
       snapCollapseAt={150}
-      collapsed={sidebarCollapsed}
+      collapsed={rail ? false : sidebarCollapsed}
       onCollapse={toggleSidebar}
       tooltipLabel={t('layout', 'resizeHandleTooltip')}
       shortcut={['mod', 'B']}
@@ -50,26 +72,7 @@ export const ProjectSidebar: React.FC<ProjectSidebarProps> = ({
         className,
       )}
     >
-      <div className="flex flex-col h-full">
-        <SidebarHeader projectName={projectName} open={switcherOpen} onOpenChange={onSwitcherOpenChange} />
-        <nav className="flex-1 p-2 space-y-0.5 overflow-y-auto">
-          {sidebarSections.map((section) => (
-            <SidebarSection key={section.title} title={section.title}>
-              {section.items.map((item) => (
-                <SidebarNavItem
-                  key={item.id}
-                  icon={item.icon}
-                  label={item.label}
-                  shortcut={item.shortcut}
-                  active={activeTab === item.id}
-                  onClick={() => onTabChange(item.id)}
-                />
-              ))}
-            </SidebarSection>
-          ))}
-        </nav>
-        <SidebarFooter />
-      </div>
+      {content}
     </ResizablePanel>
   );
 };

--- a/frontend/components/layout/SidebarContent.tsx
+++ b/frontend/components/layout/SidebarContent.tsx
@@ -1,0 +1,54 @@
+/**
+ * Inner sidebar tree: header (switcher) + nav sections + footer.
+ * Shared by the full ProjectSidebar (inside ResizablePanel) and the collapsed
+ * SidebarRail's peek overlay, so labels/shortcuts/active-state have one source
+ * of truth. Inside a collapsed rail (a `group/rail` with data-peek="closed"),
+ * the text degrades to icon-only via rail-aware classes on the child rows;
+ * those classes are inert here (no group/rail ancestor).
+ * See docs/superpowers/design-system/sidebar-and-panels.md
+ */
+import React from 'react';
+import {SidebarHeader} from './SidebarHeader';
+import {SidebarSection} from './SidebarSection';
+import {SidebarNavItem} from './SidebarNavItem';
+import {SidebarFooter} from './SidebarFooter';
+import {sidebarSections, type SidebarTabId} from './sidebarConfig';
+
+interface SidebarContentProps {
+  activeTab: string;
+  onTabChange: (tab: SidebarTabId) => void;
+  projectName?: string;
+  switcherOpen?: boolean;
+  onSwitcherOpenChange?: (open: boolean) => void;
+}
+
+export const SidebarContent: React.FC<SidebarContentProps> = ({
+  activeTab,
+  onTabChange,
+  projectName,
+  switcherOpen,
+  onSwitcherOpenChange,
+}) => (
+  <div className="flex flex-col h-full">
+    <SidebarHeader projectName={projectName} open={switcherOpen} onOpenChange={onSwitcherOpenChange} />
+    <nav className="flex-1 p-2 space-y-0.5 overflow-y-auto">
+      {sidebarSections.map((section) => (
+        <SidebarSection key={section.title} title={section.title}>
+          {section.items.map((item) => (
+            <SidebarNavItem
+              key={item.id}
+              icon={item.icon}
+              label={item.label}
+              shortcut={item.shortcut}
+              active={activeTab === item.id}
+              onClick={() => onTabChange(item.id)}
+            />
+          ))}
+        </SidebarSection>
+      ))}
+    </nav>
+    <SidebarFooter />
+  </div>
+);
+
+export default SidebarContent;

--- a/frontend/components/layout/SidebarHeader.tsx
+++ b/frontend/components/layout/SidebarHeader.tsx
@@ -66,13 +66,13 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({projectName, open, 
                 {(projectName || 'P')[0].toUpperCase()}
               </span>
             </div>
-            <div className="min-w-0 flex-1 text-left">
+            <div className="min-w-0 flex-1 text-left transition-opacity group-data-[peek=closed]/rail:opacity-0">
               <h2 className="text-[13px] font-medium truncate text-foreground/80">
                 {projectName || t('layout', 'defaultProjectName')}
               </h2>
             </div>
-            <ChevronDown className="h-3 w-3 text-muted-foreground/50" />
-            <KbdBadge keys={['G', 'P']} variant="sequence" className="ml-1" />
+            <ChevronDown className="h-3 w-3 text-muted-foreground/50 transition-opacity group-data-[peek=closed]/rail:opacity-0" />
+            <KbdBadge keys={['G', 'P']} variant="sequence" className="ml-1 transition-opacity group-data-[peek=closed]/rail:opacity-0" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-[260px] p-1 shadow-elev-popover border-border/50">

--- a/frontend/components/layout/SidebarNavItem.tsx
+++ b/frontend/components/layout/SidebarNavItem.tsx
@@ -30,7 +30,7 @@ export const SidebarNavItem: React.FC<SidebarNavItemProps> = ({icon: Icon, label
     )}
   >
     <Icon className={cn('h-4 w-4 shrink-0', active ? 'text-foreground' : 'group-hover:text-foreground/80')} strokeWidth={1.5} />
-    <span className="text-[13px] flex-1 text-left truncate">{label}</span>
+    <span className="text-[13px] flex-1 text-left truncate transition-opacity group-data-[peek=closed]/rail:opacity-0">{label}</span>
     <KbdBadge
       keys={['G', shortcut]}
       variant="sequence"

--- a/frontend/components/layout/SidebarRail.test.tsx
+++ b/frontend/components/layout/SidebarRail.test.tsx
@@ -1,0 +1,57 @@
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {act, fireEvent, render} from '@testing-library/react';
+import {SidebarRail} from './SidebarRail';
+
+describe('SidebarRail', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('renders its content and starts collapsed (56px, data-peek=closed)', () => {
+    const {container, getByText} = render(
+      <SidebarRail>
+        <div>Nav content</div>
+      </SidebarRail>,
+    );
+    expect(getByText('Nav content')).toBeInTheDocument();
+    const aside = container.querySelector('[data-peek]') as HTMLElement;
+    expect(aside.getAttribute('data-peek')).toBe('closed');
+    expect(aside.className).toContain('w-14');
+    expect(aside.className).not.toContain('w-64 shadow');
+  });
+
+  it('opens immediately on keyboard focus and closes on Escape', () => {
+    const {container} = render(
+      <SidebarRail>
+        <button>Item</button>
+      </SidebarRail>,
+    );
+    const aside = container.querySelector('[data-peek]') as HTMLElement;
+    act(() => {
+      fireEvent.focus(container.querySelector('button')!);
+    });
+    expect(aside.getAttribute('data-peek')).toBe('open');
+    expect(aside.className).toContain('w-64');
+
+    act(() => {
+      fireEvent.keyDown(aside, {key: 'Escape'});
+    });
+    expect(aside.getAttribute('data-peek')).toBe('closed');
+  });
+
+  it('peeks open only after the hover-in delay', () => {
+    vi.useFakeTimers();
+    const {container} = render(
+      <SidebarRail>
+        <div>Nav</div>
+      </SidebarRail>,
+    );
+    const aside = container.querySelector('[data-peek]') as HTMLElement;
+    act(() => {
+      fireEvent.mouseEnter(aside);
+    });
+    expect(aside.getAttribute('data-peek')).toBe('closed');
+    act(() => {
+      vi.advanceTimersByTime(120);
+    });
+    expect(aside.getAttribute('data-peek')).toBe('open');
+  });
+});

--- a/frontend/components/layout/SidebarRail.tsx
+++ b/frontend/components/layout/SidebarRail.tsx
@@ -1,0 +1,60 @@
+/**
+ * Collapsed mini-rail: a 56px icon column that peeks to 256px (overlaying the
+ * content, never reflowing it) on hover or keyboard focus, then settles back.
+ *
+ * It hosts the SAME SidebarContent as the expanded sidebar, so there is one set
+ * of focusable nav buttons (no duplicate tab stops). Rail-aware classes on the
+ * content's text (group-data-[peek=closed]/rail:opacity-0) degrade it to
+ * icon-only while collapsed and reveal labels on peek; the 56px aside clips the
+ * 256px-wide inner via overflow-hidden so rows never reflow as it widens.
+ *
+ * Main sidebar only — the per-article focus shell opts out (stays width-0).
+ * See docs/superpowers/design-system/sidebar-and-panels.md §1, §8.
+ */
+import React from 'react';
+import {useSidebarPeek} from '@/hooks/useSidebarPeek';
+import {cn} from '@/lib/utils';
+
+interface SidebarRailProps {
+  /** A <SidebarContent /> — the shared inner tree. */
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const SidebarRail: React.FC<SidebarRailProps> = ({children, className}) => {
+  const {open, onEnter, onLeave, openNow, closeNow} = useSidebarPeek();
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    // Esc dismisses the peek without moving the pointer (WCAG 1.4.13).
+    if (e.key === 'Escape' && open) {
+      e.stopPropagation();
+      closeNow();
+    }
+  };
+
+  return (
+    // In-flow 56px slot reserves the rail's column; the rail/peek floats over `main`.
+    <div className="relative w-14 shrink-0 hidden lg:block">
+      <aside
+        data-peek={open ? 'open' : 'closed'}
+        onMouseEnter={onEnter}
+        onMouseLeave={onLeave}
+        onFocus={openNow}
+        onBlur={onLeave}
+        onKeyDown={onKeyDown}
+        className={cn(
+          'group/rail absolute inset-y-0 left-0 z-20 overflow-hidden',
+          'bg-[#fafafa] dark:bg-[#0c0c0c] border-r border-border/40',
+          'transition-[width,box-shadow] duration-[180ms] ease-out motion-reduce:duration-0',
+          open ? 'w-64 shadow-elev-popover' : 'w-14',
+          className,
+        )}
+      >
+        {/* Fixed open-width inner so rows never reflow as the rail widens. */}
+        <div className="h-full w-64">{children}</div>
+      </aside>
+    </div>
+  );
+};
+
+export default SidebarRail;

--- a/frontend/components/layout/SidebarSection.tsx
+++ b/frontend/components/layout/SidebarSection.tsx
@@ -12,7 +12,7 @@ interface SidebarSectionProps {
 export const SidebarSection: React.FC<SidebarSectionProps> = ({title, children}) => (
   <div>
     <div className="px-2.5 pb-1 pt-2">
-      <span className="text-[11px] font-medium text-muted-foreground/50 uppercase tracking-wider select-none">
+      <span className="text-[11px] font-medium text-muted-foreground/50 uppercase tracking-wider select-none transition-opacity group-data-[peek=closed]/rail:opacity-0">
         {title}
       </span>
     </div>

--- a/frontend/hooks/useSidebarPeek.test.ts
+++ b/frontend/hooks/useSidebarPeek.test.ts
@@ -1,0 +1,74 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {act, renderHook} from '@testing-library/react';
+import {useSidebarPeek} from './useSidebarPeek';
+
+describe('useSidebarPeek', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('opens only after the hover-in delay', () => {
+    const {result} = renderHook(() => useSidebarPeek({inMs: 120, outMs: 250}));
+    expect(result.current.open).toBe(false);
+    act(() => result.current.onEnter());
+    act(() => {
+      vi.advanceTimersByTime(119);
+    });
+    expect(result.current.open).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.open).toBe(true);
+  });
+
+  it('closes only after the hover-out grace', () => {
+    const {result} = renderHook(() => useSidebarPeek({inMs: 120, outMs: 250}));
+    act(() => {
+      result.current.onEnter();
+      vi.advanceTimersByTime(120);
+    });
+    expect(result.current.open).toBe(true);
+    act(() => result.current.onLeave());
+    act(() => {
+      vi.advanceTimersByTime(249);
+    });
+    expect(result.current.open).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it('a leave during the grace can be cancelled by re-entering', () => {
+    const {result} = renderHook(() => useSidebarPeek({inMs: 120, outMs: 250}));
+    act(() => {
+      result.current.onEnter();
+      vi.advanceTimersByTime(120);
+    });
+    act(() => {
+      result.current.onLeave();
+      vi.advanceTimersByTime(100);
+      result.current.onEnter();
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current.open).toBe(true);
+  });
+
+  it('leave cancels a still-pending open', () => {
+    const {result} = renderHook(() => useSidebarPeek({inMs: 120, outMs: 250}));
+    act(() => {
+      result.current.onEnter();
+      vi.advanceTimersByTime(60);
+      result.current.onLeave();
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it('openNow / closeNow act immediately (focus / Esc)', () => {
+    const {result} = renderHook(() => useSidebarPeek({inMs: 120, outMs: 250}));
+    act(() => result.current.openNow());
+    expect(result.current.open).toBe(true);
+    act(() => result.current.closeNow());
+    expect(result.current.open).toBe(false);
+  });
+});

--- a/frontend/hooks/useSidebarPeek.ts
+++ b/frontend/hooks/useSidebarPeek.ts
@@ -1,0 +1,79 @@
+/**
+ * Hover/focus peek state for the collapsed sidebar mini-rail.
+ * - onEnter/onLeave drive the hover peek with an in-delay and an out-grace so
+ *   the cursor can travel from the rail into the floating panel without it
+ *   vanishing (WCAG 1.4.13 "Hoverable").
+ * - openNow/closeNow are the keyboard path: focus-within opens the peek, Esc
+ *   dismisses it (WCAG 1.4.13 "Dismissable"), both immediate.
+ * Pure setTimeout/clearTimeout state — no IO, React-Compiler safe.
+ * See docs/superpowers/design-system/sidebar-and-panels.md §1, §8.
+ */
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+interface UseSidebarPeekOptions {
+  inMs?: number;
+  outMs?: number;
+}
+
+export interface SidebarPeek {
+  open: boolean;
+  onEnter: () => void;
+  onLeave: () => void;
+  openNow: () => void;
+  closeNow: () => void;
+}
+
+export function useSidebarPeek({inMs = 120, outMs = 250}: UseSidebarPeekOptions = {}): SidebarPeek {
+  const [open, setOpen] = useState(false);
+  const inTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const outTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimers = useCallback(() => {
+    if (inTimer.current) {
+      clearTimeout(inTimer.current);
+      inTimer.current = null;
+    }
+    if (outTimer.current) {
+      clearTimeout(outTimer.current);
+      outTimer.current = null;
+    }
+  }, []);
+
+  const onEnter = useCallback(() => {
+    if (outTimer.current) {
+      clearTimeout(outTimer.current);
+      outTimer.current = null;
+    }
+    if (inTimer.current) return;
+    inTimer.current = setTimeout(() => {
+      inTimer.current = null;
+      setOpen(true);
+    }, inMs);
+  }, [inMs]);
+
+  const onLeave = useCallback(() => {
+    if (inTimer.current) {
+      clearTimeout(inTimer.current);
+      inTimer.current = null;
+    }
+    if (outTimer.current) return;
+    outTimer.current = setTimeout(() => {
+      outTimer.current = null;
+      setOpen(false);
+    }, outMs);
+  }, [outMs]);
+
+  const openNow = useCallback(() => {
+    clearTimers();
+    setOpen(true);
+  }, [clearTimers]);
+
+  const closeNow = useCallback(() => {
+    clearTimers();
+    setOpen(false);
+  }, [clearTimers]);
+
+  useEffect(() => clearTimers, [clearTimers]);
+
+  return {open, onEnter, onLeave, openNow, closeNow};
+}


### PR DESCRIPTION
## What

Follow-up to #360. The collapsed **main** sidebar becomes a **56px icon rail** that **peeks to a 256px overlay** on hover/keyboard-focus, then **pins open** (pushing content) via ⌘B. Approved design (mockup + selection): transient overlay · main sidebar only · explicit ⌘B/click pin. Spec: `docs/superpowers/specs/2026-06-21-sidebar-sota-polish-design.md` (follow-up section).

### Behaviour
- **Transient overlay model.** `sidebarCollapsed` stays binary; the rail is a third *visual* state shown only while collapsed. No tri-state enum, no storage migration — the `persist` invariant and the focus-shell width-0 path are untouched.
- **Peek = overlay, pin = push.** Hover/focus floats the 256px panel over content (no reflow); ⌘B flips to the full 280px panel (the normal `ResizablePanel`).
- **One set of nav buttons.** The rail hosts the extracted `SidebarContent`; rail-aware classes (`group-data-[peek=closed]/rail:opacity-0`) hide labels/chips/titles when collapsed and reveal them on peek — no duplicate tab stops, no drift. The 56px aside clips a fixed-256 inner so rows never reflow.
- **Main sidebar only.** `ProjectSidebar` gains `rail`; `ProjectLayout` opts in, `RunWorkspaceShell` does not (focus shell keeps width-0 for max canvas).
- **A11y (WCAG 1.4.13).** Focus opens the peek, Esc dismisses, 250ms hover-out grace keeps it Hoverable; `aria-keyshortcuts`/`aria-current` preserved.

### Components
`useSidebarPeek` (120ms in / 250ms grace + focus + Esc) · `SidebarRail` · `SidebarContent` (extracted) · rail-aware classes on `SidebarNavItem`/`SidebarHeader`/`SidebarSection`.

## Verification
- `npm run test:run` — 802 passed (new: `useSidebarPeek` timers/focus/Esc; `SidebarRail` collapsed-default / focus-opens-Esc-closes / hover-in delay).
- `npm run typecheck` clean; `eslint` on changed files clean.
- Visual (DEV harness mounting the real `ProjectSidebar rail`): collapsed 56px icon rail (icon-only, active highlight, switcher tile, user avatar), peek = 256px overlay floating over content with full labels/section-titles/chip/footer, pinned = 280px full panel pushing content. Harness removed before commit.

## Notes
- The rail⇆full **pin** is an instant swap (only the peek animates) — out of scope to animate, noted in the spec.
- Builds on #360 (must merge after it; already on `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)