### PR TITLE
fix: post-merge review — criticals, BOLAs, edit-loss, QA finalize + cleanups

### DIFF
--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -106,7 +106,9 @@ async def post_form_runs(
     """
     await ensure_project_member(db, body.project_id, current_user_sub)
 
-    refs = await resolve_form_runs(db, body.article_ids, template_id=body.template_id)
+    refs = await resolve_form_runs(
+        db, body.article_ids, project_id=body.project_id, template_id=body.template_id
+    )
     return ApiResponse.success(refs, trace_id=_trace(request))
 
 

--- a/backend/app/services/extraction_export_service.py
+++ b/backend/app/services/extraction_export_service.py
@@ -1948,14 +1948,24 @@ def _build_tidy_tables(
     value_map: dict[tuple[Any, ...], Any],
     mode: ExportMode,
 ) -> tuple[TidyTable, ...]:
-    """One publication table per non-container section at its cardinality grain.
+    """One publication table per non-container section at its record grain.
 
-    ``cardinality==MANY`` fans out one row per (article × instance) for ANY
-    role (spec §5.2 — never a ``role==MODEL_SECTION`` allow-list); ``ONE``
-    yields one row per article. Columns are the section fields in their
-    resolved order; values are baked from ``value_map`` (already-resolved
-    scalars — §5.3). The ``MODEL_CONTAINER`` and field-less sections are
-    skipped (nothing to project).
+    The record axis is selected by ROLE first, then cardinality — mirroring
+    ``matrix._resolve_instance_id``:
+
+      * ``MODEL_SECTION`` fans out one row per model instance
+        (``article.model_instances``) regardless of its own cardinality.
+        Production model sections are ``cardinality='one'``; the N-model
+        fan-out is always sourced from ``model_instances``, never from
+        ``section_instances`` (spec §5.2).
+      * non-model ``cardinality==MANY`` fans out one row per instance
+        (``section_instances``).
+      * non-model ``cardinality==ONE`` yields one row per article.
+
+    Columns are the section fields in their resolved order; values are baked
+    from ``value_map`` (already-resolved scalars — §5.3). The
+    ``MODEL_CONTAINER`` and field-less sections are skipped (nothing to
+    project).
     """
     tables: list[TidyTable] = []
     for section in sections:
@@ -1969,20 +1979,30 @@ def _build_tidy_tables(
         for article in articles:
             if article.run_id is None:
                 continue
-            if section.cardinality is ExtractionCardinality.MANY:
-                if section.role is ExtractionEntityRole.MODEL_SECTION:
-                    instances = article.model_instances
-                    label_stem = "Model"
-                else:
-                    instances = article.section_instances.get(section.entity_type_id, ())
-                    label_stem = section.label
+            if section.role is ExtractionEntityRole.MODEL_SECTION:
+                # Role-first: model sections always fan out over model_instances
+                # regardless of their own cardinality (production model sections
+                # are cardinality ONE, yet carry one record per model).
+                for idx, instance_id in enumerate(article.model_instances, start=1):
+                    rows.append(
+                        _tidy_row(
+                            section=section,
+                            article=article,
+                            instance_id=instance_id,
+                            record_label=f"{article.header_label} — Model {idx}",
+                            value_map=value_map,
+                            mode=mode,
+                        )
+                    )
+            elif section.cardinality is ExtractionCardinality.MANY:
+                instances = article.section_instances.get(section.entity_type_id, ())
                 for idx, instance_id in enumerate(instances, start=1):
                     rows.append(
                         _tidy_row(
                             section=section,
                             article=article,
                             instance_id=instance_id,
-                            record_label=f"{article.header_label} — {label_stem} {idx}",
+                            record_label=f"{article.header_label} — {section.label} {idx}",
                             value_map=value_map,
                             mode=mode,
                         )

--- a/backend/app/services/extraction_export_service.py
+++ b/backend/app/services/extraction_export_service.py
@@ -738,11 +738,9 @@ class ExtractionExportService(LoggerMixin):
     ) -> tuple[ProjectExtractionTemplate, Any]:
         """Load the project template + its currently-active version row.
 
-        Scoped by ``project_id`` (defense-in-depth, mirroring the reviewer
-        picker query): a template id belonging to another project must not
-        resolve here even though the caller passed our own project's
-        membership gate — otherwise the async export path would build and
-        upload a workbook carrying a foreign project's template metadata.
+        Scoped by ``project_id`` (BOLA): a template id from another project must
+        not resolve even though the caller passed our own project's gate, else
+        the async export path would leak a foreign project's template metadata.
         """
         template = (
             await self.db.execute(
@@ -1961,22 +1959,11 @@ def _build_tidy_tables(
 ) -> tuple[TidyTable, ...]:
     """One publication table per non-container section at its record grain.
 
-    The record axis is selected by ROLE first, then cardinality — mirroring
-    ``matrix._resolve_instance_id``:
-
-      * ``MODEL_SECTION`` fans out one row per model instance
-        (``article.model_instances``) regardless of its own cardinality.
-        Production model sections are ``cardinality='one'``; the N-model
-        fan-out is always sourced from ``model_instances``, never from
-        ``section_instances`` (spec §5.2).
-      * non-model ``cardinality==MANY`` fans out one row per instance
-        (``section_instances``).
-      * non-model ``cardinality==ONE`` yields one row per article.
-
-    Columns are the section fields in their resolved order; values are baked
-    from ``value_map`` (already-resolved scalars — §5.3). The
-    ``MODEL_CONTAINER`` and field-less sections are skipped (nothing to
-    project).
+    Record axis is selected by ROLE first, then cardinality (mirrors
+    ``matrix._resolve_instance_id``): a ``MODEL_SECTION`` fans out one row per
+    ``model_instances`` entry regardless of its own cardinality (spec §5.2);
+    non-model ``MANY`` fans out per ``section_instances``; non-model ``ONE`` is
+    one row per article. ``MODEL_CONTAINER`` and field-less sections are skipped.
     """
     tables: list[TidyTable] = []
     for section in sections:
@@ -1991,44 +1978,26 @@ def _build_tidy_tables(
             if article.run_id is None:
                 continue
             if section.role is ExtractionEntityRole.MODEL_SECTION:
-                # Role-first: model sections always fan out over model_instances
-                # regardless of their own cardinality (production model sections
-                # are cardinality ONE, yet carry one record per model).
-                for idx, instance_id in enumerate(article.model_instances, start=1):
-                    rows.append(
-                        _tidy_row(
-                            section=section,
-                            article=article,
-                            instance_id=instance_id,
-                            record_label=f"{article.header_label} — Model {idx}",
-                            value_map=value_map,
-                            mode=mode,
-                        )
-                    )
+                instances = article.model_instances
+                stem = "Model"
             elif section.cardinality is ExtractionCardinality.MANY:
                 instances = article.section_instances.get(section.entity_type_id, ())
-                for idx, instance_id in enumerate(instances, start=1):
-                    rows.append(
-                        _tidy_row(
-                            section=section,
-                            article=article,
-                            instance_id=instance_id,
-                            record_label=f"{article.header_label} — {section.label} {idx}",
-                            value_map=value_map,
-                            mode=mode,
-                        )
-                    )
+                stem = section.label
             else:
-                instances = article.section_instances.get(section.entity_type_id, ())
-                instance_id = instances[0] if instances else None
-                if instance_id is None:
-                    continue
+                instances = article.section_instances.get(section.entity_type_id, ())[:1]
+                stem = None
+            for idx, instance_id in enumerate(instances, start=1):
+                label = (
+                    article.header_label
+                    if stem is None
+                    else f"{article.header_label} — {stem} {idx}"
+                )
                 rows.append(
                     _tidy_row(
                         section=section,
                         article=article,
                         instance_id=instance_id,
-                        record_label=article.header_label,
+                        record_label=label,
                         value_map=value_map,
                         mode=mode,
                     )

--- a/backend/app/services/extraction_export_service.py
+++ b/backend/app/services/extraction_export_service.py
@@ -430,7 +430,7 @@ class ExtractionExportService(LoggerMixin):
         map and returns a fully-populated ``ExportLayout``. Columns are
         anchored on the active-version snapshot (spec §5.1).
         """
-        template, version = await self._load_active_template_version(template_id)
+        template, version = await self._load_active_template_version(template_id, project_id)
         project_name = await self._resolve_project_name(project_id)
         sections = await self._load_sections(version.id)
         data_dictionary = _build_data_dictionary(sections)
@@ -734,11 +734,22 @@ class ExtractionExportService(LoggerMixin):
     async def _load_active_template_version(
         self,
         template_id: UUID,
+        project_id: UUID,
     ) -> tuple[ProjectExtractionTemplate, Any]:
-        """Load the project template + its currently-active version row."""
+        """Load the project template + its currently-active version row.
+
+        Scoped by ``project_id`` (defense-in-depth, mirroring the reviewer
+        picker query): a template id belonging to another project must not
+        resolve here even though the caller passed our own project's
+        membership gate — otherwise the async export path would build and
+        upload a workbook carrying a foreign project's template metadata.
+        """
         template = (
             await self.db.execute(
-                select(ProjectExtractionTemplate).where(ProjectExtractionTemplate.id == template_id)
+                select(ProjectExtractionTemplate).where(
+                    ProjectExtractionTemplate.id == template_id,
+                    ProjectExtractionTemplate.project_id == project_id,
+                )
             )
         ).scalar_one_or_none()
         if template is None:

--- a/backend/app/services/extraction_run_read_service.py
+++ b/backend/app/services/extraction_run_read_service.py
@@ -574,6 +574,7 @@ async def resolve_form_runs(
     db: AsyncSession,
     article_ids: list[UUID],
     *,
+    project_id: UUID,
     template_id: UUID,
 ) -> list[ArticleRunRef]:
     """Resolve the latest relevant run per article for the extraction form.
@@ -582,6 +583,11 @@ async def resolve_form_runs(
     - Per article: latest non-terminal run; else latest finalized run.
     - Cancelled runs are excluded.
     - Returns one ArticleRunRef per input article_id (run_id=None when no run).
+
+    Scoped by ``project_id`` (BOLA): the caller's membership is gated on
+    ``project_id``, so runs must be resolved within that project. Without this
+    filter a member of project P could pass ``article_ids`` belonging to a
+    different project Q and read back Q's run ids (confused-deputy IDOR).
     """
     if not article_ids:
         return []
@@ -592,6 +598,7 @@ async def resolve_form_runs(
     stmt = (
         select(ExtractionRun)
         .where(
+            ExtractionRun.project_id == project_id,
             ExtractionRun.article_id.in_(article_ids),
             ExtractionRun.template_id == template_id,
             ExtractionRun.kind == "extraction",

--- a/backend/tests/integration/test_extraction_export_template_bola.py
+++ b/backend/tests/integration/test_extraction_export_template_bola.py
@@ -1,0 +1,56 @@
+"""Regression: export template load must be scoped by project_id (BOLA).
+
+``_load_active_template_version`` loaded the template by id alone, so a member
+of project A could request an export with ``project_id=A`` (passing the
+membership gate in ``assert_can_export``) but ``template_id`` belonging to
+project B. The async (Celery) export path then built and uploaded a downloadable
+workbook carrying project B's template metadata — a cross-project info leak.
+
+The loader now filters by ``project_id``, mirroring the reviewer-picker query.
+See post-merge review 2026-06-21.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.error_handler import NotFoundError
+from app.services.extraction_export_service import ExtractionExportService
+from tests.integration.conftest import SEED
+
+pytestmark = pytest.mark.asyncio
+
+
+def _service(db: AsyncSession) -> ExtractionExportService:
+    return ExtractionExportService(db=db, user_id=str(SEED.primary_profile), storage=MagicMock())
+
+
+async def test_template_load_rejects_cross_project_template(db_session: AsyncSession) -> None:
+    """Loading primary_template under the WRONG project must not resolve.
+
+    primary_template belongs to primary_project; requesting it under
+    secondary_project must raise a template-level NotFoundError (the project
+    filter excluded it), never leak the foreign template.
+    """
+    with pytest.raises(NotFoundError) as exc:
+        await _service(db_session)._load_active_template_version(
+            SEED.primary_template, SEED.secondary_project
+        )
+    assert "not found" in str(exc.value).lower()
+    await db_session.rollback()
+
+
+async def test_template_load_resolves_under_owning_project(db_session: AsyncSession) -> None:
+    """Positive control: the project filter does not over-reject the owner.
+
+    Loading primary_template under primary_project resolves the template
+    (proving the added project_id predicate matches the legitimate case).
+    """
+    template, _version = await _service(db_session)._load_active_template_version(
+        SEED.primary_template, SEED.primary_project
+    )
+    assert template.id == SEED.primary_template
+    await db_session.rollback()

--- a/backend/tests/integration/test_run_resolution_endpoints.py
+++ b/backend/tests/integration/test_run_resolution_endpoints.py
@@ -339,3 +339,36 @@ async def test_form_runs_returns_403_for_non_member(
     }
     resp = await db_client.post(f"{_ARTICLES_URL}/form-runs", json=body)
     assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_form_runs_scopes_resolution_to_body_project_id(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """BOLA: runs are resolved only within the body's project_id.
+
+    Confused-deputy regression. ``primary_profile`` is a member of BOTH
+    projects, so claiming ``secondary_project`` passes the membership gate.
+    The article's run lives in ``primary_project``; scoping the resolver by
+    ``project_id`` must therefore return ``run_id=None`` instead of leaking
+    the cross-project run id. Before the fix ``resolve_form_runs`` filtered
+    only on ``article_ids``+``template_id`` and returned the foreign run.
+    """
+    created = await _create_extraction_run(db_client)  # run in primary_project
+    assert created["id"]
+    article_id = str(SEED.primary_article)
+
+    body = {
+        "article_ids": [article_id],
+        "template_id": str(SEED.primary_template),
+        "project_id": str(SEED.secondary_project),  # claimed project != run's project
+    }
+    resp = await db_client.post(f"{_ARTICLES_URL}/form-runs", json=body)
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["article_id"] == article_id
+    assert data[0]["run_id"] is None, "a run from another project must not leak"

--- a/backend/tests/unit/test_extraction_export_service.py
+++ b/backend/tests/unit/test_extraction_export_service.py
@@ -1805,7 +1805,7 @@ class TestLoadActiveTemplateVersion:
         svc.db.execute = AsyncMock(return_value=result_mock)
 
         with pytest.raises(NotFoundError):
-            await svc._load_active_template_version(template_id)
+            await svc._load_active_template_version(template_id, uuid4())
 
     @pytest.mark.asyncio
     async def test_template_found_no_version_raises_not_found_error(self, monkeypatch):
@@ -1829,7 +1829,7 @@ class TestLoadActiveTemplateVersion:
         )
 
         with pytest.raises(NotFoundError):
-            await svc._load_active_template_version(template_id)
+            await svc._load_active_template_version(template_id, uuid4())
 
     @pytest.mark.asyncio
     async def test_template_and_version_found_returns_tuple(self, monkeypatch):
@@ -1852,7 +1852,7 @@ class TestLoadActiveTemplateVersion:
             lambda _: version_repo_mock,
         )
 
-        template, version = await svc._load_active_template_version(template_id)
+        template, version = await svc._load_active_template_version(template_id, uuid4())
         assert template is template_mock
         assert version is version_mock
 

--- a/backend/tests/unit/test_extraction_export_tidy_model_section.py
+++ b/backend/tests/unit/test_extraction_export_tidy_model_section.py
@@ -1,0 +1,103 @@
+"""Regression: cardinality=ONE MODEL_SECTION tidy tables must source rows from
+``model_instances`` (role-first), mirroring the matrix builder. Pure — no DB.
+
+Bug (post-merge review 2026-06-21): ``_build_tidy_tables`` read
+``section_instances`` in the cardinality=ONE branch, but model-section
+instances live in ``model_instances``. Every production CHARMS model section
+(model_development / model_performance / model_validation / model_results /
+model_interpretation — all ``cardinality='one'``) therefore rendered with zero
+rows, silently dropping every prediction-model value from the publication
+tidy-table sheet while the matrix sheet showed them correctly.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from app.models.extraction import (
+    ExtractionCardinality,
+    ExtractionEntityRole,
+    ExtractionFieldType,
+)
+from app.services.extraction_export_service import (
+    ArticleDescriptor,
+    ExportMode,
+    FieldDescriptor,
+    SectionDescriptor,
+    _build_tidy_tables,
+)
+
+
+def _model_section(field_id):
+    return SectionDescriptor(
+        entity_type_id=uuid4(),
+        label="Model development",
+        role=ExtractionEntityRole.MODEL_SECTION,
+        parent_entity_type_id=uuid4(),
+        fields=(
+            FieldDescriptor(
+                field_id=field_id,
+                label="Method",
+                type=ExtractionFieldType.TEXT,
+                allowed_values=(),
+                parent_section_id=uuid4(),
+            ),
+        ),
+        # Production model sections are cardinality ONE; the N-model fan-out
+        # is sourced from model_instances, never from cardinality MANY.
+        cardinality=ExtractionCardinality.ONE,
+    )
+
+
+def test_cardinality_one_model_section_emits_one_row_per_model():
+    field_id = uuid4()
+    section = _model_section(field_id)
+    run_id = uuid4()
+    model_iid = uuid4()
+    article = ArticleDescriptor(
+        article_id=uuid4(),
+        header_label="Gaca, 2011",
+        run_id=run_id,
+        run_stage=None,
+        version_id=None,
+        model_instances=(model_iid,),
+        section_instances={},  # model sections never populate section_instances
+    )
+    value_map = {(run_id, model_iid, field_id): "Logistic regression"}
+
+    tables = _build_tidy_tables((section,), (article,), value_map, ExportMode.CONSENSUS)
+
+    assert len(tables) == 1
+    rows = tables[0].rows
+    assert len(rows) == 1, "cardinality=ONE model section must emit a row from model_instances"
+    assert rows[0].instance_id == model_iid
+    assert rows[0].values == ("Logistic regression",)
+
+
+def test_cardinality_one_model_section_fans_out_over_multiple_models():
+    field_id = uuid4()
+    section = _model_section(field_id)
+    run_id = uuid4()
+    m1, m2 = uuid4(), uuid4()
+    article = ArticleDescriptor(
+        article_id=uuid4(),
+        header_label="Gaca, 2011",
+        run_id=run_id,
+        run_stage=None,
+        version_id=None,
+        model_instances=(m1, m2),
+        section_instances={},
+    )
+    value_map = {
+        (run_id, m1, field_id): "Logistic regression",
+        (run_id, m2, field_id): "Cox model",
+    }
+
+    tables = _build_tidy_tables((section,), (article,), value_map, ExportMode.CONSENSUS)
+
+    rows = tables[0].rows
+    assert [r.values[0] for r in rows] == ["Logistic regression", "Cox model"]
+    assert [r.record_label for r in rows] == [
+        "Gaca, 2011 — Model 1",
+        "Gaca, 2011 — Model 2",
+    ]

--- a/backend/tests/unit/test_extraction_export_tidy_model_section.py
+++ b/backend/tests/unit/test_extraction_export_tidy_model_section.py
@@ -74,6 +74,51 @@ def test_cardinality_one_model_section_emits_one_row_per_model():
     assert rows[0].values == ("Logistic regression",)
 
 
+def test_cardinality_many_study_section_fans_out_over_section_instances():
+    # Non-model MANY branch: one row per section_instance (not model_instances).
+    field_id = uuid4()
+    section = SectionDescriptor(
+        entity_type_id=uuid4(),
+        label="Outcomes",
+        role=ExtractionEntityRole.STUDY_SECTION,
+        parent_entity_type_id=None,
+        fields=(
+            FieldDescriptor(
+                field_id=field_id,
+                label="Name",
+                type=ExtractionFieldType.TEXT,
+                allowed_values=(),
+                parent_section_id=uuid4(),
+            ),
+        ),
+        cardinality=ExtractionCardinality.MANY,
+    )
+    run_id = uuid4()
+    i1, i2 = uuid4(), uuid4()
+    article = ArticleDescriptor(
+        article_id=uuid4(),
+        header_label="Gaca, 2011",
+        run_id=run_id,
+        run_stage=None,
+        version_id=None,
+        model_instances=(),
+        section_instances={section.entity_type_id: (i1, i2)},
+    )
+    value_map = {
+        (run_id, i1, field_id): "OS",
+        (run_id, i2, field_id): "PFS",
+    }
+
+    tables = _build_tidy_tables((section,), (article,), value_map, ExportMode.CONSENSUS)
+
+    rows = tables[0].rows
+    assert [r.values[0] for r in rows] == ["OS", "PFS"]
+    assert [r.record_label for r in rows] == [
+        "Gaca, 2011 — Outcomes 1",
+        "Gaca, 2011 — Outcomes 2",
+    ]
+
+
 def test_cardinality_one_model_section_fans_out_over_multiple_models():
     field_id = uuid4()
     section = _model_section(field_id)

--- a/backend/tests/unit/test_form_runs_endpoint_unit.py
+++ b/backend/tests/unit/test_form_runs_endpoint_unit.py
@@ -1,0 +1,41 @@
+"""Direct endpoint-coroutine unit test for POST /articles/form-runs.
+
+The integration coverage (test_run_resolution_endpoints) exercises this through
+the ASGI transport, whose handler lines do not register on coverage (the 80%
+diff-cover gate's blind spot). This calls the coroutine directly so the
+BOLA-scoped resolve_form_runs call is covered — mirrors test_article_files_unit.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.api.v1.endpoints.articles import post_form_runs
+from app.schemas.extraction_run import ArticleRunRef, FormRunsRequest
+
+_EP = "app.api.v1.endpoints.articles"
+
+
+@pytest.mark.asyncio
+async def test_form_runs_endpoint_threads_project_id_into_resolver() -> None:
+    pid, aid, tid = uuid4(), uuid4(), uuid4()
+    refs = [ArticleRunRef(article_id=aid, run_id=None)]
+    body = FormRunsRequest(article_ids=[aid], template_id=tid, project_id=pid)
+
+    with (
+        patch(f"{_EP}.ensure_project_member", AsyncMock()) as gate,
+        patch(f"{_EP}.resolve_form_runs", AsyncMock(return_value=refs)) as resolve,
+        patch(f"{_EP}._trace", return_value=None),
+    ):
+        resp = await post_form_runs(
+            body=body, request=MagicMock(), db=AsyncMock(), current_user_sub=uuid4()
+        )
+
+    gate.assert_awaited_once()
+    # BOLA: the body's project_id must scope the resolver, not just the gate.
+    _, kwargs = resolve.call_args
+    assert kwargs["project_id"] == pid
+    assert kwargs["template_id"] == tid
+    assert resp.ok is True
+    assert resp.data == refs

--- a/frontend/hooks/extraction/__tests__/useCitationHighlight.noProvider.test.ts
+++ b/frontend/hooks/extraction/__tests__/useCitationHighlight.noProvider.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression (post-merge review 2026-06-21): useCitationHighlight must degrade
+ * to a safe no-op when rendered OUTSIDE a ViewerProvider — the QA "jump to
+ * source" / AI suggestion-details modal mounts it with no PDF viewer present.
+ *
+ * It previously crashed with "useViewerStore must be used within a
+ * ViewerProvider" because the inner usePageHandle hook subscribed via the
+ * throwing useViewerStore during render, before the storeApi==null guard.
+ *
+ * This file deliberately does NOT mock usePageHandle — it exercises the REAL
+ * hook chain, so the no-op contract is actually verified. The sibling
+ * useCitationHighlight.test.ts mocks usePageHandle away and therefore could
+ * never observe this crash.
+ */
+import {renderHook, act} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+
+import {useCitationHighlight} from '../useCitationHighlight';
+
+const REGION_ANCHOR: CitationAnchor = {
+  kind: 'region',
+  page: 2,
+  rect: {x: 10, y: 10, width: 100, height: 20},
+};
+
+describe('useCitationHighlight without a ViewerProvider', () => {
+  it('mounts without throwing and reports isAvailable=false', () => {
+    const {result} = renderHook(() => useCitationHighlight());
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.activeHighlight).toBeNull();
+  });
+
+  it('highlight() and clear() are safe no-ops', () => {
+    const {result} = renderHook(() => useCitationHighlight());
+    expect(() => {
+      act(() => {
+        result.current.highlight(REGION_ANCHOR);
+        result.current.clear();
+      });
+    }).not.toThrow();
+    expect(result.current.activeHighlight).toBeNull();
+  });
+});

--- a/frontend/hooks/extraction/useModelManagement.ts
+++ b/frontend/hooks/extraction/useModelManagement.ts
@@ -238,7 +238,7 @@ export function useModelManagement({
     });
 
     // Update local state - remove model and capture name for toast
-    let removedModelName = 'Modelo';
+    let removedModelName = 'Model';
     let updatedModels: Model[] = [];
 
     setModels(prev => {
@@ -271,7 +271,6 @@ export function useModelManagement({
       return updatedModels[0].instanceId;
     });
 
-    console.warn('✅ Modelo removido:', removedModelName);
     toast.success(t('extraction', 'modelRemovedSuccess').replace('{{label}}', removedModelName));
   };
 

--- a/frontend/hooks/runs/useAutoSaveProposals.ts
+++ b/frontend/hooks/runs/useAutoSaveProposals.ts
@@ -160,7 +160,7 @@ export function useAutoSaveProposals(
   const [lastSavedByKey, setLastSavedByKey] = useState<Record<string, string>>({});
   // React state is async, so ``saveState === 'saving'`` cannot be used
   // as a synchronous lock across overlapping ``performSave`` invocations.
-  const activeSavePromiseRef = useRef<Promise<void> | null>(null);
+  const activeSavePromiseRef = useRef<Promise<boolean> | null>(null);
 
   const computeDirtyEntries = (): Array<[string, unknown]> =>
     selectDirtyEntries(
@@ -169,7 +169,7 @@ export function useAutoSaveProposals(
       baselineRef.current,
     );
 
-  const performSave = (): Promise<void> => {
+  const performSave = (): Promise<boolean> => {
     // Serialize concurrent saves: wait for any in-flight batch, swallowing
     // its error (the owner invocation surfaces it; queued calls still retry
     // dirty values that weren't acknowledged).
@@ -177,7 +177,7 @@ export function useAutoSaveProposals(
       ? activeSavePromiseRef.current.catch(() => undefined)
       : Promise.resolve();
 
-    const savePromise: Promise<void> = waitForActive.then(() => {
+    const savePromise: Promise<boolean> = waitForActive.then(() => {
       const currentRunId = runIdRef.current;
       // Skip when there's no run, autosave is disabled, or the run stage
       // does not accept writes (consensus/finalized/pending). The stage
@@ -188,10 +188,10 @@ export function useAutoSaveProposals(
         !enabledRef.current ||
         !isWritableStage(stageRef.current)
       )
-        return;
+        return true;
 
       const dirty = computeDirtyEntries();
-      if (dirty.length === 0) return;
+      if (dirty.length === 0) return true;
 
       setSaveState('saving');
       setError(null);
@@ -253,7 +253,7 @@ export function useAutoSaveProposals(
       });
 
       return batchPromise.then(
-        () => undefined,
+        () => true,
         (err: unknown) => {
           const message =
             err instanceof Error
@@ -263,6 +263,11 @@ export function useAutoSaveProposals(
           setError(message);
           setSaveState('error');
           toast.error(t('extraction', 'errors_autoSaveFailed'));
+          // Resolve to `false` (not reject) so fire-and-forget callers
+          // (debounce / unmount / pagehide) never raise an unhandled
+          // rejection; `saveNow` reads this flag and rejects for callers that
+          // gate a run-stage advance on a successful flush.
+          return false;
         },
       );
     }).finally(() => {
@@ -357,7 +362,13 @@ export function useAutoSaveProposals(
       clearTimeout(debounceRef.current);
       debounceRef.current = undefined;
     }
-    await performSave();
+    const ok = await performSave();
+    if (!ok) {
+      // Reject so callers that gate a run-stage advance on a successful flush
+      // (onMarkReady / onOpenConsensus `.catch(() => false)`) actually block
+      // instead of advancing past unsaved edits.
+      throw new Error('autosave failed');
+    }
   };
 
   // Re-evaluate the dirty diff whenever ``values`` changes (user typed)

--- a/frontend/lib/comparison/permissions.ts
+++ b/frontend/lib/comparison/permissions.ts
@@ -125,19 +125,3 @@ export function isValidUserRole(role: string): role is UserRole {
   return ['manager', 'reviewer', 'viewer', 'consensus'].includes(role);
 }
 
-/**
- * Returns readable label for role
- *
- * @param role - User role
- * @returns English label with emoji
- */
-export function getRoleLabel(role: UserRole): string {
-  const labels: Record<UserRole, string> = {
-      manager: '👑 Manager',
-      consensus: '⚖️ Consensus',
-      reviewer: '✍️ Reviewer',
-      viewer: '👁️ Viewer'
-  };
-  return labels[role];
-}
-

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -676,6 +676,16 @@ export default function QualityAssessmentFullScreen() {
   const showConsensusPanel = ready && inConsensusStage && !!runDetail;
   const showFormStage = ready && !inConsensusStage;
 
+  // Completeness signal for ConsensusPanel's no-divergence finalize fast-path.
+  // QA has no required-field gate (its publish preflight only requires at
+  // least one filled value — see handlePublish), so mirror that here: without
+  // this the panel never receives isComplete, canFinalize stays false, and a
+  // no-divergence QA run shows a wrong "incomplete" message with finalize
+  // disabled.
+  const qaIsComplete = Object.values(values).some(
+    (v) => v !== undefined && v !== null && v !== "",
+  );
+
   const formPanel = (
     <div className="space-y-3 p-4" data-testid="qa-form-panel">
       {error ? (
@@ -706,6 +716,7 @@ export default function QualityAssessmentFullScreen() {
           onFinalize={handleFinalizeFromConsensus}
           isResolving={consensusMutation.isPending}
           isFinalizing={advanceMutation.isPending}
+          isComplete={qaIsComplete}
         />
       ) : null}
 

--- a/frontend/pdf-viewer/hooks/usePageHandle.ts
+++ b/frontend/pdf-viewer/hooks/usePageHandle.ts
@@ -1,9 +1,21 @@
 import {useEffect, useState} from 'react';
-import {useViewerStore} from '../core/context';
+import {useStore} from 'zustand';
+import {useViewerStoreApiOptional} from '../core/context';
+import {createViewerStore} from '../core/store';
 import type {PDFPageHandle} from '../core/engine';
 
+// Fallback store for the case where usePageHandle renders OUTSIDE a
+// ViewerProvider — e.g. the QA screen mounts citation hooks (useCitationHighlight)
+// with no PDF viewer present. Its `document` is null, so the hook returns null
+// instead of throwing. Module-level + read-only: shared and never mutated.
+const NO_PROVIDER_STORE = createViewerStore();
+
 export function usePageHandle(pageNumber: number): PDFPageHandle | null {
-  const document = useViewerStore((s) => s.document);
+  // Subscribe through the optional store API so the hook degrades gracefully
+  // outside a ViewerProvider rather than throwing. In-provider behaviour is
+  // unchanged: the real store is used whenever a provider is present.
+  const storeApi = useViewerStoreApiOptional();
+  const document = useStore(storeApi ?? NO_PROVIDER_STORE, (s) => s.document);
   const [handle, setHandle] = useState<PDFPageHandle | null>(null);
 
   // Drop the stale handle as soon as the document/page changes (during render,

--- a/frontend/pdf-viewer/primitives/CitationOverlay.tsx
+++ b/frontend/pdf-viewer/primitives/CitationOverlay.tsx
@@ -64,7 +64,9 @@ export function CitationOverlay({pageNumber}: CitationOverlayProps) {
   // useEffect is allowed by React Compiler all_errors — no try/finally.
   useEffect(() => {
     if (isActiveOnThisPage && boxRef.current) {
-      boxRef.current.focus();
+      // preventScroll: the Viewer runs its own programmatic smooth-scroll to
+      // the citation; the default focus-scroll would fight it.
+      boxRef.current.focus({preventScroll: true});
     }
   }, [isActiveOnThisPage, activeCitationId]);
 

--- a/frontend/services/aiSuggestionService.ts
+++ b/frontend/services/aiSuggestionService.ts
@@ -123,7 +123,7 @@ export class AISuggestionService {
       `/api/v1/articles/${articleId}/suggestions/history?${params.toString()}`,
     );
 
-    return items.map(mapHistoryItemToSuggestion);
+    return (items ?? []).map(mapHistoryItemToSuggestion);
   }
 
   /**
@@ -196,6 +196,6 @@ export class AISuggestionService {
   }
 
   static async getArticleInstanceIds(articleId: string): Promise<string[]> {
-    return apiClient<string[]>(`/api/v1/articles/${articleId}/instance-ids`);
+    return (await apiClient<string[]>(`/api/v1/articles/${articleId}/instance-ids`)) ?? [];
   }
 }

--- a/frontend/test/hooks/useAutoSaveProposals.test.tsx
+++ b/frontend/test/hooks/useAutoSaveProposals.test.tsx
@@ -450,7 +450,9 @@ describe('useAutoSaveProposals — mutex + error handling', () => {
     );
 
     await act(async () => {
-      await result.current.saveNow();
+      // The failed coord makes saveNow reject so a caller can gate run-advance
+      // on a successful flush; saveState still reflects the partial failure.
+      await expect(result.current.saveNow()).rejects.toThrow();
     });
 
     expect(apiClientMock).toHaveBeenCalledTimes(3);
@@ -469,6 +471,31 @@ describe('useAutoSaveProposals — mutex + error handling', () => {
     expect((apiClientMock.mock.calls[0][1] as { body: { field_id: string } }).body.field_id)
       .toBe('b');
     expect(result.current.saveState).toBe('saved');
+  });
+
+  it('saveNow() rejects when a write fails so run-advance can be gated (#5)', async () => {
+    // Regression: performSave used to swallow the rejection and resolve, so
+    // saveNow always resolved and the onMarkReady / onOpenConsensus
+    // `.catch(() => false)` guard was dead — a failed flush advanced the run
+    // (EXTRACT → CONSENSUS) and the unsaved edit was lost. saveNow must reject.
+    apiClientMock.mockRejectedValue(new Error('network drop'));
+
+    const { result } = renderHook(() =>
+      useAutoSaveProposals({
+        runId: 'run-1',
+        values: { 'inst-1_field-1': 'unsaved-edit' },
+      }),
+    );
+
+    await act(async () => {
+      // Mirror the caller's guard: `.then(() => true).catch(() => false)`.
+      const gated = await result.current
+        .saveNow()
+        .then(() => true)
+        .catch(() => false);
+      expect(gated).toBe(false);
+    });
+    expect(result.current.saveState).toBe('error');
   });
 });
 
@@ -517,7 +544,7 @@ describe('useAutoSaveProposals — state machine', () => {
     );
 
     await act(async () => {
-      await result.current.saveNow();
+      await expect(result.current.saveNow()).rejects.toThrow();
     });
     expect(result.current.saveState).toBe('error');
 


### PR DESCRIPTION
## Why

Post-merge adversarial review of the batch on `dev`, all findings verified by independent skeptic agents (0 refuted). **Rebased onto current `dev`** (post HITL Phase 1–3 / #369/#374/#375) and re-triaged: every fix below was re-confirmed still present on the latest `dev`; two original findings turned out STALE (now-live code) and were deliberately left alone.

## What changed

**🔴 Critical**
- `fix(export)` — role-first `_build_tidy_tables`: cardinality=ONE `MODEL_SECTION`s rendered zero rows (silent data loss in every prediction-model export).
- `fix(pdf)` — `usePageHandle` degrades outside a `ViewerProvider` instead of throwing → QA "jump to source" / AI suggestion modal no longer crashes to blank.

**🟠 Security — two confused-deputy BOLAs**
- `resolve_form_runs` and `_load_active_template_version` now scope by `project_id` (form-runs run-id leak; async-export template-metadata leak).

**🟠 Important**
- `fix(extraction)` — `saveNow()` now rejects on autosave failure so the `onMarkReady`/`onOpenConsensus` guards block a run-advance past unsaved edits.

**🟡 Minor**
- `fix(qa)` — QA passes `isComplete` to `ConsensusPanel` so a no-divergence run can finalize (was wrongly disabled + "incomplete").
- `chore(cleanup)` — remove dead `getRoleLabel`; English fallback + drop PT/emoji debug log in `useModelManagement`; `CitationOverlay.focus({preventScroll})`; null-guards in `aiSuggestionService`.

## Test plan (all verified locally; local DB synced to `dev` head `0030`)

- [x] export tidy-table: 2 unit tests + full export suite (275) — TDD red→green.
- [x] PDF crash: no-provider vitest (real hook chain) — TDD red→green; pdf-viewer suites (32).
- [x] BOLA #3/#4: integration regression tests — TDD red-checked (fail when the `project_id` predicate is removed).
- [x] autosave: regression test mirroring the caller guard + 2 updated error-path tests — TDD red→green (23).
- [x] QA + cleanups: typecheck + eslint clean; affected suites (114) green; no regressions.

## Deliberately NOT changed (re-triaged)

- `PARSER_BACKEND`, `is_run_arbitrator` — review flagged them dead, but they are LIVE again on current `dev` (#359/#371/#374).
- `study_instances` — a documented read-compat alias load-bearing for ~15 test call sites, not dead.

## Out of scope (behavior-changing minors, deferred for a decision)

- LLM schema `number`/`integer`→`float` coercion; hard `Literal` allowed-values constraint.
- `validateFieldImpact` append-only overcount; `reparse` in-flight guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)