### PR TITLE
feat(parsing): parse-recovery affordance — re-parse in all states + concurrency-safe writes

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -45,3 +45,4 @@ docs/superpowers/plans/2026-06-10-dev-workflow-sota.md
 # Snapshot artefacts inside docs/ that are not actively maintained
 docs/superpowers/design-system/sidebar-and-panels.md
 docs/superpowers/plans/2026-06-21-parsing-fix-and-reader-switcher.md
+docs/superpowers/plans/2026-06-22-parse-recovery-affordance.md

--- a/backend/alembic/versions/0031_unique_article_text_block_idx.py
+++ b/backend/alembic/versions/0031_unique_article_text_block_idx.py
@@ -1,0 +1,56 @@
+"""unique (article_file_id, page_number, block_index) on article_text_blocks
+
+Revision ID: 0031_unique_atb_idx
+Revises: 0030_drop_instance_status
+Create Date: 2026-06-22
+
+Makes concurrent re-parse tasks (delete-then-insert) fail loudly instead
+of silently duplicating rows for the same (article_file_id, page, block_index).
+The non-unique index created in 0006 is replaced by a UNIQUE one on the same
+columns, preserving ordered-read performance.
+"""
+
+from alembic import op
+
+revision = "0031_unique_atb_idx"
+down_revision = "0030_drop_instance_status"
+branch_labels = None
+depends_on = None
+
+_OLD_INDEX = "idx_article_text_blocks_file_page_block"  # from 0006
+_UQ = "uq_article_text_blocks_file_page_block"
+
+
+def upgrade() -> None:
+    # 1. Collapse any pre-existing duplicates (keep one row per triple) so the
+    #    constraint can be created. Concurrent parses before this migration may
+    #    have produced dups.
+    op.execute(
+        """
+        DELETE FROM article_text_blocks a
+        USING article_text_blocks b
+        WHERE a.ctid < b.ctid
+          AND a.article_file_id = b.article_file_id
+          AND a.page_number = b.page_number
+          AND a.block_index = b.block_index
+        """
+    )
+    # 2. Replace the non-unique read index with a UNIQUE one (same columns, so
+    #    ordered reads keep their index).
+    op.drop_index(_OLD_INDEX, table_name="article_text_blocks")
+    op.create_index(
+        _UQ,
+        "article_text_blocks",
+        ["article_file_id", "page_number", "block_index"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_UQ, table_name="article_text_blocks")
+    op.create_index(
+        _OLD_INDEX,
+        "article_text_blocks",
+        ["article_file_id", "page_number", "block_index"],
+        unique=False,
+    )

--- a/backend/app/schemas/article.py
+++ b/backend/app/schemas/article.py
@@ -210,6 +210,7 @@ class ArticleFileListItem(BaseModel):
     file_type: str = Field(..., alias="fileType")
     original_filename: str | None = Field(default=None, alias="originalFilename")
     extraction_status: str = Field(default="pending", alias="extractionStatus")
+    extraction_error: str | None = Field(default=None, alias="extractionError")
     bytes: int | None = None
     storage_key: str = Field(..., alias="storageKey")
     created_at: datetime = Field(..., alias="createdAt")

--- a/backend/app/services/document_parsing_service.py
+++ b/backend/app/services/document_parsing_service.py
@@ -136,7 +136,7 @@ class DocumentParsingService:
         #    interleave two delete-then-insert passes. Transaction-scoped:
         #    released on commit.
         await self.db.execute(
-            text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+            text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
             {"k": str(article_file_id)},
         )
 

--- a/backend/app/services/document_parsing_service.py
+++ b/backend/app/services/document_parsing_service.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
@@ -132,7 +132,15 @@ class DocumentParsingService:
         #    truth for offset arithmetic — do NOT recompute inline).
         assign_char_offsets_to_blocks(blocks)
 
-        # 5. Persist blocks (delete-then-bulk-insert, flush only).
+        # 5. Serialize the block write per file so a concurrent Retry cannot
+        #    interleave two delete-then-insert passes. Transaction-scoped:
+        #    released on commit.
+        await self.db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+            {"k": str(article_file_id)},
+        )
+
+        # Persist blocks (delete-then-bulk-insert, flush only).
         await self._repo.replace_for_file(article_file_id, blocks)
 
         # 6. Update status.

--- a/backend/tests/integration/test_article_text_block_unique.py
+++ b/backend/tests/integration/test_article_text_block_unique.py
@@ -1,0 +1,70 @@
+"""Integration test: unique (article_file_id, page_number, block_index) constraint.
+
+After migration 0031, a duplicate triple must fail with IntegrityError.
+Uses db_session_real because we need to verify DB-level constraints,
+not ORM-level behaviour.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.integration.conftest import SEED
+
+
+async def _insert_article_file(db: AsyncSession) -> str:
+    """Insert a minimal article_files row and return its id string."""
+    file_id = str(uuid.uuid4())
+    await db.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": file_id,
+            "pid": str(SEED.primary_project),
+            "aid": str(SEED.primary_article),
+            "key": f"test-unique/{file_id}.pdf",
+        },
+    )
+    await db.commit()
+    return file_id
+
+
+async def _cleanup_article_file(db: AsyncSession, *, file_id: str) -> None:
+    await db.execute(
+        text("DELETE FROM public.article_files WHERE id = :id"),
+        {"id": file_id},
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_block_index_rejected(db_session_real: AsyncSession) -> None:
+    """After 0031, a duplicate (article_file_id, page, block_index) must fail."""
+    fid = await _insert_article_file(db_session_real)
+    try:
+        insert = text(
+            "INSERT INTO article_text_blocks "
+            "(id, article_file_id, page_number, block_index, text, char_start, char_end, "
+            "bbox, block_type) "
+            "VALUES (gen_random_uuid(), :fid, 1, 0, :t, 0, 1, "
+            "CAST(:bbox AS jsonb), 'paragraph')"
+        )
+        bbox = '{"x":0,"y":0,"width":100,"height":10}'
+        await db_session_real.execute(insert, {"fid": fid, "t": "a", "bbox": bbox})
+        await db_session_real.commit()
+
+        with pytest.raises(IntegrityError):
+            await db_session_real.execute(insert, {"fid": fid, "t": "b", "bbox": bbox})
+            await db_session_real.commit()
+    finally:
+        # rollback any open failed transaction before cleanup
+        await db_session_real.rollback()
+        await _cleanup_article_file(db_session_real, file_id=fid)

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -107,8 +107,10 @@ _ENUM_PRESENT = text("SELECT 1 FROM pg_type WHERE typname = 'extraction_instance
 @pytest.mark.asyncio
 async def test_migration_0030_round_trip(db_session: AsyncSession) -> None:
     """``0030_drop_instance_status`` removes ``extraction_instances.status`` and
-    its enum at head; ``downgrade -1`` restores the schema (column + enum, not
-    the data); ``upgrade head`` re-removes both. Guards against drift between a
+    its enum at head; downgrading below 0030 (to its parent ``0029``) restores
+    the schema (column + enum, not the data); ``upgrade head`` re-removes both.
+    Downgrades to the explicit parent revision (not ``-1``) so the test stays
+    correct as later migrations stack on top. Guards against drift between a
     fresh ``alembic upgrade head`` and ``baseline_v1.sql`` (which still ships the
     legacy column)."""
     assert (await db_session.execute(_COL_PRESENT)).scalar() is None, (
@@ -118,7 +120,7 @@ async def test_migration_0030_round_trip(db_session: AsyncSession) -> None:
         "extraction_instance_status enum must be absent at HEAD"
     )
 
-    _run_alembic("downgrade", "-1")
+    _run_alembic("downgrade", "0029_reviewer_ready_flag")
     try:
         await db_session.commit()
         assert (await db_session.execute(_COL_PRESENT)).scalar() == 1, (
@@ -147,8 +149,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0030_drop_instance_status" in out, (
-        f"Expected head revision '0030_drop_instance_status', got:\n{out}"
+    assert "0031_unique_atb_idx" in out, (
+        f"Expected head revision '0031_unique_atb_idx', got:\n{out}"
     )
 
 

--- a/backend/tests/integration/test_parse_article_file_lock.py
+++ b/backend/tests/integration/test_parse_article_file_lock.py
@@ -1,0 +1,127 @@
+"""Integration test: advisory lock is acquired before the block write.
+
+DocumentParsingService.parse_article_file must call
+``pg_advisory_xact_lock(hashtext(:k))`` immediately before
+``ArticleTextBlockRepository.replace_for_file`` so that a concurrent
+re-parse Retry serializes on the write instead of interleaving two
+delete-then-insert passes.
+
+The test spies on the real db_session_real.execute so the lock SQL
+actually hits Postgres — it is not mocked out.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.parsing.base import ParsedBlock
+from tests.integration.conftest import SEED
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubParser:
+    """Returns a single ParsedBlock — enough for a successful parse path."""
+
+    def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:  # noqa: ARG002
+        return [
+            ParsedBlock(
+                page_number=1,
+                block_index=0,
+                text="Lock test",
+                char_start=0,
+                char_end=0,
+                bbox={"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0},
+                block_type="paragraph",
+            )
+        ]
+
+
+class _StubStorage:
+    """Returns minimal PDF bytes without touching real storage."""
+
+    async def download(self, bucket: str, key: str) -> bytes:  # noqa: ARG002
+        return b"%PDF-1.4 stub"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seeded_article_file(db_session_real: AsyncSession):
+    """Insert a pending ArticleFile row; yield it; clean up after the test."""
+    from app.models.article import ArticleFile
+
+    file_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": str(file_id),
+            "pid": str(SEED.primary_project),
+            "aid": str(SEED.primary_article),
+            "key": f"articles/{file_id}.pdf",
+        },
+    )
+    await db_session_real.commit()
+
+    from sqlalchemy import select
+
+    af = (
+        await db_session_real.execute(select(ArticleFile).where(ArticleFile.id == file_id))
+    ).scalar_one()
+
+    yield af
+
+    await db_session_real.execute(
+        text("DELETE FROM public.article_files WHERE id = :id"),
+        {"id": str(file_id)},
+    )
+    await db_session_real.commit()
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parse_acquires_advisory_lock_before_write(
+    seeded_article_file, db_session_real: AsyncSession
+) -> None:
+    """parse_article_file must take pg_advisory_xact_lock before replace_for_file."""
+    from app.services.document_parsing_service import DocumentParsingService
+
+    svc = DocumentParsingService(
+        db=db_session_real,
+        user_id=str(SEED.primary_profile),
+        storage=_StubStorage(),
+        parser=_StubParser(),
+        trace_id="lock-test",
+    )
+    calls: list[str] = []
+    orig_execute = db_session_real.execute
+
+    async def _spy(stmt, *a, **k):
+        calls.append(str(stmt))
+        return await orig_execute(stmt, *a, **k)
+
+    with patch.object(db_session_real, "execute", side_effect=_spy):
+        await svc.parse_article_file(seeded_article_file.id)
+
+    assert any("pg_advisory_xact_lock" in c for c in calls), (
+        "lock not acquired; observed SQL calls:\n" + "\n".join(f"  {c!r}" for c in calls)
+    )

--- a/backend/tests/integration/test_parse_article_file_lock.py
+++ b/backend/tests/integration/test_parse_article_file_lock.py
@@ -20,7 +20,7 @@ import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.infrastructure.parsing.base import ParsedBlock
+from app.infrastructure.parsing.base import DocumentParser, ParsedBlock
 from tests.integration.conftest import SEED
 
 # ---------------------------------------------------------------------------
@@ -28,7 +28,7 @@ from tests.integration.conftest import SEED
 # ---------------------------------------------------------------------------
 
 
-class _StubParser:
+class _StubParser(DocumentParser):
     """Returns a single ParsedBlock — enough for a successful parse path."""
 
     def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:  # noqa: ARG002
@@ -124,4 +124,20 @@ async def test_parse_acquires_advisory_lock_before_write(
 
     assert any("pg_advisory_xact_lock" in c for c in calls), (
         "lock not acquired; observed SQL calls:\n" + "\n".join(f"  {c!r}" for c in calls)
+    )
+
+    # Lock must precede the block write (DELETE or INSERT on article_text_blocks).
+    lock_idx = next(i for i, c in enumerate(calls) if "pg_advisory_xact_lock" in c)
+    write_candidates = [
+        i
+        for i, c in enumerate(calls)
+        if "article_text_blocks" in c and ("DELETE" in c.upper() or "INSERT" in c.upper())
+    ]
+    assert write_candidates, "no block write detected; observed SQL calls:\n" + "\n".join(
+        f"  {c!r}" for c in calls
+    )
+    first_write_idx = min(write_candidates)
+    assert lock_idx < first_write_idx, (
+        f"lock (index {lock_idx}) did not precede block write (index {first_write_idx}); "
+        "calls:\n" + "\n".join(f"  [{i}] {c!r}" for i, c in enumerate(calls))
     )

--- a/backend/tests/unit/test_article_files_unit.py
+++ b/backend/tests/unit/test_article_files_unit.py
@@ -314,3 +314,33 @@ async def test_reparse_endpoint_defensive_404_when_service_returns_none() -> Non
                 current_user_sub=uuid4(),
             )
     assert exc.value.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# list_article_files endpoint
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_article_files_includes_extraction_error() -> None:
+    """A parse_failed file surfaces its extraction_error in the list item."""
+    from app.api.v1.endpoints.article_files import list_article_files
+
+    aid, pid = uuid4(), uuid4()
+    failed = _fake_article_file(aid, pid, status="parse_failed")
+    failed.extraction_error = "libxcb.so.1: cannot open shared object file"
+
+    with (
+        patch(f"{_EP}.get_article_project_id", AsyncMock(return_value=pid)),
+        patch(f"{_EP}.ensure_project_member", AsyncMock()),
+        patch(f"{_EP}.ArticleFileService") as svc,
+    ):
+        svc.return_value.list_for_article = AsyncMock(return_value=[failed])
+        resp = await list_article_files(
+            article_id=aid,
+            request=_request(),
+            db=AsyncMock(),
+            current_user_sub=uuid4(),
+        )
+    item = resp.data[0]
+    assert item.extraction_error == "libxcb.so.1: cannot open shared object file"

--- a/docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md
+++ b/docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md
@@ -1037,3 +1037,53 @@ rules from the constitution + `.claude/rules/`):
      earliest overlapping source span; for a multi-page prose run this is the
      first page only. Acceptable for highlight (we scroll there); confirm that is
      the desired behaviour vs storing all spanned pages.
+
+---
+
+## Amendments (2026-06-22)
+
+> Source: [`docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md`](../specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md)
+> (Workstream B), after an adversarial review. Apply these BEFORE executing the
+> phases above. They do not change the architecture — they correct stale
+> premises and an ADR conflict.
+
+1. **Amend ADR-0013 FIRST (new prerequisite, before Phase 3).** Phase 3 sets
+   `READ_FROM_BLOCKS` default `True`, removes `MAX_PDF_CHARS`, and raises the
+   prompt budget 15k→120k — i.e. markdown becomes the **default extraction
+   input**. ADR-0013 currently says blocks stay the default ("no two competing
+   extraction inputs by default"). Amend ADR-0013 (status → accepted; record the
+   decision + the bake-off evidence that markdown beats the block-assembler)
+   before landing Phase 3, and treat the 15k→120k budget change as its **own
+   verification** (latency / cost / extraction-quality), not a silent default.
+
+2. **Stale `readerBlocks` premise (#359 shipped after this plan was written).**
+   The Phase-5 claim "today neither panel passes `readerBlocks`; this adds
+   `readerMarkdown`" (≈ plan line 841) is now **false** — both panels already
+   pass `readerBlocks`/`readerLoading`
+   (`ExtractionPDFPanel.tsx:92`, `QualityAssessmentFullScreen.tsx:665`). Task 5.2
+   / 5.3 must **REPLACE** the wired props, not add new ones.
+
+3. **Answer to Open question 1 (reader-blocks fallback): YES, keep it.**
+   `ReaderTextBlock` is a **public viewer-barrel export** (removing it is a
+   breaking package API change). Keep a blocks-based fallback render until the
+   markdown endpoint (Phase 4) ships and is verified; only then retire the flat
+   dump (Task 7.1). Do not delete `ReaderTextBlock` / `useArticleTextBlocks` —
+   they still feed citation anchoring.
+
+4. **`prose` must be registered.** `@tailwindcss/typography` is installed but
+   NOT in `tailwind.config.ts` `plugins[]`; register it for `prose prose-sm`,
+   and add a `components` override so markdown tables match the dense extraction
+   table aesthetic (`ExtractionInterface.tsx:406-448`). Close the loop with a
+   `design-review` pass.
+
+5. **Process gates.** After the dep add: `npm audit --audit-level=high`
+   (security-audit gate fires on lockfile changes) and
+   `node scripts/enumerate_compiler_bailouts.mjs` (panicThreshold `all_errors`).
+   Add `rehype/remark/sanitize/nh3/GFM/markdown` to `.github/cspell-words.txt`.
+   Drive-by: fix the Portuguese comment at `AISuggestionEvidence.tsx:154` when
+   that file is touched.
+
+6. **Stack is confirmed correct as written:** `react-markdown` + `remark-gfm` +
+   `rehype-sanitize`. Do **not** add `rehype-raw` (the ADR forbids raw without
+   sanitize; the markdown is server-projected GFM) or `remark-breaks` (blocks are
+   joined with `\n\n`).

--- a/docs/superpowers/plans/2026-06-22-parse-recovery-affordance.md
+++ b/docs/superpowers/plans/2026-06-22-parse-recovery-affordance.md
@@ -1,0 +1,744 @@
+---
+status: draft
+last_reviewed: 2026-06-22
+owner: '@raphaelfh'
+---
+
+# Parse-recovery affordance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Design record: [`docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md`](../specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md) (Workstream A). This plan is **independent** of the markdown plan — it adds NO `react-markdown` dependency.
+
+**Goal:** Make every article file's parse status recoverable from the document
+switcher — a status-aware re-parse control visible in all states (pending /
+parsed / parse_failed) — and make the parse write concurrency-safe and
+non-silently-destructive so a Retry can never duplicate blocks or quietly shift
+grounded citation highlights.
+
+**Architecture:** Backend first makes the parse write safe (a UNIQUE constraint
+on `article_text_blocks(article_file_id, page_number, block_index)` + a
+`pg_advisory_xact_lock` around the delete-then-insert), then widens the file-list
+response with `extraction_error`. Frontend adds an additive `useReparseArticleFile`
+mutation hook and a `ParseStatusControl` (cva keyed on status, semantic tokens,
+an `AlertDialog` confirm for re-parsing an already-parsed file, an error tooltip
+for failures), and mounts it in both the extraction and QA PDF panels, replacing
+the current `parse_failed`-only `ReparseButton` gate.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 async + Alembic + Celery (backend);
+React 19 + TanStack Query v5 + shadcn/Radix + the in-house `@prumo/pdf-viewer`
+and `lib/copy` i18n (frontend); pytest + Vitest.
+
+## Global Constraints
+
+- **English only** for code, comments, docs, copy keys.
+- Backend layering `api → services → repositories → models` (CI-enforced).
+- `ApiResponse` envelope; read errors via `error.message` (never FastAPI
+  `detail`); every project-scoped endpoint checks `ensure_project_member`.
+- Frontend data access through the typed `apiClient`
+  (`frontend/integrations/api/client.ts`); no new `supabase.from(...)` table
+  reads or `fetch()`; TanStack keys from the `articleKeys` factory
+  (`frontend/lib/query-keys/articles.ts`).
+- No `try/finally` / `throw` in React component or hook bodies (React Compiler
+  `panicThreshold: all_errors`); IO lives in services/hooks.
+- SQLAlchemy model/DDL change ⇒ Alembic migration (run inside `backend/`);
+  Alembic revision id ≤ 32 chars.
+- Frontend tooling runs from the **repo root** (no `frontend/package.json`);
+  never `cd frontend`.
+- After any endpoint/schema change: `npm run generate:api-types` + commit the
+  regenerated `frontend/types/api/schema.d.ts`.
+- Keep `articlesService.reparseArticleFile` — it has a third caller
+  (`ArticleDetailDialog.tsx:348`) out of this plan's scope. The new hook is
+  **additive**.
+
+---
+
+## Task 1: UNIQUE constraint on `article_text_blocks` (concurrency safety, 1/2)
+
+**Files:**
+- Create: `backend/alembic/versions/0031_unique_article_text_block_idx.py`
+- Reference: `backend/alembic/versions/0006_article_text_blocks.py` (the existing
+  *non-unique* index name to drop) and `0030_drop_instance_status.py` (current
+  head → `down_revision`).
+- Test: `backend/tests/integration/test_article_text_block_unique.py`
+
+**Interfaces:**
+- Produces: a DB invariant that `(article_file_id, page_number, block_index)` is
+  unique, so two concurrent `replace_for_file` inserts fail loudly instead of
+  silently duplicating.
+
+- [ ] **Step 1: Confirm the current head and the old index name.**
+
+Run: `cd backend && uv run alembic heads`
+Expected: prints `0030 (head)` (or `0030_drop_instance_status`). Use that exact
+string as `down_revision`.
+Run: `grep -n "create_index" backend/alembic/versions/0006_article_text_blocks.py`
+Expected: shows the index name (e.g. `ix_article_text_blocks_file_page_block`).
+Note it for Step 3.
+
+- [ ] **Step 2: Write the failing test.**
+
+```python
+# backend/tests/integration/test_article_text_block_unique.py
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+
+@pytest.mark.asyncio
+async def test_duplicate_block_index_rejected(db_session_real):
+    """After 0031, a duplicate (article_file_id, page, block_index) must fail."""
+    # Insert one block, then a duplicate triple — the second must raise.
+    insert = text(
+        "INSERT INTO article_text_blocks "
+        "(id, article_file_id, page_number, block_index, text, char_start, char_end, block_type) "
+        "VALUES (gen_random_uuid(), :fid, 1, 0, :t, 0, 1, 'paragraph')"
+    )
+    fid = "00000000-0000-0000-0000-0000000000aa"
+    await db_session_real.execute(insert, {"fid": fid, "t": "a"})
+    with pytest.raises(IntegrityError):
+        await db_session_real.execute(insert, {"fid": fid, "t": "b"})
+        await db_session_real.flush()
+```
+
+- [ ] **Step 3: Run → fails** (no unique constraint yet; the second insert succeeds).
+
+Run: `make test-backend` (or `cd backend && uv run pytest tests/integration/test_article_text_block_unique.py -v`)
+Expected: FAIL — `DID NOT RAISE IntegrityError`.
+
+- [ ] **Step 4: Write the migration.**
+
+```python
+# backend/alembic/versions/0031_unique_article_text_block_idx.py
+"""unique (article_file_id, page_number, block_index) on article_text_blocks
+
+Revision ID: 0031_unique_atb_idx
+Revises: 0030
+Create Date: 2026-06-22
+"""
+from alembic import op
+
+revision = "0031_unique_atb_idx"
+down_revision = "0030"  # confirm against `alembic heads` (Step 1)
+branch_labels = None
+depends_on = None
+
+_OLD_INDEX = "ix_article_text_blocks_file_page_block"  # from 0006 (Step 1)
+_UQ = "uq_article_text_blocks_file_page_block"
+
+
+def upgrade() -> None:
+    # 1. Collapse any pre-existing duplicates (keep one row per triple) so the
+    #    constraint can be created. Concurrent parses before this migration may
+    #    have produced dups.
+    op.execute(
+        """
+        DELETE FROM article_text_blocks a
+        USING article_text_blocks b
+        WHERE a.ctid < b.ctid
+          AND a.article_file_id = b.article_file_id
+          AND a.page_number = b.page_number
+          AND a.block_index = b.block_index
+        """
+    )
+    # 2. Replace the non-unique read index with a UNIQUE one (same columns, so
+    #    ordered reads keep their index).
+    op.drop_index(_OLD_INDEX, table_name="article_text_blocks")
+    op.create_index(
+        _UQ,
+        "article_text_blocks",
+        ["article_file_id", "page_number", "block_index"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_UQ, table_name="article_text_blocks")
+    op.create_index(
+        _OLD_INDEX,
+        "article_text_blocks",
+        ["article_file_id", "page_number", "block_index"],
+        unique=False,
+    )
+```
+
+- [ ] **Step 5: Verify the migration applies offline + online.**
+
+Run: `cd backend && uv run alembic upgrade head --sql | tail -30` (offline sanity — no truncation error on the revision id)
+Run: `make db-fresh` then `cd backend && uv run alembic current`
+Expected: `0031_unique_atb_idx (head)`.
+
+- [ ] **Step 6: Run → passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_article_text_block_unique.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add backend/alembic/versions/0031_unique_article_text_block_idx.py backend/tests/integration/test_article_text_block_unique.py
+git commit -m "feat(parsing): unique (article_file_id,page,block_index) on article_text_blocks"
+```
+
+## Task 2: Advisory lock around the parse write (concurrency safety, 2/2)
+
+**Files:**
+- Modify: `backend/app/services/document_parsing_service.py` (in
+  `parse_article_file`, immediately before `self._repo.replace_for_file(...)`)
+- Test: `backend/tests/integration/test_parse_article_file_lock.py`
+
+**Interfaces:**
+- Consumes: the UNIQUE constraint from Task 1.
+- Produces: serialized block writes per `article_file_id` — a second parse that
+  starts while one holds the lock blocks until the first commits, then re-runs
+  the delete-then-insert cleanly (last-writer-wins, single clean set).
+
+- [ ] **Step 1: Write the failing test** (asserts the lock SQL is issued before the write).
+
+```python
+# backend/tests/integration/test_parse_article_file_lock.py
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.mark.asyncio
+async def test_parse_acquires_advisory_lock_before_write(seeded_article_file, db_session_real):
+    """parse_article_file must take pg_advisory_xact_lock before replace_for_file."""
+    from app.services.document_parsing_service import DocumentParsingService
+
+    svc = DocumentParsingService(db_session_real, parser=_StubParser(), storage=_StubStorage())
+    calls: list[str] = []
+    orig_execute = db_session_real.execute
+
+    async def _spy(stmt, *a, **k):
+        calls.append(str(stmt))
+        return await orig_execute(stmt, *a, **k)
+
+    with patch.object(db_session_real, "execute", side_effect=_spy):
+        await svc.parse_article_file(seeded_article_file.id)
+
+    assert any("pg_advisory_xact_lock" in c for c in calls), "lock not acquired"
+```
+
+(Use the project's existing parse-test stubs for `_StubParser`/`_StubStorage` —
+mirror `backend/tests/integration/test_parse_article_file_task.py`; if a
+`seeded_article_file` fixture does not exist, add one that inserts a `pending`
+`ArticleFile` with a fake `storage_key` and have `_StubStorage.download` return
+bytes and `_StubParser.parse` return one `ParsedBlock`.)
+
+- [ ] **Step 2: Run → fails.**
+
+Run: `cd backend && uv run pytest tests/integration/test_parse_article_file_lock.py -v`
+Expected: FAIL — `lock not acquired`.
+
+- [ ] **Step 3: Implement the lock.** In `parse_article_file`, just before the
+  `replace_for_file` call (the persist step), add:
+
+```python
+from sqlalchemy import text  # at top of file if not already imported
+
+# Serialize the block write per file so a concurrent Retry cannot interleave
+# two delete-then-insert passes. Transaction-scoped: released on commit.
+await self.db.execute(
+    text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+    {"k": str(article_file_id)},
+)
+await self._repo.replace_for_file(article_file_id, blocks)
+```
+
+- [ ] **Step 4: Run → passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_parse_article_file_lock.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/app/services/document_parsing_service.py backend/tests/integration/test_parse_article_file_lock.py
+git commit -m "feat(parsing): advisory-lock the block write so concurrent re-parse can't duplicate"
+```
+
+## Task 3: Expose `extraction_error` on the file-list response
+
+**Files:**
+- Modify: `backend/app/schemas/article.py` (`ArticleFileListItem`, ~line 205)
+- Test: `backend/tests/unit/test_article_files_unit.py` (direct endpoint-coroutine
+  test — the 80% diff-cover gate does NOT count lines hit only via httpx
+  ASGITransport, so an integration test is insufficient)
+- Regenerate: `frontend/types/api/schema.d.ts`
+
+**Interfaces:**
+- Produces: `ArticleFileListItem.extractionError: str | None` in the
+  `GET /api/v1/articles/{id}/files` response. No read-path change — the endpoint
+  already does `ArticleFileListItem.model_validate(f)` over full ORM rows, and
+  the `extraction_error` column already exists on the model
+  (`models/article.py:227`), so the field auto-populates via the alias. No
+  migration.
+
+- [ ] **Step 1: Write the failing test** (direct coroutine call, not via the app).
+
+```python
+# backend/tests/unit/test_article_files_unit.py  (add to the existing file)
+@pytest.mark.asyncio
+async def test_list_article_files_includes_extraction_error(monkeypatch):
+    """A parse_failed file surfaces its extraction_error in the list item."""
+    from app.api.v1.endpoints import article_files as ep
+
+    failed = _FakeArticleFile(  # mirror the fakes already in this test module
+        id=uuid4(), file_role="MAIN", extraction_status="parse_failed",
+        extraction_error="libxcb.so.1: cannot open shared object file",
+    )
+    monkeypatch.setattr(ep, "get_article_project_id", _async_return(PROJECT_ID))
+    monkeypatch.setattr(ep, "ensure_project_member", _async_noop)
+    monkeypatch.setattr(
+        ep.ArticleFileService, "list_for_article", _async_return([failed])
+    )
+
+    resp = await ep.list_article_files(
+        article_id=ARTICLE_ID, request=_FakeRequest(), db=_FakeDb(),
+        current_user_sub=USER_ID,
+    )
+    item = resp.data[0]
+    assert item.extraction_error == "libxcb.so.1: cannot open shared object file"
+```
+
+(Match the helper/fakes already used in `test_article_files_unit.py`. If the file
+does not yet exist, create it mirroring the direct-coroutine pattern from another
+`tests/unit/test_*_unit.py` endpoint test.)
+
+- [ ] **Step 2: Run → fails.**
+
+Run: `cd backend && uv run pytest tests/unit/test_article_files_unit.py -k extraction_error -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'extraction_error'` (or `None`).
+
+- [ ] **Step 3: Add the field.** In `ArticleFileListItem`:
+
+```python
+    extraction_error: str | None = Field(default=None, alias="extractionError")
+```
+
+(Place it right after the existing `extraction_status` line; keep the `populate_by_name`/alias config the class already uses.)
+
+- [ ] **Step 4: Run → passes.**
+
+Run: `cd backend && uv run pytest tests/unit/test_article_files_unit.py -k extraction_error -v`
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate API types + commit.**
+
+Run (repo root): `npm run generate:api-types`
+Expected: `frontend/types/api/schema.d.ts` `ArticleFileListItem` gains
+`extractionError?: string | null`.
+
+```bash
+git add backend/app/schemas/article.py backend/tests/unit/test_article_files_unit.py frontend/types/api/schema.d.ts
+git commit -m "feat(article-files): expose extractionError on the file-list item"
+```
+
+## Task 4: `useReparseArticleFile` mutation hook (additive)
+
+**Files:**
+- Create: `frontend/hooks/extraction/useReparseArticleFile.ts`
+- Test: `frontend/test/hooks/useReparseArticleFile.test.tsx`
+
+**Interfaces:**
+- Consumes: `apiClient`, `articleKeys.files` / `articleKeys.textBlocks`.
+- Produces: `useReparseArticleFile(articleId: string)` →
+  `UseMutationResult<unknown, Error, string>` (the variable is the
+  `articleFileId`). `onSuccess` invalidates **both** key families; `onError`
+  toasts. Exposes `isPending` for spinner/disable.
+
+- [ ] **Step 1: Write the failing test.**
+
+```tsx
+// frontend/test/hooks/useReparseArticleFile.test.tsx
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
+
+import { apiClient } from "@/integrations/api";
+import { useReparseArticleFile } from "@/hooks/extraction/useReparseArticleFile";
+
+function wrap() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const spy = vi.spyOn(qc, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { wrapper, spy };
+}
+
+describe("useReparseArticleFile", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("POSTs reparse and invalidates files + textBlocks", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    const { wrapper, spy } = wrap();
+    const { result } = renderHook(() => useReparseArticleFile("art-1"), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync("file-9");
+    });
+
+    expect(apiClient).toHaveBeenCalledWith(
+      "/api/v1/article-files/file-9/reparse",
+      { method: "POST" },
+    );
+    const keys = spy.mock.calls.map((c) => JSON.stringify(c[0]?.queryKey));
+    expect(keys.some((k) => k?.includes("files"))).toBe(true);
+    expect(keys.some((k) => k?.includes("text-blocks"))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run → fails.**
+
+Run (repo root): `npm run test:run -- useReparseArticleFile`
+Expected: FAIL — cannot resolve `@/hooks/extraction/useReparseArticleFile`.
+
+- [ ] **Step 3: Implement the hook** (mirror `hooks/runs/useMarkReady.ts`).
+
+```tsx
+// frontend/hooks/extraction/useReparseArticleFile.ts
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { apiClient } from "@/integrations/api";
+import { t } from "@/lib/copy";
+import { articleKeys } from "@/lib/query-keys/articles";
+
+/** Re-enqueue a parse for an ArticleFile and refresh the file list + reader blocks. */
+export function useReparseArticleFile(articleId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, Error, string>({
+    mutationFn: (articleFileId) =>
+      apiClient(`/api/v1/article-files/${articleFileId}/reparse`, { method: "POST" }),
+    onSuccess: (_data, articleFileId) => {
+      toast.success(t("pdf", "docReparseQueued"));
+      queryClient.invalidateQueries({ queryKey: articleKeys.files(articleId) });
+      queryClient.invalidateQueries({ queryKey: articleKeys.textBlocks(articleFileId) });
+    },
+    onError: (error) => {
+      toast.error(error.message || t("pdf", "docReparseError"));
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Run → passes** + typecheck.
+
+Run (repo root): `npm run test:run -- useReparseArticleFile && npm run typecheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add frontend/hooks/extraction/useReparseArticleFile.ts frontend/test/hooks/useReparseArticleFile.test.tsx
+git commit -m "feat(extraction): add useReparseArticleFile mutation hook"
+```
+
+## Task 5: `ParseStatusControl` (status-aware control + confirm + tooltip)
+
+**Files:**
+- Modify: `frontend/components/extraction/DocumentSwitcher.tsx` (add a sibling
+  export `ParseStatusControl`; convert the raw-color `STATUS_DOT` map to semantic
+  tokens via a `cva`)
+- Modify: `frontend/lib/copy/pdf.ts` (add `docParseErrorLabel` +
+  `docReparseConfirmTitle` / `docReparseConfirmBody` / `docReparseConfirmCta`)
+- Verify present: `frontend/components/ui/alert-dialog.tsx` (run
+  `npx shadcn@latest add alert-dialog` only if missing — then replace raw colors
+  per `ui-styling` before committing)
+- Test: `frontend/test/components/DocumentSwitcher.test.tsx`
+
+**Interfaces:**
+- Consumes: `useReparseArticleFile` (Task 4); the new `extractionError` field
+  (Task 3); copy keys.
+- Produces: `<ParseStatusControl articleId={string} file={ArticleFileListItem} />`
+  — renders a status dot + label, and a contextual action: `pending` → spinner +
+  "Processing…" + a ghost **Retry**; `parsed` → "Ready" + a low-emphasis
+  **Re-parse** behind an `AlertDialog` confirm; `parse_failed` → "Parse failed"
+  (error in a `Tooltip`) + a prominent **Retry parse**.
+
+- [ ] **Step 1: Add copy keys** to `frontend/lib/copy/pdf.ts` (after the
+  `docReparse*` block):
+
+```ts
+    docParseErrorLabel: 'Parse error',
+    docReparseConfirmTitle: 'Re-parse this document?',
+    docReparseConfirmBody:
+      'Re-parsing rebuilds the document text. Existing citation highlights for this file may shift and need re-checking.',
+    docReparseConfirmCta: 'Re-parse',
+```
+
+- [ ] **Step 2: Write the failing test.**
+
+```tsx
+// frontend/test/components/DocumentSwitcher.test.tsx  (replace the service mock + add cases)
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
+
+import { apiClient } from "@/integrations/api";
+import { ParseStatusControl } from "@/components/extraction/DocumentSwitcher";
+
+function renderControl(file: { id: string; extractionStatus: string; extractionError?: string | null }) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ParseStatusControl articleId="art-1" file={{ originalFilename: "a.pdf", fileRole: "MAIN", ...file } as never} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ParseStatusControl", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("failed: shows the error in a tooltip trigger and a Retry that POSTs", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f1", extractionStatus: "parse_failed", extractionError: "libxcb.so.1 missing" });
+    fireEvent.click(screen.getByRole("button", { name: /docReparse/ }));
+    expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f1/reparse", { method: "POST" });
+  });
+
+  it("parsed: Re-parse opens a confirm dialog before POSTing", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f2", extractionStatus: "parsed" });
+    fireEvent.click(screen.getByRole("button", { name: /docReparse/ }));
+    expect(apiClient).not.toHaveBeenCalled();             // confirm first
+    fireEvent.click(screen.getByRole("button", { name: /docReparseConfirmCta/ }));
+    expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f2/reparse", { method: "POST" });
+  });
+
+  it("pending: shows Processing and a Retry", () => {
+    renderControl({ id: "f3", extractionStatus: "pending" });
+    expect(screen.getByText("docStatusPending")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run → fails.**
+
+Run (repo root): `npm run test:run -- DocumentSwitcher`
+Expected: FAIL — `ParseStatusControl` is not exported.
+
+- [ ] **Step 4: Implement `ParseStatusControl`** in `DocumentSwitcher.tsx`.
+  Replace the raw-color `STATUS_DOT` object with a `cva`, and add the control.
+  (Keep the existing `DocumentSwitcher` export and `ReparseButton` for now;
+  Task 6 swaps the panel over to `ParseStatusControl`.)
+
+```tsx
+import { cva } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogTrigger } from "@/components/ui/alert-dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useReparseArticleFile } from "@/hooks/extraction/useReparseArticleFile";
+import type { ArticleFileListItem } from "@/services/articleFilesService";
+
+const statusDot = cva("h-1.5 w-1.5 shrink-0 rounded-full", {
+  variants: {
+    status: {
+      parsed: "bg-success",
+      pending: "bg-warning animate-pulse",
+      parse_failed: "bg-destructive",
+      unknown: "bg-muted-foreground/40",
+    },
+  },
+  defaultVariants: { status: "unknown" },
+});
+
+type ParseStatus = "parsed" | "pending" | "parse_failed" | "unknown";
+function toStatus(s: string): ParseStatus {
+  return s === "parsed" || s === "pending" || s === "parse_failed" ? s : "unknown";
+}
+
+export interface ParseStatusControlProps {
+  articleId: string;
+  file: ArticleFileListItem;
+}
+
+export function ParseStatusControl({ articleId, file }: ParseStatusControlProps) {
+  const status = toStatus(file.extractionStatus);
+  const reparse = useReparseArticleFile(articleId);
+  const fire = () => reparse.mutate(file.id);
+
+  const label =
+    status === "parsed" ? t("pdf", "docStatusReady")
+    : status === "pending" ? t("pdf", "docStatusPending")
+    : status === "parse_failed" ? t("pdf", "docStatusFailed")
+    : "";
+
+  return (
+    <div className="flex items-center gap-1.5 shrink-0 text-[11px] text-muted-foreground">
+      {status === "pending" ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.5} aria-hidden />
+      ) : (
+        <span aria-hidden className={statusDot({ status })} />
+      )}
+
+      {status === "parse_failed" && file.extractionError ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-default">{label}</span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t("pdf", "docParseErrorLabel")}: {file.extractionError}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <span>{label}</span>
+      )}
+
+      {status === "parsed" ? (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button size="sm" variant="ghost" className="h-7 text-xs" disabled={reparse.isPending}>
+              {t("pdf", "docReparse")}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t("pdf", "docReparseConfirmTitle")}</AlertDialogTitle>
+              <AlertDialogDescription>{t("pdf", "docReparseConfirmBody")}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t("common", "cancel")}</AlertDialogCancel>
+              <AlertDialogAction onClick={fire}>{t("pdf", "docReparseConfirmCta")}</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : (
+        (status === "parse_failed" || status === "pending") && (
+          <Button
+            size="sm"
+            variant={status === "parse_failed" ? "outline" : "ghost"}
+            className="h-7 text-xs"
+            disabled={reparse.isPending}
+            onClick={fire}
+          >
+            {t("pdf", "docReparse")}
+          </Button>
+        )
+      )}
+    </div>
+  );
+}
+```
+
+(If `t("common", "cancel")` does not exist, use the existing cancel key in
+`lib/copy/common.ts` — grep for it; do not hardcode "Cancel".)
+
+- [ ] **Step 5: Run → passes** + typecheck + compiler check.
+
+Run (repo root): `npm run test:run -- DocumentSwitcher && npm run typecheck`
+Run (repo root): `node scripts/enumerate_compiler_bailouts.mjs`
+Expected: tests PASS; no new compiler bailouts.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add frontend/components/extraction/DocumentSwitcher.tsx frontend/lib/copy/pdf.ts frontend/test/components/DocumentSwitcher.test.tsx
+git commit -m "feat(extraction): ParseStatusControl — status-aware re-parse with confirm + error tooltip"
+```
+
+## Task 6: Mount `ParseStatusControl` in both PDF panels
+
+**Files:**
+- Modify: `frontend/components/extraction/ExtractionPDFPanel.tsx` (replace the
+  `parse_failed`-only `ReparseButton` gate at ~line 80)
+- Modify: `frontend/pages/QualityAssessmentFullScreen.tsx` (the matching gate,
+  ~line 653)
+- Test: extend `frontend/test/components/DocumentSwitcher.test.tsx` or the
+  panel's existing test
+
+**Interfaces:**
+- Consumes: `ParseStatusControl` (Task 5); `selectedFile` from
+  `useArticleDocuments`.
+
+- [ ] **Step 1: Replace the gate in `ExtractionPDFPanel.tsx`.** Swap:
+
+```tsx
+{selectedFile?.extractionStatus === 'parse_failed' && (
+  <ReparseButton articleFileId={selectedFile.id} articleId={articleId} />
+)}
+```
+
+with:
+
+```tsx
+{selectedFile && (
+  <ParseStatusControl articleId={articleId} file={selectedFile} />
+)}
+```
+
+(Update the import from `DocumentSwitcher` to include `ParseStatusControl`;
+remove the now-unused `ReparseButton` import if this was its only panel use —
+but keep the `ReparseButton` export in `DocumentSwitcher.tsx` until Step 2
+confirms QA no longer references it.)
+
+- [ ] **Step 2: Replace the same gate in `QualityAssessmentFullScreen.tsx`**
+  (~line 653) identically. The QA `articleId` is already guaranteed non-null by
+  the early return earlier in the component, so pass it directly.
+
+- [ ] **Step 3: Remove the now-dead `ReparseButton`** if no caller remains.
+
+Run (repo root): `grep -rn "ReparseButton" frontend/`
+Expected: only its definition remains → delete the `ReparseButton` export from
+`DocumentSwitcher.tsx` and any leftover import. If another caller exists, leave it.
+
+- [ ] **Step 4: Run the suite + typecheck.**
+
+Run (repo root): `npm run test:run -- DocumentSwitcher ExtractionPDFPanel && npm run typecheck && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Visual verify.** Run the `design-review` loop
+  (`/design-review` on the extraction route): render → screenshot → compare to
+  the Plane/Linear target → confirm the control reads cleanly in pending /
+  parsed / failed states (dot color, spinner, tooltip, confirm dialog). Fix and
+  re-screenshot before claiming done.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add frontend/components/extraction/ExtractionPDFPanel.tsx frontend/pages/QualityAssessmentFullScreen.tsx frontend/components/extraction/DocumentSwitcher.tsx
+git commit -m "feat(extraction): mount ParseStatusControl in extraction + QA panels (retire parse_failed-only gate)"
+```
+
+## Task 7: Full verification + backlog note
+
+- [ ] **Step 1:** `make lint-backend`, `make test-backend` (parsing slices),
+  `npm run test:run`, `npm run lint`, `npm run typecheck` — all green.
+- [ ] **Step 2:** Confirm `node scripts/enumerate_compiler_bailouts.mjs` shows no
+  new bailouts.
+- [ ] **Step 3:** Backlog (deferred, user sign-off): after dev→main + Railway
+  deploy, the 39 legacy `pending` files are cleared **manually** via the new
+  control (open each article → Retry). No backfill script in this plan.
+
+---
+
+## Self-review
+
+- **Spec coverage (Workstream A):** A1 concurrency safety → Tasks 1+2; A2
+  parsed-confirm → Task 5; A3 behaviour table → Task 5; A4 schema widen (no
+  migration, no read-path change) → Task 3; A5 additive hook + keep service +
+  both mount sites + copy → Tasks 4/5/6; A6 tests incl. direct endpoint-coroutine
+  → Task 3; A7 independent of Workstream B → no `react-markdown` anywhere. ✓
+- **Placeholders:** none — every code step shows code; fixture/import gaps are
+  flagged with the exact reference file to mirror.
+- **Type consistency:** `useReparseArticleFile(articleId)` mutate variable is the
+  `articleFileId` (Task 4) and `ParseStatusControl` calls
+  `reparse.mutate(file.id)` (Task 5); `ArticleFileListItem.extractionError`
+  (Task 3) is read in Task 5; `articleKeys.files` / `articleKeys.textBlocks`
+  used consistently. ✓
+- **Migration:** Task 1 is the only DDL; Task 3 explicitly needs none. ✓

--- a/docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md
+++ b/docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md
@@ -1,0 +1,220 @@
+---
+status: draft
+last_reviewed: 2026-06-22
+owner: '@raphaelfh'
+---
+
+# Parse-recovery affordance + markdown-reader execution — design
+
+> **Status:** Draft · Date: 2026-06-22 · Deciders: @raphaelfh
+> **Relation to existing design:** This spec does **not** introduce a new
+> markdown architecture. It (1) records the reconciliation of two reported
+> user issues against design that already exists in the repo, (2) decides to
+> execute the existing markdown plan in full, and (3) specs the one genuinely
+> new piece — a status-aware *parse-recovery affordance* — that no existing
+> plan covers.
+
+## The two reported issues
+
+1. **"Why aren't articles parsing, and why did the re-parse button only appear
+   on *teste 2*?"**
+2. **"The .md viewer can't render all the fields well (want it as good as the
+   table view), it should be aligned with how extracted citations are shown —
+   and is [`react-markdown`](https://github.com/remarkjs/react-markdown)
+   adequate?"**
+
+## Root-cause evidence (production DB, 2026-06-22)
+
+- `article_files`: **39 `pending`, 2 `parsed`, 0 `parse_failed`.**
+- The two `parsed` rows were parsed **today**: `teste 2` at 11:16:43 (via a
+  re-parse) and `Parse 1` at 11:29:42 (fresh upload, parsed at ingest). The
+  worker + parser pipeline is **healthy now**.
+- The 39 `pending` rows were uploaded **2026-05-26 / 06-07 / 06-14** (plus one
+  `teste` on 06-21) — i.e. *before* the parse-at-ingest pipeline worked. They
+  have no enqueued task and nothing backfills them.
+- The re-parse button is gated on exactly one condition —
+  `selectedFile?.extractionStatus === 'parse_failed'`
+  (`frontend/components/extraction/ExtractionPDFPanel.tsx:80`). `teste 2` was
+  the **only** file ever in `parse_failed` (verified cause:
+  `extraction_error = "libxcb.so.1: cannot open shared object file"`, the
+  Docling/opencv crash), so it was the only article showing the button. The
+  user re-parsed it → it succeeded today.
+- Parsed `block.text` is **Docling markdown** (GFM tables `| … |`, lists,
+  inline `<sup>/<sub>`), currently rendered raw via `{block.text}` in a `<p>`
+  (`frontend/pdf-viewer/primitives/Reader.tsx:116`) → tables/lists/super-sub
+  show as literal source text. `react-markdown` is **not** a dependency.
+
+## Reconciliation with existing repo design
+
+Both issues are already covered by design in the repo. A fresh competing spec
+would be wrong; this spec adopts the existing design and fills the one gap.
+
+### Issue 1 — already largely fixed
+
+[`docs/superpowers/plans/2026-06-21-parsing-fix-and-reader-switcher.md`](../plans/2026-06-21-parsing-fix-and-reader-switcher.md)
+(status: **in_progress**) diagnosed the identical root cause (its "Root cause
+(verified, prod)" section names `teste 2`, the `libxcb` crash, and the never-used
+`llama_cloud` key) and **shipped** the fix: parser default → `auto`
+(LlamaParse-when-key, Docling fallback), Docling system libs, the
+`GET /articles/{id}/files` endpoint, `useArticleDocuments`, and the
+`DocumentSwitcher`. That is why parsing works now. Its **Task 7** explicitly
+defers *"backfill the 39 legacy `pending` (no auto-sweep exists)"* as a manual
+post-deploy step.
+
+**Remaining gap (this spec):** the re-parse affordance is `parse_failed`-only,
+so a stuck-`pending` file is a UI dead-end. The 39 backlog has no self-serve
+trigger. → The **parse-recovery affordance** below.
+
+### Issue 2 — fully designed, unbuilt → execute in full
+
+[ADR-0013 — dual-tier markdown representation](../../adr/0013-dual-tier-markdown-representation.md)
+(proposed) + [`docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md`](../plans/2026-06-20-markdown-view-and-markdown-citations.md)
+(**draft**, 6 phases, not started) already specify the markdown reader **and**
+markdown-anchored citations — i.e. both halves of issue 2, including the
+"align the reader with the extracted citations" ask (markdown-anchored
+citations + highlight in both the reader and the canvas, Phase 6).
+
+**Decision: execute that plan in full** (all 6 phases). An adversarial review
+(2026-06-22) confirmed the plan's choices and corrected the design I had
+sketched before reading it:
+
+- **`react-markdown` is adequate — yes.** Stack = `react-markdown` +
+  `remark-gfm` + `rehype-sanitize`. **No `rehype-raw`** (the markdown is
+  server-projected GFM, so there is no author HTML to preserve; the ADR
+  explicitly forbids `rehype-raw` without sanitization). **No `remark-breaks`**
+  (blocks are joined with `\n\n`; GFM paragraph semantics suffice). My earlier
+  `rehype-raw` + `remark-breaks` sketch is **dropped**.
+- Defense-in-depth sanitize: server-side `nh3` at the markdown read service +
+  `rehype-sanitize` (strict allowlist) at render.
+- Rendering is the **server-projected** `render_blocks_to_markdown(blocks)`
+  (the same markdown the AI reads), **not** a client-side per-block render of
+  raw block text. The flat per-block reader dump is retired (plan Task 5.2).
+- **Anchoring is safe** (verifier verdict: *sound*): reader-mode highlight does
+  not exist today (highlighting is canvas-only) and copy reads the raw prop, so
+  switching the reader to a markdown string breaks nothing; the new highlight is
+  quote-based (robust to re-rendering).
+- `@tailwindcss/typography` is installed but **not** registered in
+  `tailwind.config.ts` `plugins[]`; the plan's `prose prose-sm` requires
+  registering it (plan Task 5.2). Compose dense table cells via the markdown
+  `components` override to match the extraction table aesthetic.
+
+**No structural change to the existing plan is needed.** Fold in only these
+small corrections when executing it:
+
+- Confirm the stack stays `react-markdown + remark-gfm + rehype-sanitize`
+  (no `rehype-raw`, no `remark-breaks`) — already what the plan says.
+- `npm audit --audit-level=high` after the dep add (the security-audit gate
+  fires on `package.json`/lockfile changes) and
+  `node scripts/enumerate_compiler_bailouts.mjs` (panicThreshold `all_errors`).
+- Add `rehype / remark / sanitize / nh3 / GFM / markdown` to
+  `.github/cspell-words.txt` (already in the plan).
+- Drive-by cleanup when `AISuggestionEvidence.tsx` is touched: the Portuguese
+  comment at line 154 (`{/* Trecho do texto */}`) violates English-only — fix
+  it.
+
+(Whether the `AISuggestionEvidence` evidence blockquote *itself* also renders
+markdown is a minor optional add; the user's "align with citations" ask is met
+by Phase 2 + Phase 6 markdown-anchored citations + dual-surface highlight.)
+
+---
+
+## New design — the parse-recovery affordance (Issue 1)
+
+The one piece no existing plan covers. Manual, status-aware, lives next to the
+document switcher, visible in **all** states. (Recovery model and placement were
+decided in brainstorming: manual reparse, all states, switcher control only;
+in-flight shows "Processing…" + allows a manual retry; no schema-level "stuck"
+distinction.)
+
+### Behaviour by `extractionStatus`
+
+| Status | Indicator | Action |
+| --- | --- | --- |
+| `pending` | `Processing…` (`docStatusPending`) — `Loader2` spin or `bg-warning animate-pulse` dot | **Retry** allowed (covers the stuck case); re-parse is idempotent |
+| `parsed` | `Ready` (`docStatusReady`) — `bg-success` dot | quiet **Re-parse** (light, low-emphasis) |
+| `parse_failed` | `Parse failed` (`docStatusFailed`) — `bg-destructive` dot | prominent **Retry parse** + `extraction_error` in a Tooltip |
+| unknown | muted fallback dot (`bg-muted-foreground/40`) | none |
+
+### Backend (small)
+
+- Add `extraction_error: str | None` to **`ArticleFileListItem`**
+  (`backend/app/schemas/article.py:205`) — it currently exposes only
+  `extraction_status`; the error string lives only on `ArticleFileResponse`.
+  Required for the failed-state tooltip. Populate it in
+  `list_files_for_article` (the read path already selects the row).
+- `npm run generate:api-types` + commit the regenerated
+  `frontend/types/api/schema.d.ts`.
+- **No migration** (the `extraction_error` column already exists on the model;
+  this only widens a response schema).
+- The `POST /article-files/{id}/reparse` endpoint already accepts any status —
+  no backend change to recovery itself.
+
+### Frontend
+
+- **Create `frontend/hooks/extraction/useReparseArticleFile.ts`** — a
+  `useMutation` modeled on `hooks/runs/useMarkReady.ts`:
+  `mutationFn: (articleFileId) => apiClient('/api/v1/article-files/${id}/reparse', {method:'POST'})`;
+  `onSuccess`: invalidate **both** `articleKeys.files(articleId)` **and**
+  `articleKeys.textBlocks(articleFileId)` (stale-cache incident class — both are
+  mandatory); `onError`: `toast.error(error.message || t('pdf','docReparseError'))`.
+  This supersedes the existing inline `useState(busy)` + `.then()/.finally()` in
+  `ReparseButton` and gives `isPending` for the spinner for free. (Reuses the
+  existing `reparseArticleFile` URL; the existing `articlesService.reparseArticleFile`
+  ErrorResult function may be retired or kept — pick the mutation-hook path,
+  one IO convention.)
+- **Build a `ParseStatusControl`** co-located in
+  `frontend/components/extraction/DocumentSwitcher.tsx` (sibling export, the way
+  `ReparseButton` already is). It reads `selectedFile.extractionStatus` (+ the
+  new `extractionError`) from `useArticleDocuments` and renders the dot +
+  collapsible label + the contextual action. A `cva` keyed on `status` (mirror
+  `frontend/components/layout/HeaderChip.tsx`), using **semantic tokens**
+  (`success` / `warning` / `destructive`) — replacing the raw `emerald/amber/red`
+  in the current `STATUS_DOT` map. Icon-only actions use `Button size="header-icon"`
+  + `aria-label`; the failed tooltip uses the global `TooltipProvider`.
+- **Replace the `parse_failed`-only gate** at both mount sites with the new
+  control: `ExtractionPDFPanel.tsx:80` and
+  `QualityAssessmentFullScreen.tsx` (preserve the QA site's `articleId`
+  null-guard). Keep both in sync.
+- **Copy:** reuse the existing-but-unused `pdf` keys `docStatusReady` /
+  `docStatusPending` (`'Processing…'`) / `docStatusFailed` and
+  `docReparse` / `docReparseQueued` / `docReparseError` in
+  `frontend/lib/copy/pdf.ts`. Add only an error-tooltip prefix key if needed.
+  English-only, via `t('pdf', key)`.
+- **Auto-refresh:** `useArticleDocuments` already polls `articleKeys.files`
+  every 4s while any file is `pending`; after a re-parse the status flips to
+  `pending`, polling resumes, and the reader fills when blocks/markdown land.
+  No new polling wiring.
+
+### Out of scope (deferred)
+
+- **Clearing the 39 `pending` backlog** — needs prod/Railway access (currently
+  unreachable from this session). Once the affordance ships, each is
+  self-serviceable from the UI; or a one-off re-enqueue script can be run
+  separately. Explicitly *not* a bulk auto-sweep (user decision).
+- No schema-level "stuck vs in-flight" distinction (user decision: treat
+  `pending` uniformly, allow manual retry).
+
+## Testing
+
+- **`useReparseArticleFile`** — hook test mirroring
+  `frontend/test/hooks-runs.test.tsx`: `vi.mock('@/integrations/api', { apiClient })`,
+  `QueryClient` with retries off, `await act(mutateAsync)`, assert
+  `apiClient('/api/v1/article-files/${id}/reparse', {method:'POST'})` and that
+  both key families are invalidated.
+- **`DocumentSwitcher` / `ParseStatusControl`** — extend
+  `frontend/test/components/DocumentSwitcher.test.tsx`: each status renders its
+  dot/label/action; the failed tooltip shows `extractionError`; the action
+  fires the mutation. `vi.mock('@/lib/copy', { t: (_n,k)=>k })`. Keep the test
+  env-free (no AuthContext/supabase imports) so it passes in env-less CI.
+- **Issue 2 tests** are owned by the existing plan (each phase has failing-test
+  steps), including the `Reader` XSS test and the design-review + axe pass.
+
+## Acceptance
+
+- A `pending` or `parse_failed` file shows a clear, status-appropriate re-parse
+  action next to the switcher; a successful re-parse transitions the file to
+  `parsed` and the reader renders it — no UI dead-end in any state.
+- The reader renders sanitized server-projected markdown (GFM tables/lists/
+  super-sub) at parity with the extraction table aesthetic, and AI citations are
+  anchored in the markdown and highlighted in both the reader and the canvas
+  (per the existing markdown plan).

--- a/docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md
+++ b/docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md
@@ -9,10 +9,14 @@ owner: '@raphaelfh'
 > **Status:** Draft · Date: 2026-06-22 · Deciders: @raphaelfh
 > **Relation to existing design:** This spec does **not** introduce a new
 > markdown architecture. It (1) records the reconciliation of two reported
-> user issues against design that already exists in the repo, (2) decides to
-> execute the existing markdown plan in full, and (3) specs the one genuinely
-> new piece — a status-aware *parse-recovery affordance* — that no existing
-> plan covers.
+> user issues against design that already exists in the repo, (2) decides how
+> to execute the existing markdown plan, and (3) specs the one genuinely new
+> piece — a status-aware *parse-recovery affordance* — that no existing plan
+> covers.
+> **Revised 2026-06-22** after an adversarial review (verdict: *revise*). The
+> two blockers (re-parse concurrency; re-parse corrupting grounded citations)
+> and the five majors are addressed below; the affordance and the markdown
+> work are now **two independently-shippable workstreams** (A and B).
 
 ## The two reported issues
 
@@ -37,8 +41,7 @@ owner: '@raphaelfh'
   (`frontend/components/extraction/ExtractionPDFPanel.tsx:80`). `teste 2` was
   the **only** file ever in `parse_failed` (verified cause:
   `extraction_error = "libxcb.so.1: cannot open shared object file"`, the
-  Docling/opencv crash), so it was the only article showing the button. The
-  user re-parsed it → it succeeded today.
+  Docling/opencv crash), so it was the only article showing the button.
 - Parsed `block.text` is **Docling markdown** (GFM tables `| … |`, lists,
   inline `<sup>/<sub>`), currently rendered raw via `{block.text}` in a `<p>`
   (`frontend/pdf-viewer/primitives/Reader.tsx:116`) → tables/lists/super-sub
@@ -49,172 +52,235 @@ owner: '@raphaelfh'
 Both issues are already covered by design in the repo. A fresh competing spec
 would be wrong; this spec adopts the existing design and fills the one gap.
 
-### Issue 1 — already largely fixed
+- **Issue 1** was diagnosed and largely fixed by
+  [`docs/superpowers/plans/2026-06-21-parsing-fix-and-reader-switcher.md`](../plans/2026-06-21-parsing-fix-and-reader-switcher.md)
+  (status: **in_progress**) — same verified root cause (`teste 2`, the `libxcb`
+  crash, the never-used `llama_cloud` key). It shipped the parser-default → `auto`
+  fix, the Docling libs, `GET /articles/{id}/files`, `useArticleDocuments`, and
+  the `DocumentSwitcher` (that is why parsing works now). Its **Task 7** defers
+  the 39-backlog. The remaining UI gap — re-parse is `parse_failed`-only, so a
+  stuck-`pending` file is a dead-end — is **Workstream A** below.
+- **Issue 2** is fully designed but unbuilt in
+  [ADR-0013](../../adr/0013-dual-tier-markdown-representation.md) (proposed) +
+  [`docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md`](../plans/2026-06-20-markdown-view-and-markdown-citations.md)
+  (draft, 6 phases, not started). Execute it — **Workstream B** below.
 
-[`docs/superpowers/plans/2026-06-21-parsing-fix-and-reader-switcher.md`](../plans/2026-06-21-parsing-fix-and-reader-switcher.md)
-(status: **in_progress**) diagnosed the identical root cause (its "Root cause
-(verified, prod)" section names `teste 2`, the `libxcb` crash, and the never-used
-`llama_cloud` key) and **shipped** the fix: parser default → `auto`
-(LlamaParse-when-key, Docling fallback), Docling system libs, the
-`GET /articles/{id}/files` endpoint, `useArticleDocuments`, and the
-`DocumentSwitcher`. That is why parsing works now. Its **Task 7** explicitly
-defers *"backfill the 39 legacy `pending` (no auto-sweep exists)"* as a manual
-post-deploy step.
-
-**Remaining gap (this spec):** the re-parse affordance is `parse_failed`-only,
-so a stuck-`pending` file is a UI dead-end. The 39 backlog has no self-serve
-trigger. → The **parse-recovery affordance** below.
-
-### Issue 2 — fully designed, unbuilt → execute in full
-
-[ADR-0013 — dual-tier markdown representation](../../adr/0013-dual-tier-markdown-representation.md)
-(proposed) + [`docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md`](../plans/2026-06-20-markdown-view-and-markdown-citations.md)
-(**draft**, 6 phases, not started) already specify the markdown reader **and**
-markdown-anchored citations — i.e. both halves of issue 2, including the
-"align the reader with the extracted citations" ask (markdown-anchored
-citations + highlight in both the reader and the canvas, Phase 6).
-
-**Decision: execute that plan in full** (all 6 phases). An adversarial review
-(2026-06-22) confirmed the plan's choices and corrected the design I had
-sketched before reading it:
-
-- **`react-markdown` is adequate — yes.** Stack = `react-markdown` +
-  `remark-gfm` + `rehype-sanitize`. **No `rehype-raw`** (the markdown is
-  server-projected GFM, so there is no author HTML to preserve; the ADR
-  explicitly forbids `rehype-raw` without sanitization). **No `remark-breaks`**
-  (blocks are joined with `\n\n`; GFM paragraph semantics suffice). My earlier
-  `rehype-raw` + `remark-breaks` sketch is **dropped**.
-- Defense-in-depth sanitize: server-side `nh3` at the markdown read service +
-  `rehype-sanitize` (strict allowlist) at render.
-- Rendering is the **server-projected** `render_blocks_to_markdown(blocks)`
-  (the same markdown the AI reads), **not** a client-side per-block render of
-  raw block text. The flat per-block reader dump is retired (plan Task 5.2).
-- **Anchoring is safe** (verifier verdict: *sound*): reader-mode highlight does
-  not exist today (highlighting is canvas-only) and copy reads the raw prop, so
-  switching the reader to a markdown string breaks nothing; the new highlight is
-  quote-based (robust to re-rendering).
-- `@tailwindcss/typography` is installed but **not** registered in
-  `tailwind.config.ts` `plugins[]`; the plan's `prose prose-sm` requires
-  registering it (plan Task 5.2). Compose dense table cells via the markdown
-  `components` override to match the extraction table aesthetic.
-
-**No structural change to the existing plan is needed.** Fold in only these
-small corrections when executing it:
-
-- Confirm the stack stays `react-markdown + remark-gfm + rehype-sanitize`
-  (no `rehype-raw`, no `remark-breaks`) — already what the plan says.
-- `npm audit --audit-level=high` after the dep add (the security-audit gate
-  fires on `package.json`/lockfile changes) and
-  `node scripts/enumerate_compiler_bailouts.mjs` (panicThreshold `all_errors`).
-- Add `rehype / remark / sanitize / nh3 / GFM / markdown` to
-  `.github/cspell-words.txt` (already in the plan).
-- Drive-by cleanup when `AISuggestionEvidence.tsx` is touched: the Portuguese
-  comment at line 154 (`{/* Trecho do texto */}`) violates English-only — fix
-  it.
-
-(Whether the `AISuggestionEvidence` evidence blockquote *itself* also renders
-markdown is a minor optional add; the user's "align with citations" ask is met
-by Phase 2 + Phase 6 markdown-anchored citations + dual-surface highlight.)
+These two workstreams are **independent** and ship separately. Workstream A does
+not depend on `react-markdown` or the (still-unbuilt) `render_blocks_to_markdown`;
+Workstream B is multi-PR greenfield. The affordance ships first.
 
 ---
 
-## New design — the parse-recovery affordance (Issue 1)
+## Workstream A — parse-recovery affordance (Issue 1, new)
 
-The one piece no existing plan covers. Manual, status-aware, lives next to the
-document switcher, visible in **all** states. (Recovery model and placement were
-decided in brainstorming: manual reparse, all states, switcher control only;
-in-flight shows "Processing…" + allows a manual retry; no schema-level "stuck"
-distinction.)
+Manual, status-aware re-parse control next to the document switcher, visible in
+**all** states (decided in brainstorming: manual reparse, all states, switcher
+control only; in-flight shows "Processing…").
 
-### Behaviour by `extractionStatus`
+> **Adversarial correction:** re-parse is **NOT** "idempotent / safe in all
+> states" as originally written. The parse write is destructive (delete-then-
+> insert blocks) and not concurrency-safe, and re-parsing a `parsed` file can
+> invalidate grounded citations. The affordance therefore needs **backend
+> safety work** — it is not frontend-only.
+
+### A1. Concurrency safety (blocker fix — backend)
+
+`ArticleFileService.reparse()` resets `extraction_status='pending'` and enqueues
+a fresh task with no in-flight guard; the worker runs `concurrency=4` +
+`task_acks_late=True`; `ArticleTextBlockRepository.replace_for_file` is a
+non-atomic DELETE-then-bulk-INSERT; and the
+`(article_file_id, page_number, block_index)` index (migration 0006) is **plain,
+not unique**. Two concurrent parse tasks ⇒ silent **duplicate or lost blocks**,
+which corrupts `concat_page_text` char-offset math and the reader order.
+
+**Required:**
+- Add a **UNIQUE** constraint on
+  `article_text_blocks(article_file_id, page_number, block_index)` (Alembic
+  migration; **dedupe any existing duplicate rows first** so the constraint can
+  be created). This makes concurrent double-inserts fail loudly instead of
+  silently duplicating.
+- **Serialize the parse write** with a `pg_advisory_xact_lock` keyed on
+  `article_file_id` held across `replace_for_file` in the parse path
+  (`DocumentParsingService.parse_article_file` / the worker task), so a Retry on
+  an in-flight file cannot interleave two replaces.
+- Correct the earlier claim "no backend change to recovery itself" — allowing
+  Retry while a parse may be in flight **does** require this backend change.
+
+### A2. Re-parsing a `parsed` file (blocker fix — UX guard)
+
+`extraction_evidence.position` is a **JSONB snapshot** (char range + block_index
++ bbox; `extraction.py:516`), `article_file_id` is `ondelete='SET NULL'` with no
+FK to block ids. Re-parsing mints new block ids and possibly different offsets
+(esp. across the `auto` LlamaParse↔Docling switch), so it **silently shifts
+every previously-grounded citation highlight** on that file — no error surfaces.
+
+**Required:**
+- The `parsed`-state action is a **confirm dialog** (`AlertDialog`), not a quiet
+  re-parse. The dialog warns that re-parsing rebuilds the document and may shift
+  existing citation highlights. (Enhancement, optional: only warn when the file
+  has grounded `extraction_evidence` — needs a count/boolean; the floor is
+  always-confirm for `parsed`.)
+- A proper **re-anchoring** step (re-run `build_anchor` over the new blocks for
+  affected evidence) is **out of scope** here and recorded as a follow-up.
+- Remove all blanket "idempotent" wording. The only true sense of "idempotent"
+  is that re-parse does **not** re-trigger AI extraction (verified:
+  `reparse()` → `parse_article_file_task` runs `DocumentParsingService` only).
+
+### A3. Behaviour by `extractionStatus`
 
 | Status | Indicator | Action |
 | --- | --- | --- |
-| `pending` | `Processing…` (`docStatusPending`) — `Loader2` spin or `bg-warning animate-pulse` dot | **Retry** allowed (covers the stuck case); re-parse is idempotent |
-| `parsed` | `Ready` (`docStatusReady`) — `bg-success` dot | quiet **Re-parse** (light, low-emphasis) |
+| `pending` | `Processing…` (`docStatusPending`) — `Loader2` spin / `bg-warning animate-pulse` dot | **Retry** allowed (covers the stuck case); safe because of A1's lock + UNIQUE constraint |
+| `parsed` | `Ready` (`docStatusReady`) — `bg-success` dot | **Re-parse** behind the A2 confirm dialog |
 | `parse_failed` | `Parse failed` (`docStatusFailed`) — `bg-destructive` dot | prominent **Retry parse** + `extraction_error` in a Tooltip |
 | unknown | muted fallback dot (`bg-muted-foreground/40`) | none |
 
-### Backend (small)
+### A4. Backend (schema + read path)
 
 - Add `extraction_error: str | None` to **`ArticleFileListItem`**
-  (`backend/app/schemas/article.py:205`) — it currently exposes only
-  `extraction_status`; the error string lives only on `ArticleFileResponse`.
-  Required for the failed-state tooltip. Populate it in
-  `list_files_for_article` (the read path already selects the row).
-- `npm run generate:api-types` + commit the regenerated
-  `frontend/types/api/schema.d.ts`.
-- **No migration** (the `extraction_error` column already exists on the model;
-  this only widens a response schema).
-- The `POST /article-files/{id}/reparse` endpoint already accepts any status —
-  no backend change to recovery itself.
+  (`backend/app/schemas/article.py:205`). **No read-path change** —
+  `ArticleFileService.list_for_article` returns full ORM rows and the endpoint
+  uses `ArticleFileListItem.model_validate(f)`, so the field auto-populates via
+  the alias. (Verified: the method is `list_for_article`, not the earlier
+  mis-named `list_files_for_article`.)
+- **No migration for this field** — the `extraction_error` column already exists
+  on the `ArticleFile` model (`models/article.py:227`); this only widens a
+  response schema. (The UNIQUE constraint in A1 is a *separate* migration.)
+- Not a security leak: the list endpoint is gated by `ensure_project_member`
+  identically to the detail endpoint that already returns `extraction_error`
+  (adversarial review: unfounded).
+- `npm run generate:api-types` + commit the regenerated `schema.d.ts` (additive,
+  optional field — no consumer breaks).
 
-### Frontend
+### A5. Frontend
 
 - **Create `frontend/hooks/extraction/useReparseArticleFile.ts`** — a
   `useMutation` modeled on `hooks/runs/useMarkReady.ts`:
-  `mutationFn: (articleFileId) => apiClient('/api/v1/article-files/${id}/reparse', {method:'POST'})`;
+  `mutationFn: (id) => apiClient('/api/v1/article-files/${id}/reparse', {method:'POST'})`;
   `onSuccess`: invalidate **both** `articleKeys.files(articleId)` **and**
-  `articleKeys.textBlocks(articleFileId)` (stale-cache incident class — both are
-  mandatory); `onError`: `toast.error(error.message || t('pdf','docReparseError'))`.
-  This supersedes the existing inline `useState(busy)` + `.then()/.finally()` in
-  `ReparseButton` and gives `isPending` for the spinner for free. (Reuses the
-  existing `reparseArticleFile` URL; the existing `articlesService.reparseArticleFile`
-  ErrorResult function may be retired or kept — pick the mutation-hook path,
-  one IO convention.)
-- **Build a `ParseStatusControl`** co-located in
-  `frontend/components/extraction/DocumentSwitcher.tsx` (sibling export, the way
-  `ReparseButton` already is). It reads `selectedFile.extractionStatus` (+ the
-  new `extractionError`) from `useArticleDocuments` and renders the dot +
-  collapsible label + the contextual action. A `cva` keyed on `status` (mirror
-  `frontend/components/layout/HeaderChip.tsx`), using **semantic tokens**
-  (`success` / `warning` / `destructive`) — replacing the raw `emerald/amber/red`
-  in the current `STATUS_DOT` map. Icon-only actions use `Button size="header-icon"`
-  + `aria-label`; the failed tooltip uses the global `TooltipProvider`.
-- **Replace the `parse_failed`-only gate** at both mount sites with the new
-  control: `ExtractionPDFPanel.tsx:80` and
-  `QualityAssessmentFullScreen.tsx` (preserve the QA site's `articleId`
-  null-guard). Keep both in sync.
-- **Copy:** reuse the existing-but-unused `pdf` keys `docStatusReady` /
-  `docStatusPending` (`'Processing…'`) / `docStatusFailed` and
-  `docReparse` / `docReparseQueued` / `docReparseError` in
-  `frontend/lib/copy/pdf.ts`. Add only an error-tooltip prefix key if needed.
-  English-only, via `t('pdf', key)`.
-- **Auto-refresh:** `useArticleDocuments` already polls `articleKeys.files`
-  every 4s while any file is `pending`; after a re-parse the status flips to
-  `pending`, polling resumes, and the reader fills when blocks/markdown land.
-  No new polling wiring.
+  `articleKeys.textBlocks(articleFileId)` (stale-cache class — both mandatory);
+  `onError`: `toast.error(error.message || t('pdf','docReparseError'))`. Gives
+  `isPending` for the spinner. **Additive only.**
+- **KEEP `articlesService.reparseArticleFile`** — it has a third caller
+  (`ArticleDetailDialog.tsx:348`) + a unit test (`articlesService.test.ts:257`)
+  outside this scope. A mixed IO convention (ErrorResult service for the dialog,
+  `useMutation` for the switcher) is accepted; migrating the dialog is an
+  explicit later follow-up, not this spec.
+- **Build `ParseStatusControl`** co-located in
+  `frontend/components/extraction/DocumentSwitcher.tsx` (sibling export). Reads
+  `selectedFile.extractionStatus` + the new `extractionError` from
+  `useArticleDocuments`; renders dot + collapsible label + the contextual action
+  (with the A2 `AlertDialog` for `parsed`). A `cva` keyed on `status` (mirror
+  `frontend/components/layout/HeaderChip.tsx`) using **semantic tokens**
+  (`success`/`warning`/`destructive`), replacing the raw `emerald/amber/red`
+  `STATUS_DOT`. Icon-only actions use `Button size="header-icon"` + `aria-label`;
+  the failed tooltip uses the global `TooltipProvider`.
+- **Replace the `parse_failed`-only gate** at **both** mount sites:
+  `ExtractionPDFPanel.tsx:80` and `QualityAssessmentFullScreen.tsx` (the QA
+  `articleId` early-return at line ~500 already guarantees non-null; keep the
+  control consistent across both). No third switcher mount site exists
+  (`ArticleDetailDialog` is a separate non-switcher surface, out of scope).
+- **Copy** (`frontend/lib/copy/pdf.ts`): reuse the **unused** `docStatusReady` /
+  `docStatusPending` (`'Processing…'`) / `docStatusFailed`. `docReparse` /
+  `docReparseQueued` / `docReparseError` are **already in use** by the current
+  `ReparseButton` — reuse them. Add one tooltip-prefix key
+  (`docParseErrorLabel: 'Parse error'`) so the raw `extraction_error` is
+  labelled, not shown bare. English-only via `t('pdf', key)`.
+- **Auto-refresh:** `useArticleDocuments` already polls `articleKeys.files` every
+  4s while any file is `pending`; after a re-parse the status flips to `pending`,
+  polling resumes, and the reader fills when blocks land. No new polling wiring.
 
-### Out of scope (deferred)
-
-- **Clearing the 39 `pending` backlog** — needs prod/Railway access (currently
-  unreachable from this session). Once the affordance ships, each is
-  self-serviceable from the UI; or a one-off re-enqueue script can be run
-  separately. Explicitly *not* a bulk auto-sweep (user decision).
-- No schema-level "stuck vs in-flight" distinction (user decision: treat
-  `pending` uniformly, allow manual retry).
-
-## Testing
+### A6. Tests
 
 - **`useReparseArticleFile`** — hook test mirroring
-  `frontend/test/hooks-runs.test.tsx`: `vi.mock('@/integrations/api', { apiClient })`,
-  `QueryClient` with retries off, `await act(mutateAsync)`, assert
-  `apiClient('/api/v1/article-files/${id}/reparse', {method:'POST'})` and that
-  both key families are invalidated.
+  `frontend/test/hooks-runs.test.tsx`: `vi.mock('@/integrations/api',{apiClient})`,
+  `QueryClient` retries off, `await act(mutateAsync)`, assert the POST URL and
+  that both key families are invalidated.
 - **`DocumentSwitcher` / `ParseStatusControl`** — extend
   `frontend/test/components/DocumentSwitcher.test.tsx`: each status renders its
-  dot/label/action; the failed tooltip shows `extractionError`; the action
-  fires the mutation. `vi.mock('@/lib/copy', { t: (_n,k)=>k })`. Keep the test
-  env-free (no AuthContext/supabase imports) so it passes in env-less CI.
-- **Issue 2 tests** are owned by the existing plan (each phase has failing-test
-  steps), including the `Reader` XSS test and the design-review + axe pass.
+  dot/label/action; the failed tooltip shows `extractionError`; the `parsed`
+  confirm dialog appears; the action fires the mutation. **The existing
+  `vi.mock('@/services/articlesService')` must change to
+  `vi.mock('@/integrations/api',{apiClient})` + a `QueryClientProvider` wrapper**
+  (the control now drives a `useMutation`). `vi.mock('@/lib/copy',{t:(_n,k)=>k})`.
+  Keep the test env-free (no AuthContext/supabase imports) for env-less CI.
+- **Backend (CI gate):** a **direct endpoint-coroutine unit test** for
+  `list_article_files` asserting `extraction_error` is serialized for a failed
+  file — mirror `test_article_files_unit.py`, NOT only an integration test
+  (endpoint lines exercised via httpx ASGITransport do not register coverage, so
+  the 80% diff-cover gate fails without a direct coroutine test). Also cover the
+  A1 advisory-lock/unique-constraint path.
 
-## Acceptance
+### A7. Acceptance (Workstream A, self-contained)
 
 - A `pending` or `parse_failed` file shows a clear, status-appropriate re-parse
-  action next to the switcher; a successful re-parse transitions the file to
-  `parsed` and the reader renders it — no UI dead-end in any state.
-- The reader renders sanitized server-projected markdown (GFM tables/lists/
-  super-sub) at parity with the extraction table aesthetic, and AI citations are
-  anchored in the markdown and highlighted in both the reader and the canvas
-  (per the existing markdown plan).
+  action next to the switcher; re-parsing a `parsed` file requires the A2
+  confirm. A successful re-parse transitions the file to `parsed` and the reader
+  renders it — no UI dead-end in any state.
+- Two concurrent parse tasks on one file cannot produce duplicate/lost blocks
+  (A1). Re-parsing a `parsed` file never *silently* invalidates citations (A2).
+- Ships **independently** of Workstream B (no `react-markdown` dependency).
+
+---
+
+## Workstream B — markdown view + markdown-anchored citations (Issue 2)
+
+**Decision: execute the existing 6-phase plan in full, after amending
+ADR-0013** (user decision). `react-markdown` is adequate; the plan's stack is
+correct: `react-markdown` + `remark-gfm` + `rehype-sanitize` — **no
+`rehype-raw`** (server-projected GFM; the ADR forbids raw without sanitize) and
+**no `remark-breaks`** (blocks joined with `\n\n`). Defense-in-depth: server
+`nh3` + `rehype-sanitize`. My earlier `rehype-raw` + `remark-breaks` sketch is
+**dropped**. Anchoring is safe (adversarial verdict: *sound*) — reader-mode
+highlight does not exist today and copy reads the raw prop; the new highlight is
+quote-based.
+
+Corrections to fold in while executing the plan:
+
+- **Amend ADR-0013 first.** Plan Phase 3 sets `READ_FROM_BLOCKS` default `True`,
+  removes `MAX_PDF_CHARS`, and raises the prompt budget 15k→120k — i.e. markdown
+  becomes the **default extraction input**. ADR-0013 currently says blocks stay
+  the default ("no two competing extraction inputs by default"). Amend the ADR
+  to make markdown the default, recording the **bake-off evidence** that markdown
+  beats the block-assembler, and treat the 15k→120k budget change as its **own
+  verification** (latency/cost/quality), before/with Phase 3.
+- **Stale `readerBlocks` premise (#359).** The plan predates the shipped
+  reader-switcher; its claim "neither panel passes `readerBlocks`; this adds
+  `readerMarkdown`" is now **false** — both panels already pass `readerBlocks`
+  (`ExtractionPDFPanel.tsx:92`, `QualityAssessmentFullScreen.tsx:665`). Plan
+  Tasks 5.2/5.3 must **replace** the wired `readerBlocks`/`readerLoading` props,
+  not add new ones. `ReaderTextBlock` is a **public viewer-barrel export**
+  (removing it is a breaking package API change); keep a **blocks-based fallback
+  render** until the markdown endpoint ships and is verified.
+- **`prose` vs density.** `@tailwindcss/typography` is installed but **not** in
+  `tailwind.config.ts` `plugins[]`; registering it for `prose prose-sm` is
+  required, and the dense table cells need a `components` override to match the
+  extraction table aesthetic (`ExtractionInterface.tsx:406-448`). Resolve in the
+  plan + a `design-review` pass; do not hand-wave.
+- Process: `npm audit --audit-level=high` after the dep add (security-audit gate
+  fires on lockfile changes); `node scripts/enumerate_compiler_bailouts.mjs`
+  (panicThreshold `all_errors`); add `rehype/remark/sanitize/nh3/GFM/markdown` to
+  `.github/cspell-words.txt` (already a plan step). Drive-by: fix the Portuguese
+  comment at `AISuggestionEvidence.tsx:154` when that file is touched.
+
+### Acceptance (Workstream B)
+
+Owned by the markdown plan's own per-phase acceptance: the reader renders
+sanitized server-projected markdown (GFM tables/lists/super-sub) at parity with
+the extraction table aesthetic; AI citations are anchored in the markdown and
+highlighted in **both** the reader and the canvas; ADR-0013 amended; Phase 3's
+extraction-input swap verified by the bake-off.
+
+---
+
+## Out of scope / deferred
+
+- **Clearing the 39 `pending` backlog** — **user sign-off to clear manually via
+  the new affordance after deploy** (open each article, click Retry). No backfill
+  script; no auto-sweep.
+- **Re-anchoring grounded citations after a `parsed` re-parse** (A2) — recorded
+  follow-up; the confirm dialog is the interim guard.
+- **Migrating `ArticleDetailDialog` to the new mutation hook** — later cleanup;
+  `articlesService.reparseArticleFile` is kept.
+- No schema-level "stuck vs in-flight" distinction (user decision: treat
+  `pending` uniformly, allow guarded manual retry).

--- a/frontend/components/extraction/DocumentSwitcher.tsx
+++ b/frontend/components/extraction/DocumentSwitcher.tsx
@@ -154,13 +154,15 @@ export function ParseStatusControl({ articleId, file }: ParseStatusControlProps)
         <span aria-hidden className={statusDot({ status })} />
       )}
 
-      {status === 'parse_failed' && file.extractionError ? (
+      {status === 'parse_failed' ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="cursor-default">{label}</span>
           </TooltipTrigger>
           <TooltipContent>
-            {t('pdf', 'docParseErrorLabel')}: {file.extractionError}
+            {file.extractionError
+              ? `${t('pdf', 'docParseErrorLabel')}: ${file.extractionError}`
+              : t('pdf', 'docParseErrorUnknown')}
           </TooltipContent>
         </Tooltip>
       ) : (

--- a/frontend/components/extraction/DocumentSwitcher.tsx
+++ b/frontend/components/extraction/DocumentSwitcher.tsx
@@ -4,12 +4,11 @@
  * Presentational dropdown over an article's files (MAIN + supplements), with a
  * per-file parse-status dot. Selecting a document is the caller's concern
  * (it also clears viewer citations/search/page to avoid cross-document leak).
- * `ReparseButton` recovers a `parse_failed` file in-place — the same recovery
- * the Articles dialog offers, surfaced where the failure is seen.
- * `ParseStatusControl` is a status-aware sibling that adds a confirm dialog for
- * re-parsing a successfully-parsed file and an error tooltip for parse failures.
+ * `ParseStatusControl` is a status-aware control that shows parse status and
+ * surfaces a contextual re-parse action (with a confirm dialog for already-parsed
+ * files and an error tooltip for parse failures).
  */
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import { cva } from 'class-variance-authority';
 import { Loader2 } from 'lucide-react';
 
@@ -35,11 +34,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { FILE_ROLE_LABELS, type FileRole } from '@/lib/file-constants';
 import { t } from '@/lib/copy';
 import { cn } from '@/lib/utils';
-import { articleKeys } from '@/lib/query-keys';
-import { reparseArticleFile } from '@/services/articlesService';
 import type { ArticleFileListItem } from '@/services/articleFilesService';
-import { useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
 import { useReparseArticleFile } from '@/hooks/extraction/useReparseArticleFile';
 
 // Module-level cva — kept at module scope to satisfy React Compiler (no inline objects).
@@ -128,46 +123,6 @@ function DocumentSwitcherComponent({
 
 export const DocumentSwitcher = memo(DocumentSwitcherComponent);
 DocumentSwitcher.displayName = 'DocumentSwitcher';
-
-export interface ReparseButtonProps {
-  articleFileId: string;
-  articleId: string;
-}
-
-/** Re-enqueue a parse for a `parse_failed` file and refresh the file + blocks. */
-export function ReparseButton({ articleFileId, articleId }: ReparseButtonProps) {
-  const queryClient = useQueryClient();
-  const [busy, setBusy] = useState(false);
-
-  const onClick = () => {
-    setBusy(true);
-    reparseArticleFile(articleFileId)
-      .then((res) => {
-        if (!res.ok) {
-          toast.error(res.error.message || t('pdf', 'docReparseError'));
-          return;
-        }
-        toast.success(t('pdf', 'docReparseQueued'));
-        void queryClient.invalidateQueries({ queryKey: articleKeys.files(articleId) });
-        void queryClient.invalidateQueries({
-          queryKey: articleKeys.textBlocks(articleFileId),
-        });
-      })
-      .finally(() => setBusy(false));
-  };
-
-  return (
-    <Button
-      size="sm"
-      variant="outline"
-      className="h-7 shrink-0 text-xs"
-      disabled={busy}
-      onClick={onClick}
-    >
-      {t('pdf', 'docReparse')}
-    </Button>
-  );
-}
 
 export interface ParseStatusControlProps {
   articleId: string;

--- a/frontend/components/extraction/DocumentSwitcher.tsx
+++ b/frontend/components/extraction/DocumentSwitcher.tsx
@@ -146,6 +146,46 @@ export function ParseStatusControl({ articleId, file }: ParseStatusControlProps)
     : status === 'parse_failed' ? t('pdf', 'docStatusFailed')
     : '';
 
+  const reparseAction =
+    status === 'parsed' ? (
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-xs"
+            disabled={reparse.isPending}
+            aria-label={t('pdf', 'docReparse')}
+          >
+            {t('pdf', 'docReparse')}
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('pdf', 'docReparseConfirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('pdf', 'docReparseConfirmBody')}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common', 'cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={fire} aria-label={t('pdf', 'docReparseConfirmCta')}>
+              {t('pdf', 'docReparseConfirmCta')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    ) : status !== 'unknown' ? (
+      <Button
+        size="sm"
+        variant={status === 'parse_failed' ? 'outline' : 'ghost'}
+        className="h-7 text-xs"
+        disabled={reparse.isPending}
+        onClick={fire}
+        aria-label={t('pdf', 'docReparse')}
+      >
+        {t('pdf', 'docReparse')}
+      </Button>
+    ) : null;
+
   return (
     <div className="flex items-center gap-1.5 shrink-0 text-[11px] text-muted-foreground">
       {status === 'pending' ? (
@@ -169,46 +209,7 @@ export function ParseStatusControl({ articleId, file }: ParseStatusControlProps)
         <span>{label}</span>
       )}
 
-      {status === 'parsed' ? (
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="h-7 text-xs"
-              disabled={reparse.isPending}
-              aria-label={t('pdf', 'docReparse')}
-            >
-              {t('pdf', 'docReparse')}
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>{t('pdf', 'docReparseConfirmTitle')}</AlertDialogTitle>
-              <AlertDialogDescription>{t('pdf', 'docReparseConfirmBody')}</AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>{t('common', 'cancel')}</AlertDialogCancel>
-              <AlertDialogAction onClick={fire} aria-label={t('pdf', 'docReparseConfirmCta')}>
-                {t('pdf', 'docReparseConfirmCta')}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      ) : (
-        (status === 'parse_failed' || status === 'pending') && (
-          <Button
-            size="sm"
-            variant={status === 'parse_failed' ? 'outline' : 'ghost'}
-            className="h-7 text-xs"
-            disabled={reparse.isPending}
-            onClick={fire}
-            aria-label={t('pdf', 'docReparse')}
-          >
-            {t('pdf', 'docReparse')}
-          </Button>
-        )
-      )}
+      {reparseAction}
     </div>
   );
 }

--- a/frontend/components/extraction/DocumentSwitcher.tsx
+++ b/frontend/components/extraction/DocumentSwitcher.tsx
@@ -6,8 +6,12 @@
  * (it also clears viewer citations/search/page to avoid cross-document leak).
  * `ReparseButton` recovers a `parse_failed` file in-place — the same recovery
  * the Articles dialog offers, surfaced where the failure is seen.
+ * `ParseStatusControl` is a status-aware sibling that adds a confirm dialog for
+ * re-parsing a successfully-parsed file and an error tooltip for parse failures.
  */
 import { memo, useState } from 'react';
+import { cva } from 'class-variance-authority';
+import { Loader2 } from 'lucide-react';
 
 import {
   Select,
@@ -16,6 +20,18 @@ import {
   SelectTrigger,
 } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { FILE_ROLE_LABELS, type FileRole } from '@/lib/file-constants';
 import { t } from '@/lib/copy';
 import { cn } from '@/lib/utils';
@@ -24,12 +40,20 @@ import { reparseArticleFile } from '@/services/articlesService';
 import type { ArticleFileListItem } from '@/services/articleFilesService';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { useReparseArticleFile } from '@/hooks/extraction/useReparseArticleFile';
 
-const STATUS_DOT: Record<string, string> = {
-  parsed: 'bg-emerald-500',
-  pending: 'bg-amber-500 animate-pulse',
-  parse_failed: 'bg-red-500',
-};
+// Module-level cva — kept at module scope to satisfy React Compiler (no inline objects).
+const statusDot = cva('h-1.5 w-1.5 shrink-0 rounded-full', {
+  variants: {
+    status: {
+      parsed: 'bg-success',
+      pending: 'bg-warning animate-pulse',
+      parse_failed: 'bg-destructive',
+      unknown: 'bg-muted-foreground/40',
+    },
+  },
+  defaultVariants: { status: 'unknown' },
+});
 
 function roleLabel(role: string): string {
   return FILE_ROLE_LABELS[role as FileRole] ?? role;
@@ -44,6 +68,12 @@ export interface DocumentSwitcherProps {
   selectedFileId: string | null;
   onSelect: (id: string) => void;
   className?: string;
+}
+
+type ParseStatus = 'parsed' | 'pending' | 'parse_failed' | 'unknown';
+
+function toStatus(s: string): ParseStatus {
+  return s === 'parsed' || s === 'pending' || s === 'parse_failed' ? s : 'unknown';
 }
 
 function DocumentSwitcherComponent({
@@ -68,10 +98,7 @@ function DocumentSwitcherComponent({
           {selected && (
             <span
               aria-hidden
-              className={cn(
-                'h-1.5 w-1.5 shrink-0 rounded-full',
-                STATUS_DOT[selected.extractionStatus] ?? 'bg-muted-foreground/40',
-              )}
+              className={statusDot({ status: toStatus(selected.extractionStatus) })}
             />
           )}
           <span className="truncate">
@@ -85,10 +112,7 @@ function DocumentSwitcherComponent({
             <span className="flex items-center gap-2">
               <span
                 aria-hidden
-                className={cn(
-                  'h-1.5 w-1.5 shrink-0 rounded-full',
-                  STATUS_DOT[file.extractionStatus] ?? 'bg-muted-foreground/40',
-                )}
+                className={statusDot({ status: toStatus(file.extractionStatus) })}
               />
               <span className="truncate">{fileLabel(file)}</span>
               <span className="ml-1 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
@@ -142,5 +166,92 @@ export function ReparseButton({ articleFileId, articleId }: ReparseButtonProps) 
     >
       {t('pdf', 'docReparse')}
     </Button>
+  );
+}
+
+export interface ParseStatusControlProps {
+  articleId: string;
+  file: ArticleFileListItem;
+}
+
+/**
+ * Status-aware control showing parse status + a contextual re-parse action.
+ * - `pending`     → spinner + "Processing…" + ghost Retry
+ * - `parsed`      → "Ready" + low-emphasis Re-parse behind an AlertDialog confirm
+ * - `parse_failed`→ "Parse failed" (error in Tooltip) + prominent Retry parse
+ */
+export function ParseStatusControl({ articleId, file }: ParseStatusControlProps) {
+  const status = toStatus(file.extractionStatus);
+  const reparse = useReparseArticleFile(articleId);
+  const fire = () => reparse.mutate(file.id);
+
+  const label =
+    status === 'parsed' ? t('pdf', 'docStatusReady')
+    : status === 'pending' ? t('pdf', 'docStatusPending')
+    : status === 'parse_failed' ? t('pdf', 'docStatusFailed')
+    : '';
+
+  return (
+    <div className="flex items-center gap-1.5 shrink-0 text-[11px] text-muted-foreground">
+      {status === 'pending' ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.5} aria-hidden />
+      ) : (
+        <span aria-hidden className={statusDot({ status })} />
+      )}
+
+      {status === 'parse_failed' && file.extractionError ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-default">{label}</span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t('pdf', 'docParseErrorLabel')}: {file.extractionError}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <span>{label}</span>
+      )}
+
+      {status === 'parsed' ? (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs"
+              disabled={reparse.isPending}
+              aria-label={t('pdf', 'docReparse')}
+            >
+              {t('pdf', 'docReparse')}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t('pdf', 'docReparseConfirmTitle')}</AlertDialogTitle>
+              <AlertDialogDescription>{t('pdf', 'docReparseConfirmBody')}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t('common', 'cancel')}</AlertDialogCancel>
+              <AlertDialogAction onClick={fire} aria-label={t('pdf', 'docReparseConfirmCta')}>
+                {t('pdf', 'docReparseConfirmCta')}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : (
+        (status === 'parse_failed' || status === 'pending') && (
+          <Button
+            size="sm"
+            variant={status === 'parse_failed' ? 'outline' : 'ghost'}
+            className="h-7 text-xs"
+            disabled={reparse.isPending}
+            onClick={fire}
+            aria-label={t('pdf', 'docReparse')}
+          >
+            {t('pdf', 'docReparse')}
+          </Button>
+        )
+      )}
+    </div>
   );
 }

--- a/frontend/components/extraction/ExtractionPDFPanel.tsx
+++ b/frontend/components/extraction/ExtractionPDFPanel.tsx
@@ -12,7 +12,7 @@ import {ResizableHandle, ResizablePanel} from '@/components/ui/resizable';
 import {PrumoPdfViewer} from '@prumo/pdf-viewer';
 import type {ViewerState} from '@prumo/pdf-viewer';
 import {useArticleDocuments} from '@/hooks/extraction/useArticleDocuments';
-import {DocumentSwitcher, ReparseButton} from './DocumentSwitcher';
+import {DocumentSwitcher, ParseStatusControl} from './DocumentSwitcher';
 
 export interface ExtractionPDFPanelProps {
   articleId: string;
@@ -77,11 +77,8 @@ function ExtractionPDFPanelComponent({
                 selectedFileId={selectedFileId}
                 onSelect={handleSelect}
               />
-              {selectedFile?.extractionStatus === 'parse_failed' && (
-                <ReparseButton
-                  articleFileId={selectedFile.id}
-                  articleId={articleId}
-                />
+              {selectedFile && (
+                <ParseStatusControl articleId={articleId} file={selectedFile} />
               )}
             </div>
           )}

--- a/frontend/hooks/extraction/useReparseArticleFile.ts
+++ b/frontend/hooks/extraction/useReparseArticleFile.ts
@@ -1,10 +1,9 @@
-// frontend/hooks/extraction/useReparseArticleFile.ts
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { apiClient } from "@/integrations/api";
 import { t } from "@/lib/copy";
-import { articleKeys } from "@/lib/query-keys/articles";
+import { articleKeys } from "@/lib/query-keys";
 
 /** Re-enqueue a parse for an ArticleFile and refresh the file list + reader blocks. */
 export function useReparseArticleFile(articleId: string) {

--- a/frontend/hooks/extraction/useReparseArticleFile.ts
+++ b/frontend/hooks/extraction/useReparseArticleFile.ts
@@ -1,0 +1,25 @@
+// frontend/hooks/extraction/useReparseArticleFile.ts
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { apiClient } from "@/integrations/api";
+import { t } from "@/lib/copy";
+import { articleKeys } from "@/lib/query-keys/articles";
+
+/** Re-enqueue a parse for an ArticleFile and refresh the file list + reader blocks. */
+export function useReparseArticleFile(articleId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, Error, string>({
+    mutationFn: (articleFileId) =>
+      apiClient(`/api/v1/article-files/${articleFileId}/reparse`, { method: "POST" }),
+    onSuccess: (_data, articleFileId) => {
+      toast.success(t("pdf", "docReparseQueued"));
+      queryClient.invalidateQueries({ queryKey: articleKeys.files(articleId) });
+      queryClient.invalidateQueries({ queryKey: articleKeys.textBlocks(articleFileId) });
+    },
+    onError: (error) => {
+      toast.error(error.message || t("pdf", "docReparseError"));
+    },
+  });
+}

--- a/frontend/lib/copy/pdf.ts
+++ b/frontend/lib/copy/pdf.ts
@@ -81,6 +81,11 @@ export const pdf = {
     docReparse: 'Re-parse',
     docReparseQueued: 'Re-parse queued',
     docReparseError: 'Failed to queue re-parse',
+    docParseErrorLabel: 'Parse error',
+    docReparseConfirmTitle: 'Re-parse this document?',
+    docReparseConfirmBody:
+      'Re-parsing rebuilds the document text. Existing citation highlights for this file may shift and need re-checking.',
+    docReparseConfirmCta: 'Re-parse',
 } as const;
 
 export type PdfCopy = typeof pdf;

--- a/frontend/lib/copy/pdf.ts
+++ b/frontend/lib/copy/pdf.ts
@@ -82,6 +82,7 @@ export const pdf = {
     docReparseQueued: 'Re-parse queued',
     docReparseError: 'Failed to queue re-parse',
     docParseErrorLabel: 'Parse error',
+    docParseErrorUnknown: 'Parse failed — no error details recorded',
     docReparseConfirmTitle: 'Re-parse this document?',
     docReparseConfirmBody:
       'Re-parsing rebuilds the document text. Existing citation highlights for this file may shift and need re-checking.',

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -33,7 +33,7 @@ import { PrumoPdfViewer } from "@prumo/pdf-viewer";
 import { useArticleDocuments } from "@/hooks/extraction/useArticleDocuments";
 import {
   DocumentSwitcher,
-  ReparseButton,
+  ParseStatusControl,
 } from "@/components/extraction/DocumentSwitcher";
 import { Badge } from "@/components/ui/badge";
 import { useProjectQATemplate } from "@/hooks/qa/useProjectQATemplate";
@@ -650,13 +650,9 @@ export default function QualityAssessmentFullScreen() {
             selectedFileId={documents.selectedFileId}
             onSelect={documents.setSelectedFileId}
           />
-          {documents.selectedFile?.extractionStatus === "parse_failed" &&
-            articleId && (
-              <ReparseButton
-                articleFileId={documents.selectedFile.id}
-                articleId={articleId}
-              />
-            )}
+          {documents.selectedFile && (
+            <ParseStatusControl articleId={articleId} file={documents.selectedFile} />
+          )}
         </div>
       )}
       <div className="min-h-0 flex-1">

--- a/frontend/test/components/DocumentSwitcher.test.tsx
+++ b/frontend/test/components/DocumentSwitcher.test.tsx
@@ -8,7 +8,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
-vi.mock("@/services/articlesService", () => ({ reparseArticleFile: vi.fn() }));
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
 

--- a/frontend/test/components/DocumentSwitcher.test.tsx
+++ b/frontend/test/components/DocumentSwitcher.test.tsx
@@ -107,4 +107,13 @@ describe("ParseStatusControl", () => {
     renderControl({ id: "f3", extractionStatus: "pending" });
     expect(screen.getByText("docStatusPending")).toBeInTheDocument();
   });
+
+  it("pending: Retry button POSTs to reparse endpoint", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f4", extractionStatus: "pending" });
+    fireEvent.click(screen.getByRole("button", { name: /docReparse/ }));
+    await waitFor(() => {
+      expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f4/reparse", { method: "POST" });
+    });
+  });
 });

--- a/frontend/test/components/DocumentSwitcher.test.tsx
+++ b/frontend/test/components/DocumentSwitcher.test.tsx
@@ -1,53 +1,66 @@
 /**
- * Tests for DocumentSwitcher (presentational document selector).
- *
- * Covers:
- *  - renders nothing when the article has no files
- *  - shows the selected file's label in the trigger
+ * Tests for DocumentSwitcher (presentational document selector) and
+ * ParseStatusControl (status-aware re-parse control).
  */
-import {render, screen} from '@testing-library/react';
-import {describe, expect, it, vi} from 'vitest';
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
-vi.mock('@/lib/copy', () => ({
-  t: (_ns: string, key: string) => key,
-}));
-vi.mock('@/services/articlesService', () => ({
-  reparseArticleFile: vi.fn(),
-}));
+vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
+vi.mock("@/services/articlesService", () => ({ reparseArticleFile: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
 
-import {DocumentSwitcher} from '@/components/extraction/DocumentSwitcher';
-import type {ArticleFileListItem} from '@/services/articleFilesService';
+import { apiClient } from "@/integrations/api";
+import { DocumentSwitcher, ParseStatusControl } from "@/components/extraction/DocumentSwitcher";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ArticleFileListItem } from "@/services/articleFilesService";
 
 function file(
   id: string,
   fileRole: string,
   originalFilename: string,
-  extractionStatus = 'parsed',
+  extractionStatus = "parsed",
 ): ArticleFileListItem {
   return {
     id,
     fileRole,
-    fileType: 'PDF',
+    fileType: "PDF",
     originalFilename,
     extractionStatus,
     bytes: 1,
     storageKey: `k/${id}.pdf`,
-    createdAt: '2026-06-21T00:00:00Z',
+    createdAt: "2026-06-21T00:00:00Z",
   };
 }
 
-describe('DocumentSwitcher', () => {
-  it('renders nothing when there are no files', () => {
-    const {container} = render(
+function renderControl(f: { id: string; extractionStatus: string; extractionError?: string | null }) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <ParseStatusControl
+          articleId="art-1"
+          file={{ originalFilename: "a.pdf", fileRole: "MAIN", ...f } as never}
+        />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DocumentSwitcher", () => {
+  it("renders nothing when there are no files", () => {
+    const { container } = render(
       <DocumentSwitcher files={[]} selectedFileId={null} onSelect={() => {}} />,
     );
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('shows the selected file label in the trigger', () => {
+  it("shows the selected file label in the trigger", () => {
     const files = [
-      file('main-1', 'MAIN', 'main.pdf'),
-      file('supp-1', 'SUPPLEMENT', 'supp.pdf', 'pending'),
+      file("main-1", "MAIN", "main.pdf"),
+      file("supp-1", "SUPPLEMENT", "supp.pdf", "pending"),
     ];
     render(
       <DocumentSwitcher
@@ -58,10 +71,41 @@ describe('DocumentSwitcher', () => {
     );
     // The trigger renders the selected file's label explicitly (not via the
     // unmounted Radix item list).
-    expect(screen.getByText('main.pdf')).toBeInTheDocument();
-    expect(screen.getByRole('combobox')).toHaveAttribute(
-      'aria-label',
-      'docSwitcherAria',
+    expect(screen.getByText("main.pdf")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveAttribute(
+      "aria-label",
+      "docSwitcherAria",
     );
+  });
+});
+
+describe("ParseStatusControl", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("failed: shows the error in a tooltip trigger and a Retry that POSTs", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f1", extractionStatus: "parse_failed", extractionError: "libxcb.so.1 missing" });
+    fireEvent.click(screen.getByRole("button", { name: /docReparse/ }));
+    await waitFor(() => {
+      expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f1/reparse", { method: "POST" });
+    });
+  });
+
+  it("parsed: Re-parse opens a confirm dialog before POSTing", async () => {
+    const user = userEvent.setup();
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f2", extractionStatus: "parsed" });
+    await user.click(screen.getByRole("button", { name: /docReparse/ }));
+    expect(apiClient).not.toHaveBeenCalled();             // confirm first
+    const confirmBtn = await screen.findByRole("button", { name: /docReparseConfirmCta/ });
+    await user.click(confirmBtn);
+    await waitFor(() => {
+      expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f2/reparse", { method: "POST" });
+    });
+  });
+
+  it("pending: shows Processing and a Retry", () => {
+    renderControl({ id: "f3", extractionStatus: "pending" });
+    expect(screen.getByText("docStatusPending")).toBeInTheDocument();
   });
 });

--- a/frontend/test/hooks/useReparseArticleFile.test.tsx
+++ b/frontend/test/hooks/useReparseArticleFile.test.tsx
@@ -1,0 +1,45 @@
+// frontend/test/hooks/useReparseArticleFile.test.tsx
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
+
+import { apiClient } from "@/integrations/api";
+import { useReparseArticleFile } from "@/hooks/extraction/useReparseArticleFile";
+
+function wrap() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const spy = vi.spyOn(qc, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { wrapper, spy };
+}
+
+describe("useReparseArticleFile", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("POSTs reparse and invalidates files + textBlocks", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    const { wrapper, spy } = wrap();
+    const { result } = renderHook(() => useReparseArticleFile("art-1"), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync("file-9");
+    });
+
+    expect(apiClient).toHaveBeenCalledWith(
+      "/api/v1/article-files/file-9/reparse",
+      { method: "POST" },
+    );
+    const keys = spy.mock.calls.map((c) => JSON.stringify(c[0]?.queryKey));
+    expect(keys.some((k) => k?.includes("files"))).toBe(true);
+    expect(keys.some((k) => k?.includes("text-blocks"))).toBe(true);
+  });
+});

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -2210,6 +2210,17 @@
             "title": "Createdat",
             "type": "string"
           },
+          "extractionError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extractionerror"
+          },
           "extractionStatus": {
             "default": "pending",
             "title": "Extractionstatus",

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -1847,6 +1847,8 @@ export interface components {
              * Format: date-time
              */
             createdAt: string;
+            /** Extractionerror */
+            extractionError?: string | null;
             /**
              * Extractionstatus
              * @default pending


### PR DESCRIPTION
## What & why

Fixes the reported issue: **"articles aren't parsing and the re-parse button only shows on *teste 2*."**

Root cause (verified against prod): parsing **works**, but the re-parse affordance was gated on `extractionStatus === 'parse_failed'` only — so a file stuck in `pending` (e.g. the 39 legacy files uploaded before the parse pipeline worked) was a UI dead-end, and `teste 2` was the lone `parse_failed` row so it was the only one showing the button.

This PR makes parse status **recoverable from the document switcher in every state**, and hardens the parse write so the new "retry anytime" affordance can't corrupt data.

> Scope: this is **Workstream A** of the design in
> `docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md`.
> **Workstream B** (the markdown reader view + markdown-anchored citations — the
> second reported issue) is **design-only** here: ADR-0013 + the existing markdown
> plan, amended for execution but not implemented.

## Changes

**Backend — concurrency safety (the two blockers an adversarial review caught):**
- `0031` migration: **UNIQUE** constraint on `article_text_blocks(article_file_id, page_number, block_index)` (dedupes existing rows first), so concurrent re-parse writes fail loudly instead of silently duplicating blocks.
- `pg_advisory_xact_lock(hashtextextended(...))` around the block delete-then-insert in `DocumentParsingService.parse_article_file` — serializes concurrent re-parses (matches the canonical lock pattern in `hitl_session_service`).
- `extraction_error` exposed on `ArticleFileListItem` (no migration — column already on the model; + a direct endpoint-coroutine unit test for the diff-cover ASGI blind spot).

**Frontend — the affordance:**
- New additive `useReparseArticleFile` mutation hook (invalidates both the files + text-blocks key families).
- `ParseStatusControl` (in `DocumentSwitcher`): status-aware, all states — `pending` → "Processing…" + Retry, `parsed` → Re-parse behind an **AlertDialog confirm** (re-parse can shift grounded citation highlights), `parse_failed` → error in a Tooltip (with a fallback when no error string) + prominent Retry. Semantic-token `cva` (replaces the raw emerald/amber/red dots).
- Mounted in both the extraction and QA PDF panels; the old `parse_failed`-only `ReparseButton` is retired.

## Verification

- TDD per task; per-task spec+quality reviews; an opus whole-branch review (Ready to merge); a `/simplify` pass; and a `/design-review` visual loop (no P0/P1 — light + dark + 390px, status tokens verified via computed styles).
- Backend parsing/article-file slices: 23 passing. Frontend switcher/hook: 7 passing. `typecheck` clean, `lint` clean, **0** React-Compiler bailouts.

## Follow-ups (deferred, out of scope)

- Clearing the 39 legacy `pending` files — **manual via the new button** after deploy (per author sign-off; no backfill script).
- Re-anchoring grounded `extraction_evidence` after a `parsed` re-parse (the confirm dialog is the interim guard).
- Migrating `ArticleDetailDialog`'s reparse to the shared hook.
- **Workstream B** (markdown view + citations) — separate effort; amend ADR-0013 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
