### PR TITLE
fix(parsing): map LlamaParse 2.x items.pages[].items[] tree to blocks

### DIFF
--- a/backend/app/infrastructure/parsing/llamaparse_parser.py
+++ b/backend/app/infrastructure/parsing/llamaparse_parser.py
@@ -10,6 +10,7 @@ scripts/parsing_bakeoff/parsers.py (one mapper, not two).
 from __future__ import annotations
 
 import tempfile
+from typing import Any
 
 from app.infrastructure.parsing.base import (
     DocumentParser,
@@ -17,21 +18,98 @@ from app.infrastructure.parsing.base import (
     normalize_block_type,
 )
 
-# LlamaParse item type -> our closed block_type
+# LlamaParse item ``type`` discriminator -> our closed block_type. The llama_cloud
+# 2.x items tree is a discriminated union (text/heading/list/code/table/image/
+# link/header/footer); anything unmapped normalises to "paragraph".
 _TYPE_MAP = {
     "text": "paragraph",
     "heading": "heading",
     "title": "heading",
     "list": "list_item",
     "list_item": "list_item",
+    "code": "paragraph",
     "table": "table_cell",
     "table_cell": "table_cell",
+    "image": "figure_caption",
     "figure_caption": "figure_caption",
     "caption": "figure_caption",
+    "link": "paragraph",
+    "header": "header",
+    "footer": "footer",
 }
 
 # Sentinel for a box-less item: bbox is NOT NULL in the DB, so never emit None.
 _SENTINEL_BBOX = {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}
+
+
+def _item_text(item: Any) -> str:
+    """Best-effort visible text for any item variant.
+
+    text/heading/code expose ``value``; link exposes ``text``; image exposes
+    ``caption``; list/table/header/footer expose only rendered ``md``. Try the
+    richest field first, then fall back to the markdown projection.
+    """
+    for attr in ("value", "text", "caption"):
+        candidate = getattr(item, attr, None)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    md = getattr(item, "md", None)
+    return md.strip() if isinstance(md, str) else ""
+
+
+def _union_bbox(raw_boxes: Any, page_height: float) -> dict[str, float]:
+    """Collapse a list of granular ``BBox`` into one PDF-space bbox.
+
+    LlamaParse returns ``bbox`` as a LIST of word/line/cell boxes in a
+    top-left origin; we take their union and Y-flip it to the PDF bottom-left
+    origin (points). Returns the sentinel when there are no boxes (the DB
+    column is NOT NULL).
+    """
+    boxes = [b for b in (raw_boxes or []) if b is not None]
+    if not boxes:
+        return dict(_SENTINEL_BBOX)
+    x0 = y0_top = float("inf")
+    x1 = y1_top = float("-inf")
+    for b in boxes:
+        x, y, w, h = float(b.x), float(b.y), float(b.w), float(b.h)
+        x0 = min(x0, x)
+        y0_top = min(y0_top, y)
+        x1 = max(x1, x + w)
+        y1_top = max(y1_top, y + h)
+    width = x1 - x0
+    height = y1_top - y0_top
+    y_bottom = page_height - y0_top - height if page_height else y0_top
+    return {"x": x0, "y": y_bottom, "width": width, "height": height}
+
+
+def _blocks_from_markdown(result: Any) -> list[ParsedBlock]:
+    """Fallback: one paragraph block per rendered markdown page.
+
+    Used when the structured items tree is empty but the document still
+    produced page markdown, so the reader is never left blank. No bboxes are
+    available on this path (sentinel).
+    """
+    markdown = getattr(result, "markdown", None)
+    blocks: list[ParsedBlock] = []
+    for page in getattr(markdown, "pages", None) or []:
+        if not getattr(page, "success", False):
+            continue
+        text = (getattr(page, "markdown", "") or "").strip()
+        if not text:
+            continue
+        page_no = int(getattr(page, "page_number", None) or len(blocks) + 1)
+        blocks.append(
+            ParsedBlock(
+                page_number=page_no,
+                block_index=0,
+                text=text,
+                char_start=0,
+                char_end=0,
+                bbox=dict(_SENTINEL_BBOX),
+                block_type="paragraph",
+            )
+        )
+    return blocks
 
 
 class LlamaParseParser(DocumentParser):
@@ -60,48 +138,45 @@ class LlamaParseParser(DocumentParser):
         return self._map_result(result)
 
     @staticmethod
-    def _map_result(result) -> list[ParsedBlock]:
-        # page_number -> page height (for the Y-flip).
-        page_heights: dict[int, float] = {}
-        for page in getattr(result, "pages", None) or []:
-            page_heights[int(page.page)] = float(getattr(page, "height", 0.0) or 0.0)
-
+    def _map_result(result: Any) -> list[ParsedBlock]:
+        # llama_cloud 2.x shape: result.items.pages[] -> {items, page_height,
+        # page_number, success}; each item is a discriminated-union block with
+        # .type, a text field, and bbox as a LIST of granular boxes. (The old
+        # flat ``result.items`` / ``result.pages`` assumption produced zero
+        # blocks — see tests/unit/test_llamaparse_parser.py.)
+        items = getattr(result, "items", None)
         blocks: list[ParsedBlock] = []
-        per_page_index: dict[int, int] = {}
 
-        for item in getattr(result, "items", None) or []:
-            text = (getattr(item, "value", "") or "").strip()
-            if not text:
-                continue
-            page_no = int(getattr(item, "page", 1))
-            block_type = normalize_block_type(_TYPE_MAP.get(getattr(item, "type", ""), "paragraph"))
-
-            raw_box = getattr(item, "bbox", None)
-            if raw_box:
-                x = float(raw_box["x"])
-                y_top = float(raw_box["y"])
-                w = float(raw_box["w"])
-                h = float(raw_box["h"])
-                page_h = page_heights.get(page_no, 0.0)
-                # Y-flip: top-left origin -> bottom-left origin.
-                y_bottom = page_h - y_top - h if page_h else y_top
-                bbox = {"x": x, "y": y_bottom, "width": w, "height": h}
-            else:
-                bbox = dict(_SENTINEL_BBOX)
-
-            idx = per_page_index.get(page_no, 0)
-            per_page_index[page_no] = idx + 1
-            blocks.append(
-                ParsedBlock(
-                    page_number=page_no,
-                    block_index=idx,
-                    text=text,
-                    char_start=0,
-                    char_end=0,
-                    bbox=bbox,
-                    block_type=block_type,
+        for page in getattr(items, "pages", None) or []:
+            if not getattr(page, "success", False):
+                continue  # ItemsPageFailedStructuredPage carries no items
+            page_height = float(getattr(page, "page_height", 0.0) or 0.0)
+            page_no = int(getattr(page, "page_number", 1) or 1)
+            idx = 0
+            for item in getattr(page, "items", None) or []:
+                text = _item_text(item)
+                if not text:
+                    continue
+                block_type = normalize_block_type(
+                    _TYPE_MAP.get(getattr(item, "type", "") or "", "paragraph")
                 )
-            )
+                bbox = _union_bbox(getattr(item, "bbox", None), page_height)
+                blocks.append(
+                    ParsedBlock(
+                        page_number=page_no,
+                        block_index=idx,
+                        text=text,
+                        char_start=0,
+                        char_end=0,
+                        bbox=bbox,
+                        block_type=block_type,
+                    )
+                )
+                idx += 1
+
+        if not blocks:
+            # Structured items empty but the doc may still have page markdown.
+            blocks = _blocks_from_markdown(result)
 
         if not blocks:
             raise ValueError("LlamaParse produced no text blocks")

--- a/backend/tests/integration/test_llamaparse_parser.py
+++ b/backend/tests/integration/test_llamaparse_parser.py
@@ -1,6 +1,16 @@
 # backend/tests/integration/test_llamaparse_parser.py
 from unittest.mock import MagicMock, patch
 
+from llama_cloud.types.b_box import BBox
+from llama_cloud.types.code_item import CodeItem
+from llama_cloud.types.heading_item import HeadingItem
+from llama_cloud.types.parsing_get_response import (
+    Items,
+    ItemsPageStructuredResultPage,
+    ParsingGetResponse,
+)
+from llama_cloud.types.text_item import TextItem
+
 from app.infrastructure.parsing.base import (
     BLOCK_TYPES,
     assign_char_offsets_to_blocks,
@@ -9,27 +19,35 @@ from app.infrastructure.parsing.base import (
 from app.infrastructure.parsing.llamaparse_parser import LlamaParseParser
 
 
-def _fake_result():
-    # Minimal items tree + page sizes mirroring the agentic granular-bbox shape.
-    # One heading + one box-less item on page 1 (page_height = 800), top-left origin.
-    return MagicMock(
-        pages=[MagicMock(page=1, height=800.0, width=600.0)],
+def _fake_result() -> ParsingGetResponse:
+    # Real llama_cloud 2.x models (NOT a hand-shaped MagicMock — the previous
+    # mock encoded a flat result.items/result.pages shape the SDK never returns,
+    # which is exactly why the prod mapper silently produced zero blocks).
+    # One structured page (height 800, top-left origin): heading + box-less text
+    # + a code item that normalises to paragraph.
+    page = ItemsPageStructuredResultPage(
+        page_number=1,
+        page_height=800.0,
+        page_width=600.0,
+        success=True,
         items=[
-            MagicMock(
+            HeadingItem(
                 type="heading",
-                page=1,
+                level=1,
                 value="Results",
-                bbox={"x": 50.0, "y": 100.0, "w": 200.0, "h": 20.0},
+                md="# Results",
+                bbox=[BBox(x=50.0, y=100.0, w=200.0, h=20.0)],
             ),
-            MagicMock(type="text", page=1, value="A box-less line", bbox=None),
-            MagicMock(
-                type="weird_unknown",
-                page=1,
+            TextItem(type="text", value="A box-less line", md="A box-less line", bbox=None),
+            CodeItem(
+                type="code",
                 value="Mystery",
-                bbox={"x": 10.0, "y": 700.0, "w": 80.0, "h": 12.0},
+                md="`Mystery`",
+                bbox=[BBox(x=10.0, y=700.0, w=80.0, h=12.0)],
             ),
         ],
     )
+    return ParsingGetResponse.model_construct(items=Items(pages=[page]), markdown=None)
 
 
 def test_llamaparse_maps_items_to_blocks_with_yflip():
@@ -47,7 +65,7 @@ def test_llamaparse_maps_items_to_blocks_with_yflip():
         assert kwargs["output_options"] == {"granular_bboxes": ["word", "line", "cell"]}
         assert set(kwargs["expand"]) == {"markdown", "items"}
 
-    # block_type mapping: heading->heading, text->paragraph, unknown->paragraph
+    # block_type mapping: heading->heading, text->paragraph, code->paragraph
     by_text = {b.text: b for b in blocks}
     assert by_text["Results"].block_type == "heading"
     assert by_text["A box-less line"].block_type == "paragraph"

--- a/backend/tests/unit/test_llamaparse_parser.py
+++ b/backend/tests/unit/test_llamaparse_parser.py
@@ -1,0 +1,107 @@
+"""Unit tests for the LlamaParse result -> ParsedBlock mapping.
+
+These build *real* ``llama_cloud`` 2.x response models (not duck-typed fakes)
+so the mapper is pinned to the SDK's actual ``items.pages[].items[]`` shape
+and cannot silently drift back to the old (broken) flat ``result.items``
+assumption that produced zero blocks in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+from llama_cloud.types.b_box import BBox
+from llama_cloud.types.heading_item import HeadingItem
+from llama_cloud.types.parsing_get_response import (
+    Items,
+    ItemsPageFailedStructuredPage,
+    ItemsPageStructuredResultPage,
+    Markdown,
+    MarkdownPageMarkdownResultPage,
+    ParsingGetResponse,
+)
+from llama_cloud.types.text_item import TextItem
+
+from app.infrastructure.parsing.llamaparse_parser import LlamaParseParser
+
+
+def _response(
+    *, items: Items | None = None, markdown: Markdown | None = None
+) -> ParsingGetResponse:
+    """Build a minimal ParsingGetResponse with only the fields the mapper reads."""
+    return ParsingGetResponse.model_construct(items=items, markdown=markdown)
+
+
+def test_maps_structured_page_items_to_blocks_with_y_flip() -> None:
+    heading = HeadingItem(
+        type="heading",
+        level=1,
+        value="Title",
+        md="# Title",
+        bbox=[BBox(x=5.0, y=5.0, w=200.0, h=20.0)],
+    )
+    text = TextItem(
+        type="text",
+        value="Hello world",
+        md="Hello world",
+        bbox=[BBox(x=10.0, y=20.0, w=100.0, h=12.0)],
+    )
+    page = ItemsPageStructuredResultPage(
+        items=[heading, text], page_height=800.0, page_number=1, page_width=600.0, success=True
+    )
+    result = _response(items=Items(pages=[page]))
+
+    blocks = LlamaParseParser._map_result(result)
+
+    assert [b.text for b in blocks] == ["Title", "Hello world"]
+    assert [b.block_type for b in blocks] == ["heading", "paragraph"]
+    assert [b.page_number for b in blocks] == [1, 1]
+    assert [b.block_index for b in blocks] == [0, 1]
+    # Y-flip from top-left origin to PDF bottom-left: y_bottom = page_h - y_top - h.
+    assert blocks[0].bbox == {"x": 5.0, "y": 775.0, "width": 200.0, "height": 20.0}
+    assert blocks[1].bbox == {"x": 10.0, "y": 768.0, "width": 100.0, "height": 12.0}
+
+
+def test_skips_failed_pages_and_empty_items() -> None:
+    good = ItemsPageStructuredResultPage(
+        items=[TextItem(type="text", value="keep", md="keep", bbox=None)],
+        page_height=500.0,
+        page_number=2,
+        page_width=400.0,
+        success=True,
+    )
+    failed = ItemsPageFailedStructuredPage(error="boom", page_number=1, success=False)
+    result = _response(items=Items(pages=[failed, good]))
+
+    blocks = LlamaParseParser._map_result(result)
+
+    assert len(blocks) == 1
+    assert blocks[0].text == "keep"
+    assert blocks[0].page_number == 2
+    # No bbox on the item -> sentinel (DB column is NOT NULL).
+    assert blocks[0].bbox == {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}
+
+
+def test_falls_back_to_markdown_pages_when_no_structured_items() -> None:
+    # A document that parsed (markdown present) but yielded no structured
+    # items must still produce blocks so the reader is not empty.
+    md = Markdown(
+        pages=[
+            MarkdownPageMarkdownResultPage(
+                markdown="## Page one\n\nBody.", page_number=1, success=True
+            ),
+            MarkdownPageMarkdownResultPage(markdown="Page two body.", page_number=2, success=True),
+        ]
+    )
+    result = _response(items=Items(pages=[]), markdown=md)
+
+    blocks = LlamaParseParser._map_result(result)
+
+    assert [b.page_number for b in blocks] == [1, 2]
+    assert "Page one" in blocks[0].text
+    assert blocks[1].text == "Page two body."
+
+
+def test_raises_only_when_truly_empty() -> None:
+    result = _response(items=Items(pages=[]), markdown=Markdown(pages=[]))
+    with pytest.raises(ValueError, match="no text blocks"):
+        LlamaParseParser._map_result(result)


### PR DESCRIPTION
## What

Fixes the LlamaParse result→`ParsedBlock` mapping so parsed PDFs actually
produce `article_text_blocks`. Discovered live: after the deploy of #359/#368,
re-parsing a real article routed to LlamaParse correctly (no more `libxcb`
crash) but failed with **`ValueError: LlamaParse produced no text blocks`**.

## Root cause

The mapper assumed a flat shape — `result.items` as a list of blocks and a
top-level `result.pages` — but `llama_cloud` 2.x returns:

```
ParsingGetResponse
  .items: Items
    .pages: [ ItemsPageStructuredResultPage { items, page_height, page_number, success } | ...Failed ]
  .markdown: Markdown { pages: [...] }
```

Each item is a discriminated-union block (`text`/`heading`/`list`/`code`/
`table`/`image`/`link`/`header`/`footer`) whose `bbox` is a **list** of granular
boxes. Iterating the `Items` wrapper yielded pydantic `(field, value)` tuples
with empty `.value` → every block skipped → "no text blocks" on the first prod
parse.

The shape was **never validated**: the bakeoff `_map_llamaparse_result` it was
modeled on is a `NotImplementedError` stub, and the existing integration test
asserted a hand-built `MagicMock` matching the *imagined* flat shape (testing
the mock, not the SDK).

## Fix

- Walk `result.items.pages`, skip failed pages, use `page.page_height` for the
  Y-flip and `page.page_number`.
- Extract text per variant (`value`/`text`/`caption`/`md`) and **union** the
  `List[BBox]` into one PDF-space (Y-flipped) box.
- Fall back to one block per rendered markdown page when the items tree is
  empty, so the reader is never left blank.

## Tests

- New `tests/unit/test_llamaparse_parser.py` builds **real `llama_cloud`
  models** (heading/text/code/page/bbox) so the mapper is pinned to the SDK's
  actual shape and can't silently drift back. Covers Y-flip, failed-page skip,
  box-less sentinel, and the markdown fallback.
- Rebuilt `tests/integration/test_llamaparse_parser.py` on real models instead
  of the mis-shaped mock (kept the SDK-call-shape assertions).
- Full parsing suite green (23 passed); ruff clean.

End-to-end proof (blocks populating for the real "teste 2" file) lands after
this deploys.
