### PR TITLE
test(integration): self-provision fixtures to de-flake the skip-budget guard

### DIFF
--- a/backend/tests/integration/test_calculate_model_progress.py
+++ b/backend/tests/integration/test_calculate_model_progress.py
@@ -28,6 +28,8 @@ import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.integration.conftest import SEED
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -35,29 +37,16 @@ pytestmark = pytest.mark.asyncio
 async def project_with_run(db_session: AsyncSession) -> AsyncGenerator[dict, None]:
     """Build a self-contained model fixture: project + article + template +
     prediction_models entity_type + parent instance + child instance + run.
-    Returns the IDs the caller needs; tears the chain down at the end."""
-    project_row = (
-        await db_session.execute(
-            text(
-                "SELECT id, (SELECT user_id FROM project_members WHERE project_id = projects.id LIMIT 1) "
-                "FROM projects LIMIT 1"
-            )
-        )
-    ).first()
-    if project_row is None or project_row[1] is None:
-        pytest.skip("Need a project with at least one member")
-    project_id = UUID(str(project_row[0]))
-    user_id = UUID(str(project_row[1]))
+    Returns the IDs the caller needs; tears the chain down at the end.
 
-    article_row = (
-        await db_session.execute(
-            text("SELECT id FROM articles WHERE project_id = :pid LIMIT 1"),
-            {"pid": str(project_id)},
-        )
-    ).first()
-    if article_row is None:
-        pytest.skip("Need an article in the project")
-    article_id = UUID(str(article_row[0]))
+    Scoped to the seeded ``SEED.primary_project`` / ``SEED.primary_article``
+    so the full extraction graph (and a manager member to author the rows)
+    is guaranteed present — no order-dependent "find an article" skip. The
+    isolated ``is_active=False`` template this fixture builds keeps it
+    independent of the seed's own active template."""
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    user_id = SEED.primary_profile
 
     # Inert isolated template so cleanup is safe regardless of the running
     # CHARMS state. Bypass the partial-active index by using is_active=False.
@@ -439,14 +428,14 @@ async def test_published_state_counts_when_value_present(
             """
             INSERT INTO public.extraction_published_states
                 (run_id, instance_id, field_id, value, version, published_by)
-            VALUES (:rid, :inst, :fid, to_jsonb('final-value'::text), 1,
-                    (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1))
+            VALUES (:rid, :inst, :fid, to_jsonb('final-value'::text), 1, :uid)
             """
         ),
         {
             "rid": str(project_with_run["run_id"]),
             "inst": str(project_with_run["parent_inst"]),
             "fid": str(project_with_run["parent_field"]),
+            "uid": str(project_with_run["user_id"]),
         },
     )
     await db_session.commit()
@@ -470,14 +459,14 @@ async def test_published_state_with_jsonb_null_does_not_count(
             """
             INSERT INTO public.extraction_published_states
                 (run_id, instance_id, field_id, value, version, published_by)
-            VALUES (:rid, :inst, :fid, 'null'::jsonb, 1,
-                    (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1))
+            VALUES (:rid, :inst, :fid, 'null'::jsonb, 1, :uid)
             """
         ),
         {
             "rid": str(project_with_run["run_id"]),
             "inst": str(project_with_run["parent_inst"]),
             "fid": str(project_with_run["parent_field"]),
+            "uid": str(project_with_run["user_id"]),
         },
     )
     await db_session.commit()

--- a/backend/tests/integration/test_extraction_review_service.py
+++ b/backend/tests/integration/test_extraction_review_service.py
@@ -222,6 +222,29 @@ async def test_accept_proposal_rejects_cross_coordinate_proposal(
         pytest.skip("Missing fixtures.")
     run_id, instance_id, field_id, profile_id, _, _ = fx
 
+    # Self-provision a SECOND coordinate in the same template. The seed
+    # ships exactly one entity_type + one field (one coordinate), so add a
+    # distinct field on the SAME entity_type as the existing instance: the
+    # existing instance paired with this new field is a second valid
+    # (instance, field) coordinate in the same template. Rolled back with
+    # db_session, so there is no leak.
+    other_field_id = (
+        await db_session.execute(
+            text(
+                "INSERT INTO public.extraction_fields "
+                "(id, entity_type_id, name, label, field_type, is_required) "
+                "SELECT gen_random_uuid(), et.id, 'second_coordinate_field', "
+                " 'Second Coordinate Field', 'text', false "
+                "FROM public.extraction_entity_types et "
+                "WHERE et.id = (SELECT entity_type_id FROM public.extraction_instances "
+                "               WHERE id = :iid) "
+                "RETURNING id"
+            ),
+            {"iid": instance_id},
+        )
+    ).scalar_one()
+    await db_session.flush()
+
     # Build a second proposal targeting a DIFFERENT (instance, field) in the same run.
     other_row = await db_session.execute(
         text(
@@ -231,17 +254,17 @@ async def test_accept_proposal_rejects_cross_coordinate_proposal(
             JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
             JOIN public.extraction_fields f ON f.entity_type_id = et.id
             WHERE (i.id <> :iid OR f.id <> :fid)
+              AND f.id = :other_fid
               AND i.template_id = (
                   SELECT template_id FROM public.extraction_instances WHERE id = :iid
               )
             LIMIT 1
             """
         ),
-        {"iid": instance_id, "fid": field_id},
+        {"iid": instance_id, "fid": field_id, "other_fid": other_field_id},
     )
     other = other_row.first()
-    if other is None:
-        pytest.skip("Need a second coordinate in the same template.")
+    assert other is not None, "self-provisioned second coordinate must be discoverable"
     other_instance_id, other_field_id = other
 
     # The setup left the run in REVIEW; record_proposal requires PROPOSAL.

--- a/backend/tests/integration/test_kind_discriminator.py
+++ b/backend/tests/integration/test_kind_discriminator.py
@@ -5,6 +5,9 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
+
 
 @pytest.mark.asyncio
 async def test_kind_column_exists_on_global_template(
@@ -148,23 +151,17 @@ async def test_composite_fk_blocks_kind_mismatch(
     db_session: AsyncSession,
 ) -> None:
     # Composite FK on (template_id, kind) must reject a Run.kind that doesn't
-    # match its Template.kind. Pick a run whose template is 'extraction' and
-    # try to flip the run's kind — that breaks coherence and the UPDATE raises.
-    target_id = (
-        await db_session.execute(
-            text(
-                """
-                SELECT r.id
-                FROM public.extraction_runs r
-                JOIN public.project_extraction_templates t ON t.id = r.template_id
-                WHERE t.kind = 'extraction'
-                LIMIT 1
-                """
-            )
-        )
-    ).scalar()
-    if target_id is None:
-        pytest.skip("No extraction-kind runs available.")
+    # match its Template.kind. Provision a run on the seed's primary template
+    # (kind='extraction'); create_run copies the template's kind onto the run,
+    # so flipping the run's kind breaks coherence and the UPDATE must raise.
+    run = await RunLifecycleService(db_session).create_run(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        project_template_id=SEED.primary_template,
+        user_id=SEED.primary_profile,
+    )
+    await db_session.flush()
+    target_id = run.id
 
     with pytest.raises(IntegrityError):
         await db_session.execute(

--- a/backend/tests/integration/test_membership_guards.py
+++ b/backend/tests/integration/test_membership_guards.py
@@ -10,9 +10,13 @@ The cluster of fixes share two helpers:
   ``handle_new_user`` trigger materializes a matching ``public.profiles``
   row) and overrides ``get_current_user`` so the JWT sub is the outsider's
   id. Cleaned up at teardown.
-* ``insider_run`` — picks an existing run owned by a project the outsider
-  does NOT belong to, plus matching ``(instance_id, field_id)`` coords for
-  the proposal/decision/consensus payloads.
+* ``_provision_run_for_outsider`` — creates a run (via
+  ``RunLifecycleService``) inside the seeded primary project, which the
+  outsider is NOT a member of, plus the matching seeded
+  ``(instance_id, field_id)`` coords for the proposal/decision/consensus
+  payloads. Self-provisioned on the rolled-back ``db_session`` so the run
+  never persists; the membership guard fires on the project, so any run in
+  that project exercises the 403 path.
 """
 
 from __future__ import annotations
@@ -29,6 +33,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 # =================== FIXTURES ===================
 
@@ -89,30 +95,37 @@ async def outsider_user(
         await db_session.commit()
 
 
-async def _pick_run_for_outsider(
-    db: AsyncSession, outsider_id: UUID
-) -> tuple[UUID, UUID, UUID, UUID] | None:
-    """Return (run_id, project_id, instance_id, field_id) for any run whose
-    project does NOT include ``outsider_id`` as a member."""
-    row = (
-        await db.execute(
-            text(
-                """
-                SELECT r.id, r.project_id, i.id, f.id
-                FROM public.extraction_runs r
-                JOIN public.extraction_instances i ON i.template_id = r.template_id
-                JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
-                JOIN public.extraction_fields f ON f.entity_type_id = et.id
-                WHERE NOT public.is_project_member(r.project_id, :uid)
-                LIMIT 1
-                """
-            ),
-            {"uid": str(outsider_id)},
-        )
-    ).first()
-    if row is None:
-        return None
-    return UUID(str(row[0])), UUID(str(row[1])), UUID(str(row[2])), UUID(str(row[3]))
+async def _provision_run_for_outsider(
+    db: AsyncSession,
+    outsider_id: UUID,  # noqa: ARG001
+) -> tuple[UUID, UUID, UUID, UUID]:
+    """Provision a run in a project the outsider is NOT a member of.
+
+    Returns ``(run_id, project_id, instance_id, field_id)``.
+
+    The seed deliberately ships no ``extraction_run``, so searching for a
+    pre-existing one made these tests order-dependent skips. Instead we
+    create a run inside ``SEED.primary_project`` — which the outsider (a
+    member of no project) is not in — via ``RunLifecycleService``, mirroring
+    ``_setup_consensus_run`` in ``test_extraction_consensus_service.py``. The
+    membership guard fires on the project, so a freshly created run in that
+    project exercises the same 403 path a real run would. The coordinates
+    come from the seeded instance + field, which are coherent with the
+    seeded template. The run is created on the rolled-back ``db_session``,
+    so it never persists.
+    """
+    run = await RunLifecycleService(db).create_run(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        project_template_id=SEED.primary_template,
+        user_id=SEED.primary_profile,
+    )
+    return (
+        run.id,
+        SEED.primary_project,
+        SEED.primary_instance,
+        SEED.primary_field,
+    )
 
 
 async def _pick_template_for_outsider(
@@ -164,10 +177,7 @@ async def test_get_run_403_for_non_member(
     db_session: AsyncSession,
     outsider_user: UUID,
 ) -> None:
-    fx = await _pick_run_for_outsider(db_session, outsider_user)
-    if fx is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
-    run_id, _, _, _ = fx
+    run_id, _, _, _ = await _provision_run_for_outsider(db_session, outsider_user)
 
     res = await db_client.get(f"/api/v1/runs/{run_id}")
     assert res.status_code == 403, res.text
@@ -182,10 +192,7 @@ async def test_list_run_reviewers_403_for_non_member(
     db_session: AsyncSession,
     outsider_user: UUID,
 ) -> None:
-    fx = await _pick_run_for_outsider(db_session, outsider_user)
-    if fx is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
-    run_id, _, _, _ = fx
+    run_id, _, _, _ = await _provision_run_for_outsider(db_session, outsider_user)
 
     res = await db_client.get(f"/api/v1/runs/{run_id}/reviewers")
     assert res.status_code == 403, res.text
@@ -200,10 +207,7 @@ async def test_advance_run_403_for_non_member(
     db_session: AsyncSession,
     outsider_user: UUID,
 ) -> None:
-    fx = await _pick_run_for_outsider(db_session, outsider_user)
-    if fx is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
-    run_id, _, _, _ = fx
+    run_id, _, _, _ = await _provision_run_for_outsider(db_session, outsider_user)
 
     res = await db_client.post(
         f"/api/v1/runs/{run_id}/advance",
@@ -218,10 +222,7 @@ async def test_reopen_run_403_for_non_member(
     db_session: AsyncSession,
     outsider_user: UUID,
 ) -> None:
-    fx = await _pick_run_for_outsider(db_session, outsider_user)
-    if fx is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
-    run_id, _, _, _ = fx
+    run_id, _, _, _ = await _provision_run_for_outsider(db_session, outsider_user)
 
     res = await db_client.post(f"/api/v1/runs/{run_id}/reopen")
     assert res.status_code == 403, res.text
@@ -325,25 +326,9 @@ async def test_section_extraction_run_id_403_for_non_member(
     db_session: AsyncSession,
     outsider_user: UUID,
 ) -> None:
-    fx = await _pick_run_for_outsider(db_session, outsider_user)
-    if fx is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
-    run_id, _, _, _ = fx
-    row = (
-        await db_session.execute(
-            text(
-                """
-                SELECT project_id, article_id, template_id
-                FROM public.extraction_runs
-                WHERE id = :rid
-                """
-            ),
-            {"rid": str(run_id)},
-        )
-    ).first()
-    if row is None:
-        pytest.skip("Run disappeared before request")
-    project_id, article_id, template_id = row
+    run_id, project_id, _, _ = await _provision_run_for_outsider(db_session, outsider_user)
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
 
     res = await db_client.post(
         "/api/v1/extraction/sections",
@@ -415,10 +400,7 @@ async def test_create_proposal_403_for_non_member(
     db_session: AsyncSession,
     outsider_user: UUID,
 ) -> None:
-    fx = await _pick_run_for_outsider(db_session, outsider_user)
-    if fx is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
-    run_id, _, instance_id, field_id = fx
+    run_id, _, instance_id, field_id = await _provision_run_for_outsider(db_session, outsider_user)
 
     res = await db_client.post(
         f"/api/v1/runs/{run_id}/proposals",
@@ -438,10 +420,7 @@ async def test_create_decision_403_for_non_member(
     db_session: AsyncSession,
     outsider_user: UUID,
 ) -> None:
-    fx = await _pick_run_for_outsider(db_session, outsider_user)
-    if fx is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
-    run_id, _, instance_id, field_id = fx
+    run_id, _, instance_id, field_id = await _provision_run_for_outsider(db_session, outsider_user)
 
     res = await db_client.post(
         f"/api/v1/runs/{run_id}/decisions",
@@ -460,10 +439,7 @@ async def test_create_consensus_403_for_non_member(
     db_session: AsyncSession,
     outsider_user: UUID,
 ) -> None:
-    fx = await _pick_run_for_outsider(db_session, outsider_user)
-    if fx is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
-    run_id, _, instance_id, field_id = fx
+    run_id, _, instance_id, field_id = await _provision_run_for_outsider(db_session, outsider_user)
 
     res = await db_client.post(
         f"/api/v1/runs/{run_id}/consensus",

--- a/backend/tests/integration/test_run_view_endpoint.py
+++ b/backend/tests/integration/test_run_view_endpoint.py
@@ -33,6 +33,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from app.services.run_lifecycle_service import RunLifecycleService
 from tests.integration.conftest import SEED
 
 API_PREFIX = "/api/v1/runs"
@@ -184,24 +185,22 @@ async def _open_qa_session(
     return res.json()["data"]
 
 
-async def _pick_run_for_outsider(db: AsyncSession, outsider_id: UUID) -> UUID | None:
-    """Return any run_id belonging to a project the outsider is NOT a member of."""
-    row = (
-        await db.execute(
-            text(
-                """
-                SELECT r.id
-                FROM public.extraction_runs r
-                WHERE NOT public.is_project_member(r.project_id, :uid)
-                LIMIT 1
-                """
-            ),
-            {"uid": str(outsider_id)},
-        )
-    ).first()
-    if row is None:
-        return None
-    return UUID(str(row[0]))
+async def _provision_run_outsider_cannot_see(db: AsyncSession) -> UUID:
+    """Create a run in SEED.primary_project (the outsider is not a member).
+
+    Provisioned directly via ``RunLifecycleService`` on the shared rolled-back
+    ``db_session`` so the BOLA test has a concrete run target without depending
+    on order-of-execution leftovers in the DB. The run is created as the seed
+    manager (``SEED.primary_profile``); the outsider is intentionally not a
+    member of ``primary_project``, so the ``/view`` BOLA gate must reject them.
+    """
+    run = await RunLifecycleService(db).create_run(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        project_template_id=SEED.primary_template,
+        user_id=SEED.primary_profile,
+    )
+    return run.id
 
 
 # =================== TESTS ===================
@@ -261,9 +260,8 @@ async def test_get_run_view_returns_403_for_non_member(
     outsider_user: UUID,
 ) -> None:
     """BOLA gate: a caller who is not a member of the run's project gets 403."""
-    run_id = await _pick_run_for_outsider(db_session, outsider_user)
-    if run_id is None:
-        pytest.skip("Need a run in a project the outsider does not belong to")
+    del outsider_user  # auth override active via fixture; sub is the outsider
+    run_id = await _provision_run_outsider_cannot_see(db_session)
 
     resp = await db_client.get(f"{API_PREFIX}/{run_id}/view")
     assert resp.status_code == 403, resp.text

--- a/backend/tests/integration/test_workflow_tables.py
+++ b/backend/tests/integration/test_workflow_tables.py
@@ -1,9 +1,14 @@
 """Integration tests for the 5 HITL workflow tables."""
 
+from uuid import UUID
+
 import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 WORKFLOW_TABLES = [
     "extraction_proposal_records",
@@ -12,6 +17,24 @@ WORKFLOW_TABLES = [
     "extraction_consensus_decisions",
     "extraction_published_states",
 ]
+
+
+async def _provision_run(db: AsyncSession) -> tuple[UUID, UUID, UUID]:
+    """Create a run on the seed project/article/template; return (run_id, instance_id, field_id).
+
+    The seed provides the article + template + entity_type + field +
+    instance chain but intentionally leaves ``extraction_runs`` empty, so
+    these CHECK-constraint tests must materialise their own run rather than
+    probing for a pre-existing one (which made them skip in CI). The run is
+    created on the rolled-back ``db_session``, so it never persists.
+    """
+    run = await RunLifecycleService(db).create_run(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        project_template_id=SEED.primary_template,
+        user_id=SEED.primary_profile,
+    )
+    return run.id, SEED.primary_instance, SEED.primary_field
 
 
 @pytest.mark.asyncio
@@ -55,21 +78,7 @@ async def test_workflow_table_updated_at_trigger(
 
 @pytest.mark.asyncio
 async def test_proposal_record_human_requires_user_check(db_session: AsyncSession) -> None:
-    run_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_runs LIMIT 1"))
-    ).scalar()
-    if run_id is None:
-        pytest.skip("No extraction_runs rows.")
-    instance_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_instances LIMIT 1"))
-    ).scalar()
-    if instance_id is None:
-        pytest.skip("No extraction_instances rows.")
-    field_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_fields LIMIT 1"))
-    ).scalar()
-    if field_id is None:
-        pytest.skip("No extraction_fields rows.")
+    run_id, instance_id, field_id = await _provision_run(db_session)
 
     with pytest.raises(IntegrityError):
         await db_session.execute(
@@ -89,30 +98,8 @@ async def test_proposal_record_human_requires_user_check(db_session: AsyncSessio
 async def test_reviewer_decision_accept_requires_proposal_check(
     db_session: AsyncSession,
 ) -> None:
-    run_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_runs LIMIT 1"))
-    ).scalar()
-    if run_id is None:
-        pytest.skip("No extraction_runs rows.")
-    instance_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_instances LIMIT 1"))
-    ).scalar()
-    if instance_id is None:
-        pytest.skip("No extraction_instances rows.")
-    field_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_fields LIMIT 1"))
-    ).scalar()
-    if field_id is None:
-        pytest.skip("No extraction_fields rows.")
-    reviewer_id = (
-        await db_session.execute(
-            text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
-        )
-    ).scalar()
-    if reviewer_id is None:
-        pytest.skip("No profiles rows.")
+    run_id, instance_id, field_id = await _provision_run(db_session)
+    reviewer_id = SEED.primary_profile
 
     with pytest.raises(IntegrityError):
         await db_session.execute(
@@ -137,30 +124,8 @@ async def test_reviewer_decision_accept_requires_proposal_check(
 async def test_reviewer_decision_edit_requires_value_check(
     db_session: AsyncSession,
 ) -> None:
-    run_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_runs LIMIT 1"))
-    ).scalar()
-    if run_id is None:
-        pytest.skip("No extraction_runs rows.")
-    instance_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_instances LIMIT 1"))
-    ).scalar()
-    if instance_id is None:
-        pytest.skip("No extraction_instances rows.")
-    field_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_fields LIMIT 1"))
-    ).scalar()
-    if field_id is None:
-        pytest.skip("No extraction_fields rows.")
-    reviewer_id = (
-        await db_session.execute(
-            text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
-        )
-    ).scalar()
-    if reviewer_id is None:
-        pytest.skip("No profiles rows.")
+    run_id, instance_id, field_id = await _provision_run(db_session)
+    reviewer_id = SEED.primary_profile
 
     with pytest.raises(IntegrityError):
         await db_session.execute(
@@ -185,30 +150,8 @@ async def test_reviewer_decision_edit_requires_value_check(
 async def test_consensus_decision_select_existing_requires_decision_check(
     db_session: AsyncSession,
 ) -> None:
-    run_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_runs LIMIT 1"))
-    ).scalar()
-    if run_id is None:
-        pytest.skip("No extraction_runs rows.")
-    instance_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_instances LIMIT 1"))
-    ).scalar()
-    if instance_id is None:
-        pytest.skip("No extraction_instances rows.")
-    field_id = (
-        await db_session.execute(text("SELECT id FROM public.extraction_fields LIMIT 1"))
-    ).scalar()
-    if field_id is None:
-        pytest.skip("No extraction_fields rows.")
-    consensus_user_id = (
-        await db_session.execute(
-            text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
-        )
-    ).scalar()
-    if consensus_user_id is None:
-        pytest.skip("No profiles rows.")
+    run_id, instance_id, field_id = await _provision_run(db_session)
+    consensus_user_id = SEED.primary_profile
 
     with pytest.raises(IntegrityError):
         await db_session.execute(


### PR DESCRIPTION
## What

De-flakes the **Backend Tests skip-budget guard** that is blocking the dev→main
promotion (#368). Six integration test files now **self-provision** their run /
article fixtures instead of probing the DB for a pre-existing row and skipping
when order-of-execution leaves none. This drops the integration skip count from
a flaky **29 → 4** on a clean DB (well under the guard's 25 limit), with zero new
failures.

## Why

The seed deliberately ships the article + template + entity_type + field +
instance chain but **no `extraction_runs`** row. Tests that needed a run (or a
second coordinate, or an article in a specific project) used unscoped
`SELECT ... LIMIT 1` lookups and `pytest.skip(...)` when the lookup came up
empty. Under random test ordering that made the skip count non-deterministic
(20–60), tripping the >25 skip-budget guard intermittently — a false positive
with **0 real test failures**. The picker-scoping half of the fix already
shipped in #359; this is the self-provision half.

## How

Each affected test now materialises exactly what it asserts on, on the shared
**rolled-back `db_session`** (nothing persists):

- `test_membership_guards` / `test_run_view_endpoint` — `RunLifecycleService`
  creates a run inside `SEED.primary_project` (the outsider is a member of no
  project, so the membership/BOLA guard still fires on the project).
- `test_workflow_tables` / `test_kind_discriminator` — provision a run on the
  seed's primary template for the CHECK-constraint / composite-FK assertions.
- `test_calculate_model_progress` — scope the model fixture to
  `SEED.primary_project` / `primary_article` and pass the manager `user_id`
  explicitly instead of a correlated `published_by` subquery.
- `test_extraction_review_service` — self-provision a second field on the same
  entity_type so the "second coordinate in the same template" path is always
  reachable.

No production code touched — tests only.

## Verification

`make db-fresh` → `uv run pytest tests/integration -q` on a clean 0027 DB:
**71 passed, 4 skipped, 0 failed**. ruff lint + format clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
