### PR TITLE
chore(scripts): drop stale extraction_instance_status enum probe

### DIFF
--- a/scripts/apply_and_test_migration.sh
+++ b/scripts/apply_and_test_migration.sh
@@ -150,12 +150,6 @@ WHERE tablename IN ('extraction_instances', 'extracted_values')
   AND indexname LIKE 'idx_%unique%'
 ORDER BY tablename, indexname;
 
-SELECT typname, enumlabel
-FROM pg_type t
-JOIN pg_enum e ON t.oid = e.enumtypid
-WHERE typname = 'extraction_instance_status'
-ORDER BY e.enumsortorder;
-
 SELECT constraint_name, check_clause
 FROM information_schema.check_constraints
 WHERE constraint_name = 'chk_extraction_instances_metadata_object';
@@ -175,12 +169,6 @@ FROM pg_indexes
 WHERE tablename IN ('extraction_instances', 'extracted_values')
   AND indexname LIKE 'idx_%unique%'
 ORDER BY tablename, indexname;
-
-SELECT typname, enumlabel
-FROM pg_type t
-JOIN pg_enum e ON t.oid = e.enumtypid
-WHERE typname = 'extraction_instance_status'
-ORDER BY e.enumsortorder;
 
 SELECT constraint_name, check_clause
 FROM information_schema.check_constraints


### PR DESCRIPTION
## What

Remove the now-dead `extraction_instance_status` enum verification query from `scripts/apply_and_test_migration.sh` (both the `DATABASE_URL` branch and the local-psql branch).

## Why

The enum and `extraction_instances.status` column were dropped in HITL Phase 3 (Alembic `0030_drop_instance_status`, #375). The probe:

```sql
SELECT typname, enumlabel
FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid
WHERE typname = 'extraction_instance_status'
ORDER BY e.enumsortorder;
```

now returns zero rows — dead verification logic that misleads anyone running this manual helper. It is not wired into CI; the canonical gate is `backend/tests/integration/test_migration_roundtrip.py`.

## Scope

Tiny, isolated cleanup — no behavior change. The surrounding unique-index and check-constraint probes are untouched and both heredocs remain valid.

## Verification

- `bash -n scripts/apply_and_test_migration.sh` passes (both heredocs well-formed)
- `grep` for `enum`/`pg_enum`/`extraction_instance_status` returns nothing
- Pre-push fast gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)