### PR TITLE
chore(release): promote dev → main

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -6,8 +6,15 @@ paths:
 
 # Backend conventions (prumo)
 
-Deep dives live in the `backend-development` skill and
-`docs/reference/` — this file is the always-true core.
+For any non-trivial backend change, load the `backend-development` skill
+before writing code (deep dives also in `docs/reference/`). This file is the
+always-true core.
+
+## Repository vs service SQL
+
+Use a repository (`backend/app/repositories/`) when a query is reused by >1
+service, or the entity has several distinct query shapes. Otherwise inline
+`select()` in the owning service. Repositories call `flush()`, never `commit()`.
 
 ## Layering (CI-enforced by `scripts/fitness/check_layered_arch.py`)
 

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -8,8 +8,20 @@ paths:
 
 # Frontend conventions (prumo)
 
-Visual language lives in the `frontend-ux` skill; Tailwind/shadcn
-mechanics in `ui-styling`. This file is the always-true core.
+For any non-trivial frontend change, load the `frontend-development` skill
+(structure/data/state) before writing code. Visual language → `frontend-ux`;
+Tailwind/shadcn mechanics → `ui-styling`. This file is the always-true core.
+
+## Structure
+
+- Data flows `component → hook (TanStack Query) → service (apiClient) →
+  backend`. Components never call `fetch()` or `supabase.from(...)` directly
+  (`fetch()` is a convention enforced at review; `supabase.from(` and
+  `import.meta.env.VITE_API_URL` are CI-enforced by
+  `scripts/fitness/check_frontend_data_path.py`).
+- `frontend/services/*Service.ts` functions return `ErrorResult<T>`
+  (`frontend/lib/error-utils.ts:toResult`); they never throw across the
+  boundary and never toast.
 
 ## Data access
 

--- a/.claude/skills/frontend-development/SKILL.md
+++ b/.claude/skills/frontend-development/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: frontend-development
+description: Use when writing or modifying the STRUCTURE of anything under `frontend/` — where code lives, data flow, and state. Covers components/{domain} organization, TanStack Query hooks + key factories, `services/*Service.ts` via the typed apiClient, Zustand stores vs React Context, react-hook-form + Zod forms, generated `types/api/schema.d.ts`, ErrorResult boundaries, and the React Compiler constraints. Trigger on "add a page", "add a data hook", "add a mutation", "wire a form", "new store", "fetch data", or anything about how the frontend is organized. NOT for visual language (use `frontend-ux`) or Tailwind/shadcn class mechanics (use `ui-styling`).
+---
+
+# Frontend Development (prumo)
+
+Structural manual for prumo's React 19 + TS + Vite frontend. This is the *how
+the code is organized / how data flows* layer. Visual language is `frontend-ux`;
+Tailwind/shadcn class mechanics are `ui-styling`. SKILL.md is the index — pull a
+reference for depth.
+
+## Repository layout you must respect
+
+```
+frontend/
+  pages/{PageName}.tsx          # route-level screens
+  components/{domain}/*.tsx      # domain components, functional + hooks only
+  hooks/{domain}/use{Name}.ts    # TanStack Query/mutation hooks
+  services/{domain}Service.ts    # apiClient calls; return ErrorResult, never throw/toast
+  stores/                        # Zustand stores (cross-component UI state)
+  contexts/                      # React Context (app-wide singletons: Auth/Project/Sidebar)
+  integrations/api/client.ts     # the ONE typed HTTP client (apiClient)
+  integrations/supabase/         # auth + storage ONLY (never table reads)
+  lib/copy/                      # in-house i18n; all user-facing text
+  lib/query-keys/                # TanStack key factories
+  types/api/schema.d.ts          # generated from FastAPI openapi — never hand-edit
+```
+
+## Hard rules (with reasoning)
+
+1. **One read path.** All backend data goes through `apiClient`
+   (`integrations/api/client.ts`). Never `fetch()` or `supabase.from(...)` in a
+   component/hook/service — the dual read path is the documented slow-load /
+   status-drift / blind-leak incident class (constitution §VI). `supabase.from(`
+   and `import.meta.env.VITE_API_URL` are CI-enforced by
+   `check_frontend_data_path.py`; `fetch()` is a convention enforced at review.
+2. **Services don't throw across the boundary.** `services/*Service.ts` return
+   `ErrorResult<T>` via `lib/error-utils.ts:toResult`; the hook maps the result,
+   the component renders it. Services never toast.
+3. **Keys come from factories.** TanStack `queryKey` comes from
+   `lib/query-keys/` (CI-enforced by `check_react_query_keys.py`). Mutations
+   invalidate the owning key family.
+4. **Types are generated.** Import request/response shapes from
+   `types/api/schema.d.ts` (`npm run generate:api-types` after a backend change).
+   Never hand-mirror backend enums/models.
+5. **Copy through `lib/copy/`.** Never hardcode user-facing strings.
+6. **React Compiler.** No `try/finally` (or `throw` inside `try`) in
+   component/hook bodies — move IO into a service returning `ErrorResult`. Last
+   resort: `'use no memo'` + a `// kept:` comment.
+
+## Data flow
+
+`component → hook (TanStack Query) → service (apiClient) → backend`. See
+[`references/data-and-state.md`](references/data-and-state.md) for the hook /
+service / store / context shapes with code.
+
+## Common workflows
+
+| Task | Steps |
+|---|---|
+| Add a page | `pages/{Name}.tsx` → route in the router → data via a hook (never inline fetch) |
+| Add a data hook | `hooks/{domain}/use{Name}.ts` → `useQuery` with a key-factory key → call the service |
+| Add a mutation | `useMutation` in the hook → on success `invalidateQueries` the owning key family |
+| Add a service call | `services/{domain}Service.ts` → `apiClient` → return `ErrorResult<T>` |
+| Add a form | `react-hook-form` + `Zod` resolver; submit calls the service hook |
+| Add cross-component UI state | Zustand store in `stores/`; app-wide singleton → Context |
+
+## References index
+
+| File | Use when |
+|---|---|
+| [`references/data-and-state.md`](references/data-and-state.md) | hook/service/store/context shapes, query-key factories, invalidation |
+| [`references/components-and-forms.md`](references/components-and-forms.md) | component shape, react-hook-form + Zod, copy, generated types |

--- a/.claude/skills/frontend-development/references/components-and-forms.md
+++ b/.claude/skills/frontend-development/references/components-and-forms.md
@@ -1,0 +1,187 @@
+# Components and forms patterns
+
+## Component shape
+
+Components are functional, typed, and never fetch directly. Domain components live in `components/{domain}/`. The domain mirrors `hooks/{domain}/` and `services/{domain}Service.ts`.
+
+```typescript
+// components/articles/ArticleCitationList.tsx
+import { cn } from '@/lib/utils';
+import { t } from '@/lib/copy';
+import { useArticleCitations } from '@/hooks/articles/useArticleCitations';
+
+interface ArticleCitationListProps {
+  articleId: string;
+  className?: string;
+}
+
+export function ArticleCitationList({ articleId, className }: ArticleCitationListProps) {
+  const { data: citations, isLoading, error } = useArticleCitations(articleId);
+
+  if (isLoading) return <div>{t('common', 'loading')}</div>;
+  if (error) return <div>{t('common', 'errors_unknownError')}</div>;
+
+  return (
+    <ul className={cn('space-y-2', className)}>
+      {citations?.map((c) => (
+        <li key={c.id}>{c.text}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Rules:
+- Props are typed with an explicit `interface`, never `React.FC<Props>`.
+- `cn()` from `@/lib/utils` merges class names. Accept a `className` prop on leaf components so the caller can tweak spacing without forking the component.
+- Every interactive element (`Button`, `Input`, `Select`) must retain a visible focus ring — shadcn/Radix primitives ship one by default; don't remove `focus-visible:ring-*` classes.
+- No `React.memo()` without a `// kept:` comment explaining why. The React Compiler memoizes automatically; explicit memo without that comment is dead weight.
+
+## shadcn/Radix primitives
+
+Import from `@/components/ui/`:
+
+```typescript
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+```
+
+Use `AppDialog` from `@/components/patterns/AppDialog` for confirm/cancel dialogs — it wraps Dialog with consistent header, footer, loading state, and keyboard handling.
+
+## react-hook-form + Zod forms
+
+All forms use `react-hook-form` with a `zodResolver`. The submit handler calls the mutation hook (or the service directly for non-TanStack mutations). No `try/finally` in the submit handler — the service returns `ErrorResult`, the component branches on `ok`.
+
+```typescript
+// components/project/AddProjectDialog.tsx
+import { useForm, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  Form, FormControl, FormField, FormItem, FormLabel, FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { t } from '@/lib/copy';
+
+const schema = z.object({
+  name: z
+    .string()
+    .min(1, t('project', 'addDialogNameRequired'))
+    .max(100, t('project', 'addDialogNameMaxLength')),
+  description: z.string().max(500).optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export function AddProjectDialog({ onProjectCreate }: { onProjectCreate: (data: FormValues) => Promise<void> }) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: '', description: '' },
+  });
+
+  // useWatch — not form.watch() — React Compiler compatibility
+  const description = useWatch({ control: form.control, name: 'description' }) ?? '';
+
+  const onSubmit = async (values: FormValues) => {
+    await onProjectCreate(values);
+    form.reset();
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('project', 'addDialogNameLabel')}</FormLabel>
+              <FormControl>
+                <Input {...field} autoFocus />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  );
+}
+```
+
+Key rules:
+- Always use `useWatch` instead of `form.watch()` — `form.watch()` is incompatible with the React Compiler (`react-hooks/incompatible-library`).
+- Zod messages should use `t()` so they go through the copy system.
+- `Form {...form}` spreads the RHF context; shadcn's `FormField` / `FormItem` / `FormMessage` consume it automatically.
+- Reset `form.reset()` on successful submit and on dialog close, not just on submit.
+- The submit handler is `async`; move any throwing IO into the service layer (returns `ErrorResult`) and branch on `ok` — never let a raw `throw` escape the handler.
+
+## Copy — `lib/copy/`
+
+All user-facing text goes through `t(namespace, key)`:
+
+```typescript
+import { t } from '@/lib/copy';
+
+// render
+<Button>{t('common', 'save')}</Button>
+<p>{t('project', 'addDialogNameRequired')}</p>
+```
+
+Never hardcode English strings in JSX or Zod messages. The CI `cspell` run will flag unknown words; `prumoai` is in the allowlist.
+
+Copy files live under `frontend/lib/copy/` organised by namespace (e.g. `common.ts`, `project.ts`, `extraction.ts`). Add a new key to the matching namespace file — don't create a new namespace for a single string.
+
+## Generated types from `types/api/schema.d.ts`
+
+The schema file is generated from the FastAPI app with `npm run generate:api-types`. Never hand-edit it or hand-mirror its types in a separate interface.
+
+```typescript
+import type { components } from '@/types/api/schema';
+
+// Use the generated schema shape directly
+type ArticleCitationItem = components['schemas']['ArticleCitationItem'];
+type RunSummaryResponse = components['schemas']['RunSummaryResponse'];
+
+// For operation-level request/response types
+import type { operations } from '@/types/api/schema';
+type CreateRunBody = operations['create_run_api_v1_runs_post']['requestBody']['content']['application/json'];
+```
+
+After changing a backend Pydantic schema or adding an endpoint:
+1. Run `npm run generate:api-types` from the repo root.
+2. Commit the updated `frontend/types/api/{openapi.json,schema.d.ts}`.
+3. Update any component/service/hook that consumed the old shape.
+
+The CI `api-contract` job fails any PR where the committed output doesn't match the running backend — so the diff must be committed, not just regenerated locally and left out.
+
+## ErrorResult in the component
+
+Services return `ErrorResult<T>` — components that call a service directly (outside a query hook) must branch on `ok`:
+
+```typescript
+// inside an event handler or useEffect-like imperative flow
+const result = await someService.doSomething(params);
+if (!result.ok) {
+  // show error state; result.error is an Error instance
+  setError(result.error.message);
+  return;
+}
+// use result.data
+```
+
+Inside a `queryFn`, throw the error so TanStack owns the error state:
+
+```typescript
+queryFn: async () => {
+  const result = await fetchSomething(id);
+  if (!result.ok) throw result.error;
+  return result.data;
+},
+```
+
+Do not call `toast.error()` in a component in response to a service error — the service already logged it. Use `toast` only for user-initiated feedback (success confirmation, undo actions).

--- a/.claude/skills/frontend-development/references/data-and-state.md
+++ b/.claude/skills/frontend-development/references/data-and-state.md
@@ -1,0 +1,226 @@
+# Data and state patterns
+
+The data layer has four layers: **service** (HTTP) → **hook** (TanStack Query) → **component** (renders). Cross-component UI state uses Zustand or Context depending on scope.
+
+## Service — `services/{domain}Service.ts`
+
+Services are the only place that call `apiClient`. They return `ErrorResult<T>` via `toResult` from `lib/error-utils.ts`. They never throw across the boundary, never toast, and never import Zustand or React hooks.
+
+```typescript
+// services/citationsService.ts
+import { apiClient } from '@/integrations/api';
+import { toResult, type ErrorResult } from '@/lib/error-utils';
+import type { components } from '@/types/api/schema';
+
+export type ArticleCitationItem = components['schemas']['ArticleCitationItem'];
+
+export function fetchArticleCitations(
+  articleId: string,
+): Promise<ErrorResult<ArticleCitationItem[]>> {
+  return toResult(
+    () => apiClient<ArticleCitationItem[]>(`/api/v1/articles/${articleId}/citations`),
+    'citationsService.fetchArticleCitations',
+  );
+}
+```
+
+`toResult(operation, context)` runs `operation()` in a `try/catch`: on success it returns `{ ok: true, data }`, on failure it logs and returns `{ ok: false, error }`. The context string ends up in the log line — keep it stable (it feeds dashboards).
+
+For mutations the pattern is the same — `toResult` wraps the `apiClient` POST/PATCH/DELETE:
+
+```typescript
+// services/extractionRunService.ts
+import { apiClient } from '@/integrations/api';
+import { toResult, type ErrorResult } from '@/lib/error-utils';
+
+export interface ExtractForRunRequest {
+  projectId: string;
+  articleId: string;
+  templateId: string;
+  runId: string;
+}
+
+export interface ExtractForRunResult {
+  extractionRunId: string;
+  totalSuggestionsCreated: number;
+}
+
+export function extractForRun(
+  params: ExtractForRunRequest,
+): Promise<ErrorResult<ExtractForRunResult>> {
+  return toResult(
+    () =>
+      apiClient<ExtractForRunResult>('/api/v1/extraction/sections', {
+        method: 'POST',
+        body: params,
+      }),
+    'extractionRunService.extractForRun',
+  );
+}
+```
+
+## Query hook — `hooks/{domain}/use{Name}.ts`
+
+Query hooks wrap `useQuery` (reads) or `useMutation` (writes). The `queryKey` always comes from a factory in `lib/query-keys/`. The `queryFn` calls the service and throws the error on failure — that surfaces it to TanStack's error boundary:
+
+```typescript
+// hooks/articles/useArticleCitations.ts
+import { useQuery } from '@tanstack/react-query';
+import { articleKeys } from '@/lib/query-keys';
+import { fetchArticleCitations, type ArticleCitationItem } from '@/services/citationsService';
+
+const STALE_MS = 5 * 60_000;
+
+export function useArticleCitations(articleId: string | null | undefined) {
+  return useQuery({
+    queryKey: articleKeys.citations(articleId ?? ''),
+    enabled: Boolean(articleId),
+    staleTime: STALE_MS,
+    queryFn: async (): Promise<ArticleCitationItem[]> => {
+      const result = await fetchArticleCitations(articleId!);
+      if (!result.ok) throw result.error;   // TanStack handles the error state
+      return result.data;
+    },
+  });
+}
+```
+
+The component destructures `{ data, isLoading, error }` from the hook — it never fetches directly.
+
+## Mutation hook — `useMutation` + invalidation
+
+```typescript
+// hooks/runs/useCreateRun.ts
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/integrations/api';
+import { extractionKeys } from '@/lib/query-keys';
+import type { CreateRunRequest, RunSummaryResponse } from './types';
+
+export function useCreateRun() {
+  const queryClient = useQueryClient();
+
+  return useMutation<RunSummaryResponse, Error, CreateRunRequest>({
+    mutationFn: (body) =>
+      apiClient<RunSummaryResponse>('/api/v1/runs', { method: 'POST', body }),
+    onSuccess: (run) => {
+      queryClient.invalidateQueries({ queryKey: extractionKeys.runDetail(run.id) });
+    },
+  });
+}
+```
+
+`onSuccess` invalidates the owning key family so lists/detail views re-fetch automatically. Stale-cache bugs are a recurring incident class — always invalidate.
+
+Note: `useCreateRun` calls `apiClient` directly (no service wrapper) because the mutation doesn't need `ErrorResult` — `useMutation` owns the error surface. Either pattern is acceptable for mutations; use `toResult` when you want the service reusable outside a hook.
+
+> **Hook-local key exception:** `hooks/runs/types.ts` also exports a `runsKeys` object for a handful of reviewer-availability queries that have no `lib/query-keys/` counterpart. That is a documented exception — those keys are scoped to the hooks that use them and are not re-exported. All other keys, including run-detail and extraction data, live in `lib/query-keys/` and must be imported from there.
+
+## Query-key factories — `lib/query-keys/`
+
+All keys live in `lib/query-keys/{domain}.ts` and are exported from the barrel:
+
+```typescript
+// lib/query-keys/articles.ts
+export const articleKeys = {
+  all: ['articles'] as const,
+  byProject: (projectId: string, filters?: Record<string, unknown>) =>
+    [...articleKeys.all, 'by-project', projectId, filters ?? null] as const,
+  detail: (articleId: string) =>
+    [...articleKeys.all, 'detail', articleId] as const,
+  files: (articleId: string) =>
+    [...articleKeys.all, 'files', articleId] as const,
+  citations: (articleId: string) =>
+    [...articleKeys.all, 'citations', articleId] as const,
+} as const;
+```
+
+```typescript
+// lib/query-keys/extraction.ts
+export const extractionKeys = {
+  all: ['extraction'] as const,
+  runsForProject: (projectId: string, filters?: Record<string, unknown>) =>
+    [...extractionKeys.all, 'runs', projectId, filters ?? null] as const,
+  runDetail: (runId: string) =>
+    [...extractionKeys.all, 'run-detail', runId] as const,
+  proposals: (runId: string) =>
+    [...extractionKeys.all, 'proposals', runId] as const,
+  hitlSession: (sessionId: string) =>
+    [...extractionKeys.all, 'hitl-session', sessionId] as const,
+} as const;
+```
+
+Import via the barrel: `import { articleKeys, extractionKeys } from '@/lib/query-keys'`. The CI gate `check_react_query_keys.py` rejects inline string arrays.
+
+When adding a new domain, create `lib/query-keys/{domain}.ts` and add it to `lib/query-keys/index.ts`.
+
+## Zustand stores — `stores/`
+
+Zustand stores hold cross-component UI state that isn't server-cache (server cache = TanStack). Declare state and actions in one `create()` call. Use `devtools` middleware in dev; use `persist` only when the state genuinely survives page reload:
+
+```typescript
+// stores/useExtractionStore.ts
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+interface ExtractionState {
+  showPDF: boolean;
+  viewMode: 'extract' | 'compare';
+  activeModelId: string | null;
+}
+
+interface ExtractionActions {
+  setShowPDF: (show: boolean) => void;
+  setViewMode: (mode: 'extract' | 'compare') => void;
+  setActiveModelId: (id: string | null) => void;
+}
+
+export const useExtractionStore = create<ExtractionState & ExtractionActions>()(
+  devtools(
+    (set) => ({
+      showPDF: false,
+      viewMode: 'extract',
+      activeModelId: null,
+      setShowPDF: (show) => set({ showPDF: show }),
+      setViewMode: (mode) => set({ viewMode: mode }),
+      setActiveModelId: (id) => set({ activeModelId: id }),
+    }),
+    { name: 'ExtractionStore' },
+  ),
+);
+```
+
+Stores are for UI concerns (panel visibility, active selection, view toggles). **Do not put server data in a Zustand store** — that belongs in TanStack Query.
+
+## React Context — `contexts/`
+
+Context is for app-wide singletons that need to be provided once at the root: Auth, Project scope, Sidebar. The existing contexts (`AuthContext`, `ProjectContext`, `SidebarContext`, `ThemeContext`) cover those slots.
+
+When to use Context instead of Zustand:
+- The value is provided by the app shell and consumed by many subtrees (not just sibling components).
+- The update is infrequent and the consumer tree is large enough that a Zustand subscription would be more complex than a Context provider.
+
+When to use Zustand instead of Context:
+- State is scoped to a feature subtree (e.g. extraction panel).
+- Fine-grained subscriptions matter (Zustand only re-renders components that subscribe to the changed slice).
+- Don't create a new Context for feature state — that path leads to prop-drilling via provider nesting.
+
+## `apiClient` — the one HTTP client
+
+`apiClient<T>(endpoint, options)` in `integrations/api/client.ts`:
+- Attaches the Supabase JWT automatically.
+- Throws `ApiError` (carrying `.code`, `.message`, `.status`, `.traceId`) on non-2xx or `ok: false` envelope.
+- Accepts `body`, `method`, `timeout` (default 60 s), `skipAuth`, and standard `RequestInit` options.
+- Wraps the backend `ApiResponse<T>` envelope and returns the unwrapped `data`.
+
+Never import `VITE_API_URL` or call `fetch()` directly outside `integrations/api/client.ts`.
+
+```typescript
+// typical service usage
+const data = await apiClient<RunSummaryResponse>('/api/v1/runs', {
+  method: 'POST',
+  body: { project_id: projectId, article_id: articleId },
+  timeout: 30_000,
+});
+```
+
+For blob downloads use `apiBlobClient` from the same module (returns `{ kind: 'sync', blob, filename }` or `{ kind: 'async', job_id }`).

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -45,3 +45,4 @@ docs/superpowers/plans/2026-06-10-dev-workflow-sota.md
 # Snapshot artefacts inside docs/ that are not actively maintained
 docs/superpowers/design-system/sidebar-and-panels.md
 docs/superpowers/plans/2026-06-21-parsing-fix-and-reader-switcher.md
+docs/superpowers/plans/2026-06-22-parse-recovery-affordance.md

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -20,6 +20,7 @@ docs/superpowers/plans/2026-06-20-parse-pipeline-activation-prb.md
 docs/superpowers/plans/2026-06-21-hitl-phase1-stage-collapse.md
 docs/superpowers/plans/2026-06-21-hitl-phase2-consensus-finalize.md
 docs/superpowers/plans/2026-06-21-header-system-responsive-frosted.md
+docs/superpowers/plans/2026-06-22-architecture-clarity.md
 
 # Design specs — likewise snapshots
 docs/superpowers/specs/2026-*-design.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,44 @@ owner: '@raphaelfh'
 - Project history lives in `git log` and `docs/adr/` — do not append
   changelogs to this file. Keep this section to ≤ 5 lines.
 
+## Working principles
+
+These bias toward caution over speed. For trivial changes, use judgment.
+
+- **Think before coding.** State assumptions; if a requirement has multiple
+  readings, surface them — don't choose silently. If a simpler path exists, say
+  so; push back with evidence, not deference. Genuinely unclear, or the call is
+  the user's? Stop and ask — otherwise act, don't re-litigate settled choices.
+  Feature/creative work starts with `superpowers:brainstorming`.
+- **Simplicity first (YAGNI).** The minimum code that solves the asked problem —
+  no speculative abstractions, config, or handling for impossible cases. Any
+  complexity beyond what a principle prescribes must be justified (constitution
+  §Governance). If 200 lines could be 50, rewrite it.
+- **Surgical on unrelated code; clean in code you touch.** Change only what the
+  task requires; match surrounding style; flag unrelated dead code, don't delete
+  it. But where you DO edit, prefer the clean fix over grandfathering a
+  violation — no new legacy left for later.
+- **Goal-driven and verified.** Turn the task into a checkable goal (write the
+  failing test, then make it pass). State a short plan with a verify step each.
+  Evidence before "done" — run the command and read the output, never assert
+  (`code-review` Iron Law; `verification-before-completion`).
+
+## Which skill to load
+
+Load the skill before non-trivial work in its area (skills are on-demand —
+naming them here is what makes them load reliably).
+
+- Backend (FastAPI/SQLAlchemy/Alembic/Celery/RLS) → `backend-development`
+- Frontend structure/data/state (components/hooks/services/stores) → `frontend-development`
+- Frontend visual language (density/layout/empty states) → `frontend-ux`
+- Tailwind/shadcn class mechanics → `ui-styling`
+- Before "done" / PR / review → `code-review`
+- Bug / failing test / weird behavior → `debugging`
+- Tests (Vitest/Playwright/pytest/MSW) → `web-testing`
+- Deploy / promotion / rollback → `deploy-release`
+- Architectural drift sweep → `architectural-quality-loop`
+- Visual feedback loop on a screen → `design-review`
+
 ## Stack
 
 - **Backend**: Python 3.11+, FastAPI, SQLAlchemy 2.0 async, Alembic,

--- a/backend/alembic/versions/0031_unique_article_text_block_idx.py
+++ b/backend/alembic/versions/0031_unique_article_text_block_idx.py
@@ -1,0 +1,56 @@
+"""unique (article_file_id, page_number, block_index) on article_text_blocks
+
+Revision ID: 0031_unique_atb_idx
+Revises: 0030_drop_instance_status
+Create Date: 2026-06-22
+
+Makes concurrent re-parse tasks (delete-then-insert) fail loudly instead
+of silently duplicating rows for the same (article_file_id, page, block_index).
+The non-unique index created in 0006 is replaced by a UNIQUE one on the same
+columns, preserving ordered-read performance.
+"""
+
+from alembic import op
+
+revision = "0031_unique_atb_idx"
+down_revision = "0030_drop_instance_status"
+branch_labels = None
+depends_on = None
+
+_OLD_INDEX = "idx_article_text_blocks_file_page_block"  # from 0006
+_UQ = "uq_article_text_blocks_file_page_block"
+
+
+def upgrade() -> None:
+    # 1. Collapse any pre-existing duplicates (keep one row per triple) so the
+    #    constraint can be created. Concurrent parses before this migration may
+    #    have produced dups.
+    op.execute(
+        """
+        DELETE FROM article_text_blocks a
+        USING article_text_blocks b
+        WHERE a.ctid < b.ctid
+          AND a.article_file_id = b.article_file_id
+          AND a.page_number = b.page_number
+          AND a.block_index = b.block_index
+        """
+    )
+    # 2. Replace the non-unique read index with a UNIQUE one (same columns, so
+    #    ordered reads keep their index).
+    op.drop_index(_OLD_INDEX, table_name="article_text_blocks")
+    op.create_index(
+        _UQ,
+        "article_text_blocks",
+        ["article_file_id", "page_number", "block_index"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_UQ, table_name="article_text_blocks")
+    op.create_index(
+        _OLD_INDEX,
+        "article_text_blocks",
+        ["article_file_id", "page_number", "block_index"],
+        unique=False,
+    )

--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -106,7 +106,9 @@ async def post_form_runs(
     """
     await ensure_project_member(db, body.project_id, current_user_sub)
 
-    refs = await resolve_form_runs(db, body.article_ids, template_id=body.template_id)
+    refs = await resolve_form_runs(
+        db, body.article_ids, project_id=body.project_id, template_id=body.template_id
+    )
     return ApiResponse.success(refs, trace_id=_trace(request))
 
 

--- a/backend/app/schemas/article.py
+++ b/backend/app/schemas/article.py
@@ -210,6 +210,7 @@ class ArticleFileListItem(BaseModel):
     file_type: str = Field(..., alias="fileType")
     original_filename: str | None = Field(default=None, alias="originalFilename")
     extraction_status: str = Field(default="pending", alias="extractionStatus")
+    extraction_error: str | None = Field(default=None, alias="extractionError")
     bytes: int | None = None
     storage_key: str = Field(..., alias="storageKey")
     created_at: datetime = Field(..., alias="createdAt")

--- a/backend/app/services/document_parsing_service.py
+++ b/backend/app/services/document_parsing_service.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logging import get_logger
@@ -132,7 +132,15 @@ class DocumentParsingService:
         #    truth for offset arithmetic — do NOT recompute inline).
         assign_char_offsets_to_blocks(blocks)
 
-        # 5. Persist blocks (delete-then-bulk-insert, flush only).
+        # 5. Serialize the block write per file so a concurrent Retry cannot
+        #    interleave two delete-then-insert passes. Transaction-scoped:
+        #    released on commit.
+        await self.db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+            {"k": str(article_file_id)},
+        )
+
+        # Persist blocks (delete-then-bulk-insert, flush only).
         await self._repo.replace_for_file(article_file_id, blocks)
 
         # 6. Update status.

--- a/backend/app/services/extraction_export_service.py
+++ b/backend/app/services/extraction_export_service.py
@@ -430,7 +430,7 @@ class ExtractionExportService(LoggerMixin):
         map and returns a fully-populated ``ExportLayout``. Columns are
         anchored on the active-version snapshot (spec §5.1).
         """
-        template, version = await self._load_active_template_version(template_id)
+        template, version = await self._load_active_template_version(template_id, project_id)
         project_name = await self._resolve_project_name(project_id)
         sections = await self._load_sections(version.id)
         data_dictionary = _build_data_dictionary(sections)
@@ -734,11 +734,20 @@ class ExtractionExportService(LoggerMixin):
     async def _load_active_template_version(
         self,
         template_id: UUID,
+        project_id: UUID,
     ) -> tuple[ProjectExtractionTemplate, Any]:
-        """Load the project template + its currently-active version row."""
+        """Load the project template + its currently-active version row.
+
+        Scoped by ``project_id`` (BOLA): a template id from another project must
+        not resolve even though the caller passed our own project's gate, else
+        the async export path would leak a foreign project's template metadata.
+        """
         template = (
             await self.db.execute(
-                select(ProjectExtractionTemplate).where(ProjectExtractionTemplate.id == template_id)
+                select(ProjectExtractionTemplate).where(
+                    ProjectExtractionTemplate.id == template_id,
+                    ProjectExtractionTemplate.project_id == project_id,
+                )
             )
         ).scalar_one_or_none()
         if template is None:
@@ -1948,14 +1957,13 @@ def _build_tidy_tables(
     value_map: dict[tuple[Any, ...], Any],
     mode: ExportMode,
 ) -> tuple[TidyTable, ...]:
-    """One publication table per non-container section at its cardinality grain.
+    """One publication table per non-container section at its record grain.
 
-    ``cardinality==MANY`` fans out one row per (article × instance) for ANY
-    role (spec §5.2 — never a ``role==MODEL_SECTION`` allow-list); ``ONE``
-    yields one row per article. Columns are the section fields in their
-    resolved order; values are baked from ``value_map`` (already-resolved
-    scalars — §5.3). The ``MODEL_CONTAINER`` and field-less sections are
-    skipped (nothing to project).
+    Record axis is selected by ROLE first, then cardinality (mirrors
+    ``matrix._resolve_instance_id``): a ``MODEL_SECTION`` fans out one row per
+    ``model_instances`` entry regardless of its own cardinality (spec §5.2);
+    non-model ``MANY`` fans out per ``section_instances``; non-model ``ONE`` is
+    one row per article. ``MODEL_CONTAINER`` and field-less sections are skipped.
     """
     tables: list[TidyTable] = []
     for section in sections:
@@ -1969,35 +1977,27 @@ def _build_tidy_tables(
         for article in articles:
             if article.run_id is None:
                 continue
-            if section.cardinality is ExtractionCardinality.MANY:
-                if section.role is ExtractionEntityRole.MODEL_SECTION:
-                    instances = article.model_instances
-                    label_stem = "Model"
-                else:
-                    instances = article.section_instances.get(section.entity_type_id, ())
-                    label_stem = section.label
-                for idx, instance_id in enumerate(instances, start=1):
-                    rows.append(
-                        _tidy_row(
-                            section=section,
-                            article=article,
-                            instance_id=instance_id,
-                            record_label=f"{article.header_label} — {label_stem} {idx}",
-                            value_map=value_map,
-                            mode=mode,
-                        )
-                    )
-            else:
+            if section.role is ExtractionEntityRole.MODEL_SECTION:
+                instances = article.model_instances
+                stem = "Model"
+            elif section.cardinality is ExtractionCardinality.MANY:
                 instances = article.section_instances.get(section.entity_type_id, ())
-                instance_id = instances[0] if instances else None
-                if instance_id is None:
-                    continue
+                stem = section.label
+            else:
+                instances = article.section_instances.get(section.entity_type_id, ())[:1]
+                stem = None
+            for idx, instance_id in enumerate(instances, start=1):
+                label = (
+                    article.header_label
+                    if stem is None
+                    else f"{article.header_label} — {stem} {idx}"
+                )
                 rows.append(
                     _tidy_row(
                         section=section,
                         article=article,
                         instance_id=instance_id,
-                        record_label=article.header_label,
+                        record_label=label,
                         value_map=value_map,
                         mode=mode,
                     )

--- a/backend/app/services/extraction_run_read_service.py
+++ b/backend/app/services/extraction_run_read_service.py
@@ -574,6 +574,7 @@ async def resolve_form_runs(
     db: AsyncSession,
     article_ids: list[UUID],
     *,
+    project_id: UUID,
     template_id: UUID,
 ) -> list[ArticleRunRef]:
     """Resolve the latest relevant run per article for the extraction form.
@@ -582,6 +583,11 @@ async def resolve_form_runs(
     - Per article: latest non-terminal run; else latest finalized run.
     - Cancelled runs are excluded.
     - Returns one ArticleRunRef per input article_id (run_id=None when no run).
+
+    Scoped by ``project_id`` (BOLA): the caller's membership is gated on
+    ``project_id``, so runs must be resolved within that project. Without this
+    filter a member of project P could pass ``article_ids`` belonging to a
+    different project Q and read back Q's run ids (confused-deputy IDOR).
     """
     if not article_ids:
         return []
@@ -592,6 +598,7 @@ async def resolve_form_runs(
     stmt = (
         select(ExtractionRun)
         .where(
+            ExtractionRun.project_id == project_id,
             ExtractionRun.article_id.in_(article_ids),
             ExtractionRun.template_id == template_id,
             ExtractionRun.kind == "extraction",

--- a/backend/tests/integration/test_article_text_block_unique.py
+++ b/backend/tests/integration/test_article_text_block_unique.py
@@ -1,0 +1,70 @@
+"""Integration test: unique (article_file_id, page_number, block_index) constraint.
+
+After migration 0031, a duplicate triple must fail with IntegrityError.
+Uses db_session_real because we need to verify DB-level constraints,
+not ORM-level behaviour.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.integration.conftest import SEED
+
+
+async def _insert_article_file(db: AsyncSession) -> str:
+    """Insert a minimal article_files row and return its id string."""
+    file_id = str(uuid.uuid4())
+    await db.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": file_id,
+            "pid": str(SEED.primary_project),
+            "aid": str(SEED.primary_article),
+            "key": f"test-unique/{file_id}.pdf",
+        },
+    )
+    await db.commit()
+    return file_id
+
+
+async def _cleanup_article_file(db: AsyncSession, *, file_id: str) -> None:
+    await db.execute(
+        text("DELETE FROM public.article_files WHERE id = :id"),
+        {"id": file_id},
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_block_index_rejected(db_session_real: AsyncSession) -> None:
+    """After 0031, a duplicate (article_file_id, page, block_index) must fail."""
+    fid = await _insert_article_file(db_session_real)
+    try:
+        insert = text(
+            "INSERT INTO article_text_blocks "
+            "(id, article_file_id, page_number, block_index, text, char_start, char_end, "
+            "bbox, block_type) "
+            "VALUES (gen_random_uuid(), :fid, 1, 0, :t, 0, 1, "
+            "CAST(:bbox AS jsonb), 'paragraph')"
+        )
+        bbox = '{"x":0,"y":0,"width":100,"height":10}'
+        await db_session_real.execute(insert, {"fid": fid, "t": "a", "bbox": bbox})
+        await db_session_real.commit()
+
+        with pytest.raises(IntegrityError):
+            await db_session_real.execute(insert, {"fid": fid, "t": "b", "bbox": bbox})
+            await db_session_real.commit()
+    finally:
+        # rollback any open failed transaction before cleanup
+        await db_session_real.rollback()
+        await _cleanup_article_file(db_session_real, file_id=fid)

--- a/backend/tests/integration/test_extraction_export_template_bola.py
+++ b/backend/tests/integration/test_extraction_export_template_bola.py
@@ -1,0 +1,56 @@
+"""Regression: export template load must be scoped by project_id (BOLA).
+
+``_load_active_template_version`` loaded the template by id alone, so a member
+of project A could request an export with ``project_id=A`` (passing the
+membership gate in ``assert_can_export``) but ``template_id`` belonging to
+project B. The async (Celery) export path then built and uploaded a downloadable
+workbook carrying project B's template metadata — a cross-project info leak.
+
+The loader now filters by ``project_id``, mirroring the reviewer-picker query.
+See post-merge review 2026-06-21.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.error_handler import NotFoundError
+from app.services.extraction_export_service import ExtractionExportService
+from tests.integration.conftest import SEED
+
+pytestmark = pytest.mark.asyncio
+
+
+def _service(db: AsyncSession) -> ExtractionExportService:
+    return ExtractionExportService(db=db, user_id=str(SEED.primary_profile), storage=MagicMock())
+
+
+async def test_template_load_rejects_cross_project_template(db_session: AsyncSession) -> None:
+    """Loading primary_template under the WRONG project must not resolve.
+
+    primary_template belongs to primary_project; requesting it under
+    secondary_project must raise a template-level NotFoundError (the project
+    filter excluded it), never leak the foreign template.
+    """
+    with pytest.raises(NotFoundError) as exc:
+        await _service(db_session)._load_active_template_version(
+            SEED.primary_template, SEED.secondary_project
+        )
+    assert "not found" in str(exc.value).lower()
+    await db_session.rollback()
+
+
+async def test_template_load_resolves_under_owning_project(db_session: AsyncSession) -> None:
+    """Positive control: the project filter does not over-reject the owner.
+
+    Loading primary_template under primary_project resolves the template
+    (proving the added project_id predicate matches the legitimate case).
+    """
+    template, _version = await _service(db_session)._load_active_template_version(
+        SEED.primary_template, SEED.primary_project
+    )
+    assert template.id == SEED.primary_template
+    await db_session.rollback()

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -107,8 +107,10 @@ _ENUM_PRESENT = text("SELECT 1 FROM pg_type WHERE typname = 'extraction_instance
 @pytest.mark.asyncio
 async def test_migration_0030_round_trip(db_session: AsyncSession) -> None:
     """``0030_drop_instance_status`` removes ``extraction_instances.status`` and
-    its enum at head; ``downgrade -1`` restores the schema (column + enum, not
-    the data); ``upgrade head`` re-removes both. Guards against drift between a
+    its enum at head; downgrading below 0030 (to its parent ``0029``) restores
+    the schema (column + enum, not the data); ``upgrade head`` re-removes both.
+    Downgrades to the explicit parent revision (not ``-1``) so the test stays
+    correct as later migrations stack on top. Guards against drift between a
     fresh ``alembic upgrade head`` and ``baseline_v1.sql`` (which still ships the
     legacy column)."""
     assert (await db_session.execute(_COL_PRESENT)).scalar() is None, (
@@ -118,7 +120,7 @@ async def test_migration_0030_round_trip(db_session: AsyncSession) -> None:
         "extraction_instance_status enum must be absent at HEAD"
     )
 
-    _run_alembic("downgrade", "-1")
+    _run_alembic("downgrade", "0029_reviewer_ready_flag")
     try:
         await db_session.commit()
         assert (await db_session.execute(_COL_PRESENT)).scalar() == 1, (
@@ -147,8 +149,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0030_drop_instance_status" in out, (
-        f"Expected head revision '0030_drop_instance_status', got:\n{out}"
+    assert "0031_unique_atb_idx" in out, (
+        f"Expected head revision '0031_unique_atb_idx', got:\n{out}"
     )
 
 

--- a/backend/tests/integration/test_parse_article_file_lock.py
+++ b/backend/tests/integration/test_parse_article_file_lock.py
@@ -1,0 +1,143 @@
+"""Integration test: advisory lock is acquired before the block write.
+
+DocumentParsingService.parse_article_file must call
+``pg_advisory_xact_lock(hashtext(:k))`` immediately before
+``ArticleTextBlockRepository.replace_for_file`` so that a concurrent
+re-parse Retry serializes on the write instead of interleaving two
+delete-then-insert passes.
+
+The test spies on the real db_session_real.execute so the lock SQL
+actually hits Postgres — it is not mocked out.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.parsing.base import DocumentParser, ParsedBlock
+from tests.integration.conftest import SEED
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubParser(DocumentParser):
+    """Returns a single ParsedBlock — enough for a successful parse path."""
+
+    def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:  # noqa: ARG002
+        return [
+            ParsedBlock(
+                page_number=1,
+                block_index=0,
+                text="Lock test",
+                char_start=0,
+                char_end=0,
+                bbox={"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0},
+                block_type="paragraph",
+            )
+        ]
+
+
+class _StubStorage:
+    """Returns minimal PDF bytes without touching real storage."""
+
+    async def download(self, bucket: str, key: str) -> bytes:  # noqa: ARG002
+        return b"%PDF-1.4 stub"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seeded_article_file(db_session_real: AsyncSession):
+    """Insert a pending ArticleFile row; yield it; clean up after the test."""
+    from app.models.article import ArticleFile
+
+    file_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.article_files "
+            "(id, project_id, article_id, file_type, storage_key, file_role) "
+            "VALUES (:id, :pid, :aid, 'pdf', :key, 'MAIN')"
+        ),
+        {
+            "id": str(file_id),
+            "pid": str(SEED.primary_project),
+            "aid": str(SEED.primary_article),
+            "key": f"articles/{file_id}.pdf",
+        },
+    )
+    await db_session_real.commit()
+
+    from sqlalchemy import select
+
+    af = (
+        await db_session_real.execute(select(ArticleFile).where(ArticleFile.id == file_id))
+    ).scalar_one()
+
+    yield af
+
+    await db_session_real.execute(
+        text("DELETE FROM public.article_files WHERE id = :id"),
+        {"id": str(file_id)},
+    )
+    await db_session_real.commit()
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parse_acquires_advisory_lock_before_write(
+    seeded_article_file, db_session_real: AsyncSession
+) -> None:
+    """parse_article_file must take pg_advisory_xact_lock before replace_for_file."""
+    from app.services.document_parsing_service import DocumentParsingService
+
+    svc = DocumentParsingService(
+        db=db_session_real,
+        user_id=str(SEED.primary_profile),
+        storage=_StubStorage(),
+        parser=_StubParser(),
+        trace_id="lock-test",
+    )
+    calls: list[str] = []
+    orig_execute = db_session_real.execute
+
+    async def _spy(stmt, *a, **k):
+        calls.append(str(stmt))
+        return await orig_execute(stmt, *a, **k)
+
+    with patch.object(db_session_real, "execute", side_effect=_spy):
+        await svc.parse_article_file(seeded_article_file.id)
+
+    assert any("pg_advisory_xact_lock" in c for c in calls), (
+        "lock not acquired; observed SQL calls:\n" + "\n".join(f"  {c!r}" for c in calls)
+    )
+
+    # Lock must precede the block write (DELETE or INSERT on article_text_blocks).
+    lock_idx = next(i for i, c in enumerate(calls) if "pg_advisory_xact_lock" in c)
+    write_candidates = [
+        i
+        for i, c in enumerate(calls)
+        if "article_text_blocks" in c and ("DELETE" in c.upper() or "INSERT" in c.upper())
+    ]
+    assert write_candidates, "no block write detected; observed SQL calls:\n" + "\n".join(
+        f"  {c!r}" for c in calls
+    )
+    first_write_idx = min(write_candidates)
+    assert lock_idx < first_write_idx, (
+        f"lock (index {lock_idx}) did not precede block write (index {first_write_idx}); "
+        "calls:\n" + "\n".join(f"  [{i}] {c!r}" for i, c in enumerate(calls))
+    )

--- a/backend/tests/integration/test_run_resolution_endpoints.py
+++ b/backend/tests/integration/test_run_resolution_endpoints.py
@@ -339,3 +339,36 @@ async def test_form_runs_returns_403_for_non_member(
     }
     resp = await db_client.post(f"{_ARTICLES_URL}/form-runs", json=body)
     assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_form_runs_scopes_resolution_to_body_project_id(
+    db_client: AsyncClient,
+    db_session: AsyncSession,  # noqa: ARG001
+    auth_as_profile: UUID,  # noqa: ARG001
+) -> None:
+    """BOLA: runs are resolved only within the body's project_id.
+
+    Confused-deputy regression. ``primary_profile`` is a member of BOTH
+    projects, so claiming ``secondary_project`` passes the membership gate.
+    The article's run lives in ``primary_project``; scoping the resolver by
+    ``project_id`` must therefore return ``run_id=None`` instead of leaking
+    the cross-project run id. Before the fix ``resolve_form_runs`` filtered
+    only on ``article_ids``+``template_id`` and returned the foreign run.
+    """
+    created = await _create_extraction_run(db_client)  # run in primary_project
+    assert created["id"]
+    article_id = str(SEED.primary_article)
+
+    body = {
+        "article_ids": [article_id],
+        "template_id": str(SEED.primary_template),
+        "project_id": str(SEED.secondary_project),  # claimed project != run's project
+    }
+    resp = await db_client.post(f"{_ARTICLES_URL}/form-runs", json=body)
+    assert resp.status_code == 200, resp.text
+
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["article_id"] == article_id
+    assert data[0]["run_id"] is None, "a run from another project must not leak"

--- a/backend/tests/unit/scripts/test_check_file_size.py
+++ b/backend/tests/unit/scripts/test_check_file_size.py
@@ -1,0 +1,15 @@
+"""Green-path test for the file-size ratchet."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_file_size.py"
+
+
+def test_current_tree_matches_baseline() -> None:
+    proc = subprocess.run([sys.executable, str(CHECK)], capture_output=True, text=True, timeout=20)
+    assert proc.returncode == 0, f"a file grew past its baseline\n{proc.stdout}"

--- a/backend/tests/unit/scripts/test_check_file_size_canary.py
+++ b/backend/tests/unit/scripts/test_check_file_size_canary.py
@@ -1,0 +1,67 @@
+"""Canary for the file-size ratchet in scripts/fitness/check_file_size.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_file_size.py"
+
+
+def _mk(root: Path, rel: str, lines: int) -> None:
+    f = root / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("x = 1\n" * lines)
+
+
+def _run(root: Path, baseline: Path, max_lines: int = 50):
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECK),
+            "--repo-root",
+            str(root),
+            "--baseline",
+            str(baseline),
+            "--max-lines",
+            str(max_lines),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def test_new_offender_fails(tmp_path: Path) -> None:
+    _mk(tmp_path, "backend/app/new_god.py", 80)
+    baseline = tmp_path / "bl"
+    baseline.write_text("")
+    proc = _run(tmp_path, baseline)
+    assert proc.returncode == 1, proc.stdout
+    assert "new_god.py" in proc.stdout
+
+
+def test_baselined_growth_fails(tmp_path: Path) -> None:
+    _mk(tmp_path, "backend/app/god.py", 90)
+    baseline = tmp_path / "bl"
+    baseline.write_text("backend/app/god.py:80\n")
+    proc = _run(tmp_path, baseline)
+    assert proc.returncode == 1, proc.stdout
+
+
+def test_baselined_unchanged_passes(tmp_path: Path) -> None:
+    _mk(tmp_path, "backend/app/god.py", 80)
+    baseline = tmp_path / "bl"
+    baseline.write_text("backend/app/god.py:80\n")
+    proc = _run(tmp_path, baseline)
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_baselined_shrink_passes(tmp_path: Path) -> None:
+    _mk(tmp_path, "backend/app/god.py", 60)
+    baseline = tmp_path / "bl"
+    baseline.write_text("backend/app/god.py:80\n")
+    proc = _run(tmp_path, baseline)
+    assert proc.returncode == 0, proc.stdout

--- a/backend/tests/unit/scripts/test_check_frontend_data_path.py
+++ b/backend/tests/unit/scripts/test_check_frontend_data_path.py
@@ -1,0 +1,15 @@
+"""Green-path test for scripts/fitness/check_frontend_data_path.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_frontend_data_path.py"
+
+
+def test_data_path_clean_or_baseline_matched() -> None:
+    proc = subprocess.run([sys.executable, str(CHECK)], capture_output=True, text=True, timeout=15)
+    assert proc.returncode == 0, f"new data-path violation\n{proc.stdout}"

--- a/backend/tests/unit/scripts/test_check_frontend_data_path_canary.py
+++ b/backend/tests/unit/scripts/test_check_frontend_data_path_canary.py
@@ -1,0 +1,59 @@
+"""Canary for scripts/fitness/check_frontend_data_path.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_frontend_data_path.py"
+
+
+def _run(tmp_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECK), "--repo-root", str(tmp_root), "--baseline", "/dev/null"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def test_fires_on_supabase_from_in_component(tmp_path: Path) -> None:
+    f = tmp_path / "frontend" / "components" / "x" / "Bad.tsx"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("const r = await supabase.from('projects').select('*');\n")
+    proc = _run(tmp_path)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "Bad.tsx" in proc.stdout
+
+
+def test_fires_on_vite_api_url(tmp_path: Path) -> None:
+    f = tmp_path / "frontend" / "hooks" / "useX.ts"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("const base = import.meta.env.VITE_API_URL;\n")
+    proc = _run(tmp_path)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+
+
+def test_integration_layer_is_allowed(tmp_path: Path) -> None:
+    f = tmp_path / "frontend" / "integrations" / "supabase" / "client.ts"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("export const q = () => supabase.from('x').select();\n")
+    proc = _run(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_baseline_grandfathers(tmp_path: Path) -> None:
+    f = tmp_path / "frontend" / "services" / "legacyService.ts"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("const r = supabase.from('legacy').select();\n")
+    baseline = tmp_path / "bl"
+    baseline.write_text("frontend/services/legacyService.ts:1\n")
+    proc = subprocess.run(
+        [sys.executable, str(CHECK), "--repo-root", str(tmp_path), "--baseline", str(baseline)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr

--- a/backend/tests/unit/scripts/test_check_skill_router_sync.py
+++ b/backend/tests/unit/scripts/test_check_skill_router_sync.py
@@ -1,0 +1,15 @@
+"""Green-path test for scripts/fitness/check_skill_router_sync.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_skill_router_sync.py"
+
+
+def test_router_in_sync_with_skills() -> None:
+    proc = subprocess.run([sys.executable, str(CHECK)], capture_output=True, text=True, timeout=15)
+    assert proc.returncode == 0, f"dead router entry\n{proc.stdout}"

--- a/backend/tests/unit/scripts/test_check_skill_router_sync_canary.py
+++ b/backend/tests/unit/scripts/test_check_skill_router_sync_canary.py
@@ -1,0 +1,49 @@
+"""Canary for scripts/fitness/check_skill_router_sync.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_skill_router_sync.py"
+
+
+def _setup(root: Path, router_skills: list[str], real_skills: list[str]) -> None:
+    claude = root / "CLAUDE.md"
+    lines = ["# x", "", "## Which skill to load", ""]
+    lines += [f"- area → `{s}`" for s in router_skills]
+    claude.write_text("\n".join(lines) + "\n")
+    for s in real_skills:
+        (root / ".claude" / "skills" / s).mkdir(parents=True, exist_ok=True)
+
+
+def _run(root: Path):
+    return subprocess.run(
+        [sys.executable, str(CHECK), "--repo-root", str(root)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def test_dead_router_entry_fails(tmp_path: Path) -> None:
+    _setup(
+        tmp_path,
+        router_skills=["backend-development", "ghost-skill"],
+        real_skills=["backend-development"],
+    )
+    proc = _run(tmp_path)
+    assert proc.returncode == 1, proc.stdout
+    assert "ghost-skill" in proc.stdout
+
+
+def test_in_sync_passes(tmp_path: Path) -> None:
+    _setup(
+        tmp_path,
+        router_skills=["backend-development", "code-review"],
+        real_skills=["backend-development", "code-review", "debugging"],
+    )
+    proc = _run(tmp_path)
+    assert proc.returncode == 0, proc.stdout

--- a/backend/tests/unit/test_article_files_unit.py
+++ b/backend/tests/unit/test_article_files_unit.py
@@ -314,3 +314,33 @@ async def test_reparse_endpoint_defensive_404_when_service_returns_none() -> Non
                 current_user_sub=uuid4(),
             )
     assert exc.value.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# list_article_files endpoint
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_article_files_includes_extraction_error() -> None:
+    """A parse_failed file surfaces its extraction_error in the list item."""
+    from app.api.v1.endpoints.article_files import list_article_files
+
+    aid, pid = uuid4(), uuid4()
+    failed = _fake_article_file(aid, pid, status="parse_failed")
+    failed.extraction_error = "libxcb.so.1: cannot open shared object file"
+
+    with (
+        patch(f"{_EP}.get_article_project_id", AsyncMock(return_value=pid)),
+        patch(f"{_EP}.ensure_project_member", AsyncMock()),
+        patch(f"{_EP}.ArticleFileService") as svc,
+    ):
+        svc.return_value.list_for_article = AsyncMock(return_value=[failed])
+        resp = await list_article_files(
+            article_id=aid,
+            request=_request(),
+            db=AsyncMock(),
+            current_user_sub=uuid4(),
+        )
+    item = resp.data[0]
+    assert item.extraction_error == "libxcb.so.1: cannot open shared object file"

--- a/backend/tests/unit/test_extraction_export_service.py
+++ b/backend/tests/unit/test_extraction_export_service.py
@@ -1805,7 +1805,7 @@ class TestLoadActiveTemplateVersion:
         svc.db.execute = AsyncMock(return_value=result_mock)
 
         with pytest.raises(NotFoundError):
-            await svc._load_active_template_version(template_id)
+            await svc._load_active_template_version(template_id, uuid4())
 
     @pytest.mark.asyncio
     async def test_template_found_no_version_raises_not_found_error(self, monkeypatch):
@@ -1829,7 +1829,7 @@ class TestLoadActiveTemplateVersion:
         )
 
         with pytest.raises(NotFoundError):
-            await svc._load_active_template_version(template_id)
+            await svc._load_active_template_version(template_id, uuid4())
 
     @pytest.mark.asyncio
     async def test_template_and_version_found_returns_tuple(self, monkeypatch):
@@ -1852,7 +1852,7 @@ class TestLoadActiveTemplateVersion:
             lambda _: version_repo_mock,
         )
 
-        template, version = await svc._load_active_template_version(template_id)
+        template, version = await svc._load_active_template_version(template_id, uuid4())
         assert template is template_mock
         assert version is version_mock
 

--- a/backend/tests/unit/test_extraction_export_tidy_model_section.py
+++ b/backend/tests/unit/test_extraction_export_tidy_model_section.py
@@ -1,0 +1,148 @@
+"""Regression: cardinality=ONE MODEL_SECTION tidy tables must source rows from
+``model_instances`` (role-first), mirroring the matrix builder. Pure — no DB.
+
+Bug (post-merge review 2026-06-21): ``_build_tidy_tables`` read
+``section_instances`` in the cardinality=ONE branch, but model-section
+instances live in ``model_instances``. Every production CHARMS model section
+(model_development / model_performance / model_validation / model_results /
+model_interpretation — all ``cardinality='one'``) therefore rendered with zero
+rows, silently dropping every prediction-model value from the publication
+tidy-table sheet while the matrix sheet showed them correctly.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from app.models.extraction import (
+    ExtractionCardinality,
+    ExtractionEntityRole,
+    ExtractionFieldType,
+)
+from app.services.extraction_export_service import (
+    ArticleDescriptor,
+    ExportMode,
+    FieldDescriptor,
+    SectionDescriptor,
+    _build_tidy_tables,
+)
+
+
+def _model_section(field_id):
+    return SectionDescriptor(
+        entity_type_id=uuid4(),
+        label="Model development",
+        role=ExtractionEntityRole.MODEL_SECTION,
+        parent_entity_type_id=uuid4(),
+        fields=(
+            FieldDescriptor(
+                field_id=field_id,
+                label="Method",
+                type=ExtractionFieldType.TEXT,
+                allowed_values=(),
+                parent_section_id=uuid4(),
+            ),
+        ),
+        # Production model sections are cardinality ONE; the N-model fan-out
+        # is sourced from model_instances, never from cardinality MANY.
+        cardinality=ExtractionCardinality.ONE,
+    )
+
+
+def test_cardinality_one_model_section_emits_one_row_per_model():
+    field_id = uuid4()
+    section = _model_section(field_id)
+    run_id = uuid4()
+    model_iid = uuid4()
+    article = ArticleDescriptor(
+        article_id=uuid4(),
+        header_label="Gaca, 2011",
+        run_id=run_id,
+        run_stage=None,
+        version_id=None,
+        model_instances=(model_iid,),
+        section_instances={},  # model sections never populate section_instances
+    )
+    value_map = {(run_id, model_iid, field_id): "Logistic regression"}
+
+    tables = _build_tidy_tables((section,), (article,), value_map, ExportMode.CONSENSUS)
+
+    assert len(tables) == 1
+    rows = tables[0].rows
+    assert len(rows) == 1, "cardinality=ONE model section must emit a row from model_instances"
+    assert rows[0].instance_id == model_iid
+    assert rows[0].values == ("Logistic regression",)
+
+
+def test_cardinality_many_study_section_fans_out_over_section_instances():
+    # Non-model MANY branch: one row per section_instance (not model_instances).
+    field_id = uuid4()
+    section = SectionDescriptor(
+        entity_type_id=uuid4(),
+        label="Outcomes",
+        role=ExtractionEntityRole.STUDY_SECTION,
+        parent_entity_type_id=None,
+        fields=(
+            FieldDescriptor(
+                field_id=field_id,
+                label="Name",
+                type=ExtractionFieldType.TEXT,
+                allowed_values=(),
+                parent_section_id=uuid4(),
+            ),
+        ),
+        cardinality=ExtractionCardinality.MANY,
+    )
+    run_id = uuid4()
+    i1, i2 = uuid4(), uuid4()
+    article = ArticleDescriptor(
+        article_id=uuid4(),
+        header_label="Gaca, 2011",
+        run_id=run_id,
+        run_stage=None,
+        version_id=None,
+        model_instances=(),
+        section_instances={section.entity_type_id: (i1, i2)},
+    )
+    value_map = {
+        (run_id, i1, field_id): "OS",
+        (run_id, i2, field_id): "PFS",
+    }
+
+    tables = _build_tidy_tables((section,), (article,), value_map, ExportMode.CONSENSUS)
+
+    rows = tables[0].rows
+    assert [r.values[0] for r in rows] == ["OS", "PFS"]
+    assert [r.record_label for r in rows] == [
+        "Gaca, 2011 — Outcomes 1",
+        "Gaca, 2011 — Outcomes 2",
+    ]
+
+
+def test_cardinality_one_model_section_fans_out_over_multiple_models():
+    field_id = uuid4()
+    section = _model_section(field_id)
+    run_id = uuid4()
+    m1, m2 = uuid4(), uuid4()
+    article = ArticleDescriptor(
+        article_id=uuid4(),
+        header_label="Gaca, 2011",
+        run_id=run_id,
+        run_stage=None,
+        version_id=None,
+        model_instances=(m1, m2),
+        section_instances={},
+    )
+    value_map = {
+        (run_id, m1, field_id): "Logistic regression",
+        (run_id, m2, field_id): "Cox model",
+    }
+
+    tables = _build_tidy_tables((section,), (article,), value_map, ExportMode.CONSENSUS)
+
+    rows = tables[0].rows
+    assert [r.values[0] for r in rows] == ["Logistic regression", "Cox model"]
+    assert [r.record_label for r in rows] == [
+        "Gaca, 2011 — Model 1",
+        "Gaca, 2011 — Model 2",
+    ]

--- a/backend/tests/unit/test_form_runs_endpoint_unit.py
+++ b/backend/tests/unit/test_form_runs_endpoint_unit.py
@@ -1,0 +1,41 @@
+"""Direct endpoint-coroutine unit test for POST /articles/form-runs.
+
+The integration coverage (test_run_resolution_endpoints) exercises this through
+the ASGI transport, whose handler lines do not register on coverage (the 80%
+diff-cover gate's blind spot). This calls the coroutine directly so the
+BOLA-scoped resolve_form_runs call is covered — mirrors test_article_files_unit.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.api.v1.endpoints.articles import post_form_runs
+from app.schemas.extraction_run import ArticleRunRef, FormRunsRequest
+
+_EP = "app.api.v1.endpoints.articles"
+
+
+@pytest.mark.asyncio
+async def test_form_runs_endpoint_threads_project_id_into_resolver() -> None:
+    pid, aid, tid = uuid4(), uuid4(), uuid4()
+    refs = [ArticleRunRef(article_id=aid, run_id=None)]
+    body = FormRunsRequest(article_ids=[aid], template_id=tid, project_id=pid)
+
+    with (
+        patch(f"{_EP}.ensure_project_member", AsyncMock()) as gate,
+        patch(f"{_EP}.resolve_form_runs", AsyncMock(return_value=refs)) as resolve,
+        patch(f"{_EP}._trace", return_value=None),
+    ):
+        resp = await post_form_runs(
+            body=body, request=MagicMock(), db=AsyncMock(), current_user_sub=uuid4()
+        )
+
+    gate.assert_awaited_once()
+    # BOLA: the body's project_id must scope the resolver, not just the gate.
+    _, kwargs = resolve.call_args
+    assert kwargs["project_id"] == pid
+    assert kwargs["template_id"] == tid
+    assert resp.ok is True
+    assert resp.data == refs

--- a/docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md
+++ b/docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md
@@ -1037,3 +1037,53 @@ rules from the constitution + `.claude/rules/`):
      earliest overlapping source span; for a multi-page prose run this is the
      first page only. Acceptable for highlight (we scroll there); confirm that is
      the desired behaviour vs storing all spanned pages.
+
+---
+
+## Amendments (2026-06-22)
+
+> Source: [`docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md`](../specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md)
+> (Workstream B), after an adversarial review. Apply these BEFORE executing the
+> phases above. They do not change the architecture — they correct stale
+> premises and an ADR conflict.
+
+1. **Amend ADR-0013 FIRST (new prerequisite, before Phase 3).** Phase 3 sets
+   `READ_FROM_BLOCKS` default `True`, removes `MAX_PDF_CHARS`, and raises the
+   prompt budget 15k→120k — i.e. markdown becomes the **default extraction
+   input**. ADR-0013 currently says blocks stay the default ("no two competing
+   extraction inputs by default"). Amend ADR-0013 (status → accepted; record the
+   decision + the bake-off evidence that markdown beats the block-assembler)
+   before landing Phase 3, and treat the 15k→120k budget change as its **own
+   verification** (latency / cost / extraction-quality), not a silent default.
+
+2. **Stale `readerBlocks` premise (#359 shipped after this plan was written).**
+   The Phase-5 claim "today neither panel passes `readerBlocks`; this adds
+   `readerMarkdown`" (≈ plan line 841) is now **false** — both panels already
+   pass `readerBlocks`/`readerLoading`
+   (`ExtractionPDFPanel.tsx:92`, `QualityAssessmentFullScreen.tsx:665`). Task 5.2
+   / 5.3 must **REPLACE** the wired props, not add new ones.
+
+3. **Answer to Open question 1 (reader-blocks fallback): YES, keep it.**
+   `ReaderTextBlock` is a **public viewer-barrel export** (removing it is a
+   breaking package API change). Keep a blocks-based fallback render until the
+   markdown endpoint (Phase 4) ships and is verified; only then retire the flat
+   dump (Task 7.1). Do not delete `ReaderTextBlock` / `useArticleTextBlocks` —
+   they still feed citation anchoring.
+
+4. **`prose` must be registered.** `@tailwindcss/typography` is installed but
+   NOT in `tailwind.config.ts` `plugins[]`; register it for `prose prose-sm`,
+   and add a `components` override so markdown tables match the dense extraction
+   table aesthetic (`ExtractionInterface.tsx:406-448`). Close the loop with a
+   `design-review` pass.
+
+5. **Process gates.** After the dep add: `npm audit --audit-level=high`
+   (security-audit gate fires on lockfile changes) and
+   `node scripts/enumerate_compiler_bailouts.mjs` (panicThreshold `all_errors`).
+   Add `rehype/remark/sanitize/nh3/GFM/markdown` to `.github/cspell-words.txt`.
+   Drive-by: fix the Portuguese comment at `AISuggestionEvidence.tsx:154` when
+   that file is touched.
+
+6. **Stack is confirmed correct as written:** `react-markdown` + `remark-gfm` +
+   `rehype-sanitize`. Do **not** add `rehype-raw` (the ADR forbids raw without
+   sanitize; the markdown is server-projected GFM) or `remark-breaks` (blocks are
+   joined with `\n\n`).

--- a/docs/superpowers/plans/2026-06-22-architecture-clarity.md
+++ b/docs/superpowers/plans/2026-06-22-architecture-clarity.md
@@ -1,0 +1,1123 @@
+---
+status: draft
+last_reviewed: 2026-06-22
+owner: '@raphaelfh'
+---
+
+# Architecture Clarity + Organization Gates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it obvious which pattern an agent should follow (canonical-home + skill router) and enforce organization with deterministic gates, without inflating always-loaded context.
+
+**Architecture:** Keep prumo's layered agent-context model (constitution=principles, `.claude/rules/*`=always-true shapes, skills=procedures, gates=mechanically-checkable). Add a `Working principles` block + a skill router to the always-loaded CLAUDE.md, a structural `frontend-development` skill mirroring `backend-development`, and three fitness functions (frontend data-path, file-size ratchet, skill-router sync) that follow the existing `scripts/fitness/` convention.
+
+**Tech Stack:** Markdown (CLAUDE.md, rules, skills), Python 3.11 fitness checks (stdlib only, mirroring `check_react_query_keys.py`), pytest green+canary tests.
+
+## Global Constraints
+
+- **English only** for all code, comments, docs, copy (constitution).
+- Fitness checks: stdlib-only Python; CLI `--repo-root` + `--baseline` + `--emit-telemetry` + `--jsonl-out`; exit codes `0` (baseline matched) / `1` (new violation) / `2` (internal); default baseline path `SCRIPT_DIR / "<name>.baseline"`; wired into `scripts/fitness/run_all.sh`.
+- Each fitness check ships a green-path test (`test_<check>.py`) and a canary test (`test_<check>_canary.py`) under `backend/tests/unit/scripts/`, using `Path(__file__).resolve().parents[4]` for the repo root and `--repo-root`/`--baseline` to drive synthetic trees.
+- CLAUDE.md must stay under ~150 lines (Anthropic budget; currently ~89).
+- `.claude/**` is markdownlint-ignored and outside the frontmatter gate; `docs/superpowers/specs/2026-*-design.md` is markdownlint-globbed; new **plan** docs need one line in `.markdownlintignore`.
+- Conventional commits; PRs target `dev`, squash-merged.
+- Verify backend Python via `cd backend && uv run pytest <path>`; fitness checks run with system `python3`.
+
+---
+
+### Task 1: CLAUDE.md — `Working principles` + skill router (+ llms.txt mirror)
+
+**Files:**
+- Modify: `CLAUDE.md` (add two sections after `## Current focus`)
+- Modify: `llms.txt` (replace the ad-hoc skill mentions with a navigational skill-map mirror)
+
+**Interfaces:**
+- Produces: a `## Which skill to load` section in `CLAUDE.md` whose backticked skill names (`backend-development`, `frontend-development`, `frontend-ux`, `ui-styling`, `code-review`, `debugging`, `web-testing`, `deploy-release`, `architectural-quality-loop`, `design-review`) Task 6's router-sync check parses.
+
+- [ ] **Step 1: Add the `Working principles` block to CLAUDE.md**
+
+Insert immediately after the `## Current focus` section (before `## Stack`):
+
+```markdown
+## Working principles
+
+These bias toward caution over speed. For trivial changes, use judgment.
+
+- **Think before coding.** State assumptions; if a requirement has multiple
+  readings, surface them — don't choose silently. If a simpler path exists, say
+  so; push back with evidence, not deference. Genuinely unclear, or the call is
+  the user's? Stop and ask — otherwise act, don't re-litigate settled choices.
+  Feature/creative work starts with `superpowers:brainstorming`.
+- **Simplicity first (YAGNI).** The minimum code that solves the asked problem —
+  no speculative abstractions, config, or handling for impossible cases. Any
+  complexity beyond what a principle prescribes must be justified (constitution
+  §Governance). If 200 lines could be 50, rewrite it.
+- **Surgical on unrelated code; clean in code you touch.** Change only what the
+  task requires; match surrounding style; flag unrelated dead code, don't delete
+  it. But where you DO edit, prefer the clean fix over grandfathering a
+  violation — no new legacy left for later.
+- **Goal-driven and verified.** Turn the task into a checkable goal (write the
+  failing test, then make it pass). State a short plan with a verify step each.
+  Evidence before "done" — run the command and read the output, never assert
+  (`code-review` Iron Law; `verification-before-completion`).
+```
+
+- [ ] **Step 2: Add the skill router to CLAUDE.md**
+
+Insert after the new `## Working principles` section:
+
+```markdown
+## Which skill to load
+
+Load the skill before non-trivial work in its area (skills are on-demand —
+naming them here is what makes them load reliably).
+
+- Backend (FastAPI/SQLAlchemy/Alembic/Celery/RLS) → `backend-development`
+- Frontend structure/data/state (components/hooks/services/stores) → `frontend-development`
+- Frontend visual language (density/layout/empty states) → `frontend-ux`
+- Tailwind/shadcn class mechanics → `ui-styling`
+- Before "done" / PR / review → `code-review`
+- Bug / failing test / weird behavior → `debugging`
+- Tests (Vitest/Playwright/pytest/MSW) → `web-testing`
+- Deploy / promotion / rollback → `deploy-release`
+- Architectural drift sweep → `architectural-quality-loop`
+- Visual feedback loop on a screen → `design-review`
+```
+
+- [ ] **Step 3: Reconcile llms.txt (remove duplication, point to the router)**
+
+In `llms.txt`, replace the bullet under `## Then, depending on what you are touching` that reads `Frontend UI / visual changes → the frontend-ux + ui-styling skills; close the loop with design-review ...` with a single pointer to the canonical router:
+
+```markdown
+- Which skill to load for a given area → the `## Which skill to load` map in
+  [CLAUDE.md](CLAUDE.md) (the always-loaded source; this index mirrors it)
+```
+
+Keep the rest of `llms.txt` unchanged (it already defers hard rules to CLAUDE.md/constitution).
+
+- [ ] **Step 4: Verify CLAUDE.md budget + content**
+
+Run: `awk 'END{print NR}' CLAUDE.md`
+Expected: a number under 150.
+
+Run: `grep -c '`backend-development`\|`frontend-development`\|Working principles' CLAUDE.md`
+Expected: ≥ 3.
+
+- [ ] **Step 5: Verify docs gates locally**
+
+Run: `bash scripts/docs/check-frontmatter.sh 2>&1 | grep -i 'CLAUDE.md\|llms.txt\|MISSING\|FAIL' || echo OK`
+Expected: `OK` (CLAUDE.md keeps its frontmatter; llms.txt unchanged frontmatter).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md llms.txt
+git commit -m "docs(context): add Working principles + skill router to CLAUDE.md"
+```
+
+---
+
+### Task 2: rules — explicit skill directives, repository-vs-service, frontend shapes
+
+**Files:**
+- Modify: `.claude/rules/backend.md`
+- Modify: `.claude/rules/frontend.md`
+
+**Interfaces:**
+- Produces: the two non-negotiable frontend shapes (ErrorResult boundary; component→hook→service data flow) that Task 4's data-path gate enforces.
+
+- [ ] **Step 1: Strengthen the backend rules pointer + add the repository rule**
+
+In `.claude/rules/backend.md`, replace the opening lines:
+
+```markdown
+Deep dives live in the `backend-development` skill and
+`docs/reference/` — this file is the always-true core.
+```
+
+with:
+
+```markdown
+For any non-trivial backend change, load the `backend-development` skill
+before writing code (deep dives also in `docs/reference/`). This file is the
+always-true core.
+
+## Repository vs service SQL
+
+Use a repository (`backend/app/repositories/`) when a query is reused by >1
+service, or the entity has several distinct query shapes. Otherwise inline
+`select()` in the owning service. Repositories call `flush()`, never `commit()`.
+```
+
+- [ ] **Step 2: Strengthen the frontend rules pointer + add the two structural shapes**
+
+In `.claude/rules/frontend.md`, replace the opening lines:
+
+```markdown
+Visual language lives in the `frontend-ux` skill; Tailwind/shadcn
+mechanics in `ui-styling`. This file is the always-true core.
+```
+
+with:
+
+```markdown
+For any non-trivial frontend change, load the `frontend-development` skill
+(structure/data/state) before writing code. Visual language → `frontend-ux`;
+Tailwind/shadcn mechanics → `ui-styling`. This file is the always-true core.
+
+## Structure (CI-enforced by `scripts/fitness/check_frontend_data_path.py`)
+
+- Data flows `component → hook (TanStack Query) → service (apiClient) →
+  backend`. Components never call `fetch()` or `supabase.from(...)` directly.
+- `frontend/services/*Service.ts` functions return `ErrorResult<T>`
+  (`frontend/lib/error-utils.ts:toResult`); they never throw across the
+  boundary and never toast.
+```
+
+- [ ] **Step 3: Verify the edits landed**
+
+Run: `grep -c 'load the .backend-development. skill\|Repository vs service' .claude/rules/backend.md`
+Expected: `2`.
+
+Run: `grep -c 'frontend-development\|component → hook\|ErrorResult' .claude/rules/frontend.md`
+Expected: ≥ 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/rules/backend.md .claude/rules/frontend.md
+git commit -m "docs(rules): explicit skill directives, repository rule, frontend data-flow shapes"
+```
+
+---
+
+### Task 3: `frontend-development` skill (structural parity with backend-development)
+
+**Files:**
+- Create: `.claude/skills/frontend-development/SKILL.md`
+- Create: `.claude/skills/frontend-development/references/data-and-state.md`
+- Create: `.claude/skills/frontend-development/references/components-and-forms.md`
+
+**Interfaces:**
+- Produces: the skill named `frontend-development` (its dir must match the router entry from Task 1; Task 6 asserts this).
+
+- [ ] **Step 1: Write `SKILL.md` with a non-overlapping description**
+
+Create `.claude/skills/frontend-development/SKILL.md`. Frontmatter description must NOT overlap `frontend-ux` (visual) or `ui-styling` (Tailwind classes):
+
+```markdown
+---
+name: frontend-development
+description: Use when writing or modifying the STRUCTURE of anything under `frontend/` — where code lives, data flow, and state. Covers components/{domain} organization, TanStack Query hooks + key factories, `services/*Service.ts` via the typed apiClient, Zustand stores vs React Context, react-hook-form + Zod forms, generated `types/api/schema.d.ts`, ErrorResult boundaries, and the React Compiler constraints. Trigger on "add a page", "add a data hook", "add a mutation", "wire a form", "new store", "fetch data", or anything about how the frontend is organized. NOT for visual language (use `frontend-ux`) or Tailwind/shadcn class mechanics (use `ui-styling`).
+---
+
+# Frontend Development (prumo)
+
+Structural manual for prumo's React 19 + TS + Vite frontend. This is the *how
+the code is organized / how data flows* layer. Visual language is `frontend-ux`;
+Tailwind/shadcn class mechanics are `ui-styling`. SKILL.md is the index — pull a
+reference for depth.
+
+## Repository layout you must respect
+
+\`\`\`
+frontend/
+  pages/{PageName}.tsx          # route-level screens
+  components/{domain}/*.tsx      # domain components, functional + hooks only
+  hooks/{domain}/use{Name}.ts    # TanStack Query/mutation hooks
+  services/{domain}Service.ts    # apiClient calls; return ErrorResult, never throw/toast
+  stores/                        # Zustand stores (cross-component UI state)
+  contexts/                      # React Context (app-wide singletons: Auth/Project/Sidebar)
+  integrations/api/client.ts     # the ONE typed HTTP client (apiClient)
+  integrations/supabase/         # auth + storage ONLY (never table reads)
+  lib/copy/                      # in-house i18n; all user-facing text
+  lib/query-keys/                # TanStack key factories
+  types/api/schema.d.ts          # generated from FastAPI openapi — never hand-edit
+\`\`\`
+
+## Hard rules (with reasoning)
+
+1. **One read path.** All backend data goes through `apiClient`
+   (`integrations/api/client.ts`). Never `fetch()` or `supabase.from(...)` in a
+   component/hook/service — the dual read path is the documented slow-load /
+   status-drift / blind-leak incident class (constitution §VI; CI-enforced by
+   `check_frontend_data_path.py`).
+2. **Services don't throw across the boundary.** `services/*Service.ts` return
+   `ErrorResult<T>` via `lib/error-utils.ts:toResult`; the hook maps the result,
+   the component renders it. Services never toast.
+3. **Keys come from factories.** TanStack `queryKey` comes from
+   `lib/query-keys/` (CI-enforced by `check_react_query_keys.py`). Mutations
+   invalidate the owning key family.
+4. **Types are generated.** Import request/response shapes from
+   `types/api/schema.d.ts` (`npm run generate:api-types` after a backend change).
+   Never hand-mirror backend enums/models.
+5. **Copy through `lib/copy/`.** Never hardcode user-facing strings.
+6. **React Compiler.** No `try/finally` (or `throw` inside `try`) in
+   component/hook bodies — move IO into a service returning `ErrorResult`. Last
+   resort: `'use no memo'` + a `// kept:` comment.
+
+## Data flow
+
+`component → hook (TanStack Query) → service (apiClient) → backend`. See
+[`references/data-and-state.md`](references/data-and-state.md) for the hook /
+service / store / context shapes with code.
+
+## Common workflows
+
+| Task | Steps |
+|---|---|
+| Add a page | `pages/{Name}.tsx` → route in the router → data via a hook (never inline fetch) |
+| Add a data hook | `hooks/{domain}/use{Name}.ts` → `useQuery` with a key-factory key → call the service |
+| Add a mutation | `useMutation` in the hook → on success `invalidateQueries` the owning key family |
+| Add a service call | `services/{domain}Service.ts` → `apiClient` → return `ErrorResult<T>` |
+| Add a form | `react-hook-form` + `Zod` resolver; submit calls the service hook |
+| Add cross-component UI state | Zustand store in `stores/`; app-wide singleton → Context |
+
+## References index
+
+| File | Use when |
+|---|---|
+| [`references/data-and-state.md`](references/data-and-state.md) | hook/service/store/context shapes, query-key factories, invalidation |
+| [`references/components-and-forms.md`](references/components-and-forms.md) | component shape, react-hook-form + Zod, copy, generated types |
+```
+
+- [ ] **Step 2: Write `references/data-and-state.md`**
+
+Create `.claude/skills/frontend-development/references/data-and-state.md` with the concrete shapes (hook with `useQuery`/`useMutation` + key factory + `invalidateQueries`; service returning `ErrorResult` via `toResult`; Zustand store; when Context instead of a store). Use real prumo names (`apiClient`, `lib/query-keys/`, `lib/error-utils.ts`). Mirror the depth of `backend-development`'s `references/sqlalchemy.md`.
+
+- [ ] **Step 3: Write `references/components-and-forms.md`**
+
+Create `.claude/skills/frontend-development/references/components-and-forms.md` covering the functional-component shape (shadcn primitives, focus states), `react-hook-form` + `Zod` form pattern, copy via `lib/copy/`, and importing generated types from `types/api/schema.d.ts`.
+
+- [ ] **Step 4: Verify the skill is well-formed**
+
+Run: `test -f .claude/skills/frontend-development/SKILL.md && head -3 .claude/skills/frontend-development/SKILL.md`
+Expected: prints the frontmatter `---` and `name: frontend-development`.
+
+Run: `grep -c 'NOT for visual language\|component → hook\|ErrorResult' .claude/skills/frontend-development/SKILL.md`
+Expected: ≥ 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/frontend-development/
+git commit -m "docs(skill): add frontend-development structural pattern manual"
+```
+
+---
+
+### Task 4: `check_frontend_data_path` fitness gate (TDD)
+
+**Files:**
+- Create: `scripts/fitness/check_frontend_data_path.py`
+- Create: `scripts/fitness/check_frontend_data_path.baseline`
+- Create: `backend/tests/unit/scripts/test_check_frontend_data_path.py`
+- Create: `backend/tests/unit/scripts/test_check_frontend_data_path_canary.py`
+- Modify: `scripts/fitness/run_all.sh`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `scripts/fitness/check_frontend_data_path.py` callable as `python3 check_frontend_data_path.py [--repo-root P] [--baseline P]`, exit `0/1/2`.
+
+- [ ] **Step 1: Write the canary test (fails first)**
+
+Create `backend/tests/unit/scripts/test_check_frontend_data_path_canary.py`:
+
+```python
+"""Canary for scripts/fitness/check_frontend_data_path.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_frontend_data_path.py"
+
+
+def _run(tmp_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECK), "--repo-root", str(tmp_root), "--baseline", "/dev/null"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def test_fires_on_supabase_from_in_component(tmp_path: Path) -> None:
+    f = tmp_path / "frontend" / "components" / "x" / "Bad.tsx"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("const r = await supabase.from('projects').select('*');\n")
+    proc = _run(tmp_path)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "Bad.tsx" in proc.stdout
+
+
+def test_fires_on_vite_api_url(tmp_path: Path) -> None:
+    f = tmp_path / "frontend" / "hooks" / "useX.ts"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("const base = import.meta.env.VITE_API_URL;\n")
+    proc = _run(tmp_path)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+
+
+def test_integration_layer_is_allowed(tmp_path: Path) -> None:
+    f = tmp_path / "frontend" / "integrations" / "supabase" / "client.ts"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("export const q = () => supabase.from('x').select();\n")
+    proc = _run(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_baseline_grandfathers(tmp_path: Path) -> None:
+    f = tmp_path / "frontend" / "services" / "legacyService.ts"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("const r = supabase.from('legacy').select();\n")
+    baseline = tmp_path / "bl"
+    baseline.write_text("frontend/services/legacyService.ts:1\n")
+    proc = subprocess.run(
+        [sys.executable, str(CHECK), "--repo-root", str(tmp_path), "--baseline", str(baseline)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+```
+
+- [ ] **Step 2: Run the canary to confirm it fails**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_frontend_data_path_canary.py -q`
+Expected: FAIL (collection error or failures — `check_frontend_data_path.py` does not exist yet).
+
+- [ ] **Step 3: Write the check (minimal to pass)**
+
+Create `scripts/fitness/check_frontend_data_path.py`:
+
+```python
+#!/usr/bin/env python3
+"""check_frontend_data_path.py — prumo fitness function.
+
+Enforces the single read path (constitution §VI): all backend data flows
+through the typed apiClient. Flags, OUTSIDE `frontend/integrations/`:
+  - `supabase.from(` — direct table reads (auth/storage are allowed via
+    supabase.auth/.storage, which this does not match)
+  - `import.meta.env.VITE_API_URL` — ad-hoc base-URL wiring around the client
+
+Regex-based (does not parse TS); a `.baseline` grandfathers residual sites.
+
+Exit codes: 0 (baseline matched) | 1 (new violation) | 2 (internal).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_REPO_ROOT = SCRIPT_DIR.parent.parent
+
+FRONTEND_ROOT = "frontend"
+ALLOWED_PREFIX = "frontend/integrations/"
+SKIP_DIRS = {"node_modules", "dist", "build", ".next", "coverage", "test-results", "playwright-report"}
+
+PATTERNS = (
+    re.compile(r"\bsupabase\s*\.\s*from\s*\("),
+    re.compile(r"\bimport\.meta\.env\.VITE_API_URL\b"),
+)
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    snippet: str
+
+    def stable_id(self) -> str:
+        return f"{self.file}:{self.line}"
+
+
+def _walk(start: Path):
+    for p in start.rglob("*"):
+        if p.is_file() and p.suffix in {".ts", ".tsx"} and not any(part in SKIP_DIRS for part in p.parts):
+            yield p
+
+
+def scan(root: Path) -> list[Violation]:
+    fe = root / FRONTEND_ROOT
+    if not fe.is_dir():
+        return []
+    out: list[Violation] = []
+    for path in sorted(_walk(fe)):
+        rel = path.relative_to(root).as_posix()
+        if rel.startswith(ALLOWED_PREFIX):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for i, line in enumerate(text.splitlines(), start=1):
+            if any(pat.search(line) for pat in PATTERNS):
+                out.append(Violation(rel, i, line.strip()[:160]))
+    return out
+
+
+def load_baseline(path: Path) -> set[str]:
+    if not path.is_file():
+        return set()
+    return {
+        ln.strip()
+        for ln in path.read_text(encoding="utf-8").splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    }
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description="prumo frontend single-read-path enforcement")
+    p.add_argument("--repo-root", default=None)
+    p.add_argument("--baseline", default=None)
+    p.add_argument("--emit-telemetry", default=None)
+    p.add_argument("--jsonl-out", default=None)
+    args = p.parse_args(argv)
+
+    root = Path(args.repo_root).resolve() if args.repo_root else DEFAULT_REPO_ROOT
+    baseline_path = Path(args.baseline) if args.baseline else SCRIPT_DIR / "check_frontend_data_path.baseline"
+
+    started = time.time()
+    violations = scan(root)
+    duration_ms = int((time.time() - started) * 1000)
+    baseline = load_baseline(baseline_path)
+    new = [v for v in violations if v.stable_id() not in baseline]
+    exit_code = 1 if new else 0
+
+    if args.jsonl_out:
+        rows = [
+            {
+                "category": "data-path",
+                "severity": "high",
+                "confidence": 0.9,
+                "file": v.file,
+                "line": v.line,
+                "evidence": v.snippet,
+                "suggested_action": "Route through apiClient (frontend/integrations/api/client.ts); supabase only for auth/storage.",
+                "source": "fitness:check_frontend_data_path",
+            }
+            for v in new
+        ]
+        Path(args.jsonl_out).write_text("\n".join(json.dumps(r) for r in rows) + ("\n" if rows else ""))
+
+    if args.emit_telemetry:
+        with open(args.emit_telemetry, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "phase": "fitness",
+                "gate": "check_frontend_data_path",
+                "duration_ms": duration_ms,
+                "exit_code": exit_code,
+                "violation_count": len(violations),
+                "new_violation_count": len(new),
+                "baseline_size": len(baseline),
+            }) + "\n")
+
+    if new:
+        print(f"check_frontend_data_path.py: FAIL ({duration_ms} ms; {len(new)} new, {len(baseline)} grandfathered)")
+        print("NEW direct-data-path violations (route through apiClient):")
+        for v in new[:10]:
+            print(f"  {v.file}:{v.line}  {v.snippet[:100]}")
+        print(f"To grandfather a known site: add 'file:line' to {baseline_path.name}.")
+    else:
+        print(f"check_frontend_data_path.py: OK ({duration_ms} ms; {len(violations)} found, {len(baseline)} grandfathered)")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run the canary to confirm it passes**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_frontend_data_path_canary.py -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Generate the baseline from the current tree**
+
+Run: `python3 scripts/fitness/check_frontend_data_path.py --jsonl-out /tmp/fdp.jsonl; printf '%s\n' "$(python3 - <<'PY'\nimport json,sys\ntry:\n    rows=[json.loads(l) for l in open('/tmp/fdp.jsonl') if l.strip()]\nexcept FileNotFoundError:\n    rows=[]\nfor r in rows: print(f\"{r['file']}:{r['line']}\")\nPY\n)" > scripts/fitness/check_frontend_data_path.baseline`
+Then prepend a header line: edit `scripts/fitness/check_frontend_data_path.baseline` to start with `# residual single-read-path violations grandfathered post-#324; shrink, don't grow`.
+Expected: the file lists any current `supabase.from`/`VITE_API_URL` sites outside `frontend/integrations/` (likely few or none post-#324).
+
+- [ ] **Step 6: Write the green-path test**
+
+Create `backend/tests/unit/scripts/test_check_frontend_data_path.py`:
+
+```python
+"""Green-path test for scripts/fitness/check_frontend_data_path.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_frontend_data_path.py"
+
+
+def test_data_path_clean_or_baseline_matched() -> None:
+    proc = subprocess.run([sys.executable, str(CHECK)], capture_output=True, text=True, timeout=15)
+    assert proc.returncode == 0, f"new data-path violation\n{proc.stdout}"
+```
+
+- [ ] **Step 7: Run the green-path test**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_frontend_data_path.py -q`
+Expected: PASS.
+
+- [ ] **Step 8: Wire into run_all.sh**
+
+In `scripts/fitness/run_all.sh`, add after the `check_react_query_keys.py` block:
+
+```bash
+run_check "check_frontend_data_path.py" \
+  python3 "${SCRIPT_DIR}/check_frontend_data_path.py" "${SCOPE_ARGS[@]}"
+```
+
+Run: `bash scripts/fitness/run_all.sh 2>&1 | grep check_frontend_data_path`
+Expected: `check_frontend_data_path.py: OK (...)`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add scripts/fitness/check_frontend_data_path.py scripts/fitness/check_frontend_data_path.baseline scripts/fitness/run_all.sh backend/tests/unit/scripts/test_check_frontend_data_path.py backend/tests/unit/scripts/test_check_frontend_data_path_canary.py
+git commit -m "ci(fitness): enforce frontend single read path (supabase.from / VITE_API_URL)"
+```
+
+---
+
+### Task 5: `check_file_size` ratchet (freeze drift) (TDD)
+
+**Files:**
+- Modify: `scripts/fitness/check_file_size.py`
+- Create: `scripts/fitness/check_file_size.baseline`
+- Create: `backend/tests/unit/scripts/test_check_file_size.py`
+- Create: `backend/tests/unit/scripts/test_check_file_size_canary.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `check_file_size.py` with `--baseline P` and `--update-baseline`; exit `0` (no offender grew / no new offender), `1` otherwise.
+
+- [ ] **Step 1: Write the canary test (fails first)**
+
+Create `backend/tests/unit/scripts/test_check_file_size_canary.py`:
+
+```python
+"""Canary for the file-size ratchet in scripts/fitness/check_file_size.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_file_size.py"
+
+
+def _mk(root: Path, rel: str, lines: int) -> None:
+    f = root / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("x = 1\n" * lines)
+
+
+def _run(root: Path, baseline: Path, max_lines: int = 50):
+    return subprocess.run(
+        [sys.executable, str(CHECK), "--repo-root", str(root), "--baseline", str(baseline), "--max-lines", str(max_lines)],
+        capture_output=True, text=True, timeout=15,
+    )
+
+
+def test_new_offender_fails(tmp_path: Path) -> None:
+    _mk(tmp_path, "backend/app/new_god.py", 80)
+    baseline = tmp_path / "bl"; baseline.write_text("")
+    proc = _run(tmp_path, baseline)
+    assert proc.returncode == 1, proc.stdout
+    assert "new_god.py" in proc.stdout
+
+
+def test_baselined_growth_fails(tmp_path: Path) -> None:
+    _mk(tmp_path, "backend/app/god.py", 90)
+    baseline = tmp_path / "bl"; baseline.write_text("backend/app/god.py:80\n")
+    proc = _run(tmp_path, baseline)
+    assert proc.returncode == 1, proc.stdout
+
+
+def test_baselined_unchanged_passes(tmp_path: Path) -> None:
+    _mk(tmp_path, "backend/app/god.py", 80)
+    baseline = tmp_path / "bl"; baseline.write_text("backend/app/god.py:80\n")
+    proc = _run(tmp_path, baseline)
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_baselined_shrink_passes(tmp_path: Path) -> None:
+    _mk(tmp_path, "backend/app/god.py", 60)
+    baseline = tmp_path / "bl"; baseline.write_text("backend/app/god.py:80\n")
+    proc = _run(tmp_path, baseline)
+    assert proc.returncode == 0, proc.stdout
+```
+
+- [ ] **Step 2: Run the canary to confirm it fails**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_file_size_canary.py -q`
+Expected: FAIL (current `check_file_size.py` ignores `--baseline`, always exits 0 → `test_new_offender_fails` and `test_baselined_growth_fails` fail).
+
+- [ ] **Step 3: Rewrite `check_file_size.py` as a ratchet**
+
+Replace the full contents of `scripts/fitness/check_file_size.py` with:
+
+```python
+#!/usr/bin/env python3
+"""check_file_size.py — prumo fitness function (ratchet).
+
+Freezes file-size drift: a baselined oversized file may not GROW, and no new
+file may cross the soft ceiling. Shrinking is always allowed (and lets you
+tighten the baseline with --update-baseline). The actual splitting of the
+current god files is a separate cleanup effort.
+
+Baseline format: one `path:max_lines` per currently-oversized file.
+
+Usage:
+  python check_file_size.py [--repo-root P] [--max-lines N] [--baseline P]
+  python check_file_size.py --update-baseline   # rewrite baseline from tree
+
+Exit codes: 0 (no growth, no new offender) | 1 (regression) | 2 (internal).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_REPO_ROOT = SCRIPT_DIR.parent.parent
+DEFAULT_BASELINE = SCRIPT_DIR / "check_file_size.baseline"
+MAX_LINES_DEFAULT = 800
+
+SCAN_ROOTS = ("backend/app", "frontend")
+SCAN_EXTS = {".py", ".ts", ".tsx"}
+SKIP_DIR_NAMES = {"node_modules", "__pycache__", ".git", ".venv", "venv", "dist", "build", ".pytest_cache", "coverage"}
+SKIP_PATH_PARTS = ("frontend/types/api/", "integrations/supabase/types.ts")
+
+
+def scan(repo_root: Path, max_lines: int) -> dict[str, int]:
+    offenders: dict[str, int] = {}
+    for root in SCAN_ROOTS:
+        base = repo_root / root
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if path.suffix not in SCAN_EXTS or not path.is_file():
+                continue
+            if any(part in SKIP_DIR_NAMES for part in path.parts):
+                continue
+            rel = path.relative_to(repo_root).as_posix()
+            if any(skip in rel for skip in SKIP_PATH_PARTS):
+                continue
+            try:
+                n = sum(1 for _ in path.open("rb"))
+            except OSError:
+                continue
+            if n > max_lines:
+                offenders[rel] = n
+    return offenders
+
+
+def load_baseline(path: Path) -> dict[str, int]:
+    if not path.is_file():
+        return {}
+    out: dict[str, int] = {}
+    for ln in path.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if not ln or ln.startswith("#"):
+            continue
+        rel, _, num = ln.rpartition(":")
+        if rel and num.isdigit():
+            out[rel] = int(num)
+    return out
+
+
+def write_baseline(path: Path, offenders: dict[str, int]) -> None:
+    header = "# file-size ratchet baseline — oversized files frozen at current size.\n# May shrink (re-run --update-baseline to tighten), never grow. Cleanup is a separate effort.\n"
+    body = "\n".join(f"{rel}:{n}" for rel, n in sorted(offenders.items()))
+    path.write_text(header + body + ("\n" if body else ""))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
+    parser.add_argument("--max-lines", type=int, default=MAX_LINES_DEFAULT)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--update-baseline", action="store_true")
+    args = parser.parse_args()
+
+    started = time.time()
+    offenders = scan(args.repo_root.resolve(), args.max_lines)
+
+    if args.update_baseline:
+        write_baseline(args.baseline, offenders)
+        print(f"file-size baseline written: {len(offenders)} oversized files -> {args.baseline}")
+        return 0
+
+    baseline = load_baseline(args.baseline)
+    regressions: list[str] = []
+    for rel, n in sorted(offenders.items(), key=lambda kv: -kv[1]):
+        cap = baseline.get(rel)
+        if cap is None:
+            regressions.append(f"NEW over-ceiling file: {rel} has {n} lines (> {args.max_lines})")
+        elif n > cap:
+            regressions.append(f"GREW: {rel} has {n} lines (baseline cap {cap})")
+
+    duration_ms = int((time.time() - started) * 1000)
+    exit_code = 1 if regressions else 0
+
+    telemetry_out = os.environ.get("PRUMO_TELEMETRY_OUT")
+    if telemetry_out:
+        with open(telemetry_out, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps({
+                "check": "check_file_size",
+                "status": "fail" if regressions else "ok",
+                "regressions": regressions,
+                "offender_count": len(offenders),
+                "duration_ms": duration_ms,
+            }) + "\n")
+
+    if regressions:
+        print(f"check_file_size.py: FAIL ({duration_ms} ms; {len(regressions)} regression(s))")
+        for r in regressions:
+            print(f"  {r}")
+        print(f"Shrink the file, or (only if intentional) run --update-baseline and commit {args.baseline.name}.")
+    else:
+        print(f"file-size: OK ({duration_ms} ms; {len(offenders)} oversized, none grew, no new offenders)")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run the canary to confirm it passes**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_file_size_canary.py -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Generate the freeze baseline from the current tree**
+
+Run: `python3 scripts/fitness/check_file_size.py --update-baseline`
+Expected: `file-size baseline written: N oversized files -> .../check_file_size.baseline` (N includes seed.py, extraction_export_service.py, etc.).
+
+Run: `python3 scripts/fitness/check_file_size.py; echo "exit=$?"`
+Expected: `file-size: OK (...)` and `exit=0`.
+
+- [ ] **Step 6: Write the green-path test**
+
+Create `backend/tests/unit/scripts/test_check_file_size.py`:
+
+```python
+"""Green-path test for the file-size ratchet."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_file_size.py"
+
+
+def test_current_tree_matches_baseline() -> None:
+    proc = subprocess.run([sys.executable, str(CHECK)], capture_output=True, text=True, timeout=20)
+    assert proc.returncode == 0, f"a file grew past its baseline\n{proc.stdout}"
+```
+
+- [ ] **Step 7: Run the green-path test**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_file_size.py -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/fitness/check_file_size.py scripts/fitness/check_file_size.baseline backend/tests/unit/scripts/test_check_file_size.py backend/tests/unit/scripts/test_check_file_size_canary.py
+git commit -m "ci(fitness): promote file-size from warn-only to a freeze ratchet"
+```
+
+---
+
+### Task 6: `check_skill_router_sync` fitness gate (TDD)
+
+**Files:**
+- Create: `scripts/fitness/check_skill_router_sync.py`
+- Create: `backend/tests/unit/scripts/test_check_skill_router_sync.py`
+- Create: `backend/tests/unit/scripts/test_check_skill_router_sync_canary.py`
+- Modify: `scripts/fitness/run_all.sh`
+
+**Interfaces:**
+- Consumes: the `## Which skill to load` section of `CLAUDE.md` (Task 1) and the dirs under `.claude/skills/` (incl. `frontend-development` from Task 3).
+- Produces: a check asserting every backticked skill named in the router resolves to a real `.claude/skills/<name>/` dir (no dead entries).
+
+- [ ] **Step 1: Write the canary test (fails first)**
+
+Create `backend/tests/unit/scripts/test_check_skill_router_sync_canary.py`:
+
+```python
+"""Canary for scripts/fitness/check_skill_router_sync.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_skill_router_sync.py"
+
+
+def _setup(root: Path, router_skills: list[str], real_skills: list[str]) -> None:
+    claude = root / "CLAUDE.md"
+    lines = ["# x", "", "## Which skill to load", ""]
+    lines += [f"- area → `{s}`" for s in router_skills]
+    claude.write_text("\n".join(lines) + "\n")
+    for s in real_skills:
+        (root / ".claude" / "skills" / s).mkdir(parents=True, exist_ok=True)
+
+
+def _run(root: Path):
+    return subprocess.run([sys.executable, str(CHECK), "--repo-root", str(root)], capture_output=True, text=True, timeout=15)
+
+
+def test_dead_router_entry_fails(tmp_path: Path) -> None:
+    _setup(tmp_path, router_skills=["backend-development", "ghost-skill"], real_skills=["backend-development"])
+    proc = _run(tmp_path)
+    assert proc.returncode == 1, proc.stdout
+    assert "ghost-skill" in proc.stdout
+
+
+def test_in_sync_passes(tmp_path: Path) -> None:
+    _setup(tmp_path, router_skills=["backend-development", "code-review"], real_skills=["backend-development", "code-review", "debugging"])
+    proc = _run(tmp_path)
+    assert proc.returncode == 0, proc.stdout
+```
+
+- [ ] **Step 2: Run the canary to confirm it fails**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_skill_router_sync_canary.py -q`
+Expected: FAIL (check does not exist yet).
+
+- [ ] **Step 3: Write the check**
+
+Create `scripts/fitness/check_skill_router_sync.py`:
+
+```python
+#!/usr/bin/env python3
+"""check_skill_router_sync.py — prumo fitness function.
+
+Asserts every skill named in CLAUDE.md's `## Which skill to load` router
+resolves to a real `.claude/skills/<name>/` directory. A dead router entry
+sends agents to a skill that does not exist; this fires the moment the router
+and the skills tree drift apart.
+
+Exit codes: 0 (no dead entries) | 1 (dead entry) | 2 (router section missing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_REPO_ROOT = SCRIPT_DIR.parent.parent
+
+ROUTER_HEADING = "## Which skill to load"
+SKILL_TICK_RE = re.compile(r"→\s*`([a-z][a-z0-9-]+)`")
+
+
+def router_skills(claude_md: str) -> list[str]:
+    lines = claude_md.splitlines()
+    out: list[str] = []
+    in_section = False
+    for line in lines:
+        if line.strip() == ROUTER_HEADING:
+            in_section = True
+            continue
+        if in_section and line.startswith("## "):
+            break
+        if in_section:
+            m = SKILL_TICK_RE.search(line)
+            if m:
+                out.append(m.group(1))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description="prumo skill-router sync check")
+    p.add_argument("--repo-root", default=None)
+    p.add_argument("--emit-telemetry", default=None)
+    args = p.parse_args(argv)
+
+    root = Path(args.repo_root).resolve() if args.repo_root else DEFAULT_REPO_ROOT
+    claude_path = root / "CLAUDE.md"
+    skills_dir = root / ".claude" / "skills"
+
+    if not claude_path.is_file():
+        print(f"ERROR: CLAUDE.md not found: {claude_path}", file=sys.stderr)
+        return 2
+
+    started = time.time()
+    named = router_skills(claude_path.read_text(encoding="utf-8"))
+    if not named:
+        print(f"ERROR: no '{ROUTER_HEADING}' router entries found in CLAUDE.md", file=sys.stderr)
+        return 2
+
+    existing = {p.name for p in skills_dir.iterdir() if p.is_dir()} if skills_dir.is_dir() else set()
+    dead = [s for s in named if s not in existing]
+    duration_ms = int((time.time() - started) * 1000)
+    exit_code = 1 if dead else 0
+
+    if dead:
+        print(f"check_skill_router_sync.py: FAIL ({duration_ms} ms; {len(dead)} dead router entries)")
+        for s in dead:
+            print(f"  `{s}` in CLAUDE.md router has no .claude/skills/{s}/ dir")
+    else:
+        print(f"check_skill_router_sync.py: OK ({duration_ms} ms; {len(named)} router entries all resolve)")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run the canary to confirm it passes**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_skill_router_sync_canary.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Write the green-path test**
+
+Create `backend/tests/unit/scripts/test_check_skill_router_sync.py`:
+
+```python
+"""Green-path test for scripts/fitness/check_skill_router_sync.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHECK = REPO_ROOT / "scripts" / "fitness" / "check_skill_router_sync.py"
+
+
+def test_router_in_sync_with_skills() -> None:
+    proc = subprocess.run([sys.executable, str(CHECK)], capture_output=True, text=True, timeout=15)
+    assert proc.returncode == 0, f"dead router entry\n{proc.stdout}"
+```
+
+- [ ] **Step 6: Run the green-path test (validates Tasks 1+3 landed)**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/test_check_skill_router_sync.py -q`
+Expected: PASS (every router skill, incl. `frontend-development`, resolves).
+
+- [ ] **Step 7: Wire into run_all.sh**
+
+In `scripts/fitness/run_all.sh`, add after the `check_frontend_data_path.py` block:
+
+```bash
+run_check "check_skill_router_sync.py" \
+  python3 "${SCRIPT_DIR}/check_skill_router_sync.py"
+```
+
+Run: `bash scripts/fitness/run_all.sh 2>&1 | grep check_skill_router_sync`
+Expected: `check_skill_router_sync.py: OK (...)`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/fitness/check_skill_router_sync.py scripts/fitness/run_all.sh backend/tests/unit/scripts/test_check_skill_router_sync.py backend/tests/unit/scripts/test_check_skill_router_sync_canary.py
+git commit -m "ci(fitness): keep the CLAUDE.md skill router in sync with .claude/skills/"
+```
+
+---
+
+### Task 7: De-dup verification + full-gate green
+
+**Files:**
+- Modify: `.markdownlintignore` (add this plan)
+- Modify (only if the audit finds duplication): `CLAUDE.md`, `.claude/rules/*`
+
+**Interfaces:**
+- Consumes: all prior tasks.
+
+- [ ] **Step 1: Add this plan to `.markdownlintignore`**
+
+Append to `.markdownlintignore` (under the "Active in-flight plans" group):
+
+```
+docs/superpowers/plans/2026-06-22-architecture-clarity.md
+```
+
+- [ ] **Step 2: De-dup audit — no prose duplicates a gate**
+
+Run: `grep -rn 'ruff format\|ruff check' CLAUDE.md .claude/rules/ | grep -iv 'command\|make lint'`
+Expected: no rule that *instructs running* ruff as a behavioral rule (the PostToolUse hook + CI own it). If any prose rule says "always run ruff format", delete it (the `make lint-backend` command reference in `## Commands` is fine — it documents the command, not a rule).
+
+Run: `grep -rn 'check_layered_arch\|check_react_query_keys\|check_frontend_data_path' .claude/rules/`
+Expected: rules reference each gate by name (point to it) rather than restating its logic — confirm, no edits needed.
+
+- [ ] **Step 3: De-dup audit — single source per fact**
+
+Run: `grep -rin 'English only\|ApiResponse envelope\|error.message' CLAUDE.md docs/reference/constitution.md .claude/rules/backend.md`
+Expected: each fact appears as a terse shape in CLAUDE.md/rules AND as the deep principle in the constitution — that layering is intended. Confirm there is no *verbatim* paragraph duplicated across two files; if found, keep the rules/CLAUDE.md terse version and let the constitution hold the full one.
+
+- [ ] **Step 4: Run the full fitness suite**
+
+Run: `bash scripts/fitness/run_all.sh`
+Expected: Summary shows OK for all checks, including `check_frontend_data_path.py`, `check_file_size.py`, `check_skill_router_sync.py`. Final exit 0.
+
+- [ ] **Step 5: Run the fitness unit tests**
+
+Run: `cd backend && uv run pytest tests/unit/scripts/ -q`
+Expected: all pass (existing + the 6 new test files).
+
+- [ ] **Step 6: Run the full quality gate**
+
+Run: `make quality-scan`
+Expected: lint + typecheck + tests + architectural fitness all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "chore(context): de-dup audit + register plan in markdownlintignore"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** WS1 → Tasks 1, 2, 7 (Working principles, router, rules directives, repository rule, de-dup). WS2 → Task 3 (`frontend-development` skill + rules shapes in Task 2). WS3 → Tasks 4, 5, 6 (data-path gate, file-size ratchet, router-sync). Out-of-scope drift cleanup correctly excluded (Task 5 freezes only). All spec acceptance criteria map to a task.
+- **Deviation from spec:** the router-sync check enforces "no dead router entries" (router ⊆ skills) rather than a strict bijection — a bijection would break CI whenever a non-routed process skill is added. Documented in Task 6.
+- **Type/name consistency:** check filenames, baseline filenames, and CLI flags (`--repo-root`, `--baseline`, `--update-baseline`, `--max-lines`) are consistent across the checks, their tests, and `run_all.sh` wiring. `frontend-development` is spelled identically in the router (Task 1), the skill dir (Task 3), and the router-sync green test (Task 6).
+- **Placeholders:** none — every check, baseline-generation step, and test has complete code; the two skill `references/*.md` (Task 3 steps 2–3) specify exact content + the existing file to mirror, not a TODO.

--- a/docs/superpowers/plans/2026-06-22-parse-recovery-affordance.md
+++ b/docs/superpowers/plans/2026-06-22-parse-recovery-affordance.md
@@ -1,0 +1,744 @@
+---
+status: draft
+last_reviewed: 2026-06-22
+owner: '@raphaelfh'
+---
+
+# Parse-recovery affordance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Design record: [`docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md`](../specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md) (Workstream A). This plan is **independent** of the markdown plan — it adds NO `react-markdown` dependency.
+
+**Goal:** Make every article file's parse status recoverable from the document
+switcher — a status-aware re-parse control visible in all states (pending /
+parsed / parse_failed) — and make the parse write concurrency-safe and
+non-silently-destructive so a Retry can never duplicate blocks or quietly shift
+grounded citation highlights.
+
+**Architecture:** Backend first makes the parse write safe (a UNIQUE constraint
+on `article_text_blocks(article_file_id, page_number, block_index)` + a
+`pg_advisory_xact_lock` around the delete-then-insert), then widens the file-list
+response with `extraction_error`. Frontend adds an additive `useReparseArticleFile`
+mutation hook and a `ParseStatusControl` (cva keyed on status, semantic tokens,
+an `AlertDialog` confirm for re-parsing an already-parsed file, an error tooltip
+for failures), and mounts it in both the extraction and QA PDF panels, replacing
+the current `parse_failed`-only `ReparseButton` gate.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 async + Alembic + Celery (backend);
+React 19 + TanStack Query v5 + shadcn/Radix + the in-house `@prumo/pdf-viewer`
+and `lib/copy` i18n (frontend); pytest + Vitest.
+
+## Global Constraints
+
+- **English only** for code, comments, docs, copy keys.
+- Backend layering `api → services → repositories → models` (CI-enforced).
+- `ApiResponse` envelope; read errors via `error.message` (never FastAPI
+  `detail`); every project-scoped endpoint checks `ensure_project_member`.
+- Frontend data access through the typed `apiClient`
+  (`frontend/integrations/api/client.ts`); no new `supabase.from(...)` table
+  reads or `fetch()`; TanStack keys from the `articleKeys` factory
+  (`frontend/lib/query-keys/articles.ts`).
+- No `try/finally` / `throw` in React component or hook bodies (React Compiler
+  `panicThreshold: all_errors`); IO lives in services/hooks.
+- SQLAlchemy model/DDL change ⇒ Alembic migration (run inside `backend/`);
+  Alembic revision id ≤ 32 chars.
+- Frontend tooling runs from the **repo root** (no `frontend/package.json`);
+  never `cd frontend`.
+- After any endpoint/schema change: `npm run generate:api-types` + commit the
+  regenerated `frontend/types/api/schema.d.ts`.
+- Keep `articlesService.reparseArticleFile` — it has a third caller
+  (`ArticleDetailDialog.tsx:348`) out of this plan's scope. The new hook is
+  **additive**.
+
+---
+
+## Task 1: UNIQUE constraint on `article_text_blocks` (concurrency safety, 1/2)
+
+**Files:**
+- Create: `backend/alembic/versions/0031_unique_article_text_block_idx.py`
+- Reference: `backend/alembic/versions/0006_article_text_blocks.py` (the existing
+  *non-unique* index name to drop) and `0030_drop_instance_status.py` (current
+  head → `down_revision`).
+- Test: `backend/tests/integration/test_article_text_block_unique.py`
+
+**Interfaces:**
+- Produces: a DB invariant that `(article_file_id, page_number, block_index)` is
+  unique, so two concurrent `replace_for_file` inserts fail loudly instead of
+  silently duplicating.
+
+- [ ] **Step 1: Confirm the current head and the old index name.**
+
+Run: `cd backend && uv run alembic heads`
+Expected: prints `0030 (head)` (or `0030_drop_instance_status`). Use that exact
+string as `down_revision`.
+Run: `grep -n "create_index" backend/alembic/versions/0006_article_text_blocks.py`
+Expected: shows the index name (e.g. `ix_article_text_blocks_file_page_block`).
+Note it for Step 3.
+
+- [ ] **Step 2: Write the failing test.**
+
+```python
+# backend/tests/integration/test_article_text_block_unique.py
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+
+@pytest.mark.asyncio
+async def test_duplicate_block_index_rejected(db_session_real):
+    """After 0031, a duplicate (article_file_id, page, block_index) must fail."""
+    # Insert one block, then a duplicate triple — the second must raise.
+    insert = text(
+        "INSERT INTO article_text_blocks "
+        "(id, article_file_id, page_number, block_index, text, char_start, char_end, block_type) "
+        "VALUES (gen_random_uuid(), :fid, 1, 0, :t, 0, 1, 'paragraph')"
+    )
+    fid = "00000000-0000-0000-0000-0000000000aa"
+    await db_session_real.execute(insert, {"fid": fid, "t": "a"})
+    with pytest.raises(IntegrityError):
+        await db_session_real.execute(insert, {"fid": fid, "t": "b"})
+        await db_session_real.flush()
+```
+
+- [ ] **Step 3: Run → fails** (no unique constraint yet; the second insert succeeds).
+
+Run: `make test-backend` (or `cd backend && uv run pytest tests/integration/test_article_text_block_unique.py -v`)
+Expected: FAIL — `DID NOT RAISE IntegrityError`.
+
+- [ ] **Step 4: Write the migration.**
+
+```python
+# backend/alembic/versions/0031_unique_article_text_block_idx.py
+"""unique (article_file_id, page_number, block_index) on article_text_blocks
+
+Revision ID: 0031_unique_atb_idx
+Revises: 0030
+Create Date: 2026-06-22
+"""
+from alembic import op
+
+revision = "0031_unique_atb_idx"
+down_revision = "0030"  # confirm against `alembic heads` (Step 1)
+branch_labels = None
+depends_on = None
+
+_OLD_INDEX = "ix_article_text_blocks_file_page_block"  # from 0006 (Step 1)
+_UQ = "uq_article_text_blocks_file_page_block"
+
+
+def upgrade() -> None:
+    # 1. Collapse any pre-existing duplicates (keep one row per triple) so the
+    #    constraint can be created. Concurrent parses before this migration may
+    #    have produced dups.
+    op.execute(
+        """
+        DELETE FROM article_text_blocks a
+        USING article_text_blocks b
+        WHERE a.ctid < b.ctid
+          AND a.article_file_id = b.article_file_id
+          AND a.page_number = b.page_number
+          AND a.block_index = b.block_index
+        """
+    )
+    # 2. Replace the non-unique read index with a UNIQUE one (same columns, so
+    #    ordered reads keep their index).
+    op.drop_index(_OLD_INDEX, table_name="article_text_blocks")
+    op.create_index(
+        _UQ,
+        "article_text_blocks",
+        ["article_file_id", "page_number", "block_index"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_UQ, table_name="article_text_blocks")
+    op.create_index(
+        _OLD_INDEX,
+        "article_text_blocks",
+        ["article_file_id", "page_number", "block_index"],
+        unique=False,
+    )
+```
+
+- [ ] **Step 5: Verify the migration applies offline + online.**
+
+Run: `cd backend && uv run alembic upgrade head --sql | tail -30` (offline sanity — no truncation error on the revision id)
+Run: `make db-fresh` then `cd backend && uv run alembic current`
+Expected: `0031_unique_atb_idx (head)`.
+
+- [ ] **Step 6: Run → passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_article_text_block_unique.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add backend/alembic/versions/0031_unique_article_text_block_idx.py backend/tests/integration/test_article_text_block_unique.py
+git commit -m "feat(parsing): unique (article_file_id,page,block_index) on article_text_blocks"
+```
+
+## Task 2: Advisory lock around the parse write (concurrency safety, 2/2)
+
+**Files:**
+- Modify: `backend/app/services/document_parsing_service.py` (in
+  `parse_article_file`, immediately before `self._repo.replace_for_file(...)`)
+- Test: `backend/tests/integration/test_parse_article_file_lock.py`
+
+**Interfaces:**
+- Consumes: the UNIQUE constraint from Task 1.
+- Produces: serialized block writes per `article_file_id` — a second parse that
+  starts while one holds the lock blocks until the first commits, then re-runs
+  the delete-then-insert cleanly (last-writer-wins, single clean set).
+
+- [ ] **Step 1: Write the failing test** (asserts the lock SQL is issued before the write).
+
+```python
+# backend/tests/integration/test_parse_article_file_lock.py
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.mark.asyncio
+async def test_parse_acquires_advisory_lock_before_write(seeded_article_file, db_session_real):
+    """parse_article_file must take pg_advisory_xact_lock before replace_for_file."""
+    from app.services.document_parsing_service import DocumentParsingService
+
+    svc = DocumentParsingService(db_session_real, parser=_StubParser(), storage=_StubStorage())
+    calls: list[str] = []
+    orig_execute = db_session_real.execute
+
+    async def _spy(stmt, *a, **k):
+        calls.append(str(stmt))
+        return await orig_execute(stmt, *a, **k)
+
+    with patch.object(db_session_real, "execute", side_effect=_spy):
+        await svc.parse_article_file(seeded_article_file.id)
+
+    assert any("pg_advisory_xact_lock" in c for c in calls), "lock not acquired"
+```
+
+(Use the project's existing parse-test stubs for `_StubParser`/`_StubStorage` —
+mirror `backend/tests/integration/test_parse_article_file_task.py`; if a
+`seeded_article_file` fixture does not exist, add one that inserts a `pending`
+`ArticleFile` with a fake `storage_key` and have `_StubStorage.download` return
+bytes and `_StubParser.parse` return one `ParsedBlock`.)
+
+- [ ] **Step 2: Run → fails.**
+
+Run: `cd backend && uv run pytest tests/integration/test_parse_article_file_lock.py -v`
+Expected: FAIL — `lock not acquired`.
+
+- [ ] **Step 3: Implement the lock.** In `parse_article_file`, just before the
+  `replace_for_file` call (the persist step), add:
+
+```python
+from sqlalchemy import text  # at top of file if not already imported
+
+# Serialize the block write per file so a concurrent Retry cannot interleave
+# two delete-then-insert passes. Transaction-scoped: released on commit.
+await self.db.execute(
+    text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+    {"k": str(article_file_id)},
+)
+await self._repo.replace_for_file(article_file_id, blocks)
+```
+
+- [ ] **Step 4: Run → passes.**
+
+Run: `cd backend && uv run pytest tests/integration/test_parse_article_file_lock.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/app/services/document_parsing_service.py backend/tests/integration/test_parse_article_file_lock.py
+git commit -m "feat(parsing): advisory-lock the block write so concurrent re-parse can't duplicate"
+```
+
+## Task 3: Expose `extraction_error` on the file-list response
+
+**Files:**
+- Modify: `backend/app/schemas/article.py` (`ArticleFileListItem`, ~line 205)
+- Test: `backend/tests/unit/test_article_files_unit.py` (direct endpoint-coroutine
+  test — the 80% diff-cover gate does NOT count lines hit only via httpx
+  ASGITransport, so an integration test is insufficient)
+- Regenerate: `frontend/types/api/schema.d.ts`
+
+**Interfaces:**
+- Produces: `ArticleFileListItem.extractionError: str | None` in the
+  `GET /api/v1/articles/{id}/files` response. No read-path change — the endpoint
+  already does `ArticleFileListItem.model_validate(f)` over full ORM rows, and
+  the `extraction_error` column already exists on the model
+  (`models/article.py:227`), so the field auto-populates via the alias. No
+  migration.
+
+- [ ] **Step 1: Write the failing test** (direct coroutine call, not via the app).
+
+```python
+# backend/tests/unit/test_article_files_unit.py  (add to the existing file)
+@pytest.mark.asyncio
+async def test_list_article_files_includes_extraction_error(monkeypatch):
+    """A parse_failed file surfaces its extraction_error in the list item."""
+    from app.api.v1.endpoints import article_files as ep
+
+    failed = _FakeArticleFile(  # mirror the fakes already in this test module
+        id=uuid4(), file_role="MAIN", extraction_status="parse_failed",
+        extraction_error="libxcb.so.1: cannot open shared object file",
+    )
+    monkeypatch.setattr(ep, "get_article_project_id", _async_return(PROJECT_ID))
+    monkeypatch.setattr(ep, "ensure_project_member", _async_noop)
+    monkeypatch.setattr(
+        ep.ArticleFileService, "list_for_article", _async_return([failed])
+    )
+
+    resp = await ep.list_article_files(
+        article_id=ARTICLE_ID, request=_FakeRequest(), db=_FakeDb(),
+        current_user_sub=USER_ID,
+    )
+    item = resp.data[0]
+    assert item.extraction_error == "libxcb.so.1: cannot open shared object file"
+```
+
+(Match the helper/fakes already used in `test_article_files_unit.py`. If the file
+does not yet exist, create it mirroring the direct-coroutine pattern from another
+`tests/unit/test_*_unit.py` endpoint test.)
+
+- [ ] **Step 2: Run → fails.**
+
+Run: `cd backend && uv run pytest tests/unit/test_article_files_unit.py -k extraction_error -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'extraction_error'` (or `None`).
+
+- [ ] **Step 3: Add the field.** In `ArticleFileListItem`:
+
+```python
+    extraction_error: str | None = Field(default=None, alias="extractionError")
+```
+
+(Place it right after the existing `extraction_status` line; keep the `populate_by_name`/alias config the class already uses.)
+
+- [ ] **Step 4: Run → passes.**
+
+Run: `cd backend && uv run pytest tests/unit/test_article_files_unit.py -k extraction_error -v`
+Expected: PASS.
+
+- [ ] **Step 5: Regenerate API types + commit.**
+
+Run (repo root): `npm run generate:api-types`
+Expected: `frontend/types/api/schema.d.ts` `ArticleFileListItem` gains
+`extractionError?: string | null`.
+
+```bash
+git add backend/app/schemas/article.py backend/tests/unit/test_article_files_unit.py frontend/types/api/schema.d.ts
+git commit -m "feat(article-files): expose extractionError on the file-list item"
+```
+
+## Task 4: `useReparseArticleFile` mutation hook (additive)
+
+**Files:**
+- Create: `frontend/hooks/extraction/useReparseArticleFile.ts`
+- Test: `frontend/test/hooks/useReparseArticleFile.test.tsx`
+
+**Interfaces:**
+- Consumes: `apiClient`, `articleKeys.files` / `articleKeys.textBlocks`.
+- Produces: `useReparseArticleFile(articleId: string)` →
+  `UseMutationResult<unknown, Error, string>` (the variable is the
+  `articleFileId`). `onSuccess` invalidates **both** key families; `onError`
+  toasts. Exposes `isPending` for spinner/disable.
+
+- [ ] **Step 1: Write the failing test.**
+
+```tsx
+// frontend/test/hooks/useReparseArticleFile.test.tsx
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
+
+import { apiClient } from "@/integrations/api";
+import { useReparseArticleFile } from "@/hooks/extraction/useReparseArticleFile";
+
+function wrap() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const spy = vi.spyOn(qc, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { wrapper, spy };
+}
+
+describe("useReparseArticleFile", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("POSTs reparse and invalidates files + textBlocks", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    const { wrapper, spy } = wrap();
+    const { result } = renderHook(() => useReparseArticleFile("art-1"), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync("file-9");
+    });
+
+    expect(apiClient).toHaveBeenCalledWith(
+      "/api/v1/article-files/file-9/reparse",
+      { method: "POST" },
+    );
+    const keys = spy.mock.calls.map((c) => JSON.stringify(c[0]?.queryKey));
+    expect(keys.some((k) => k?.includes("files"))).toBe(true);
+    expect(keys.some((k) => k?.includes("text-blocks"))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run → fails.**
+
+Run (repo root): `npm run test:run -- useReparseArticleFile`
+Expected: FAIL — cannot resolve `@/hooks/extraction/useReparseArticleFile`.
+
+- [ ] **Step 3: Implement the hook** (mirror `hooks/runs/useMarkReady.ts`).
+
+```tsx
+// frontend/hooks/extraction/useReparseArticleFile.ts
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { apiClient } from "@/integrations/api";
+import { t } from "@/lib/copy";
+import { articleKeys } from "@/lib/query-keys/articles";
+
+/** Re-enqueue a parse for an ArticleFile and refresh the file list + reader blocks. */
+export function useReparseArticleFile(articleId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, Error, string>({
+    mutationFn: (articleFileId) =>
+      apiClient(`/api/v1/article-files/${articleFileId}/reparse`, { method: "POST" }),
+    onSuccess: (_data, articleFileId) => {
+      toast.success(t("pdf", "docReparseQueued"));
+      queryClient.invalidateQueries({ queryKey: articleKeys.files(articleId) });
+      queryClient.invalidateQueries({ queryKey: articleKeys.textBlocks(articleFileId) });
+    },
+    onError: (error) => {
+      toast.error(error.message || t("pdf", "docReparseError"));
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Run → passes** + typecheck.
+
+Run (repo root): `npm run test:run -- useReparseArticleFile && npm run typecheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add frontend/hooks/extraction/useReparseArticleFile.ts frontend/test/hooks/useReparseArticleFile.test.tsx
+git commit -m "feat(extraction): add useReparseArticleFile mutation hook"
+```
+
+## Task 5: `ParseStatusControl` (status-aware control + confirm + tooltip)
+
+**Files:**
+- Modify: `frontend/components/extraction/DocumentSwitcher.tsx` (add a sibling
+  export `ParseStatusControl`; convert the raw-color `STATUS_DOT` map to semantic
+  tokens via a `cva`)
+- Modify: `frontend/lib/copy/pdf.ts` (add `docParseErrorLabel` +
+  `docReparseConfirmTitle` / `docReparseConfirmBody` / `docReparseConfirmCta`)
+- Verify present: `frontend/components/ui/alert-dialog.tsx` (run
+  `npx shadcn@latest add alert-dialog` only if missing — then replace raw colors
+  per `ui-styling` before committing)
+- Test: `frontend/test/components/DocumentSwitcher.test.tsx`
+
+**Interfaces:**
+- Consumes: `useReparseArticleFile` (Task 4); the new `extractionError` field
+  (Task 3); copy keys.
+- Produces: `<ParseStatusControl articleId={string} file={ArticleFileListItem} />`
+  — renders a status dot + label, and a contextual action: `pending` → spinner +
+  "Processing…" + a ghost **Retry**; `parsed` → "Ready" + a low-emphasis
+  **Re-parse** behind an `AlertDialog` confirm; `parse_failed` → "Parse failed"
+  (error in a `Tooltip`) + a prominent **Retry parse**.
+
+- [ ] **Step 1: Add copy keys** to `frontend/lib/copy/pdf.ts` (after the
+  `docReparse*` block):
+
+```ts
+    docParseErrorLabel: 'Parse error',
+    docReparseConfirmTitle: 'Re-parse this document?',
+    docReparseConfirmBody:
+      'Re-parsing rebuilds the document text. Existing citation highlights for this file may shift and need re-checking.',
+    docReparseConfirmCta: 'Re-parse',
+```
+
+- [ ] **Step 2: Write the failing test.**
+
+```tsx
+// frontend/test/components/DocumentSwitcher.test.tsx  (replace the service mock + add cases)
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
+
+import { apiClient } from "@/integrations/api";
+import { ParseStatusControl } from "@/components/extraction/DocumentSwitcher";
+
+function renderControl(file: { id: string; extractionStatus: string; extractionError?: string | null }) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ParseStatusControl articleId="art-1" file={{ originalFilename: "a.pdf", fileRole: "MAIN", ...file } as never} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ParseStatusControl", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("failed: shows the error in a tooltip trigger and a Retry that POSTs", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f1", extractionStatus: "parse_failed", extractionError: "libxcb.so.1 missing" });
+    fireEvent.click(screen.getByRole("button", { name: /docReparse/ }));
+    expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f1/reparse", { method: "POST" });
+  });
+
+  it("parsed: Re-parse opens a confirm dialog before POSTing", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f2", extractionStatus: "parsed" });
+    fireEvent.click(screen.getByRole("button", { name: /docReparse/ }));
+    expect(apiClient).not.toHaveBeenCalled();             // confirm first
+    fireEvent.click(screen.getByRole("button", { name: /docReparseConfirmCta/ }));
+    expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f2/reparse", { method: "POST" });
+  });
+
+  it("pending: shows Processing and a Retry", () => {
+    renderControl({ id: "f3", extractionStatus: "pending" });
+    expect(screen.getByText("docStatusPending")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run → fails.**
+
+Run (repo root): `npm run test:run -- DocumentSwitcher`
+Expected: FAIL — `ParseStatusControl` is not exported.
+
+- [ ] **Step 4: Implement `ParseStatusControl`** in `DocumentSwitcher.tsx`.
+  Replace the raw-color `STATUS_DOT` object with a `cva`, and add the control.
+  (Keep the existing `DocumentSwitcher` export and `ReparseButton` for now;
+  Task 6 swaps the panel over to `ParseStatusControl`.)
+
+```tsx
+import { cva } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogTrigger } from "@/components/ui/alert-dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useReparseArticleFile } from "@/hooks/extraction/useReparseArticleFile";
+import type { ArticleFileListItem } from "@/services/articleFilesService";
+
+const statusDot = cva("h-1.5 w-1.5 shrink-0 rounded-full", {
+  variants: {
+    status: {
+      parsed: "bg-success",
+      pending: "bg-warning animate-pulse",
+      parse_failed: "bg-destructive",
+      unknown: "bg-muted-foreground/40",
+    },
+  },
+  defaultVariants: { status: "unknown" },
+});
+
+type ParseStatus = "parsed" | "pending" | "parse_failed" | "unknown";
+function toStatus(s: string): ParseStatus {
+  return s === "parsed" || s === "pending" || s === "parse_failed" ? s : "unknown";
+}
+
+export interface ParseStatusControlProps {
+  articleId: string;
+  file: ArticleFileListItem;
+}
+
+export function ParseStatusControl({ articleId, file }: ParseStatusControlProps) {
+  const status = toStatus(file.extractionStatus);
+  const reparse = useReparseArticleFile(articleId);
+  const fire = () => reparse.mutate(file.id);
+
+  const label =
+    status === "parsed" ? t("pdf", "docStatusReady")
+    : status === "pending" ? t("pdf", "docStatusPending")
+    : status === "parse_failed" ? t("pdf", "docStatusFailed")
+    : "";
+
+  return (
+    <div className="flex items-center gap-1.5 shrink-0 text-[11px] text-muted-foreground">
+      {status === "pending" ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.5} aria-hidden />
+      ) : (
+        <span aria-hidden className={statusDot({ status })} />
+      )}
+
+      {status === "parse_failed" && file.extractionError ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-default">{label}</span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {t("pdf", "docParseErrorLabel")}: {file.extractionError}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <span>{label}</span>
+      )}
+
+      {status === "parsed" ? (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button size="sm" variant="ghost" className="h-7 text-xs" disabled={reparse.isPending}>
+              {t("pdf", "docReparse")}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t("pdf", "docReparseConfirmTitle")}</AlertDialogTitle>
+              <AlertDialogDescription>{t("pdf", "docReparseConfirmBody")}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t("common", "cancel")}</AlertDialogCancel>
+              <AlertDialogAction onClick={fire}>{t("pdf", "docReparseConfirmCta")}</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : (
+        (status === "parse_failed" || status === "pending") && (
+          <Button
+            size="sm"
+            variant={status === "parse_failed" ? "outline" : "ghost"}
+            className="h-7 text-xs"
+            disabled={reparse.isPending}
+            onClick={fire}
+          >
+            {t("pdf", "docReparse")}
+          </Button>
+        )
+      )}
+    </div>
+  );
+}
+```
+
+(If `t("common", "cancel")` does not exist, use the existing cancel key in
+`lib/copy/common.ts` — grep for it; do not hardcode "Cancel".)
+
+- [ ] **Step 5: Run → passes** + typecheck + compiler check.
+
+Run (repo root): `npm run test:run -- DocumentSwitcher && npm run typecheck`
+Run (repo root): `node scripts/enumerate_compiler_bailouts.mjs`
+Expected: tests PASS; no new compiler bailouts.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add frontend/components/extraction/DocumentSwitcher.tsx frontend/lib/copy/pdf.ts frontend/test/components/DocumentSwitcher.test.tsx
+git commit -m "feat(extraction): ParseStatusControl — status-aware re-parse with confirm + error tooltip"
+```
+
+## Task 6: Mount `ParseStatusControl` in both PDF panels
+
+**Files:**
+- Modify: `frontend/components/extraction/ExtractionPDFPanel.tsx` (replace the
+  `parse_failed`-only `ReparseButton` gate at ~line 80)
+- Modify: `frontend/pages/QualityAssessmentFullScreen.tsx` (the matching gate,
+  ~line 653)
+- Test: extend `frontend/test/components/DocumentSwitcher.test.tsx` or the
+  panel's existing test
+
+**Interfaces:**
+- Consumes: `ParseStatusControl` (Task 5); `selectedFile` from
+  `useArticleDocuments`.
+
+- [ ] **Step 1: Replace the gate in `ExtractionPDFPanel.tsx`.** Swap:
+
+```tsx
+{selectedFile?.extractionStatus === 'parse_failed' && (
+  <ReparseButton articleFileId={selectedFile.id} articleId={articleId} />
+)}
+```
+
+with:
+
+```tsx
+{selectedFile && (
+  <ParseStatusControl articleId={articleId} file={selectedFile} />
+)}
+```
+
+(Update the import from `DocumentSwitcher` to include `ParseStatusControl`;
+remove the now-unused `ReparseButton` import if this was its only panel use —
+but keep the `ReparseButton` export in `DocumentSwitcher.tsx` until Step 2
+confirms QA no longer references it.)
+
+- [ ] **Step 2: Replace the same gate in `QualityAssessmentFullScreen.tsx`**
+  (~line 653) identically. The QA `articleId` is already guaranteed non-null by
+  the early return earlier in the component, so pass it directly.
+
+- [ ] **Step 3: Remove the now-dead `ReparseButton`** if no caller remains.
+
+Run (repo root): `grep -rn "ReparseButton" frontend/`
+Expected: only its definition remains → delete the `ReparseButton` export from
+`DocumentSwitcher.tsx` and any leftover import. If another caller exists, leave it.
+
+- [ ] **Step 4: Run the suite + typecheck.**
+
+Run (repo root): `npm run test:run -- DocumentSwitcher ExtractionPDFPanel && npm run typecheck && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Visual verify.** Run the `design-review` loop
+  (`/design-review` on the extraction route): render → screenshot → compare to
+  the Plane/Linear target → confirm the control reads cleanly in pending /
+  parsed / failed states (dot color, spinner, tooltip, confirm dialog). Fix and
+  re-screenshot before claiming done.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add frontend/components/extraction/ExtractionPDFPanel.tsx frontend/pages/QualityAssessmentFullScreen.tsx frontend/components/extraction/DocumentSwitcher.tsx
+git commit -m "feat(extraction): mount ParseStatusControl in extraction + QA panels (retire parse_failed-only gate)"
+```
+
+## Task 7: Full verification + backlog note
+
+- [ ] **Step 1:** `make lint-backend`, `make test-backend` (parsing slices),
+  `npm run test:run`, `npm run lint`, `npm run typecheck` — all green.
+- [ ] **Step 2:** Confirm `node scripts/enumerate_compiler_bailouts.mjs` shows no
+  new bailouts.
+- [ ] **Step 3:** Backlog (deferred, user sign-off): after dev→main + Railway
+  deploy, the 39 legacy `pending` files are cleared **manually** via the new
+  control (open each article → Retry). No backfill script in this plan.
+
+---
+
+## Self-review
+
+- **Spec coverage (Workstream A):** A1 concurrency safety → Tasks 1+2; A2
+  parsed-confirm → Task 5; A3 behaviour table → Task 5; A4 schema widen (no
+  migration, no read-path change) → Task 3; A5 additive hook + keep service +
+  both mount sites + copy → Tasks 4/5/6; A6 tests incl. direct endpoint-coroutine
+  → Task 3; A7 independent of Workstream B → no `react-markdown` anywhere. ✓
+- **Placeholders:** none — every code step shows code; fixture/import gaps are
+  flagged with the exact reference file to mirror.
+- **Type consistency:** `useReparseArticleFile(articleId)` mutate variable is the
+  `articleFileId` (Task 4) and `ParseStatusControl` calls
+  `reparse.mutate(file.id)` (Task 5); `ArticleFileListItem.extractionError`
+  (Task 3) is read in Task 5; `articleKeys.files` / `articleKeys.textBlocks`
+  used consistently. ✓
+- **Migration:** Task 1 is the only DDL; Task 3 explicitly needs none. ✓

--- a/docs/superpowers/specs/2026-06-22-architecture-clarity-design.md
+++ b/docs/superpowers/specs/2026-06-22-architecture-clarity-design.md
@@ -1,0 +1,232 @@
+---
+status: draft
+last_reviewed: 2026-06-22
+owner: '@raphaelfh'
+---
+
+# Architecture clarity + organization gates — design
+
+## Context & goal
+
+prumo's architecture is well-codified (constitution §I–VIII, the `backend-development`
+skill, path-scoped `.claude/rules/`, fitness functions), but the guidance is spread
+across 4–5 places with overlap, the richest material (skills) is on-demand and is not
+reliably loaded, the frontend has no structural pattern manual to match the backend,
+and organization conventions (file size, single read-path) are not all enforced.
+
+Goal: make it **obvious which pattern to follow** and **enforce organization with
+gates**, without inflating always-loaded context. Three workstreams:
+1. Canonical home + discoverability (router + de-dup).
+2. Frontend structural guide (`frontend-development` skill).
+3. Gates that enforce organization.
+
+## Decision: layered hierarchy, refined (not a monolith, not always-loaded consolidation)
+
+Researched against Anthropic's official guidance, the AGENTS.md standard, and
+practitioner failure-modes (all web-verified, 2026):
+
+- Anthropic: CLAUDE.md < 200 lines because "longer files consume more context and
+  reduce adherence"; "smallest set of high-signal tokens"; the laundry-list is a named
+  anti-pattern; growth path is "additive layering, NOT consolidation"; Skills use
+  progressive disclosure (metadata always loaded, body on demand, references at zero
+  idle cost).
+- AGENTS.md standard: favors nested per-directory files; monoliths suffer silent
+  truncation (Codex ≥32 KiB) and information burial; link out for depth to avoid drift.
+- Failure-modes: instruction adherence decays uniformly as count rises (≈150–200
+  ceiling, decay from ~80 lines) + lost-in-the-middle. **Vercel eval (decisive):** a
+  skill on default auto-discovery was never invoked in 56% of cases (zero lift); an
+  explicit pointer from an always-loaded file raised trigger to 95%+ (+26pp), and an
+  in-context index hit 100% (+47pp).
+
+So: keep the layers; **divide by usage pattern** — always-true *shapes* → rules;
+*procedures* → skills; *mechanically checkable* → gates — plus an explicit router that
+guarantees skill loading, and aggressive de-dup (single source per fact).
+
+This layout also ports to AGENTS.md (root + nested) unchanged if cross-tool support is
+ever wanted.
+
+## Out of scope (separate spec)
+
+Drift cleanup — splitting current god-files (`extraction_export_service.py` 2237,
+`seed.py` 1941, `section_extraction_service.py` 1396; frontend `ExtractionFullScreen.tsx`
+1360, `ArticlesList.tsx` 1359, `ArticleForm.tsx` 1272) and reorganizing grouped
+`models/` / `schemas/`. This spec only **freezes** that drift (the file-size ratchet);
+shrinking is its own spec.
+
+---
+
+## Workstream 1 — Canonical home, router, de-dup
+
+### Layer roles (single source per fact)
+
+| Layer | Owns | Loads |
+|---|---|---|
+| `docs/reference/constitution.md` §I–VIII | principles (the *why*), versioned | on-demand |
+| `.claude/rules/{backend,frontend}.md` | non-negotiable always-true **shapes** (terse), per path | auto on path-match |
+| `.claude/skills/*-development` | **procedures / pattern manuals** (the *how*) | on-demand (description + router) |
+| `docs/reference/*` | deep dives (schema, migrations, deployment) | on-demand (linked) |
+| `CLAUDE.md` + `llms.txt` | lean pointers + the **router** | always / navigational index |
+| `.githooks/` + fitness CI | **mechanically-checkable** rules (no prose dup) | deterministic |
+
+### 1a. `Working principles` block in CLAUDE.md
+
+Add the following section to `CLAUDE.md` (after *Current focus*). Behavioral, always
+relevant → belongs in the always-loaded layer. Adapted from a community pattern, with
+prumo de-dup (points to skills, not duplicates), the surgical-vs-clean reconciliation,
+and prumo-tied verification:
+
+```markdown
+## Working principles
+
+These bias toward caution over speed. For trivial changes, use judgment.
+
+- **Think before coding.** State assumptions; if a requirement has multiple
+  readings, surface them — don't choose silently. If a simpler path exists, say
+  so; push back with evidence, not deference. Genuinely unclear, or the call is
+  the user's? Stop and ask — otherwise act, don't re-litigate settled choices.
+  Feature/creative work starts with `superpowers:brainstorming`.
+- **Simplicity first (YAGNI).** The minimum code that solves the asked problem —
+  no speculative abstractions, config, or handling for impossible cases. Any
+  complexity beyond what a principle prescribes must be justified (constitution
+  §Governance). If 200 lines could be 50, rewrite it.
+- **Surgical on unrelated code; clean in code you touch.** Change only what the
+  task requires; match surrounding style; flag unrelated dead code, don't delete
+  it. But where you DO edit, prefer the clean fix over grandfathering a
+  violation — no new legacy left for later.
+- **Goal-driven and verified.** Turn the task into a checkable goal (write the
+  failing test, then make it pass). State a short plan with a verify step each.
+  Evidence before "done" — run the command and read the output, never assert
+  (`code-review` Iron Law; `verification-before-completion`).
+```
+
+### 1b. Skill router (the discoverability fix)
+
+Add a compact skill map (~12–15 lines) to `CLAUDE.md` (always-loaded — this is the
+explicit pointer the Vercel eval showed raises load to ~100%). Example shape:
+
+```markdown
+## Which skill to load
+
+- Backend change (FastAPI/SQLAlchemy/Alembic/Celery/RLS) → `backend-development`
+- Frontend structure/data/state (components/hooks/services/stores) → `frontend-development`
+- Frontend visual language (density/layout/empty states) → `frontend-ux`
+- Tailwind/shadcn class mechanics → `ui-styling`
+- Before "done" / PR / review → `code-review`
+- Bug / failing test → `debugging`
+- Tests (Vitest/Playwright/pytest/MSW) → `web-testing`
+- Deploy / promotion / rollback → `deploy-release`
+```
+
+Mirror this map navigationally in `llms.txt` (it stays a thin index; the load-guaranteeing
+copy lives in always-loaded CLAUDE.md).
+
+### 1c. Strengthen rules → skill pointers
+
+In `.claude/rules/{backend,frontend}.md`, change soft pointers ("deep dives live in the
+skill") to explicit directives: "For any non-trivial {backend,frontend} change, load the
+`{backend,frontend}-development` skill before writing code." Path-scoped → fires exactly
+when relevant.
+
+### 1d. De-dup pass
+
+Audit constitution / rules / skills for the same fact stated in >1 place. Keep: shape →
+rules (terse); deep pattern → skill; principle → constitution. Remove verbatim repeats.
+Delete any prose rule a hook/CI already enforces (e.g. "run ruff format" — the
+PostToolUse hook + CI already do it).
+
+### 1e. Repository-vs-service rule
+
+Add to `rules/backend.md` + `backend-development`: "Use a repository when a query is
+reused by >1 service, or the entity has several distinct query shapes; otherwise inline
+`select()` in the owning service." Starting convention — refine if it causes friction.
+
+---
+
+## Workstream 2 — `frontend-development` skill (structural parity)
+
+New skill `.claude/skills/frontend-development/SKILL.md` (index) + `references/*` (deep
+dives, zero idle cost), mirroring `backend-development`:
+
+- **Stack snapshot** + **repo layout to respect**: `components/{domain}/`, `pages/`,
+  `hooks/{domain}/use*.ts`, `services/{domain}Service.ts`, `stores/` (Zustand),
+  `contexts/`, `integrations/api/client.ts`, `lib/copy/`, `types/api/schema.d.ts`.
+- **Data flow (the core):** `component → hook (TanStack Query) → service (apiClient) →
+  backend`. Where each lives; what NOT to do (no `fetch`/`supabase.from` in components).
+- **Shapes with examples:** component (functional, hooks-only, shadcn), hook
+  (`useQuery`/`useMutation` + key-factory + invalidation), service (`{domain}Service.ts`
+  returns `ErrorResult`, never throws/toasts across the boundary), store (Zustand for
+  cross-component UI state; Context for app-wide singletons), form (react-hook-form + Zod).
+- **Errors + React Compiler** (no try/finally in component/hook bodies; IO via
+  `toResult`), **generated types** (`schema.d.ts`, never hand-mirror), **copy** (`lib/copy`).
+- **Common workflows** table (add page / data-hook / mutation / form / store) +
+  **references index**.
+
+**Discoverability — non-overlapping descriptions** (the description is what triggers the
+load): document the sibling boundary explicitly:
+- `frontend-development` → structure / data / state / organization
+- `frontend-ux` → visual language (density, header, hover, empty states)
+- `ui-styling` → Tailwind/shadcn/cva mechanics (classes, `cn()`, variants)
+
+**Rules promotion:** `rules/frontend.md` already has apiClient-only, query-key factories,
+copy, React Compiler. Add the two missing structural non-negotiables: "services return
+`ErrorResult`, never throw/toast across the boundary" and "data flows
+component→hook→service (no fetch/supabase.from in components)."
+
+---
+
+## Workstream 3 — Organization gates
+
+Verified: 8 fitness checks today; no frontend data-path gate; `check_file_size` is
+WARN-only with no baseline.
+
+### 3a. Frontend data-path gate (new fitness check)
+
+`scripts/fitness/check_frontend_data_path.py` — flags `supabase.from(`, raw `fetch(`,
+and `import.meta.env.VITE_API_URL` outside `frontend/integrations/`. Enforces
+constitution §VI (single read path). Baseline grandfathers any current residual
+violations (empty if clean post-#324). Ships with green-path + canary tests; wired into
+`run_all.sh` and the required `fitness` CI job.
+
+### 3b. File-size ratchet (freeze drift)
+
+Promote `check_file_size.py` from WARN-only to a ratchet: write current oversized files
+(> soft ceiling) to `check_file_size.baseline`; **fail if a baselined file grows OR a new
+file crosses the ceiling**. This freezes drift now; shrinking is the separate cleanup
+spec. Add a canary test, matching the other 7 checks.
+
+### 3c. Skill-router sync check
+
+Lightweight check (fitness or docs-ci) asserting the skill map in `CLAUDE.md` lists
+exactly the skills present in `.claude/skills/` — no stale or missing entries. Keeps the
+router honest, like `check_glossary_sync.py` does for the glossary.
+
+### 3d. De-dup execution
+
+The de-dup pass from 1d lands here as concrete edits: remove prose that a gate/hook now
+owns.
+
+---
+
+## Acceptance criteria
+
+- `CLAUDE.md` has `Working principles` + skill router; stays under ~150 lines.
+- `rules/{backend,frontend}.md` carry explicit "load the *-development skill" directives,
+  the repository-vs-service rule, and the two promoted frontend shapes; no verbatim
+  duplication of skill content.
+- `frontend-development` skill exists, mirrors `backend-development`, with a
+  non-overlapping description and the documented sibling boundary.
+- `llms.txt` mirrors the skill map navigationally; stays thin; zero rule duplication.
+- `check_frontend_data_path` is a required gate (green + canary tests), baseline reflects
+  reality.
+- `check_file_size` is a ratchet (green + canary tests), baseline freezes current
+  oversized files.
+- Skill-router sync check passes.
+- De-dup: a grep audit finds no prose rule that duplicates a gate/hook, and no fact
+  stated verbatim in >1 layer.
+
+## Open questions (confirm during implementation)
+
+- Repository-vs-service threshold (">1 service / several query shapes") — starting
+  convention; revisit if it mislabels real cases.
+- Whether the skill-router sync check lives in `scripts/fitness/` (Python) or `docs/ci`
+  (shell) — pick whichever the existing harness makes cheapest.

--- a/docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md
+++ b/docs/superpowers/specs/2026-06-22-parse-recovery-affordance-and-markdown-execution-design.md
@@ -1,0 +1,286 @@
+---
+status: draft
+last_reviewed: 2026-06-22
+owner: '@raphaelfh'
+---
+
+# Parse-recovery affordance + markdown-reader execution — design
+
+> **Status:** Draft · Date: 2026-06-22 · Deciders: @raphaelfh
+> **Relation to existing design:** This spec does **not** introduce a new
+> markdown architecture. It (1) records the reconciliation of two reported
+> user issues against design that already exists in the repo, (2) decides how
+> to execute the existing markdown plan, and (3) specs the one genuinely new
+> piece — a status-aware *parse-recovery affordance* — that no existing plan
+> covers.
+> **Revised 2026-06-22** after an adversarial review (verdict: *revise*). The
+> two blockers (re-parse concurrency; re-parse corrupting grounded citations)
+> and the five majors are addressed below; the affordance and the markdown
+> work are now **two independently-shippable workstreams** (A and B).
+
+## The two reported issues
+
+1. **"Why aren't articles parsing, and why did the re-parse button only appear
+   on *teste 2*?"**
+2. **"The .md viewer can't render all the fields well (want it as good as the
+   table view), it should be aligned with how extracted citations are shown —
+   and is [`react-markdown`](https://github.com/remarkjs/react-markdown)
+   adequate?"**
+
+## Root-cause evidence (production DB, 2026-06-22)
+
+- `article_files`: **39 `pending`, 2 `parsed`, 0 `parse_failed`.**
+- The two `parsed` rows were parsed **today**: `teste 2` at 11:16:43 (via a
+  re-parse) and `Parse 1` at 11:29:42 (fresh upload, parsed at ingest). The
+  worker + parser pipeline is **healthy now**.
+- The 39 `pending` rows were uploaded **2026-05-26 / 06-07 / 06-14** (plus one
+  `teste` on 06-21) — i.e. *before* the parse-at-ingest pipeline worked. They
+  have no enqueued task and nothing backfills them.
+- The re-parse button is gated on exactly one condition —
+  `selectedFile?.extractionStatus === 'parse_failed'`
+  (`frontend/components/extraction/ExtractionPDFPanel.tsx:80`). `teste 2` was
+  the **only** file ever in `parse_failed` (verified cause:
+  `extraction_error = "libxcb.so.1: cannot open shared object file"`, the
+  Docling/opencv crash), so it was the only article showing the button.
+- Parsed `block.text` is **Docling markdown** (GFM tables `| … |`, lists,
+  inline `<sup>/<sub>`), currently rendered raw via `{block.text}` in a `<p>`
+  (`frontend/pdf-viewer/primitives/Reader.tsx:116`) → tables/lists/super-sub
+  show as literal source text. `react-markdown` is **not** a dependency.
+
+## Reconciliation with existing repo design
+
+Both issues are already covered by design in the repo. A fresh competing spec
+would be wrong; this spec adopts the existing design and fills the one gap.
+
+- **Issue 1** was diagnosed and largely fixed by
+  [`docs/superpowers/plans/2026-06-21-parsing-fix-and-reader-switcher.md`](../plans/2026-06-21-parsing-fix-and-reader-switcher.md)
+  (status: **in_progress**) — same verified root cause (`teste 2`, the `libxcb`
+  crash, the never-used `llama_cloud` key). It shipped the parser-default → `auto`
+  fix, the Docling libs, `GET /articles/{id}/files`, `useArticleDocuments`, and
+  the `DocumentSwitcher` (that is why parsing works now). Its **Task 7** defers
+  the 39-backlog. The remaining UI gap — re-parse is `parse_failed`-only, so a
+  stuck-`pending` file is a dead-end — is **Workstream A** below.
+- **Issue 2** is fully designed but unbuilt in
+  [ADR-0013](../../adr/0013-dual-tier-markdown-representation.md) (proposed) +
+  [`docs/superpowers/plans/2026-06-20-markdown-view-and-markdown-citations.md`](../plans/2026-06-20-markdown-view-and-markdown-citations.md)
+  (draft, 6 phases, not started). Execute it — **Workstream B** below.
+
+These two workstreams are **independent** and ship separately. Workstream A does
+not depend on `react-markdown` or the (still-unbuilt) `render_blocks_to_markdown`;
+Workstream B is multi-PR greenfield. The affordance ships first.
+
+---
+
+## Workstream A — parse-recovery affordance (Issue 1, new)
+
+Manual, status-aware re-parse control next to the document switcher, visible in
+**all** states (decided in brainstorming: manual reparse, all states, switcher
+control only; in-flight shows "Processing…").
+
+> **Adversarial correction:** re-parse is **NOT** "idempotent / safe in all
+> states" as originally written. The parse write is destructive (delete-then-
+> insert blocks) and not concurrency-safe, and re-parsing a `parsed` file can
+> invalidate grounded citations. The affordance therefore needs **backend
+> safety work** — it is not frontend-only.
+
+### A1. Concurrency safety (blocker fix — backend)
+
+`ArticleFileService.reparse()` resets `extraction_status='pending'` and enqueues
+a fresh task with no in-flight guard; the worker runs `concurrency=4` +
+`task_acks_late=True`; `ArticleTextBlockRepository.replace_for_file` is a
+non-atomic DELETE-then-bulk-INSERT; and the
+`(article_file_id, page_number, block_index)` index (migration 0006) is **plain,
+not unique**. Two concurrent parse tasks ⇒ silent **duplicate or lost blocks**,
+which corrupts `concat_page_text` char-offset math and the reader order.
+
+**Required:**
+- Add a **UNIQUE** constraint on
+  `article_text_blocks(article_file_id, page_number, block_index)` (Alembic
+  migration; **dedupe any existing duplicate rows first** so the constraint can
+  be created). This makes concurrent double-inserts fail loudly instead of
+  silently duplicating.
+- **Serialize the parse write** with a `pg_advisory_xact_lock` keyed on
+  `article_file_id` held across `replace_for_file` in the parse path
+  (`DocumentParsingService.parse_article_file` / the worker task), so a Retry on
+  an in-flight file cannot interleave two replaces.
+- Correct the earlier claim "no backend change to recovery itself" — allowing
+  Retry while a parse may be in flight **does** require this backend change.
+
+### A2. Re-parsing a `parsed` file (blocker fix — UX guard)
+
+`extraction_evidence.position` is a **JSONB snapshot** (char range + block_index
++ bbox; `extraction.py:516`), `article_file_id` is `ondelete='SET NULL'` with no
+FK to block ids. Re-parsing mints new block ids and possibly different offsets
+(esp. across the `auto` LlamaParse↔Docling switch), so it **silently shifts
+every previously-grounded citation highlight** on that file — no error surfaces.
+
+**Required:**
+- The `parsed`-state action is a **confirm dialog** (`AlertDialog`), not a quiet
+  re-parse. The dialog warns that re-parsing rebuilds the document and may shift
+  existing citation highlights. (Enhancement, optional: only warn when the file
+  has grounded `extraction_evidence` — needs a count/boolean; the floor is
+  always-confirm for `parsed`.)
+- A proper **re-anchoring** step (re-run `build_anchor` over the new blocks for
+  affected evidence) is **out of scope** here and recorded as a follow-up.
+- Remove all blanket "idempotent" wording. The only true sense of "idempotent"
+  is that re-parse does **not** re-trigger AI extraction (verified:
+  `reparse()` → `parse_article_file_task` runs `DocumentParsingService` only).
+
+### A3. Behaviour by `extractionStatus`
+
+| Status | Indicator | Action |
+| --- | --- | --- |
+| `pending` | `Processing…` (`docStatusPending`) — `Loader2` spin / `bg-warning animate-pulse` dot | **Retry** allowed (covers the stuck case); safe because of A1's lock + UNIQUE constraint |
+| `parsed` | `Ready` (`docStatusReady`) — `bg-success` dot | **Re-parse** behind the A2 confirm dialog |
+| `parse_failed` | `Parse failed` (`docStatusFailed`) — `bg-destructive` dot | prominent **Retry parse** + `extraction_error` in a Tooltip |
+| unknown | muted fallback dot (`bg-muted-foreground/40`) | none |
+
+### A4. Backend (schema + read path)
+
+- Add `extraction_error: str | None` to **`ArticleFileListItem`**
+  (`backend/app/schemas/article.py:205`). **No read-path change** —
+  `ArticleFileService.list_for_article` returns full ORM rows and the endpoint
+  uses `ArticleFileListItem.model_validate(f)`, so the field auto-populates via
+  the alias. (Verified: the method is `list_for_article`, not the earlier
+  mis-named `list_files_for_article`.)
+- **No migration for this field** — the `extraction_error` column already exists
+  on the `ArticleFile` model (`models/article.py:227`); this only widens a
+  response schema. (The UNIQUE constraint in A1 is a *separate* migration.)
+- Not a security leak: the list endpoint is gated by `ensure_project_member`
+  identically to the detail endpoint that already returns `extraction_error`
+  (adversarial review: unfounded).
+- `npm run generate:api-types` + commit the regenerated `schema.d.ts` (additive,
+  optional field — no consumer breaks).
+
+### A5. Frontend
+
+- **Create `frontend/hooks/extraction/useReparseArticleFile.ts`** — a
+  `useMutation` modeled on `hooks/runs/useMarkReady.ts`:
+  `mutationFn: (id) => apiClient('/api/v1/article-files/${id}/reparse', {method:'POST'})`;
+  `onSuccess`: invalidate **both** `articleKeys.files(articleId)` **and**
+  `articleKeys.textBlocks(articleFileId)` (stale-cache class — both mandatory);
+  `onError`: `toast.error(error.message || t('pdf','docReparseError'))`. Gives
+  `isPending` for the spinner. **Additive only.**
+- **KEEP `articlesService.reparseArticleFile`** — it has a third caller
+  (`ArticleDetailDialog.tsx:348`) + a unit test (`articlesService.test.ts:257`)
+  outside this scope. A mixed IO convention (ErrorResult service for the dialog,
+  `useMutation` for the switcher) is accepted; migrating the dialog is an
+  explicit later follow-up, not this spec.
+- **Build `ParseStatusControl`** co-located in
+  `frontend/components/extraction/DocumentSwitcher.tsx` (sibling export). Reads
+  `selectedFile.extractionStatus` + the new `extractionError` from
+  `useArticleDocuments`; renders dot + collapsible label + the contextual action
+  (with the A2 `AlertDialog` for `parsed`). A `cva` keyed on `status` (mirror
+  `frontend/components/layout/HeaderChip.tsx`) using **semantic tokens**
+  (`success`/`warning`/`destructive`), replacing the raw `emerald/amber/red`
+  `STATUS_DOT`. Icon-only actions use `Button size="header-icon"` + `aria-label`;
+  the failed tooltip uses the global `TooltipProvider`.
+- **Replace the `parse_failed`-only gate** at **both** mount sites:
+  `ExtractionPDFPanel.tsx:80` and `QualityAssessmentFullScreen.tsx` (the QA
+  `articleId` early-return at line ~500 already guarantees non-null; keep the
+  control consistent across both). No third switcher mount site exists
+  (`ArticleDetailDialog` is a separate non-switcher surface, out of scope).
+- **Copy** (`frontend/lib/copy/pdf.ts`): reuse the **unused** `docStatusReady` /
+  `docStatusPending` (`'Processing…'`) / `docStatusFailed`. `docReparse` /
+  `docReparseQueued` / `docReparseError` are **already in use** by the current
+  `ReparseButton` — reuse them. Add one tooltip-prefix key
+  (`docParseErrorLabel: 'Parse error'`) so the raw `extraction_error` is
+  labelled, not shown bare. English-only via `t('pdf', key)`.
+- **Auto-refresh:** `useArticleDocuments` already polls `articleKeys.files` every
+  4s while any file is `pending`; after a re-parse the status flips to `pending`,
+  polling resumes, and the reader fills when blocks land. No new polling wiring.
+
+### A6. Tests
+
+- **`useReparseArticleFile`** — hook test mirroring
+  `frontend/test/hooks-runs.test.tsx`: `vi.mock('@/integrations/api',{apiClient})`,
+  `QueryClient` retries off, `await act(mutateAsync)`, assert the POST URL and
+  that both key families are invalidated.
+- **`DocumentSwitcher` / `ParseStatusControl`** — extend
+  `frontend/test/components/DocumentSwitcher.test.tsx`: each status renders its
+  dot/label/action; the failed tooltip shows `extractionError`; the `parsed`
+  confirm dialog appears; the action fires the mutation. **The existing
+  `vi.mock('@/services/articlesService')` must change to
+  `vi.mock('@/integrations/api',{apiClient})` + a `QueryClientProvider` wrapper**
+  (the control now drives a `useMutation`). `vi.mock('@/lib/copy',{t:(_n,k)=>k})`.
+  Keep the test env-free (no AuthContext/supabase imports) for env-less CI.
+- **Backend (CI gate):** a **direct endpoint-coroutine unit test** for
+  `list_article_files` asserting `extraction_error` is serialized for a failed
+  file — mirror `test_article_files_unit.py`, NOT only an integration test
+  (endpoint lines exercised via httpx ASGITransport do not register coverage, so
+  the 80% diff-cover gate fails without a direct coroutine test). Also cover the
+  A1 advisory-lock/unique-constraint path.
+
+### A7. Acceptance (Workstream A, self-contained)
+
+- A `pending` or `parse_failed` file shows a clear, status-appropriate re-parse
+  action next to the switcher; re-parsing a `parsed` file requires the A2
+  confirm. A successful re-parse transitions the file to `parsed` and the reader
+  renders it — no UI dead-end in any state.
+- Two concurrent parse tasks on one file cannot produce duplicate/lost blocks
+  (A1). Re-parsing a `parsed` file never *silently* invalidates citations (A2).
+- Ships **independently** of Workstream B (no `react-markdown` dependency).
+
+---
+
+## Workstream B — markdown view + markdown-anchored citations (Issue 2)
+
+**Decision: execute the existing 6-phase plan in full, after amending
+ADR-0013** (user decision). `react-markdown` is adequate; the plan's stack is
+correct: `react-markdown` + `remark-gfm` + `rehype-sanitize` — **no
+`rehype-raw`** (server-projected GFM; the ADR forbids raw without sanitize) and
+**no `remark-breaks`** (blocks joined with `\n\n`). Defense-in-depth: server
+`nh3` + `rehype-sanitize`. My earlier `rehype-raw` + `remark-breaks` sketch is
+**dropped**. Anchoring is safe (adversarial verdict: *sound*) — reader-mode
+highlight does not exist today and copy reads the raw prop; the new highlight is
+quote-based.
+
+Corrections to fold in while executing the plan:
+
+- **Amend ADR-0013 first.** Plan Phase 3 sets `READ_FROM_BLOCKS` default `True`,
+  removes `MAX_PDF_CHARS`, and raises the prompt budget 15k→120k — i.e. markdown
+  becomes the **default extraction input**. ADR-0013 currently says blocks stay
+  the default ("no two competing extraction inputs by default"). Amend the ADR
+  to make markdown the default, recording the **bake-off evidence** that markdown
+  beats the block-assembler, and treat the 15k→120k budget change as its **own
+  verification** (latency/cost/quality), before/with Phase 3.
+- **Stale `readerBlocks` premise (#359).** The plan predates the shipped
+  reader-switcher; its claim "neither panel passes `readerBlocks`; this adds
+  `readerMarkdown`" is now **false** — both panels already pass `readerBlocks`
+  (`ExtractionPDFPanel.tsx:92`, `QualityAssessmentFullScreen.tsx:665`). Plan
+  Tasks 5.2/5.3 must **replace** the wired `readerBlocks`/`readerLoading` props,
+  not add new ones. `ReaderTextBlock` is a **public viewer-barrel export**
+  (removing it is a breaking package API change); keep a **blocks-based fallback
+  render** until the markdown endpoint ships and is verified.
+- **`prose` vs density.** `@tailwindcss/typography` is installed but **not** in
+  `tailwind.config.ts` `plugins[]`; registering it for `prose prose-sm` is
+  required, and the dense table cells need a `components` override to match the
+  extraction table aesthetic (`ExtractionInterface.tsx:406-448`). Resolve in the
+  plan + a `design-review` pass; do not hand-wave.
+- Process: `npm audit --audit-level=high` after the dep add (security-audit gate
+  fires on lockfile changes); `node scripts/enumerate_compiler_bailouts.mjs`
+  (panicThreshold `all_errors`); add `rehype/remark/sanitize/nh3/GFM/markdown` to
+  `.github/cspell-words.txt` (already a plan step). Drive-by: fix the Portuguese
+  comment at `AISuggestionEvidence.tsx:154` when that file is touched.
+
+### Acceptance (Workstream B)
+
+Owned by the markdown plan's own per-phase acceptance: the reader renders
+sanitized server-projected markdown (GFM tables/lists/super-sub) at parity with
+the extraction table aesthetic; AI citations are anchored in the markdown and
+highlighted in **both** the reader and the canvas; ADR-0013 amended; Phase 3's
+extraction-input swap verified by the bake-off.
+
+---
+
+## Out of scope / deferred
+
+- **Clearing the 39 `pending` backlog** — **user sign-off to clear manually via
+  the new affordance after deploy** (open each article, click Retry). No backfill
+  script; no auto-sweep.
+- **Re-anchoring grounded citations after a `parsed` re-parse** (A2) — recorded
+  follow-up; the confirm dialog is the interim guard.
+- **Migrating `ArticleDetailDialog` to the new mutation hook** — later cleanup;
+  `articlesService.reparseArticleFile` is kept.
+- No schema-level "stuck vs in-flight" distinction (user decision: treat
+  `pending` uniformly, allow guarded manual retry).

--- a/frontend/components/extraction/DocumentSwitcher.tsx
+++ b/frontend/components/extraction/DocumentSwitcher.tsx
@@ -4,10 +4,13 @@
  * Presentational dropdown over an article's files (MAIN + supplements), with a
  * per-file parse-status dot. Selecting a document is the caller's concern
  * (it also clears viewer citations/search/page to avoid cross-document leak).
- * `ReparseButton` recovers a `parse_failed` file in-place — the same recovery
- * the Articles dialog offers, surfaced where the failure is seen.
+ * `ParseStatusControl` is a status-aware control that shows parse status and
+ * surfaces a contextual re-parse action (with a confirm dialog for already-parsed
+ * files and an error tooltip for parse failures).
  */
-import { memo, useState } from 'react';
+import { memo } from 'react';
+import { cva } from 'class-variance-authority';
+import { Loader2 } from 'lucide-react';
 
 import {
   Select,
@@ -16,20 +19,36 @@ import {
   SelectTrigger,
 } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { FILE_ROLE_LABELS, type FileRole } from '@/lib/file-constants';
 import { t } from '@/lib/copy';
 import { cn } from '@/lib/utils';
-import { articleKeys } from '@/lib/query-keys';
-import { reparseArticleFile } from '@/services/articlesService';
 import type { ArticleFileListItem } from '@/services/articleFilesService';
-import { useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
+import { useReparseArticleFile } from '@/hooks/extraction/useReparseArticleFile';
 
-const STATUS_DOT: Record<string, string> = {
-  parsed: 'bg-emerald-500',
-  pending: 'bg-amber-500 animate-pulse',
-  parse_failed: 'bg-red-500',
-};
+// Module-level cva — kept at module scope to satisfy React Compiler (no inline objects).
+const statusDot = cva('h-1.5 w-1.5 shrink-0 rounded-full', {
+  variants: {
+    status: {
+      parsed: 'bg-success',
+      pending: 'bg-warning animate-pulse',
+      parse_failed: 'bg-destructive',
+      unknown: 'bg-muted-foreground/40',
+    },
+  },
+  defaultVariants: { status: 'unknown' },
+});
 
 function roleLabel(role: string): string {
   return FILE_ROLE_LABELS[role as FileRole] ?? role;
@@ -44,6 +63,12 @@ export interface DocumentSwitcherProps {
   selectedFileId: string | null;
   onSelect: (id: string) => void;
   className?: string;
+}
+
+type ParseStatus = 'parsed' | 'pending' | 'parse_failed' | 'unknown';
+
+function toStatus(s: string): ParseStatus {
+  return s === 'parsed' || s === 'pending' || s === 'parse_failed' ? s : 'unknown';
 }
 
 function DocumentSwitcherComponent({
@@ -68,10 +93,7 @@ function DocumentSwitcherComponent({
           {selected && (
             <span
               aria-hidden
-              className={cn(
-                'h-1.5 w-1.5 shrink-0 rounded-full',
-                STATUS_DOT[selected.extractionStatus] ?? 'bg-muted-foreground/40',
-              )}
+              className={statusDot({ status: toStatus(selected.extractionStatus) })}
             />
           )}
           <span className="truncate">
@@ -85,10 +107,7 @@ function DocumentSwitcherComponent({
             <span className="flex items-center gap-2">
               <span
                 aria-hidden
-                className={cn(
-                  'h-1.5 w-1.5 shrink-0 rounded-full',
-                  STATUS_DOT[file.extractionStatus] ?? 'bg-muted-foreground/40',
-                )}
+                className={statusDot({ status: toStatus(file.extractionStatus) })}
               />
               <span className="truncate">{fileLabel(file)}</span>
               <span className="ml-1 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
@@ -105,42 +124,92 @@ function DocumentSwitcherComponent({
 export const DocumentSwitcher = memo(DocumentSwitcherComponent);
 DocumentSwitcher.displayName = 'DocumentSwitcher';
 
-export interface ReparseButtonProps {
-  articleFileId: string;
+export interface ParseStatusControlProps {
   articleId: string;
+  file: ArticleFileListItem;
 }
 
-/** Re-enqueue a parse for a `parse_failed` file and refresh the file + blocks. */
-export function ReparseButton({ articleFileId, articleId }: ReparseButtonProps) {
-  const queryClient = useQueryClient();
-  const [busy, setBusy] = useState(false);
+/**
+ * Status-aware control showing parse status + a contextual re-parse action.
+ * - `pending`     → spinner + "Processing…" + ghost Retry
+ * - `parsed`      → "Ready" + low-emphasis Re-parse behind an AlertDialog confirm
+ * - `parse_failed`→ "Parse failed" (error in Tooltip) + prominent Retry parse
+ */
+export function ParseStatusControl({ articleId, file }: ParseStatusControlProps) {
+  const status = toStatus(file.extractionStatus);
+  const reparse = useReparseArticleFile(articleId);
+  const fire = () => reparse.mutate(file.id);
 
-  const onClick = () => {
-    setBusy(true);
-    reparseArticleFile(articleFileId)
-      .then((res) => {
-        if (!res.ok) {
-          toast.error(res.error.message || t('pdf', 'docReparseError'));
-          return;
-        }
-        toast.success(t('pdf', 'docReparseQueued'));
-        void queryClient.invalidateQueries({ queryKey: articleKeys.files(articleId) });
-        void queryClient.invalidateQueries({
-          queryKey: articleKeys.textBlocks(articleFileId),
-        });
-      })
-      .finally(() => setBusy(false));
-  };
+  const label =
+    status === 'parsed' ? t('pdf', 'docStatusReady')
+    : status === 'pending' ? t('pdf', 'docStatusPending')
+    : status === 'parse_failed' ? t('pdf', 'docStatusFailed')
+    : '';
+
+  const reparseAction =
+    status === 'parsed' ? (
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 text-xs"
+            disabled={reparse.isPending}
+            aria-label={t('pdf', 'docReparse')}
+          >
+            {t('pdf', 'docReparse')}
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('pdf', 'docReparseConfirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('pdf', 'docReparseConfirmBody')}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common', 'cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={fire} aria-label={t('pdf', 'docReparseConfirmCta')}>
+              {t('pdf', 'docReparseConfirmCta')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    ) : status !== 'unknown' ? (
+      <Button
+        size="sm"
+        variant={status === 'parse_failed' ? 'outline' : 'ghost'}
+        className="h-7 text-xs"
+        disabled={reparse.isPending}
+        onClick={fire}
+        aria-label={t('pdf', 'docReparse')}
+      >
+        {t('pdf', 'docReparse')}
+      </Button>
+    ) : null;
 
   return (
-    <Button
-      size="sm"
-      variant="outline"
-      className="h-7 shrink-0 text-xs"
-      disabled={busy}
-      onClick={onClick}
-    >
-      {t('pdf', 'docReparse')}
-    </Button>
+    <div className="flex items-center gap-1.5 shrink-0 text-[11px] text-muted-foreground">
+      {status === 'pending' ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.5} aria-hidden />
+      ) : (
+        <span aria-hidden className={statusDot({ status })} />
+      )}
+
+      {status === 'parse_failed' ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-default">{label}</span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {file.extractionError
+              ? `${t('pdf', 'docParseErrorLabel')}: ${file.extractionError}`
+              : t('pdf', 'docParseErrorUnknown')}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <span>{label}</span>
+      )}
+
+      {reparseAction}
+    </div>
   );
 }

--- a/frontend/components/extraction/ExtractionPDFPanel.tsx
+++ b/frontend/components/extraction/ExtractionPDFPanel.tsx
@@ -12,7 +12,7 @@ import {ResizableHandle, ResizablePanel} from '@/components/ui/resizable';
 import {PrumoPdfViewer} from '@prumo/pdf-viewer';
 import type {ViewerState} from '@prumo/pdf-viewer';
 import {useArticleDocuments} from '@/hooks/extraction/useArticleDocuments';
-import {DocumentSwitcher, ReparseButton} from './DocumentSwitcher';
+import {DocumentSwitcher, ParseStatusControl} from './DocumentSwitcher';
 
 export interface ExtractionPDFPanelProps {
   articleId: string;
@@ -77,11 +77,8 @@ function ExtractionPDFPanelComponent({
                 selectedFileId={selectedFileId}
                 onSelect={handleSelect}
               />
-              {selectedFile?.extractionStatus === 'parse_failed' && (
-                <ReparseButton
-                  articleFileId={selectedFile.id}
-                  articleId={articleId}
-                />
+              {selectedFile && (
+                <ParseStatusControl articleId={articleId} file={selectedFile} />
               )}
             </div>
           )}

--- a/frontend/hooks/extraction/__tests__/useCitationHighlight.noProvider.test.ts
+++ b/frontend/hooks/extraction/__tests__/useCitationHighlight.noProvider.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression (post-merge review 2026-06-21): useCitationHighlight must degrade
+ * to a safe no-op when rendered OUTSIDE a ViewerProvider — the QA "jump to
+ * source" / AI suggestion-details modal mounts it with no PDF viewer present.
+ *
+ * It previously crashed with "useViewerStore must be used within a
+ * ViewerProvider" because the inner usePageHandle hook subscribed via the
+ * throwing useViewerStore during render, before the storeApi==null guard.
+ *
+ * This file deliberately does NOT mock usePageHandle — it exercises the REAL
+ * hook chain, so the no-op contract is actually verified. The sibling
+ * useCitationHighlight.test.ts mocks usePageHandle away and therefore could
+ * never observe this crash.
+ */
+import {renderHook, act} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import type {CitationAnchor} from '@/pdf-viewer/core/citation';
+
+import {useCitationHighlight} from '../useCitationHighlight';
+
+const REGION_ANCHOR: CitationAnchor = {
+  kind: 'region',
+  page: 2,
+  rect: {x: 10, y: 10, width: 100, height: 20},
+};
+
+describe('useCitationHighlight without a ViewerProvider', () => {
+  it('mounts without throwing and reports isAvailable=false', () => {
+    const {result} = renderHook(() => useCitationHighlight());
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.activeHighlight).toBeNull();
+  });
+
+  it('highlight() and clear() are safe no-ops', () => {
+    const {result} = renderHook(() => useCitationHighlight());
+    expect(() => {
+      act(() => {
+        result.current.highlight(REGION_ANCHOR);
+        result.current.clear();
+      });
+    }).not.toThrow();
+    expect(result.current.activeHighlight).toBeNull();
+  });
+});

--- a/frontend/hooks/extraction/useModelManagement.ts
+++ b/frontend/hooks/extraction/useModelManagement.ts
@@ -238,7 +238,7 @@ export function useModelManagement({
     });
 
     // Update local state - remove model and capture name for toast
-    let removedModelName = 'Modelo';
+    let removedModelName = 'Model';
     let updatedModels: Model[] = [];
 
     setModels(prev => {
@@ -271,7 +271,6 @@ export function useModelManagement({
       return updatedModels[0].instanceId;
     });
 
-    console.warn('✅ Modelo removido:', removedModelName);
     toast.success(t('extraction', 'modelRemovedSuccess').replace('{{label}}', removedModelName));
   };
 

--- a/frontend/hooks/extraction/useReparseArticleFile.ts
+++ b/frontend/hooks/extraction/useReparseArticleFile.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { apiClient } from "@/integrations/api";
+import { t } from "@/lib/copy";
+import { articleKeys } from "@/lib/query-keys";
+
+/** Re-enqueue a parse for an ArticleFile and refresh the file list + reader blocks. */
+export function useReparseArticleFile(articleId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, Error, string>({
+    mutationFn: (articleFileId) =>
+      apiClient(`/api/v1/article-files/${articleFileId}/reparse`, { method: "POST" }),
+    onSuccess: (_data, articleFileId) => {
+      toast.success(t("pdf", "docReparseQueued"));
+      queryClient.invalidateQueries({ queryKey: articleKeys.files(articleId) });
+      queryClient.invalidateQueries({ queryKey: articleKeys.textBlocks(articleFileId) });
+    },
+    onError: (error) => {
+      toast.error(error.message || t("pdf", "docReparseError"));
+    },
+  });
+}

--- a/frontend/hooks/runs/useAutoSaveProposals.ts
+++ b/frontend/hooks/runs/useAutoSaveProposals.ts
@@ -160,7 +160,7 @@ export function useAutoSaveProposals(
   const [lastSavedByKey, setLastSavedByKey] = useState<Record<string, string>>({});
   // React state is async, so ``saveState === 'saving'`` cannot be used
   // as a synchronous lock across overlapping ``performSave`` invocations.
-  const activeSavePromiseRef = useRef<Promise<void> | null>(null);
+  const activeSavePromiseRef = useRef<Promise<boolean> | null>(null);
 
   const computeDirtyEntries = (): Array<[string, unknown]> =>
     selectDirtyEntries(
@@ -169,7 +169,7 @@ export function useAutoSaveProposals(
       baselineRef.current,
     );
 
-  const performSave = (): Promise<void> => {
+  const performSave = (): Promise<boolean> => {
     // Serialize concurrent saves: wait for any in-flight batch, swallowing
     // its error (the owner invocation surfaces it; queued calls still retry
     // dirty values that weren't acknowledged).
@@ -177,7 +177,7 @@ export function useAutoSaveProposals(
       ? activeSavePromiseRef.current.catch(() => undefined)
       : Promise.resolve();
 
-    const savePromise: Promise<void> = waitForActive.then(() => {
+    const savePromise: Promise<boolean> = waitForActive.then(() => {
       const currentRunId = runIdRef.current;
       // Skip when there's no run, autosave is disabled, or the run stage
       // does not accept writes (consensus/finalized/pending). The stage
@@ -188,10 +188,10 @@ export function useAutoSaveProposals(
         !enabledRef.current ||
         !isWritableStage(stageRef.current)
       )
-        return;
+        return true;
 
       const dirty = computeDirtyEntries();
-      if (dirty.length === 0) return;
+      if (dirty.length === 0) return true;
 
       setSaveState('saving');
       setError(null);
@@ -253,7 +253,7 @@ export function useAutoSaveProposals(
       });
 
       return batchPromise.then(
-        () => undefined,
+        () => true,
         (err: unknown) => {
           const message =
             err instanceof Error
@@ -263,6 +263,11 @@ export function useAutoSaveProposals(
           setError(message);
           setSaveState('error');
           toast.error(t('extraction', 'errors_autoSaveFailed'));
+          // Resolve to `false` (not reject) so fire-and-forget callers
+          // (debounce / unmount / pagehide) never raise an unhandled
+          // rejection; `saveNow` reads this flag and rejects for callers that
+          // gate a run-stage advance on a successful flush.
+          return false;
         },
       );
     }).finally(() => {
@@ -357,7 +362,13 @@ export function useAutoSaveProposals(
       clearTimeout(debounceRef.current);
       debounceRef.current = undefined;
     }
-    await performSave();
+    const ok = await performSave();
+    if (!ok) {
+      // Reject so callers that gate a run-stage advance on a successful flush
+      // (onMarkReady / onOpenConsensus `.catch(() => false)`) actually block
+      // instead of advancing past unsaved edits.
+      throw new Error('autosave failed');
+    }
   };
 
   // Re-evaluate the dirty diff whenever ``values`` changes (user typed)

--- a/frontend/lib/comparison/permissions.ts
+++ b/frontend/lib/comparison/permissions.ts
@@ -125,19 +125,3 @@ export function isValidUserRole(role: string): role is UserRole {
   return ['manager', 'reviewer', 'viewer', 'consensus'].includes(role);
 }
 
-/**
- * Returns readable label for role
- *
- * @param role - User role
- * @returns English label with emoji
- */
-export function getRoleLabel(role: UserRole): string {
-  const labels: Record<UserRole, string> = {
-      manager: '👑 Manager',
-      consensus: '⚖️ Consensus',
-      reviewer: '✍️ Reviewer',
-      viewer: '👁️ Viewer'
-  };
-  return labels[role];
-}
-

--- a/frontend/lib/copy/pdf.ts
+++ b/frontend/lib/copy/pdf.ts
@@ -81,6 +81,12 @@ export const pdf = {
     docReparse: 'Re-parse',
     docReparseQueued: 'Re-parse queued',
     docReparseError: 'Failed to queue re-parse',
+    docParseErrorLabel: 'Parse error',
+    docParseErrorUnknown: 'Parse failed — no error details recorded',
+    docReparseConfirmTitle: 'Re-parse this document?',
+    docReparseConfirmBody:
+      'Re-parsing rebuilds the document text. Existing citation highlights for this file may shift and need re-checking.',
+    docReparseConfirmCta: 'Re-parse',
 } as const;
 
 export type PdfCopy = typeof pdf;

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -33,7 +33,7 @@ import { PrumoPdfViewer } from "@prumo/pdf-viewer";
 import { useArticleDocuments } from "@/hooks/extraction/useArticleDocuments";
 import {
   DocumentSwitcher,
-  ReparseButton,
+  ParseStatusControl,
 } from "@/components/extraction/DocumentSwitcher";
 import { Badge } from "@/components/ui/badge";
 import { useProjectQATemplate } from "@/hooks/qa/useProjectQATemplate";
@@ -650,13 +650,9 @@ export default function QualityAssessmentFullScreen() {
             selectedFileId={documents.selectedFileId}
             onSelect={documents.setSelectedFileId}
           />
-          {documents.selectedFile?.extractionStatus === "parse_failed" &&
-            articleId && (
-              <ReparseButton
-                articleFileId={documents.selectedFile.id}
-                articleId={articleId}
-              />
-            )}
+          {documents.selectedFile && (
+            <ParseStatusControl articleId={articleId} file={documents.selectedFile} />
+          )}
         </div>
       )}
       <div className="min-h-0 flex-1">

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -676,6 +676,16 @@ export default function QualityAssessmentFullScreen() {
   const showConsensusPanel = ready && inConsensusStage && !!runDetail;
   const showFormStage = ready && !inConsensusStage;
 
+  // Completeness signal for ConsensusPanel's no-divergence finalize fast-path.
+  // QA has no required-field gate (its publish preflight only requires at
+  // least one filled value — see handlePublish), so mirror that here: without
+  // this the panel never receives isComplete, canFinalize stays false, and a
+  // no-divergence QA run shows a wrong "incomplete" message with finalize
+  // disabled.
+  const qaIsComplete = Object.values(values).some(
+    (v) => v !== undefined && v !== null && v !== "",
+  );
+
   const formPanel = (
     <div className="space-y-3 p-4" data-testid="qa-form-panel">
       {error ? (
@@ -706,6 +716,7 @@ export default function QualityAssessmentFullScreen() {
           onFinalize={handleFinalizeFromConsensus}
           isResolving={consensusMutation.isPending}
           isFinalizing={advanceMutation.isPending}
+          isComplete={qaIsComplete}
         />
       ) : null}
 

--- a/frontend/pdf-viewer/hooks/usePageHandle.ts
+++ b/frontend/pdf-viewer/hooks/usePageHandle.ts
@@ -1,9 +1,21 @@
 import {useEffect, useState} from 'react';
-import {useViewerStore} from '../core/context';
+import {useStore} from 'zustand';
+import {useViewerStoreApiOptional} from '../core/context';
+import {createViewerStore} from '../core/store';
 import type {PDFPageHandle} from '../core/engine';
 
+// Fallback store for the case where usePageHandle renders OUTSIDE a
+// ViewerProvider — e.g. the QA screen mounts citation hooks (useCitationHighlight)
+// with no PDF viewer present. Its `document` is null, so the hook returns null
+// instead of throwing. Module-level + read-only: shared and never mutated.
+const NO_PROVIDER_STORE = createViewerStore();
+
 export function usePageHandle(pageNumber: number): PDFPageHandle | null {
-  const document = useViewerStore((s) => s.document);
+  // Subscribe through the optional store API so the hook degrades gracefully
+  // outside a ViewerProvider rather than throwing. In-provider behaviour is
+  // unchanged: the real store is used whenever a provider is present.
+  const storeApi = useViewerStoreApiOptional();
+  const document = useStore(storeApi ?? NO_PROVIDER_STORE, (s) => s.document);
   const [handle, setHandle] = useState<PDFPageHandle | null>(null);
 
   // Drop the stale handle as soon as the document/page changes (during render,

--- a/frontend/pdf-viewer/primitives/CitationOverlay.tsx
+++ b/frontend/pdf-viewer/primitives/CitationOverlay.tsx
@@ -64,7 +64,9 @@ export function CitationOverlay({pageNumber}: CitationOverlayProps) {
   // useEffect is allowed by React Compiler all_errors — no try/finally.
   useEffect(() => {
     if (isActiveOnThisPage && boxRef.current) {
-      boxRef.current.focus();
+      // preventScroll: the Viewer runs its own programmatic smooth-scroll to
+      // the citation; the default focus-scroll would fight it.
+      boxRef.current.focus({preventScroll: true});
     }
   }, [isActiveOnThisPage, activeCitationId]);
 

--- a/frontend/services/aiSuggestionService.ts
+++ b/frontend/services/aiSuggestionService.ts
@@ -123,7 +123,7 @@ export class AISuggestionService {
       `/api/v1/articles/${articleId}/suggestions/history?${params.toString()}`,
     );
 
-    return items.map(mapHistoryItemToSuggestion);
+    return (items ?? []).map(mapHistoryItemToSuggestion);
   }
 
   /**
@@ -196,6 +196,6 @@ export class AISuggestionService {
   }
 
   static async getArticleInstanceIds(articleId: string): Promise<string[]> {
-    return apiClient<string[]>(`/api/v1/articles/${articleId}/instance-ids`);
+    return (await apiClient<string[]>(`/api/v1/articles/${articleId}/instance-ids`)) ?? [];
   }
 }

--- a/frontend/test/components/DocumentSwitcher.test.tsx
+++ b/frontend/test/components/DocumentSwitcher.test.tsx
@@ -1,53 +1,65 @@
 /**
- * Tests for DocumentSwitcher (presentational document selector).
- *
- * Covers:
- *  - renders nothing when the article has no files
- *  - shows the selected file's label in the trigger
+ * Tests for DocumentSwitcher (presentational document selector) and
+ * ParseStatusControl (status-aware re-parse control).
  */
-import {render, screen} from '@testing-library/react';
-import {describe, expect, it, vi} from 'vitest';
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
-vi.mock('@/lib/copy', () => ({
-  t: (_ns: string, key: string) => key,
-}));
-vi.mock('@/services/articlesService', () => ({
-  reparseArticleFile: vi.fn(),
-}));
+vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
 
-import {DocumentSwitcher} from '@/components/extraction/DocumentSwitcher';
-import type {ArticleFileListItem} from '@/services/articleFilesService';
+import { apiClient } from "@/integrations/api";
+import { DocumentSwitcher, ParseStatusControl } from "@/components/extraction/DocumentSwitcher";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ArticleFileListItem } from "@/services/articleFilesService";
 
 function file(
   id: string,
   fileRole: string,
   originalFilename: string,
-  extractionStatus = 'parsed',
+  extractionStatus = "parsed",
 ): ArticleFileListItem {
   return {
     id,
     fileRole,
-    fileType: 'PDF',
+    fileType: "PDF",
     originalFilename,
     extractionStatus,
     bytes: 1,
     storageKey: `k/${id}.pdf`,
-    createdAt: '2026-06-21T00:00:00Z',
+    createdAt: "2026-06-21T00:00:00Z",
   };
 }
 
-describe('DocumentSwitcher', () => {
-  it('renders nothing when there are no files', () => {
-    const {container} = render(
+function renderControl(f: { id: string; extractionStatus: string; extractionError?: string | null }) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <ParseStatusControl
+          articleId="art-1"
+          file={{ originalFilename: "a.pdf", fileRole: "MAIN", ...f } as never}
+        />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DocumentSwitcher", () => {
+  it("renders nothing when there are no files", () => {
+    const { container } = render(
       <DocumentSwitcher files={[]} selectedFileId={null} onSelect={() => {}} />,
     );
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('shows the selected file label in the trigger', () => {
+  it("shows the selected file label in the trigger", () => {
     const files = [
-      file('main-1', 'MAIN', 'main.pdf'),
-      file('supp-1', 'SUPPLEMENT', 'supp.pdf', 'pending'),
+      file("main-1", "MAIN", "main.pdf"),
+      file("supp-1", "SUPPLEMENT", "supp.pdf", "pending"),
     ];
     render(
       <DocumentSwitcher
@@ -58,10 +70,50 @@ describe('DocumentSwitcher', () => {
     );
     // The trigger renders the selected file's label explicitly (not via the
     // unmounted Radix item list).
-    expect(screen.getByText('main.pdf')).toBeInTheDocument();
-    expect(screen.getByRole('combobox')).toHaveAttribute(
-      'aria-label',
-      'docSwitcherAria',
+    expect(screen.getByText("main.pdf")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveAttribute(
+      "aria-label",
+      "docSwitcherAria",
     );
+  });
+});
+
+describe("ParseStatusControl", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("failed: shows the error in a tooltip trigger and a Retry that POSTs", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f1", extractionStatus: "parse_failed", extractionError: "libxcb.so.1 missing" });
+    fireEvent.click(screen.getByRole("button", { name: /docReparse/ }));
+    await waitFor(() => {
+      expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f1/reparse", { method: "POST" });
+    });
+  });
+
+  it("parsed: Re-parse opens a confirm dialog before POSTing", async () => {
+    const user = userEvent.setup();
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f2", extractionStatus: "parsed" });
+    await user.click(screen.getByRole("button", { name: /docReparse/ }));
+    expect(apiClient).not.toHaveBeenCalled();             // confirm first
+    const confirmBtn = await screen.findByRole("button", { name: /docReparseConfirmCta/ });
+    await user.click(confirmBtn);
+    await waitFor(() => {
+      expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f2/reparse", { method: "POST" });
+    });
+  });
+
+  it("pending: shows Processing and a Retry", () => {
+    renderControl({ id: "f3", extractionStatus: "pending" });
+    expect(screen.getByText("docStatusPending")).toBeInTheDocument();
+  });
+
+  it("pending: Retry button POSTs to reparse endpoint", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    renderControl({ id: "f4", extractionStatus: "pending" });
+    fireEvent.click(screen.getByRole("button", { name: /docReparse/ }));
+    await waitFor(() => {
+      expect(apiClient).toHaveBeenCalledWith("/api/v1/article-files/f4/reparse", { method: "POST" });
+    });
   });
 });

--- a/frontend/test/hooks/useAutoSaveProposals.test.tsx
+++ b/frontend/test/hooks/useAutoSaveProposals.test.tsx
@@ -450,7 +450,9 @@ describe('useAutoSaveProposals — mutex + error handling', () => {
     );
 
     await act(async () => {
-      await result.current.saveNow();
+      // The failed coord makes saveNow reject so a caller can gate run-advance
+      // on a successful flush; saveState still reflects the partial failure.
+      await expect(result.current.saveNow()).rejects.toThrow();
     });
 
     expect(apiClientMock).toHaveBeenCalledTimes(3);
@@ -469,6 +471,31 @@ describe('useAutoSaveProposals — mutex + error handling', () => {
     expect((apiClientMock.mock.calls[0][1] as { body: { field_id: string } }).body.field_id)
       .toBe('b');
     expect(result.current.saveState).toBe('saved');
+  });
+
+  it('saveNow() rejects when a write fails so run-advance can be gated (#5)', async () => {
+    // Regression: performSave used to swallow the rejection and resolve, so
+    // saveNow always resolved and the onMarkReady / onOpenConsensus
+    // `.catch(() => false)` guard was dead — a failed flush advanced the run
+    // (EXTRACT → CONSENSUS) and the unsaved edit was lost. saveNow must reject.
+    apiClientMock.mockRejectedValue(new Error('network drop'));
+
+    const { result } = renderHook(() =>
+      useAutoSaveProposals({
+        runId: 'run-1',
+        values: { 'inst-1_field-1': 'unsaved-edit' },
+      }),
+    );
+
+    await act(async () => {
+      // Mirror the caller's guard: `.then(() => true).catch(() => false)`.
+      const gated = await result.current
+        .saveNow()
+        .then(() => true)
+        .catch(() => false);
+      expect(gated).toBe(false);
+    });
+    expect(result.current.saveState).toBe('error');
   });
 });
 
@@ -517,7 +544,7 @@ describe('useAutoSaveProposals — state machine', () => {
     );
 
     await act(async () => {
-      await result.current.saveNow();
+      await expect(result.current.saveNow()).rejects.toThrow();
     });
     expect(result.current.saveState).toBe('error');
 

--- a/frontend/test/hooks/useReparseArticleFile.test.tsx
+++ b/frontend/test/hooks/useReparseArticleFile.test.tsx
@@ -1,0 +1,45 @@
+// frontend/test/hooks/useReparseArticleFile.test.tsx
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/integrations/api", () => ({ apiClient: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/copy", () => ({ t: (_n: string, k: string) => k }));
+
+import { apiClient } from "@/integrations/api";
+import { useReparseArticleFile } from "@/hooks/extraction/useReparseArticleFile";
+
+function wrap() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const spy = vi.spyOn(qc, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { wrapper, spy };
+}
+
+describe("useReparseArticleFile", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("POSTs reparse and invalidates files + textBlocks", async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    const { wrapper, spy } = wrap();
+    const { result } = renderHook(() => useReparseArticleFile("art-1"), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync("file-9");
+    });
+
+    expect(apiClient).toHaveBeenCalledWith(
+      "/api/v1/article-files/file-9/reparse",
+      { method: "POST" },
+    );
+    const keys = spy.mock.calls.map((c) => JSON.stringify(c[0]?.queryKey));
+    expect(keys.some((k) => k?.includes("files"))).toBe(true);
+    expect(keys.some((k) => k?.includes("text-blocks"))).toBe(true);
+  });
+});

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -2210,6 +2210,17 @@
             "title": "Createdat",
             "type": "string"
           },
+          "extractionError": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extractionerror"
+          },
           "extractionStatus": {
             "default": "pending",
             "title": "Extractionstatus",

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -1847,6 +1847,8 @@ export interface components {
              * Format: date-time
              */
             createdAt: string;
+            /** Extractionerror */
+            extractionError?: string | null;
             /**
              * Extractionstatus
              * @default pending

--- a/llms.txt
+++ b/llms.txt
@@ -25,9 +25,8 @@ Hosting: Railway (backend + worker + Redis) + Vercel (frontend) + Supabase
 - Extraction or quality-assessment → [docs/reference/extraction-hitl-architecture.md](docs/reference/extraction-hitl-architecture.md)
 - Deployment → [docs/reference/deployment.md](docs/reference/deployment.md)
 - Tests → [docs/reference/test-strategy.md](docs/reference/test-strategy.md)
-- Frontend UI / visual changes → the `frontend-ux` + `ui-styling` skills; close
-  the loop with `design-review` (`/design-review <route>`) — render, screenshot,
-  compare to the Plane/Linear target, fix, re-screenshot — before calling a screen done
+- Which skill to load for a given area → the `## Which skill to load` map in
+  [CLAUDE.md](CLAUDE.md) (the always-loaded source; this index mirrors it)
 - An architectural decision → [docs/adr/](docs/adr/)
 
 ## Do not read these (archived / generated)

--- a/scripts/apply_and_test_migration.sh
+++ b/scripts/apply_and_test_migration.sh
@@ -150,12 +150,6 @@ WHERE tablename IN ('extraction_instances', 'extracted_values')
   AND indexname LIKE 'idx_%unique%'
 ORDER BY tablename, indexname;
 
-SELECT typname, enumlabel
-FROM pg_type t
-JOIN pg_enum e ON t.oid = e.enumtypid
-WHERE typname = 'extraction_instance_status'
-ORDER BY e.enumsortorder;
-
 SELECT constraint_name, check_clause
 FROM information_schema.check_constraints
 WHERE constraint_name = 'chk_extraction_instances_metadata_object';
@@ -175,12 +169,6 @@ FROM pg_indexes
 WHERE tablename IN ('extraction_instances', 'extracted_values')
   AND indexname LIKE 'idx_%unique%'
 ORDER BY tablename, indexname;
-
-SELECT typname, enumlabel
-FROM pg_type t
-JOIN pg_enum e ON t.oid = e.enumtypid
-WHERE typname = 'extraction_instance_status'
-ORDER BY e.enumsortorder;
 
 SELECT constraint_name, check_clause
 FROM information_schema.check_constraints

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -1,0 +1,10 @@
+# file-size ratchet baseline — oversized files frozen at current size.
+# May shrink (re-run --update-baseline to tighten), never grow. Cleanup is a separate effort.
+backend/app/seed.py:1941
+backend/app/services/extraction_export_service.py:2237
+backend/app/services/section_extraction_service.py:1396
+frontend/components/articles/ArticleForm.tsx:1272
+frontend/components/articles/ArticlesList.tsx:1360
+frontend/components/extraction/ArticleExtractionTable.tsx:1130
+frontend/lib/copy/extraction.ts:853
+frontend/pages/ExtractionFullScreen.tsx:1282

--- a/scripts/fitness/check_file_size.py
+++ b/scripts/fitness/check_file_size.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-"""check_file_size.py — prumo fitness function (WARN-only).
+"""check_file_size.py — prumo fitness function (ratchet).
 
-Flags source files over the soft ceiling. Files >1,200 lines force
-whole-file reads, raise Edit-tool uniqueness collisions, and
-concentrate merge risk for agent sessions — the audit found god files
-in both halves (seed.py 1,941; extraction_export_service.py 1,521;
-ArticlesList.tsx 1,440). This check never fails the gate; it keeps the
-outliers visible on every CI run so they shrink instead of grow.
+Freezes file-size drift: a baselined oversized file may not GROW, and no new
+file may cross the soft ceiling. Shrinking is always allowed (and lets you
+tighten the baseline with --update-baseline). The actual splitting of the
+current god files is a separate cleanup effort.
+
+Baseline format: one `path:max_lines` per currently-oversized file.
 
 Usage:
-  python check_file_size.py [--repo-root PATH] [--max-lines N]
+  python check_file_size.py [--repo-root P] [--max-lines N] [--baseline P]
+  python check_file_size.py --update-baseline   # rewrite baseline from tree
 
-Exit codes: 0 (always, unless internal error) | 2 (internal error).
+Exit codes: 0 (no growth, no new offender) | 1 (regression) | 2 (internal).
 """
 
 from __future__ import annotations
@@ -25,7 +26,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_REPO_ROOT = SCRIPT_DIR.parent.parent
-
+DEFAULT_BASELINE = SCRIPT_DIR / "check_file_size.baseline"
 MAX_LINES_DEFAULT = 800
 
 SCAN_ROOTS = ("backend/app", "frontend")
@@ -41,12 +42,11 @@ SKIP_DIR_NAMES = {
     ".pytest_cache",
     "coverage",
 }
-# Generated output is allowed to be huge.
 SKIP_PATH_PARTS = ("frontend/types/api/", "integrations/supabase/types.ts")
 
 
-def scan(repo_root: Path, max_lines: int) -> list[tuple[str, int]]:
-    offenders: list[tuple[str, int]] = []
+def scan(repo_root: Path, max_lines: int) -> dict[str, int]:
+    offenders: dict[str, int] = {}
     for root in SCAN_ROOTS:
         base = repo_root / root
         if not base.exists():
@@ -60,43 +60,90 @@ def scan(repo_root: Path, max_lines: int) -> list[tuple[str, int]]:
             if any(skip in rel for skip in SKIP_PATH_PARTS):
                 continue
             try:
-                n_lines = sum(1 for _ in path.open("rb"))
+                n = sum(1 for _ in path.open("rb"))
             except OSError:
                 continue
-            if n_lines > max_lines:
-                offenders.append((rel, n_lines))
-    offenders.sort(key=lambda item: -item[1])
+            if n > max_lines:
+                offenders[rel] = n
     return offenders
+
+
+def load_baseline(path: Path) -> dict[str, int]:
+    if not path.is_file():
+        return {}
+    out: dict[str, int] = {}
+    for ln in path.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if not ln or ln.startswith("#"):
+            continue
+        rel, _, num = ln.rpartition(":")
+        if rel and num.isdigit():
+            out[rel] = int(num)
+    return out
+
+
+def write_baseline(path: Path, offenders: dict[str, int]) -> None:
+    header = "# file-size ratchet baseline — oversized files frozen at current size.\n# May shrink (re-run --update-baseline to tighten), never grow. Cleanup is a separate effort.\n"
+    body = "\n".join(f"{rel}:{n}" for rel, n in sorted(offenders.items()))
+    path.write_text(header + body + ("\n" if body else ""))
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
     parser.add_argument("--max-lines", type=int, default=MAX_LINES_DEFAULT)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--update-baseline", action="store_true")
     args = parser.parse_args()
 
     started = time.time()
     offenders = scan(args.repo_root.resolve(), args.max_lines)
 
-    for rel, n_lines in offenders:
-        print(f"WARN file-size: {rel} has {n_lines} lines (soft ceiling {args.max_lines})")
+    if args.update_baseline:
+        write_baseline(args.baseline, offenders)
+        print(f"file-size baseline written: {len(offenders)} oversized files -> {args.baseline}")
+        return 0
+
+    baseline = load_baseline(args.baseline)
+    regressions: list[str] = []
+    for rel, n in sorted(offenders.items(), key=lambda kv: -kv[1]):
+        cap = baseline.get(rel)
+        if cap is None:
+            regressions.append(f"NEW over-ceiling file: {rel} has {n} lines (> {args.max_lines})")
+        elif n > cap:
+            regressions.append(f"GREW: {rel} has {n} lines (baseline cap {cap})")
+
+    duration_ms = int((time.time() - started) * 1000)
+    exit_code = 1 if regressions else 0
 
     telemetry_out = os.environ.get("PRUMO_TELEMETRY_OUT")
     if telemetry_out:
-        record = {
-            "check": "check_file_size",
-            "status": "warn" if offenders else "ok",
-            "violations": [{"file": rel, "lines": n_lines} for rel, n_lines in offenders],
-            "duration_ms": int((time.time() - started) * 1000),
-        }
         with open(telemetry_out, "a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record) + "\n")
+            handle.write(
+                json.dumps(
+                    {
+                        "check": "check_file_size",
+                        "status": "fail" if regressions else "ok",
+                        "regressions": regressions,
+                        "offender_count": len(offenders),
+                        "duration_ms": duration_ms,
+                    }
+                )
+                + "\n"
+            )
 
-    print(
-        f"file-size: OK ({len(offenders)} files over the {args.max_lines}-line "
-        "soft ceiling; warn-only)"
-    )
-    return 0
+    if regressions:
+        print(f"check_file_size.py: FAIL ({duration_ms} ms; {len(regressions)} regression(s))")
+        for r in regressions:
+            print(f"  {r}")
+        print(
+            f"Shrink the file, or (only if intentional) run --update-baseline and commit {args.baseline.name}."
+        )
+    else:
+        print(
+            f"file-size: OK ({duration_ms} ms; {len(offenders)} oversized, none grew, no new offenders)"
+        )
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/fitness/check_frontend_data_path.baseline
+++ b/scripts/fitness/check_frontend_data_path.baseline
@@ -1,0 +1,17 @@
+# residual single-read-path violations grandfathered post-#324; shrink, don't grow
+frontend/hooks/extraction/helpers/queryEntityTypes.ts:15
+frontend/hooks/extraction/helpers/queryEntityTypes.ts:17
+frontend/lib/supabase/baseRepository.ts:100
+frontend/lib/supabase/baseRepository.ts:120
+frontend/lib/supabase/baseRepository.ts:181
+frontend/lib/supabase/baseRepository.ts:208
+frontend/lib/supabase/baseRepository.ts:231
+frontend/lib/supabase/baseRepository.ts:259
+frontend/services/articlesExportService.ts:11
+frontend/services/articlesService.ts:130
+frontend/services/articlesService.ts:146
+frontend/services/extractionDataService.ts:63
+frontend/services/extractionDataService.ts:64
+frontend/services/extractionExportService.ts:7
+frontend/test/hooks/useModelManagement.test.tsx:74
+frontend/test/services/articlesService.test.ts:244

--- a/scripts/fitness/check_frontend_data_path.py
+++ b/scripts/fitness/check_frontend_data_path.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""check_frontend_data_path.py — prumo fitness function.
+
+Enforces the single read path (constitution §VI): all backend data flows
+through the typed apiClient. Flags, OUTSIDE `frontend/integrations/`:
+  - `supabase.from(` — direct table reads (auth/storage are allowed via
+    supabase.auth/.storage, which this does not match)
+  - `import.meta.env.VITE_API_URL` — ad-hoc base-URL wiring around the client
+
+Regex-based (does not parse TS); a `.baseline` grandfathers residual sites.
+Note: comments are not exempt — a line containing the pattern in a comment is
+still flagged and must be baselined if intentional.
+
+Exit codes: 0 (baseline matched) | 1 (new violation) | 2 (internal).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_REPO_ROOT = SCRIPT_DIR.parent.parent
+
+FRONTEND_ROOT = "frontend"
+ALLOWED_PREFIX = "frontend/integrations/"
+SKIP_DIRS = {
+    "node_modules",
+    "dist",
+    "build",
+    ".next",
+    "coverage",
+    "test-results",
+    "playwright-report",
+}
+
+PATTERNS = (
+    re.compile(r"\bsupabase\s*\.\s*from\s*\("),
+    re.compile(r"\bimport\.meta\.env\.VITE_API_URL\b"),
+)
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    snippet: str
+
+    def stable_id(self) -> str:
+        return f"{self.file}:{self.line}"
+
+
+def _walk(start: Path):
+    for p in start.rglob("*"):
+        if (
+            p.is_file()
+            and p.suffix in {".ts", ".tsx"}
+            and not any(part in SKIP_DIRS for part in p.parts)
+        ):
+            yield p
+
+
+def scan(root: Path) -> list[Violation]:
+    fe = root / FRONTEND_ROOT
+    if not fe.is_dir():
+        return []
+    out: list[Violation] = []
+    for path in sorted(_walk(fe)):
+        rel = path.relative_to(root).as_posix()
+        if rel.startswith(ALLOWED_PREFIX):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for i, line in enumerate(text.splitlines(), start=1):
+            if any(pat.search(line) for pat in PATTERNS):
+                out.append(Violation(rel, i, line.strip()[:160]))
+    return out
+
+
+def load_baseline(path: Path) -> set[str]:
+    if not path.is_file():
+        return set()
+    return {
+        ln.strip()
+        for ln in path.read_text(encoding="utf-8").splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    }
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description="prumo frontend single-read-path enforcement")
+    p.add_argument("--repo-root", default=None)
+    p.add_argument("--baseline", default=None)
+    p.add_argument("--emit-telemetry", default=None)
+    p.add_argument("--jsonl-out", default=None)
+    args = p.parse_args(argv)
+
+    root = Path(args.repo_root).resolve() if args.repo_root else DEFAULT_REPO_ROOT
+    baseline_path = (
+        Path(args.baseline) if args.baseline else SCRIPT_DIR / "check_frontend_data_path.baseline"
+    )
+
+    started = time.time()
+    violations = scan(root)
+    duration_ms = int((time.time() - started) * 1000)
+    baseline = load_baseline(baseline_path)
+    new = [v for v in violations if v.stable_id() not in baseline]
+    exit_code = 1 if new else 0
+
+    if args.jsonl_out:
+        rows = [
+            {
+                "category": "data-path",
+                "severity": "high",
+                "confidence": 0.9,
+                "file": v.file,
+                "line": v.line,
+                "evidence": v.snippet,
+                "suggested_action": "Route through apiClient (frontend/integrations/api/client.ts); supabase only for auth/storage.",
+                "source": "fitness:check_frontend_data_path",
+            }
+            for v in new
+        ]
+        Path(args.jsonl_out).write_text(
+            "\n".join(json.dumps(r) for r in rows) + ("\n" if rows else "")
+        )
+
+    if args.emit_telemetry:
+        with open(args.emit_telemetry, "a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                        "phase": "fitness",
+                        "gate": "check_frontend_data_path",
+                        "duration_ms": duration_ms,
+                        "exit_code": exit_code,
+                        "violation_count": len(violations),
+                        "new_violation_count": len(new),
+                        "baseline_size": len(baseline),
+                    }
+                )
+                + "\n"
+            )
+
+    if new:
+        print(
+            f"check_frontend_data_path.py: FAIL ({duration_ms} ms; {len(new)} new, {len(baseline)} grandfathered)"
+        )
+        print("NEW direct-data-path violations (route through apiClient):")
+        for v in new[:10]:
+            print(f"  {v.file}:{v.line}  {v.snippet[:100]}")
+        print(f"To grandfather a known site: add 'file:line' to {baseline_path.name}.")
+    else:
+        print(
+            f"check_frontend_data_path.py: OK ({duration_ms} ms; {len(violations)} found, {len(baseline)} grandfathered)"
+        )
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/fitness/check_skill_router_sync.py
+++ b/scripts/fitness/check_skill_router_sync.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""check_skill_router_sync.py — prumo fitness function.
+
+Asserts every skill named in CLAUDE.md's `## Which skill to load` router
+resolves to a real `.claude/skills/<name>/` directory. A dead router entry
+sends agents to a skill that does not exist; this fires the moment the router
+and the skills tree drift apart.
+
+Exit codes: 0 (no dead entries) | 1 (dead entry) | 2 (router section missing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_REPO_ROOT = SCRIPT_DIR.parent.parent
+
+ROUTER_HEADING = "## Which skill to load"
+SKILL_TICK_RE = re.compile(r"→\s*`([a-z][a-z0-9-]+)`")
+
+
+def router_skills(claude_md: str) -> list[str]:
+    lines = claude_md.splitlines()
+    out: list[str] = []
+    in_section = False
+    for line in lines:
+        if line.strip() == ROUTER_HEADING:
+            in_section = True
+            continue
+        if in_section and line.startswith("## "):
+            break
+        if in_section:
+            m = SKILL_TICK_RE.search(line)
+            if m:
+                out.append(m.group(1))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description="prumo skill-router sync check")
+    p.add_argument("--repo-root", default=None)
+    p.add_argument("--emit-telemetry", default=None)
+    args = p.parse_args(argv)
+
+    root = Path(args.repo_root).resolve() if args.repo_root else DEFAULT_REPO_ROOT
+    claude_path = root / "CLAUDE.md"
+    skills_dir = root / ".claude" / "skills"
+
+    if not claude_path.is_file():
+        print(f"ERROR: CLAUDE.md not found: {claude_path}", file=sys.stderr)
+        return 2
+
+    started = time.time()
+    named = router_skills(claude_path.read_text(encoding="utf-8"))
+    if not named:
+        print(f"ERROR: no '{ROUTER_HEADING}' router entries found in CLAUDE.md", file=sys.stderr)
+        return 2
+
+    existing = (
+        {p.name for p in skills_dir.iterdir() if p.is_dir()} if skills_dir.is_dir() else set()
+    )
+    dead = [s for s in named if s not in existing]
+    duration_ms = int((time.time() - started) * 1000)
+    exit_code = 1 if dead else 0
+
+    if dead:
+        print(
+            f"check_skill_router_sync.py: FAIL ({duration_ms} ms; {len(dead)} dead router entries)"
+        )
+        for s in dead:
+            print(f"  `{s}` in CLAUDE.md router has no .claude/skills/{s}/ dir")
+    else:
+        print(
+            f"check_skill_router_sync.py: OK ({duration_ms} ms; {len(named)} router entries all resolve)"
+        )
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/fitness/run_all.sh
+++ b/scripts/fitness/run_all.sh
@@ -80,6 +80,12 @@ run_check "check_layered_arch.py" \
 run_check "check_react_query_keys.py" \
   python3 "${SCRIPT_DIR}/check_react_query_keys.py"
 
+run_check "check_frontend_data_path.py" \
+  python3 "${SCRIPT_DIR}/check_frontend_data_path.py"
+
+run_check "check_skill_router_sync.py" \
+  python3 "${SCRIPT_DIR}/check_skill_router_sync.py"
+
 run_check "check_file_size.py" \
   python3 "${SCRIPT_DIR}/check_file_size.py"
 


### PR DESCRIPTION
Promote `dev` → `main` (production deploy via Railway).

## What's shipping (4 commits)
- **#380** feat(parsing): parse-recovery affordance — re-parse in all states + concurrency-safe writes
- **#372** fix: post-merge review — criticals, BOLAs, edit-loss, QA finalize + cleanups
- **#379** chore(dev-workflow): architecture clarity — skill router, frontend-development skill, organization gates
- **#378** chore(scripts): drop stale extraction_instance_status enum probe

## Readiness
- CI on dev HEAD `0f8f5202`: all 13 non-skipped checks green (Backend Tests/E2E/Lint/Docker, Frontend Build/Lint/Tests/E2E, Architectural Fitness, API Contract, CodeQL).
- `dev` is 4 commits ahead of `main`, merges cleanly (no conflicts).
- Production currently healthy (web /health 200, worker+Redis ready).

Merge strategy: **merge commit** (not squash) per promotion convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)