### PR TITLE
feat(extraction): A1 — block-markdown LLM input + windowing

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -22,6 +22,7 @@ docs/superpowers/plans/2026-06-21-hitl-phase2-consensus-finalize.md
 docs/superpowers/plans/2026-06-21-header-system-responsive-frosted.md
 docs/superpowers/plans/2026-06-22-architecture-clarity.md
 docs/superpowers/plans/2026-06-23-extraction-stabilization-phase1.md
+docs/superpowers/plans/2026-06-23-extraction-a1-block-input.md
 
 # Design specs — likewise snapshots
 docs/superpowers/specs/2026-*-design.md

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -100,6 +100,12 @@ class Settings(BaseSettings):
     LLM_PROVIDER: str = "openai"
     LLM_DEFAULT_MODEL: str = "gpt-4o-mini"
     LLM_TIMEOUT_SECONDS: float = 120.0
+    # Token budget for the per-run block-markdown assembly window (A1). A paper
+    # under this budget is sent in full; above it the assembler drops whole
+    # low-priority sections (IMRaD ranking) and logs AssemblyInfo.truncated.
+    # Leaves headroom on a 128k-context model for system prompt + schema + output
+    # + reask. No hard per-run cost ceiling (logged, not enforced — spec §8.5).
+    LLM_ASSEMBLY_BUDGET_TOKENS: int = 96_000
 
     # =================== PARSING ===================
     # Per-project default resolution is "auto" (see ParserSettingsService +

--- a/backend/app/infrastructure/parsing/base.py
+++ b/backend/app/infrastructure/parsing/base.py
@@ -26,8 +26,11 @@ the concatenation or offset logic.  The function is the single source of
 truth.
 """
 
+import math
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
 
 # ---------------------------------------------------------------------------
 # Closed block-type vocabulary
@@ -216,3 +219,94 @@ class DocumentParser(ABC):
         Raises:
             ValueError: If *pdf_bytes* cannot be parsed as a PDF.
         """
+
+
+# ---------------------------------------------------------------------------
+# render_blocks_to_markdown — canonical block→GFM projection (ADR-0013)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class BlockLike(Protocol):
+    """Structural type satisfied by both ``ParsedBlock`` and ``ArticleTextBlock``."""
+
+    page_number: int
+    block_index: int
+    text: str
+    block_type: str
+
+
+_MD_TABLE_CELL_SEP = " | "
+_MD_TABLE_RULE_CHAR = "-"
+
+
+def _infer_column_count(cell_texts: list[str]) -> int:
+    """Heuristically infer a table's column count from its flat cell list."""
+    n = len(cell_texts)
+    if n <= 1:
+        return 1
+    for cols in range(2, min(9, n + 1)):
+        if n % cols == 0:
+            return cols
+    return min(8, max(2, math.ceil(math.sqrt(n))))
+
+
+def _render_table(cell_texts: list[str]) -> str:
+    """Render a flat list of table-cell texts as a deterministic GFM table."""
+    if not cell_texts:
+        return ""
+    cols = _infer_column_count(cell_texts)
+    rows: list[list[str]] = []
+    for i in range(0, len(cell_texts), cols):
+        row = cell_texts[i : i + cols]
+        while len(row) < cols:
+            row.append("")
+        rows.append(row)
+    widths = [max(len(r[c]) for r in rows) for c in range(cols)]
+
+    def _fmt(row: list[str]) -> str:
+        cells = [r.ljust(w) for r, w in zip(row, widths, strict=True)]
+        return "| " + _MD_TABLE_CELL_SEP.join(cells) + " |"
+
+    rule = "|-" + "-|-".join(_MD_TABLE_RULE_CHAR * w for w in widths) + "-|"
+    return "\n".join([_fmt(rows[0]), rule, *(_fmt(r) for r in rows[1:])])
+
+
+def render_blocks_to_markdown(blocks: Sequence[BlockLike]) -> str:
+    """Project article text blocks to deterministic GFM markdown (ADR-0013 free tier).
+
+    Reading order (page asc, block_index asc); ``## `` headings; ``- `` list
+    items; contiguous same-page ``table_cell`` runs coalesced into a GFM table;
+    ``paragraph`` / ``figure_caption`` as plain text; ``header`` / ``footer``
+    page chrome suppressed. Pure: no DB, no IO. The extraction assembler
+    serialises each kept section through this function so the prompt's tables and
+    the reader's tables are byte-identical (one serialization codepath).
+    """
+    ordered = sorted(blocks, key=lambda b: (b.page_number, b.block_index))
+    parts: list[str] = []
+    i = 0
+    while i < len(ordered):
+        block = ordered[i]
+        if block.block_type in ("header", "footer"):
+            i += 1
+            continue
+        if block.block_type == "table_cell":
+            page = block.page_number
+            run: list[str] = []
+            while (
+                i < len(ordered)
+                and ordered[i].block_type == "table_cell"
+                and ordered[i].page_number == page
+            ):
+                run.append(ordered[i].text)
+                i += 1
+            parts.append(_render_table(run))
+            continue
+        if block.block_type == "heading":
+            parts.append(f"## {block.text}")
+        elif block.block_type == "list_item":
+            parts.append(f"- {block.text}")
+        else:
+            parts.append(block.text)
+        i += 1
+    return "\n".join(p for p in parts if p)

--- a/backend/app/llm/assembler.py
+++ b/backend/app/llm/assembler.py
@@ -43,7 +43,13 @@ import re
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
-from app.infrastructure.parsing.base import render_blocks_to_markdown
+from app.infrastructure.parsing.base import ParsedBlock, render_blocks_to_markdown
+from app.schemas.extraction import AssemblyInfo
+
+try:
+    import tiktoken
+except ImportError:  # pragma: no cover - tiktoken ships with pydantic-ai-slim[openai]
+    tiktoken = None  # type: ignore[assignment]
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -311,3 +317,85 @@ def assemble(
         result_text = separator.join(kept_list)
 
     return result_text, dropped
+
+
+# ---------------------------------------------------------------------------
+# Model-aware wrapper
+# ---------------------------------------------------------------------------
+
+_CHARS_PER_TOKEN = 4  # heuristic char→token ratio for English / scientific prose
+
+
+def estimate_tokens(text: str, model_name: str) -> int:
+    """Best-effort token count: tiktoken for OpenAI models, ``len // 4`` heuristic
+    otherwise (e.g. Anthropic, which tiktoken cannot encode — see the documented
+    skew in test_assembler)."""
+    if not text:
+        return 0
+    if tiktoken is not None:
+        try:
+            return len(tiktoken.encoding_for_model(model_name).encode(text))
+        except KeyError:
+            pass
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def assemble_for_model(
+    blocks: list[_Block],
+    *,
+    model_name: str,
+    budget_tokens: int,
+    focus: str | None = None,
+) -> tuple[str, AssemblyInfo]:
+    """Assemble *blocks* within a model-aware token budget, returning the markdown
+    plus a typed ``AssemblyInfo``. Converts the token budget to a char budget for
+    the deterministic char-based ``assemble``; reports actual usage. Never raises —
+    over-budget docs drop whole low-priority sections (``AssemblyInfo.truncated``)."""
+    char_budget = max(1, budget_tokens * _CHARS_PER_TOKEN)
+    text, dropped = assemble(blocks, budget=char_budget, focus=focus)
+    dropped_blocks = sum(d.block_count for d in dropped)
+    info = AssemblyInfo(
+        total_blocks=len(blocks),
+        included_blocks=len(blocks) - dropped_blocks,
+        truncated=bool(dropped),
+        est_tokens=estimate_tokens(text, model_name),
+    )
+    return text, info
+
+
+def blocks_from_plain_text(text: str) -> list[ParsedBlock]:
+    """Wrap pypdf-extracted plain text into per-page ``paragraph`` blocks so the
+    no-blocks fallback flows through the SAME budgeted assembler (never unbounded).
+    Splits on the ``[Page N]`` markers ``PDFProcessor.extract_text`` emits; text
+    with no markers becomes a single page-1 block."""
+    blocks: list[ParsedBlock] = []
+    segments = re.split(r"\[Page (\d+)\]\n", text)
+    # re.split keeps captured groups interleaved: ['', '1', body1, '2', body2, ...]
+    for page_str, body in zip(segments[1::2], segments[2::2], strict=False):
+        stripped = body.strip()
+        if stripped:
+            blocks.append(
+                ParsedBlock(
+                    page_number=int(page_str),
+                    block_index=0,
+                    text=stripped,
+                    char_start=0,
+                    char_end=len(stripped),
+                    bbox={},
+                    block_type="paragraph",
+                )
+            )
+    if not blocks and text.strip():
+        stripped = text.strip()
+        blocks.append(
+            ParsedBlock(
+                page_number=1,
+                block_index=0,
+                text=stripped,
+                char_start=0,
+                char_end=len(stripped),
+                bbox={},
+                block_type="paragraph",
+            )
+        )
+    return blocks

--- a/backend/app/llm/assembler.py
+++ b/backend/app/llm/assembler.py
@@ -32,41 +32,18 @@ section is promoted to rank 0 (highest priority), ahead of Abstract.  All
 other ranks shift down by one.  The ranking is a static look-up — no
 embeddings or ML.
 
-**Table reconstruction**: contiguous ``table_cell`` runs on the same page
-are detected by scanning blocks in reading order.  A run break occurs when a
-non-cell block is encountered OR when the page changes.  Each run is
-serialised as a simple markdown table.  The column count is inferred from the
-first row (the longest prefix of cells before the grid wraps — estimated by
-looking for repeated column-count patterns; if inference fails, all cells
-are placed in a single-column table).
-
-**concat_page_text reuse**: the assembler calls the canonical
-``concat_page_text`` imported from ``app.infrastructure.parsing.base`` to
-produce per-page text strings.  Local copies of the input blocks are built
-so that ``assign_char_offsets_to_blocks`` can mutate them without ever
-touching the caller's ORM objects (which would cause spurious SQLAlchemy
-dirty-tracking and unwanted UPDATEs).  Prose blocks are sourced from the
-canonical surface via ``page_texts[page][cs:ce]``, which is content-identical
-to ``block.text`` by construction but guarantees byte-for-byte alignment with
-what the evidence-anchorer will index.
-
-**Scope**: pure function, no DB, no IO, no globals.  This module is
-intentionally unwired — the call sites in ``section_extraction_service`` and
-``model_extraction_service`` are wired in a separate follow-up task.
+**Scope**: pure function, no DB, no IO, no globals.  Section serialization
+delegates to ``render_blocks_to_markdown`` (one GFM codepath shared with the
+reader).
 """
 
 from __future__ import annotations
 
-import math
 import re
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
-from app.infrastructure.parsing.base import (
-    ParsedBlock,
-    assign_char_offsets_to_blocks,
-    concat_page_text,
-)
+from app.infrastructure.parsing.base import render_blocks_to_markdown
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -84,11 +61,13 @@ class DroppedSection:
             serialised text (including the heading marker).
         rank: The priority rank assigned to this section (lower = higher
             priority, i.e. kept sections have lower rank numbers).
+        block_count: Number of blocks in the dropped section.
     """
 
     title: str
     char_count: int
     rank: int
+    block_count: int
 
 
 # ---------------------------------------------------------------------------
@@ -163,125 +142,19 @@ class _Section:
     blocks: list[_Block] = field(default_factory=list)
 
 
-def _is_chrome(block: _Block) -> bool:
-    """Return True for page chrome blocks (header / footer) that add noise."""
-    return block.block_type in ("header", "footer")
-
-
-# ---------------------------------------------------------------------------
-# Table reconstruction
-# ---------------------------------------------------------------------------
-
-_CELL_SEP = " | "
-_ROW_SEP_CHAR = "-"
-
-
-def _infer_column_count(cell_texts: list[str]) -> int:
-    """Heuristically infer the number of columns in a table.
-
-    Tries column counts from 2 to min(8, n) and picks the one where
-    n % cols == 0 (exact fit) and cols is smallest.  Falls back to 1.
-    """
-    n = len(cell_texts)
-    if n <= 1:
-        return 1
-    for cols in range(2, min(9, n + 1)):
-        if n % cols == 0:
-            return cols
-    # No exact fit — use the square-root heuristic (rounded up), capped at 8
-    return min(8, max(2, math.ceil(math.sqrt(n))))
-
-
-def _render_table(cell_texts: list[str]) -> str:
-    """Render *cell_texts* as a markdown table string."""
-    if not cell_texts:
-        return ""
-    cols = _infer_column_count(cell_texts)
-    rows: list[list[str]] = []
-    for i in range(0, len(cell_texts), cols):
-        row = cell_texts[i : i + cols]
-        # Pad the last row if it is short
-        while len(row) < cols:
-            row.append("")
-        rows.append(row)
-
-    # Compute column widths
-    col_widths = [max(len(r[c]) for r in rows) for c in range(cols)]
-
-    def _fmt_row(row: list[str]) -> str:
-        cells = [r.ljust(w) for r, w in zip(row, col_widths, strict=True)]
-        return "| " + _CELL_SEP.join(cells) + " |"
-
-    def _separator() -> str:
-        return "|-" + "-|-".join(_ROW_SEP_CHAR * w for w in col_widths) + "-|"
-
-    lines = [_fmt_row(rows[0]), _separator()]
-    for row in rows[1:]:
-        lines.append(_fmt_row(row))
-    return "\n".join(lines)
-
-
 # ---------------------------------------------------------------------------
 # Internal: serialize a section's blocks into a text string
 # ---------------------------------------------------------------------------
 
 
-def _serialize_section(
-    section: _Section,
-    page_texts: dict[int, str],
-    offsets: dict[tuple[int, int], tuple[int, int]],
-) -> str:
-    """Serialise *section* into a text string (heading marker + body).
-
-    Prose blocks are sourced from *page_texts* via *offsets* — the canonical
-    surface produced by ``concat_page_text`` — so that the assembler's output
-    is byte-for-byte consistent with what the evidence-anchorer indexes.
-    Table-cell text is taken directly from the block (cells are not indexed by
-    the anchorer via char offsets).
-
-    Args:
-        section: The section to serialise.
-        page_texts: Mapping of ``page_number → concatenated page string``
-            produced by ``concat_page_text`` on local block copies.
-        offsets: Mapping of ``(page_number, block_index) → (char_start, char_end)``
-            derived from ``assign_char_offsets_to_blocks`` on local block copies.
-    """
+def _serialize_section(section: _Section) -> str:
+    """Serialise a section: ``## title`` marker + body via render_blocks_to_markdown."""
     parts: list[str] = []
-
     if section.title:
         parts.append(f"## {section.title}")
-
-    # Walk blocks, coalescing contiguous table_cell runs.
-    # A run breaks when block type changes away from table_cell, or page changes.
-    i = 0
-    blocks = section.blocks
-    while i < len(blocks):
-        block = blocks[i]
-
-        if _is_chrome(block):
-            i += 1
-            continue
-
-        if block.block_type == "table_cell":
-            # Collect the contiguous run — cells use .text directly
-            run: list[str] = []
-            current_page = block.page_number
-            while (
-                i < len(blocks)
-                and blocks[i].block_type == "table_cell"
-                and blocks[i].page_number == current_page
-            ):
-                run.append(blocks[i].text)
-                i += 1
-            parts.append(_render_table(run))
-        else:
-            # Route prose through the canonical surface so offsets align with
-            # what the evidence-anchorer will index in concat_page_text.
-            cs, ce = offsets[(block.page_number, block.block_index)]
-            prose = page_texts[block.page_number][cs:ce]
-            parts.append(prose)
-            i += 1
-
+    body = render_blocks_to_markdown(section.blocks)
+    if body:
+        parts.append(body)
     return "\n".join(parts)
 
 
@@ -360,11 +233,9 @@ def assemble(
 
     Notes:
         - Pure function: no DB, no IO, no globals.
-        - Input blocks are never mutated; local ``ParsedBlock`` copies are used
-          so that ``assign_char_offsets_to_blocks`` does not dirty SQLAlchemy
-          ORM objects.
-        - Prose text is sourced from ``concat_page_text`` (canonical surface)
-          so char offsets match what the evidence-anchorer indexes.
+        - Input blocks are never mutated.
+        - Section body text is produced by ``render_blocks_to_markdown``
+          (ADR-0013: one GFM codepath shared with the reader).
         - ``header`` and ``footer`` blocks are suppressed (page chrome).
         - Contiguous ``table_cell`` blocks on the same page are coalesced into
           a markdown table.
@@ -377,35 +248,13 @@ def assemble(
     # 1. Sort into reading order (page asc, block_index asc).
     sorted_blocks: list[_Block] = sorted(blocks, key=lambda b: (b.page_number, b.block_index))
 
-    # 2. Build local ParsedBlock copies so assign_char_offsets_to_blocks can
-    #    mutate them without ever touching the caller's ORM objects.
-    copies = [
-        ParsedBlock(
-            page_number=b.page_number,
-            block_index=b.block_index,
-            text=b.text,
-            char_start=0,
-            char_end=0,
-            bbox=getattr(b, "bbox", {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}),
-            block_type=b.block_type,
-        )
-        for b in sorted_blocks
-    ]
-    assign_char_offsets_to_blocks(copies)  # mutates the COPIES only
-    page_texts = concat_page_text(copies)  # canonical per-page text
-    offsets: dict[tuple[int, int], tuple[int, int]] = {
-        (c.page_number, c.block_index): (c.char_start, c.char_end) for c in copies
-    }
-
-    # 3. Segment into sections.
+    # 2. Segment into sections.
     sections = _segment_into_sections(sorted_blocks, focus)
 
-    # 4. Serialise each section to compute its character cost.
-    serialised: list[tuple[_Section, str]] = [
-        (sec, _serialize_section(sec, page_texts, offsets)) for sec in sections
-    ]
+    # 3. Serialise each section to compute its character cost.
+    serialised: list[tuple[_Section, str]] = [(sec, _serialize_section(sec)) for sec in sections]
 
-    # 5. Check if everything fits within budget.
+    # 4. Check if everything fits within budget.
     #    Join with double newline between sections.
     separator = "\n\n"
     full_text_parts = [text for _, text in serialised if text]
@@ -414,7 +263,7 @@ def assemble(
     if len(full_text) <= budget:
         return full_text, []
 
-    # 6. Over budget: select whole sections greedily, highest priority first.
+    # 5. Over budget: select whole sections greedily, highest priority first.
     #    Within the same rank, preserve original document order (stable sort).
     #    We keep track of original indices so we can reconstruct document order
     #    for kept sections.
@@ -442,10 +291,11 @@ def assemble(
                     title=sec.title or "<preamble>",
                     char_count=len(text),
                     rank=sec.rank,
+                    block_count=len(sec.blocks),
                 )
             )
 
-    # 7. Reconstruct in original document order.
+    # 6. Reconstruct in original document order.
     kept_parts = [text for i, _, text in indexed if i in kept_indices]
     result_text = separator.join(kept_parts)
 

--- a/backend/app/llm/prompts/__init__.py
+++ b/backend/app/llm/prompts/__init__.py
@@ -8,9 +8,6 @@ every production trace resolves to an exact git version of the prompt.
 
 import hashlib
 
-# Truncation budget carried over from the legacy prompts.
-MAX_PDF_CHARS = 15_000
-
 
 def content_version(*parts: str) -> str:
     digest = hashlib.sha256("\n---\n".join(parts).encode("utf-8")).hexdigest()

--- a/backend/app/llm/prompts/model_identification.py
+++ b/backend/app/llm/prompts/model_identification.py
@@ -6,7 +6,7 @@ the container's children."""
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.llm.prompts import MAX_PDF_CHARS, content_version
+from app.llm.prompts import content_version
 
 NAME = "model_identification"
 
@@ -44,5 +44,5 @@ VERSION = content_version(SYSTEM_PROMPT, _USER_TEMPLATE)
 def render(*, container_label: str, article_text: str) -> str:
     return _USER_TEMPLATE.format(
         container_label=container_label,
-        article_text=article_text[:MAX_PDF_CHARS],
+        article_text=article_text,
     )

--- a/backend/app/llm/prompts/quality_assessment.py
+++ b/backend/app/llm/prompts/quality_assessment.py
@@ -2,7 +2,7 @@
 (PROBAST / QUADAS-2). Same response shape as section extraction so the
 downstream proposal writes are identical."""
 
-from app.llm.prompts import MAX_PDF_CHARS, content_version, render_memory_section
+from app.llm.prompts import content_version, render_memory_section
 
 NAME = "quality_assessment"
 
@@ -54,5 +54,5 @@ def render(
         entity_name=entity_name,
         entity_description=entity_description,
         memory_section=render_memory_section(memory_context),
-        article_text=article_text[:MAX_PDF_CHARS],
+        article_text=article_text,
     )

--- a/backend/app/llm/prompts/section_extraction.py
+++ b/backend/app/llm/prompts/section_extraction.py
@@ -1,6 +1,6 @@
 """Prompt for extracting one template section from an article."""
 
-from app.llm.prompts import MAX_PDF_CHARS, content_version, render_memory_section
+from app.llm.prompts import content_version, render_memory_section
 
 NAME = "section_extraction"
 
@@ -39,5 +39,5 @@ def render(
         entity_name=entity_name,
         entity_description=entity_description,
         memory_section=render_memory_section(memory_context),
-        article_text=article_text[:MAX_PDF_CHARS],
+        article_text=article_text,
     )

--- a/backend/app/schemas/extraction.py
+++ b/backend/app/schemas/extraction.py
@@ -12,6 +12,25 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.core.config import settings
 
+# =================== INTERNAL ASSEMBLY SCHEMAS ===================
+
+
+class AssemblyInfo(BaseModel):
+    """Internal (non-API) record for one prompt assembly — logged per run for
+    token/cost observability and to surface windowing overflow.
+
+    Deliberately NOT referenced by any endpoint response model, so it never
+    enters the OpenAPI/schema.d.ts contract.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    total_blocks: int
+    included_blocks: int
+    truncated: bool
+    est_tokens: int
+
+
 # =================== COMMON SCHEMAS ===================
 
 

--- a/backend/app/services/extraction_prompt_input.py
+++ b/backend/app/services/extraction_prompt_input.py
@@ -28,7 +28,7 @@ async def build_prompt_input(
     article_id: UUID,
     model: str,
     logger: Any,
-) -> tuple[str, list, UUID | None]:
+) -> tuple[str, list[Any], UUID | None]:
     """Return ``(markdown, anchor_blocks, anchor_file_id)`` for *article_id*.
 
     Uses persisted ``article_text_blocks`` when present; otherwise wraps pypdf
@@ -37,13 +37,13 @@ async def build_prompt_input(
     evidence anchoring (no second fetch).
     """
     main_file = await article_files.get_latest_pdf(article_id)
-    blocks: list = (
+    blocks: list[Any] = (
         await ArticleTextBlockRepository(db).list_ordered_for_file(main_file.id)
         if main_file is not None
         else []
     )
     anchor_file_id = main_file.id if main_file is not None else None
-    source = (
+    source: list[Any] = (
         blocks
         if blocks
         else blocks_from_plain_text(await pdf_processor.extract_text(await get_pdf(article_id)))

--- a/backend/app/services/extraction_prompt_input.py
+++ b/backend/app/services/extraction_prompt_input.py
@@ -1,0 +1,62 @@
+"""Shared orchestrator: build the budgeted block-markdown prompt input for a run.
+
+Service layer (touches the article_text_blocks repository); the assembler it
+calls stays pure. Both ``section_extraction_service`` and
+``model_extraction_service`` call this so the fetch-once / assemble-once / budget
+logic lives in exactly one place (keeps both god-files lean).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.llm.assembler import assemble_for_model, blocks_from_plain_text
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+
+
+async def build_prompt_input(
+    *,
+    db: AsyncSession,
+    article_files: Any,
+    pdf_processor: Any,
+    get_pdf: Callable[[UUID], Awaitable[bytes]],
+    article_id: UUID,
+    model: str,
+    logger: Any,
+) -> tuple[str, list, UUID | None]:
+    """Return ``(markdown, anchor_blocks, anchor_file_id)`` for *article_id*.
+
+    Uses persisted ``article_text_blocks`` when present; otherwise wraps pypdf
+    text into synthetic blocks through the SAME budgeted assembler so no path
+    ever sends unbounded text. ``anchor_blocks`` is reused by the caller for
+    evidence anchoring (no second fetch).
+    """
+    main_file = await article_files.get_latest_pdf(article_id)
+    blocks: list = (
+        await ArticleTextBlockRepository(db).list_ordered_for_file(main_file.id)
+        if main_file is not None
+        else []
+    )
+    anchor_file_id = main_file.id if main_file is not None else None
+    source = (
+        blocks
+        if blocks
+        else blocks_from_plain_text(await pdf_processor.extract_text(await get_pdf(article_id)))
+    )
+    text, info = assemble_for_model(
+        source, model_name=model, budget_tokens=settings.LLM_ASSEMBLY_BUDGET_TOKENS
+    )
+    logger.info(
+        "extraction.assembly",
+        article_id=str(article_id),
+        total_blocks=info.total_blocks,
+        included_blocks=info.included_blocks,
+        truncated=info.truncated,
+        est_tokens=info.est_tokens,
+    )
+    return text, blocks, anchor_file_id

--- a/backend/app/services/model_extraction_service.py
+++ b/backend/app/services/model_extraction_service.py
@@ -35,6 +35,7 @@ from app.repositories import (
     ExtractionTemplateRepository,
     GlobalTemplateRepository,
 )
+from app.services.extraction_prompt_input import build_prompt_input
 from app.services.pdf_processor import PDFProcessor
 from app.services.run_lifecycle_service import RunLifecycleService
 
@@ -150,15 +151,18 @@ class ModelExtractionService(LoggerMixin):
         )
 
         try:
-            # 2. Fetch PDF
+            # 2-3. Assemble budgeted block-markdown prompt input (pypdf fallback inside).
             phase_start = perf_counter()
-            pdf_data = await self._get_pdf(article_id)
-            phase_durations_ms["fetch_pdf"] = (perf_counter() - phase_start) * 1000
-
-            # 3. Processar texto do PDF
-            phase_start = perf_counter()
-            pdf_text = await self.pdf_processor.extract_text(pdf_data)
-            phase_durations_ms["extract_pdf_text"] = (perf_counter() - phase_start) * 1000
+            pdf_text, _, _ = await build_prompt_input(
+                db=self.db,
+                article_files=self._article_files,
+                pdf_processor=self.pdf_processor,
+                get_pdf=self._get_pdf,
+                article_id=article_id,
+                model=model,
+                logger=self.logger,
+            )
+            phase_durations_ms["assemble_prompt"] = (perf_counter() - phase_start) * 1000
 
             # 4. Fetch template and entity types
             phase_start = perf_counter()

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -47,8 +47,8 @@ from app.repositories import (
     ExtractionInstanceRepository,
     ExtractionRunRepository,
 )
-from app.repositories.article_text_block_repository import ArticleTextBlockRepository
 from app.services.evidence_anchor_service import build_anchor
+from app.services.extraction_prompt_input import build_prompt_input
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.pdf_processor import PDFProcessor
 from app.services.run_lifecycle_service import RunLifecycleService
@@ -131,6 +131,23 @@ class SectionExtractionService(LoggerMixin):
         self._lifecycle = RunLifecycleService(db)
         # Proposal service: append-only writes to extraction_proposal_records.
         self._proposals = ExtractionProposalService(db)
+        # Run-scoped anchor stash: populated once per run by build_prompt_input,
+        # reused by _create_suggestions for evidence anchoring (no second fetch).
+        self._run_anchor_blocks: list = []
+        self._run_anchor_file_id: UUID | None = None
+
+    async def _assemble_prompt_text(self, article_id: UUID, model: str) -> str:
+        """Budgeted block-markdown prompt input; stashes run anchor blocks on self."""
+        text, self._run_anchor_blocks, self._run_anchor_file_id = await build_prompt_input(
+            db=self.db,
+            article_files=self._article_files,
+            pdf_processor=self.pdf_processor,
+            get_pdf=self._get_pdf,
+            article_id=article_id,
+            model=model,
+            logger=self.logger,
+        )
+        return text
 
     async def extract_section(
         self,
@@ -210,15 +227,10 @@ class SectionExtractionService(LoggerMixin):
         )
 
         try:
-            # 2. Fetch PDF
+            # 2-3. Assemble budgeted block-markdown prompt input (pypdf fallback inside).
             phase_start = perf_counter()
-            pdf_data = await self._get_pdf(article_id)
-            phase_durations_ms["fetch_pdf"] = (perf_counter() - phase_start) * 1000
-
-            # 3. Process text
-            phase_start = perf_counter()
-            pdf_text = await self.pdf_processor.extract_text(pdf_data)
-            phase_durations_ms["extract_pdf_text"] = (perf_counter() - phase_start) * 1000
+            pdf_text = await self._assemble_prompt_text(article_id, model)
+            phase_durations_ms["assemble_prompt"] = (perf_counter() - phase_start) * 1000
 
             # 4. Fetch entity type and fields
             phase_start = perf_counter()
@@ -383,8 +395,7 @@ class SectionExtractionService(LoggerMixin):
         failed = 0
 
         try:
-            pdf_data = await self._get_pdf(run.article_id)
-            pdf_text = await self.pdf_processor.extract_text(pdf_data)
+            pdf_text = await self._assemble_prompt_text(run.article_id, model)
 
             top_level = await self._top_level_entity_types_for_template(run.template_id)
 
@@ -743,14 +754,11 @@ class SectionExtractionService(LoggerMixin):
         total_tokens = 0
 
         try:
-            # 1. Fetch/process PDF (once)
+            # 1. Assemble block-markdown prompt input once per run.
             if not pdf_text:
                 phase_start = perf_counter()
-                pdf_data = await self._get_pdf(article_id)
-                pdf_text = await self.pdf_processor.extract_text(pdf_data)
-                phase_durations_ms["fetch_and_extract_pdf_text"] = (
-                    perf_counter() - phase_start
-                ) * 1000
+                pdf_text = await self._assemble_prompt_text(article_id, model)
+                phase_durations_ms["assemble_prompt"] = (perf_counter() - phase_start) * 1000
 
             # 2. Fetch child entity types
             phase_start = perf_counter()
@@ -1303,22 +1311,10 @@ class SectionExtractionService(LoggerMixin):
                 entity_type_id=str(entity_type_id),
             )
 
-        # Resolve the article's main PDF file and its text blocks once, so
-        # build_anchor can ground each evidence quote to a PositionV1 anchor.
-        # Guard: missing main file or no blocks → empty list; safe fallback
-        # keeps position={} and the LLM's page_number (no exception raised).
-        _anchor_blocks: list = []
-        _anchor_file_id: UUID | None = None
-        try:
-            _main_file = await self._article_files.get_latest_pdf(article_id)
-            if _main_file is not None:
-                _anchor_file_id = _main_file.id
-                _anchor_blocks = await ArticleTextBlockRepository(self.db).list_ordered_for_file(
-                    _main_file.id
-                )
-        except Exception:
-            _anchor_blocks = []
-            _anchor_file_id = None
+        # Blocks were fetched once per run by _assemble_prompt_text; reuse them here
+        # to ground each evidence quote to a PositionV1 anchor (empty → position={}).
+        _anchor_blocks = self._run_anchor_blocks
+        _anchor_file_id = self._run_anchor_file_id
 
         # Record one ProposalRecord per extracted field. Evidence cited by
         # the LLM is stored as a real extraction_evidence row linked to

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -759,6 +759,9 @@ class SectionExtractionService(LoggerMixin):
                 phase_start = perf_counter()
                 pdf_text = await self._assemble_prompt_text(article_id, model)
                 phase_durations_ms["assemble_prompt"] = (perf_counter() - phase_start) * 1000
+            elif not self._run_anchor_blocks:
+                # pdf_text supplied → assembly skipped; still populate anchor stash.
+                await self._assemble_prompt_text(article_id, model)
 
             # 2. Fetch child entity types
             phase_start = perf_counter()

--- a/backend/tests/integration/test_extraction_block_chain.py
+++ b/backend/tests/integration/test_extraction_block_chain.py
@@ -1,0 +1,146 @@
+"""Full-chain integration test (spec item #10): persisted blocks → assemble
+(no 15k cut) → anchor → citation read.
+
+Proves the A1 win on REAL persisted blocks read through the production repository:
+content that lies *past* the legacy 15,000-char truncation survives assembly, and
+the model's verbatim quote from that post-15k block anchors back to the correct
+block and reads back through ``citation_read_service``.
+
+The anchor write/read primitives (TextCitationAnchor, camelCase round-trip,
+verified flag) are exhaustively covered in ``test_position_v1_anchoring.py``;
+this test reuses its helpers and focuses on the new ``assemble → anchor`` seam.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infrastructure.parsing.base import ParsedBlock
+from app.llm.assembler import assemble_for_model
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+from app.schemas.extraction import PositionV1, TextCitationAnchor
+from app.services.citation_read_service import list_article_citations
+from app.services.evidence_anchor_service import build_anchor
+from tests.integration.conftest import SEED
+from tests.integration.test_position_v1_anchoring import (
+    _cleanup_file,
+    _insert_article_file,
+    _insert_run_and_proposal,
+)
+
+_BBOX = {"x": 0.0, "y": 0.0, "width": 400.0, "height": 12.0}
+
+
+@pytest.mark.asyncio
+async def test_post_15k_block_assembles_and_anchors_and_reads_back(
+    db_session_real: AsyncSession,
+) -> None:
+    # Fresh article so evidence/run cleanup never collides with seed or sibling tests.
+    article_id = uuid.uuid4()
+    await db_session_real.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, :title, 1)"
+        ),
+        {"id": str(article_id), "pid": str(SEED.primary_project), "title": "A1 block-chain test"},
+    )
+    await db_session_real.commit()
+
+    file_id = await _insert_article_file(
+        db_session_real, project_id=SEED.primary_project, article_id=article_id
+    )
+    quote = "The C-index was 0.81 (95% CI 0.78-0.84) in the validation cohort."
+    try:
+        # Page 1: ~17k chars of filler (heading + long paragraph). Page 2: the
+        # quotable target — content that lies PAST the legacy 15k prefix cut.
+        filler = "Background and prior work. " * 640  # ~17,280 chars
+        repo = ArticleTextBlockRepository(db_session_real)
+        await repo.replace_for_file(
+            file_id,
+            [
+                ParsedBlock(1, 0, "Introduction", 0, len("Introduction"), _BBOX, "heading"),
+                ParsedBlock(1, 1, filler, 0, len(filler), _BBOX, "paragraph"),
+                ParsedBlock(2, 0, "Results", 0, len("Results"), _BBOX, "heading"),
+                ParsedBlock(2, 1, quote, 0, len(quote), _BBOX, "paragraph"),
+            ],
+        )
+        await db_session_real.commit()
+
+        blocks = await repo.list_ordered_for_file(file_id)
+        assert len(blocks) == 4
+
+        # 1. Assemble: the post-15k quote MUST survive (the 15k truncation is gone).
+        markdown, info = assemble_for_model(blocks, model_name="gpt-4o-mini", budget_tokens=96_000)
+        assert quote in markdown, "post-15k content must survive assembly (no truncation)"
+        assert info.truncated is False
+        assert info.total_blocks == 4
+
+        # 2. Anchor: the verbatim quote maps back to the correct (page-2) block.
+        pos = build_anchor(quote, blocks)
+        assert pos is not None and isinstance(pos, PositionV1)
+        assert isinstance(pos.anchor, TextCitationAnchor)
+        assert pos.anchor.range.page == 2
+        assert pos.anchor.quote == quote
+        # The anchored char range slices back to the quote in page-2's concatenated text.
+        page2 = "\n".join(b.text for b in blocks if b.page_number == 2)
+        assert page2[pos.anchor.range.char_start : pos.anchor.range.char_end] == quote
+
+        # 3. Persist evidence and read it back through citation_read_service.
+        run_id, proposal_id = await _insert_run_and_proposal(
+            db_session_real, project_id=SEED.primary_project, article_id=article_id
+        )
+        dumped = pos.model_dump(by_alias=True, mode="json")
+        evidence_id = uuid.uuid4()
+        await db_session_real.execute(
+            text(
+                "INSERT INTO public.extraction_evidence "
+                "(id, project_id, article_id, article_file_id, run_id, proposal_record_id, "
+                " page_number, text_content, position, created_by) "
+                "VALUES (:id, :pid, :aid, :fid, :rid, :propid, :pg, :tc, CAST(:pos AS jsonb), :cb)"
+            ),
+            {
+                "id": str(evidence_id),
+                "pid": str(SEED.primary_project),
+                "aid": str(article_id),
+                "fid": str(file_id),
+                "rid": str(run_id),
+                "propid": str(proposal_id),
+                "pg": pos.anchor.range.page,
+                "tc": quote,
+                "pos": json.dumps(dumped),
+                "cb": str(SEED.primary_profile),
+            },
+        )
+        await db_session_real.commit()
+
+        citations = await list_article_citations(db_session_real, article_id)
+        assert len(citations) == 1
+        c = citations[0]
+        assert c["id"] == str(evidence_id)
+        assert c["verified"] is True
+        assert c["anchorKind"] == "text"
+        assert c["anchor"]["range"]["charStart"] == pos.anchor.range.char_start
+        assert c["anchor"]["range"]["charEnd"] == pos.anchor.range.char_end
+        assert c["metadata"]["textContent"] == quote
+    finally:
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_evidence WHERE article_id = :aid"),
+            {"aid": str(article_id)},
+        )
+        await db_session_real.commit()
+        await db_session_real.execute(
+            text("DELETE FROM public.extraction_runs WHERE article_id = :aid"),
+            {"aid": str(article_id)},
+        )
+        await db_session_real.commit()
+        await _cleanup_file(db_session_real, file_id=file_id)
+        await db_session_real.execute(
+            text("DELETE FROM public.articles WHERE id = :id"),
+            {"id": str(article_id)},
+        )
+        await db_session_real.commit()

--- a/backend/tests/unit/llm/test_prompts.py
+++ b/backend/tests/unit/llm/test_prompts.py
@@ -1,4 +1,4 @@
-"""Prompt templates: rendering, truncation, and stable content versions."""
+"""Prompt templates: rendering (full-text, no truncation) and stable content versions."""
 
 from app.llm.prompts import (
     content_version,

--- a/backend/tests/unit/llm/test_prompts.py
+++ b/backend/tests/unit/llm/test_prompts.py
@@ -1,7 +1,6 @@
 """Prompt templates: rendering, truncation, and stable content versions."""
 
 from app.llm.prompts import (
-    MAX_PDF_CHARS,
     content_version,
     model_identification,
     quality_assessment,
@@ -33,17 +32,17 @@ def test_memory_section_empty_and_populated():
     assert "PREVIOUSLY EXTRACTED SECTIONS" in rendered
 
 
-def test_section_extraction_render_includes_context_and_truncates():
+def test_section_extraction_render_includes_context_and_full_text():
     prompt = section_extraction.render(
         entity_name="Population",
         entity_description="Who was studied",
-        article_text="§" * (MAX_PDF_CHARS + 5000),
+        article_text="§" * 20_000,
         memory_context=[{"entity_type_name": "Methods", "summary": "RCT"}],
     )
     assert "Section: Population" in prompt
     assert "Who was studied" in prompt
     assert "1. Methods: RCT" in prompt
-    assert prompt.count("§") == MAX_PDF_CHARS
+    assert prompt.count("§") == 20_000  # no truncation — assembler owns the budget
 
 
 def test_quality_assessment_render_mentions_framework():
@@ -62,10 +61,10 @@ def test_quality_assessment_render_mentions_framework():
 
 def test_model_identification_render_and_output_model():
     prompt = model_identification.render(
-        container_label="prediction models", article_text="§" * (MAX_PDF_CHARS + 10)
+        container_label="prediction models", article_text="§" * 20_000
     )
     assert "prediction models" in prompt
-    assert prompt.count("§") == MAX_PDF_CHARS
+    assert prompt.count("§") == 20_000  # no truncation
     output = model_identification.ModelIdentificationOutput.model_validate(
         {"models": [{"name": "Cox model"}]}
     )

--- a/backend/tests/unit/services/test_batch_failclosed.py
+++ b/backend/tests/unit/services/test_batch_failclosed.py
@@ -32,6 +32,8 @@ async def test_extract_for_run_raises_when_all_sections_fail():
     )
     svc._get_pdf = AsyncMock(return_value=b"%PDF")
     svc.pdf_processor = SimpleNamespace(extract_text=AsyncMock(return_value="text"))
+    # build_prompt_input fetches the latest PDF file first; no blocks → pypdf fallback.
+    svc._article_files = SimpleNamespace(get_latest_pdf=AsyncMock(return_value=None))
     entity_type = SimpleNamespace(id="e1", name="Sec")
     svc._top_level_entity_types_for_template = AsyncMock(return_value=[entity_type])
     # Every entity-type extraction fails -> successful == 0.

--- a/backend/tests/unit/test_assembler.py
+++ b/backend/tests/unit/test_assembler.py
@@ -9,7 +9,8 @@ Tests cover:
   no mid-section/mid-table cut.
 - In-budget: nothing past a naive 15k char cut is silently lost.
 - Optional ``focus`` hint biases section priority deterministically.
-- Prose routes through canonical concat_page_text surface.
+- Prose equals block.text (== the canonical concat_page_text slice by construction);
+  serialization now delegates to render_blocks_to_markdown.
 - Input blocks are never mutated by assemble().
 - Over-budget fallback pops WHOLE sections (never string-splits on separator).
 """

--- a/backend/tests/unit/test_assembler.py
+++ b/backend/tests/unit/test_assembler.py
@@ -19,7 +19,14 @@ from app.infrastructure.parsing.base import (
     assign_char_offsets_to_blocks,
     concat_page_text,
 )
-from app.llm.assembler import DroppedSection, assemble
+from app.llm.assembler import (
+    DroppedSection,
+    assemble,
+    assemble_for_model,
+    blocks_from_plain_text,
+    estimate_tokens,
+)
+from app.schemas.extraction import AssemblyInfo
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -509,3 +516,69 @@ class TestCanonicalSurface:
             assert b.char_end == original_ends[i], (
                 f"Block {i} char_end was mutated: {original_ends[i]} → {b.char_end}"
             )
+
+
+# ---------------------------------------------------------------------------
+# 8. Model-aware assemble wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleForModel:
+    def _imrad(self) -> list[ParsedBlock]:
+        return [
+            _b(1, 0, "Abstract", "heading"),
+            _b(1, 1, "A" * 400, "paragraph"),
+            _b(2, 0, "Results", "heading"),
+            _b(2, 1, "B" * 400, "paragraph"),
+            _b(3, 0, "References", "heading"),
+            _b(3, 1, "C" * 400, "paragraph"),
+        ]
+
+    def test_returns_markdown_and_assembly_info(self) -> None:
+        text, info = assemble_for_model(
+            self._imrad(), model_name="gpt-4o-mini", budget_tokens=100_000
+        )
+        assert isinstance(info, AssemblyInfo)
+        assert info.truncated is False
+        assert info.total_blocks == 6
+        assert info.included_blocks == 6
+        assert info.est_tokens > 0
+        assert "Abstract" in text and "Results" in text
+
+    def test_truncated_flag_set_when_over_budget(self) -> None:
+        # budget_tokens * 4 chars must be smaller than the full doc (~1.2k chars)
+        text, info = assemble_for_model(self._imrad(), model_name="gpt-4o-mini", budget_tokens=120)
+        assert info.truncated is True
+        assert info.included_blocks < info.total_blocks
+        assert len(text) <= 120 * 4
+
+    def test_est_tokens_uses_tiktoken_for_openai(self) -> None:
+        # tiktoken counts real tokens; a 400-char ASCII run is far fewer than 400 tokens.
+        n = estimate_tokens("word " * 400, "gpt-4o-mini")
+        assert 300 < n < 500
+
+    def test_heuristic_skew_for_anthropic_model(self) -> None:
+        # Anthropic models are not encodable by tiktoken → char/4 heuristic. Document
+        # the skew: the heuristic differs from the OpenAI tokeniser for the same text.
+        text = "Heterogeneous clinical-trial endpoints, n=412 (95% CI)."
+        heuristic = estimate_tokens(text, "claude-opus-4-8")  # falls back to len//4
+        assert heuristic == max(1, len(text) // 4)
+        openai = estimate_tokens(text, "gpt-4o-mini")
+        assert heuristic != openai  # documented skew between heuristic and tiktoken
+
+    def test_blocks_from_plain_text_splits_on_page_markers(self) -> None:
+        blocks = blocks_from_plain_text("[Page 1]\nIntro text.\n\n[Page 2]\nMethods text.")
+        assert [b.page_number for b in blocks] == [1, 2]
+        assert blocks[0].text == "Intro text." and blocks[0].block_type == "paragraph"
+
+    def test_blocks_from_plain_text_no_markers_single_block(self) -> None:
+        blocks = blocks_from_plain_text("just some flat text")
+        assert len(blocks) == 1 and blocks[0].page_number == 1
+
+    def test_fallback_text_flows_through_same_budgeted_assembler(self) -> None:
+        # A long marker-less pypdf string, wrapped + budgeted, never returns unbounded.
+        text, info = assemble_for_model(
+            blocks_from_plain_text("X" * 5000), model_name="gpt-4o-mini", budget_tokens=100
+        )
+        assert len(text) <= 100 * 4
+        assert info.truncated is True

--- a/backend/tests/unit/test_assembler.py
+++ b/backend/tests/unit/test_assembler.py
@@ -19,7 +19,7 @@ from app.infrastructure.parsing.base import (
     assign_char_offsets_to_blocks,
     concat_page_text,
 )
-from app.services.extraction_block_assembler import DroppedSection, assemble
+from app.llm.assembler import DroppedSection, assemble
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/backend/tests/unit/test_extraction_prompt_input.py
+++ b/backend/tests/unit/test_extraction_prompt_input.py
@@ -1,0 +1,66 @@
+"""Unit tests for build_prompt_input — the two extraction text-source paths."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.infrastructure.parsing.base import ParsedBlock
+from app.services.extraction_prompt_input import build_prompt_input
+
+_EP = "app.services.extraction_prompt_input"
+
+
+def _block(page, idx, text, bt="paragraph"):
+    return ParsedBlock(page, idx, text, 0, len(text), {}, bt)
+
+
+@pytest.mark.asyncio
+async def test_uses_blocks_when_present(monkeypatch) -> None:
+    aid, fid = uuid4(), uuid4()
+    main_file = SimpleNamespace(id=fid)
+    article_files = MagicMock()
+    article_files.get_latest_pdf = AsyncMock(return_value=main_file)
+    repo = MagicMock()
+    repo.list_ordered_for_file = AsyncMock(
+        return_value=[_block(1, 0, "Results", "heading"), _block(1, 1, "Effect size 0.81.")]
+    )
+    monkeypatch.setattr(f"{_EP}.ArticleTextBlockRepository", lambda _db: repo)
+    pdf_processor = MagicMock()
+    pdf_processor.extract_text = AsyncMock()  # must NOT be called on the blocks path
+
+    text, blocks, file_id = await build_prompt_input(
+        db=AsyncMock(),
+        article_files=article_files,
+        pdf_processor=pdf_processor,
+        get_pdf=AsyncMock(),
+        article_id=aid,
+        model="gpt-4o-mini",
+        logger=MagicMock(),
+    )
+    assert "## Results" in text and "Effect size 0.81." in text
+    assert file_id == fid and len(blocks) == 2
+    pdf_processor.extract_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_pypdf_when_no_blocks() -> None:
+    aid = uuid4()
+    article_files = MagicMock()
+    article_files.get_latest_pdf = AsyncMock(return_value=None)  # no PDF file row → no blocks
+    pdf_processor = MagicMock()
+    pdf_processor.extract_text = AsyncMock(return_value="[Page 1]\nFallback body text.")
+
+    text, blocks, file_id = await build_prompt_input(
+        db=AsyncMock(),
+        article_files=article_files,
+        pdf_processor=pdf_processor,
+        get_pdf=AsyncMock(return_value=b"%PDF"),
+        article_id=aid,
+        model="gpt-4o-mini",
+        logger=MagicMock(),
+    )
+    assert "Fallback body text." in text
+    assert blocks == [] and file_id is None
+    pdf_processor.extract_text.assert_awaited_once()

--- a/backend/tests/unit/test_model_extraction_service.py
+++ b/backend/tests/unit/test_model_extraction_service.py
@@ -51,6 +51,7 @@ def service(mock_db, mock_storage):
         ) as mock_instance_repo,
         patch("app.services.model_extraction_service.ExtractionRunRepository") as mock_run_repo,
         patch("app.services.model_extraction_service.RunLifecycleService") as mock_lifecycle_cls,
+        patch("app.services.extraction_prompt_input.ArticleTextBlockRepository") as mock_block_repo,
     ):
         mock_pdf_instance = MagicMock()
         mock_pdf.return_value = mock_pdf_instance
@@ -83,6 +84,10 @@ def service(mock_db, mock_storage):
         mock_lifecycle_instance.advance_stage = AsyncMock()
         mock_lifecycle_cls.return_value = mock_lifecycle_instance
 
+        # build_prompt_input fetches blocks; return none so the flow falls back
+        # to the per-test extract_text mock (no blocks for the article).
+        mock_block_repo.return_value.list_ordered_for_file = AsyncMock(return_value=[])
+
         svc = ModelExtractionService(
             db=mock_db,
             user_id="12345678-1234-1234-1234-123456789012",
@@ -98,7 +103,10 @@ def service(mock_db, mock_storage):
         svc._runs = mock_run_repo_instance
         svc._lifecycle = mock_lifecycle_instance
 
-        return svc
+        # yield (not return) so the patches above — notably the runtime-resolved
+        # ArticleTextBlockRepository used by build_prompt_input — stay active
+        # during the test, not just during construction.
+        yield svc
 
 
 class TestModelExtractionPDF:
@@ -605,3 +613,31 @@ class TestFullExtractionFlow:
 
         assert result.total_models == 0
         assert result.models_created == []
+
+
+@pytest.mark.asyncio
+async def test_identify_models_sends_full_text_no_truncation(service):
+    """model_identification consumes the full assembled text — the legacy 15k
+    truncation is gone (A1); _identify_models threads article_text verbatim."""
+    captured: dict[str, str] = {}
+
+    async def _fake_extract(**kwargs):
+        captured["user_prompt"] = kwargs["user_prompt"]
+        output = MagicMock()
+        output.models = []
+        return output, MagicMock()
+
+    long_text = "MODEL_SECTION_MARKER\n" + ("token " * 8000)  # far over the old 15k chars
+    template = MagicMock()
+    template.id = "tpl"
+    template.entity_types = []
+
+    with (
+        patch("app.services.model_extraction_service.extract_structured", _fake_extract),
+        patch("app.services.model_extraction_service.build_model", return_value=MagicMock()),
+    ):
+        models, _ = await service._identify_models(long_text, template, "gpt-4o-mini")
+
+    assert models == []
+    assert "MODEL_SECTION_MARKER" in captured["user_prompt"]
+    assert long_text in captured["user_prompt"]  # full text present — no prefix cut

--- a/backend/tests/unit/test_parsing_base.py
+++ b/backend/tests/unit/test_parsing_base.py
@@ -20,6 +20,7 @@ from app.infrastructure.parsing.base import (
     assign_char_offsets_to_blocks,
     concat_page_text,
     normalize_block_type,
+    render_blocks_to_markdown,
 )
 
 # ---------------------------------------------------------------------------
@@ -303,3 +304,68 @@ class TestDocumentParserABC:
         parser = ConcreteParser()
         result = parser.parse(b"")
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# render_blocks_to_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestRenderBlocksToMarkdown:
+    def _b(self, page, idx, text, block_type="paragraph"):
+        return ParsedBlock(
+            page_number=page,
+            block_index=idx,
+            text=text,
+            char_start=0,
+            char_end=len(text),
+            bbox={},
+            block_type=block_type,
+        )
+
+    def test_reading_order_across_pages(self) -> None:
+        md = render_blocks_to_markdown([self._b(2, 0, "Second page"), self._b(1, 0, "First page")])
+        assert md.index("First page") < md.index("Second page")
+
+    def test_heading_becomes_h2_marker(self) -> None:
+        md = render_blocks_to_markdown([self._b(1, 0, "Methods", "heading")])
+        assert "## Methods" in md
+
+    def test_list_item_becomes_bullet(self) -> None:
+        md = render_blocks_to_markdown([self._b(1, 0, "first point", "list_item")])
+        assert "- first point" in md
+
+    def test_header_footer_chrome_suppressed(self) -> None:
+        md = render_blocks_to_markdown(
+            [
+                self._b(1, 0, "Journal Name", "header"),
+                self._b(1, 1, "Real content.", "paragraph"),
+                self._b(1, 2, "Page 1 of 9", "footer"),
+            ]
+        )
+        assert "Real content." in md
+        assert "Journal Name" not in md
+        assert "Page 1 of 9" not in md
+
+    def test_contiguous_cells_render_as_gfm_table(self) -> None:
+        md = render_blocks_to_markdown(
+            [
+                self._b(1, 0, "Name", "table_cell"),
+                self._b(1, 1, "Age", "table_cell"),
+                self._b(1, 2, "Alice", "table_cell"),
+                self._b(1, 3, "30", "table_cell"),
+            ]
+        )
+        assert "| Name" in md and "| Alice" in md
+        assert "|-" in md  # a GFM separator row exists
+
+    def test_figure_caption_is_plain_text(self) -> None:
+        md = render_blocks_to_markdown([self._b(1, 0, "Figure 1. Flowchart.", "figure_caption")])
+        assert md == "Figure 1. Flowchart."
+
+    def test_deterministic(self) -> None:
+        blocks = [self._b(1, 1, "B"), self._b(1, 0, "A", "heading")]
+        assert render_blocks_to_markdown(blocks) == render_blocks_to_markdown(blocks)
+
+    def test_empty_input_returns_empty_string(self) -> None:
+        assert render_blocks_to_markdown([]) == ""

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -40,9 +40,7 @@ def service(mock_db, mock_storage):
     with (
         patch("app.services.section_extraction_service.PDFProcessor") as mock_pdf,
         patch("app.services.section_extraction_service.ArticleFileRepository") as mock_article_repo,
-        patch(
-            "app.services.section_extraction_service.ArticleTextBlockRepository"
-        ) as mock_block_repo,
+        patch("app.services.extraction_prompt_input.ArticleTextBlockRepository") as mock_block_repo,
         patch(
             "app.services.section_extraction_service.ExtractionEntityTypeRepository"
         ) as mock_entity_repo,
@@ -56,6 +54,9 @@ def service(mock_db, mock_storage):
         patch("app.services.section_extraction_service.RunLifecycleService") as mock_lifecycle_cls,
     ):
         mock_pdf_instance = MagicMock()
+        # build_prompt_input falls back to extract_text when an article has no
+        # blocks (get_latest_pdf → None below); make the call awaitable.
+        mock_pdf_instance.extract_text = AsyncMock(return_value="extracted article text")
         mock_pdf.return_value = mock_pdf_instance
 
         # Mock repositories
@@ -287,7 +288,7 @@ class TestSectionExtractionFullFlow:
                 "app.services.section_extraction_service.ExtractionInstance"
             ) as mock_instance_class,
             patch(
-                "app.services.section_extraction_service.ArticleTextBlockRepository"
+                "app.services.extraction_prompt_input.ArticleTextBlockRepository"
             ) as mock_blk_repo,
         ):
             mock_created_instance = MagicMock()
@@ -403,7 +404,7 @@ class TestExtractSectionWithExistingRun:
                 "app.services.section_extraction_service.ExtractionInstance"
             ) as mock_instance_class,
             patch(
-                "app.services.section_extraction_service.ArticleTextBlockRepository"
+                "app.services.extraction_prompt_input.ArticleTextBlockRepository"
             ) as mock_blk_repo,
         ):
             inst = MagicMock()
@@ -565,6 +566,7 @@ class TestExtractForRun:
         et.fields = []
         et.parent_entity_type_id = None
         self._wire_minimal_qa_pipeline(service, qa_run, qa_template, [et])
+        service._assemble_prompt_text = AsyncMock(return_value="article text")
 
         await service.extract_for_run(
             run_id=qa_run.id,
@@ -586,6 +588,7 @@ class TestExtractForRun:
         et.fields = []
         et.parent_entity_type_id = None
         self._wire_minimal_qa_pipeline(service, qa_run, qa_template, [et])
+        service._assemble_prompt_text = AsyncMock(return_value="article text")
 
         await service.extract_for_run(
             run_id=qa_run.id,
@@ -1424,6 +1427,7 @@ class TestExtractSectionLlmFailure:
         from pydantic_ai import UnexpectedModelBehavior
 
         run = self._wire_pipeline(service, mock_storage)
+        service._assemble_prompt_text = AsyncMock(return_value="article text")
 
         service._extract_with_llm = AsyncMock(
             side_effect=UnexpectedModelBehavior("reask exhausted")
@@ -1495,21 +1499,17 @@ class TestExtractAllSections:
 
         service._instances.get_by_id = AsyncMock(return_value=None)
         service._entity_types.get_children = AsyncMock(return_value=[])
-        mock_file = MagicMock()
-        mock_file.storage_key = "test.pdf"
-        service._article_files.get_latest_pdf = AsyncMock(return_value=mock_file)
-        service.storage.download = AsyncMock(return_value=b"%PDF")
-        service.pdf_processor.extract_text = AsyncMock(return_value="pdf text")
+        service._assemble_prompt_text = AsyncMock(return_value="pdf text")
 
         await service.extract_all_sections(
             project_id=uuid4(),
             article_id=uuid4(),
             template_id=uuid4(),
             parent_instance_id=uuid4(),
-            # No pdf_text provided → should fetch from storage
+            # No pdf_text provided → _assemble_prompt_text is invoked
         )
 
-        service._article_files.get_latest_pdf.assert_awaited_once()
+        service._assemble_prompt_text.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_batch_collects_failed_sections(self, service):
@@ -1757,6 +1757,7 @@ class TestExtractForRunErrorPath:
         )
         service.storage.download = AsyncMock(return_value=b"%PDF")
         service.pdf_processor.extract_text = AsyncMock(return_value="text")
+        service._assemble_prompt_text = AsyncMock(return_value="article text")
 
         good_et = MagicMock()
         good_et.id = uuid4()

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -1469,6 +1469,10 @@ class TestExtractAllSections:
         service._runs.start_run = AsyncMock()
         service._runs.complete_run = AsyncMock()
         service._runs.fail_run = AsyncMock()
+        # Batch tests exercise the flow, not assembly: stub the prompt-text source
+        # (the elif path also calls it for its stash side-effect when pdf_text is
+        # supplied). Tests that assert on it re-assign their own mock below.
+        service._assemble_prompt_text = AsyncMock(return_value="article text")
 
     @pytest.mark.asyncio
     async def test_batch_with_no_child_sections(self, service):
@@ -1509,6 +1513,31 @@ class TestExtractAllSections:
             # No pdf_text provided → _assemble_prompt_text is invoked
         )
 
+        service._assemble_prompt_text.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_batch_with_supplied_pdf_text_still_populates_anchor_stash(self, service):
+        """When a caller supplies pdf_text (the assembly fast-path is skipped), the
+        run anchor stash must STILL be populated so _create_suggestions can ground
+        evidence — otherwise evidence silently gets position={} despite blocks
+        existing. Regression guard for the build_prompt_input wiring."""
+        run = self._make_run()
+        self._minimal_lifecycle_wire(service, run)
+
+        service._instances.get_by_id = AsyncMock(return_value=None)
+        service._entity_types.get_children = AsyncMock(return_value=[])
+        service._assemble_prompt_text = AsyncMock(return_value="ignored")
+        assert service._run_anchor_blocks == []  # empty stash at the start of the run
+
+        await service.extract_all_sections(
+            project_id=uuid4(),
+            article_id=uuid4(),
+            template_id=uuid4(),
+            parent_instance_id=uuid4(),
+            pdf_text="caller-supplied precomputed text",
+        )
+
+        # The elif branch invokes _assemble_prompt_text for its stash side-effect.
         service._assemble_prompt_text.assert_awaited()
 
     @pytest.mark.asyncio
@@ -1593,8 +1622,9 @@ class TestExtractAllSections:
         service._lifecycle.advance_stage = AsyncMock(return_value=run)
         service._runs.start_run = AsyncMock()
         service._runs.rollback_and_fail = AsyncMock()
+        service._assemble_prompt_text = AsyncMock(return_value="text")
 
-        # Make the PDF fetch explode unexpectedly (before any section loops)
+        # Make the instance fetch explode unexpectedly (after assembly, before loops)
         service._instances.get_by_id = AsyncMock(side_effect=RuntimeError("db exploded"))
 
         with pytest.raises(RuntimeError, match="db exploded"):
@@ -1696,6 +1726,7 @@ class TestExtractAllSections:
         service._runs.complete_run = AsyncMock()
         service._runs.fail_run = AsyncMock()
         service._runs.rollback_and_fail = AsyncMock()
+        service._assemble_prompt_text = AsyncMock(return_value="text")
 
         parent = MagicMock()
         parent.entity_type_id = uuid4()

--- a/docs/adr/0011-structured-pdf-parsing-at-ingest.md
+++ b/docs/adr/0011-structured-pdf-parsing-at-ingest.md
@@ -182,6 +182,15 @@ Concretely, respecting the existing layering:
 
 ### Consequences
 
+> **Status update (2026-06-23, A1):** the grounded-extraction *block-input half*
+> is now built. Extraction feeds the LLM a budgeted **markdown projection of
+> `article_text_blocks`** (`infrastructure/parsing/base.py::render_blocks_to_markdown`
+> → `app/llm/assembler.py::assemble_for_model`, threaded by
+> `app/services/extraction_prompt_input.py::build_prompt_input`); the 15k
+> `MAX_PDF_CHARS` truncation is retired at all three prompt sites and the no-blocks
+> `pypdf` fallback flows through the *same* budgeted assembler. Migration-free.
+> Plan: `docs/superpowers/plans/2026-06-23-extraction-a1-block-input.md`.
+
 - Good — one persisted artifact serves both the LLM (structured text) and the
   reviewer (`bbox` highlight); `bbox` anchoring and verbatim verification
   become possible; the 15k truncation and the extract-and-discard pattern are

--- a/docs/reference/extraction-hitl-architecture.md
+++ b/docs/reference/extraction-hitl-architecture.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_reviewed: 2026-06-22
+last_reviewed: 2026-06-23
 owner: '@raphaelfh'
 ---
 
@@ -294,6 +294,17 @@ exception.
 defined next to their prompt module. Template-driven schemas whose shape
 depends on the active template version are built at runtime by
 `backend/app/llm/schema.py::build_output_models`.
+
+**Article-text input (A1, 2026-06-23).** The `article_text` passed to each
+`render(...)` is no longer raw `pypdf` text truncated at 15k. The extraction
+services call `build_prompt_input` (`app/services/extraction_prompt_input.py`),
+which fetches `article_text_blocks` **once per run** and assembles a budgeted
+**markdown projection** of the blocks via
+`app/llm/assembler.py::assemble_for_model` (a deterministic
+`render_blocks_to_markdown` + IMRaD-aware token-budget windowing). When an
+article has no blocks yet, the `pypdf` fallback is wrapped into synthetic blocks
+and routed through the *same* budgeted assembler — no path sends unbounded text.
+See ADR-0011 (block input) and ADR-0013 (markdown projection).
 
 Unit tests for the prompt layer live in
 `backend/tests/unit/llm/test_prompts.py`.

--- a/docs/superpowers/plans/2026-06-23-extraction-a1-block-input.md
+++ b/docs/superpowers/plans/2026-06-23-extraction-a1-block-input.md
@@ -1,0 +1,1048 @@
+---
+status: draft
+last_reviewed: 2026-06-23
+owner: '@raphaelfh'
+---
+
+# Extraction A1 — block-markdown LLM input + windowing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Decision record: spec `docs/superpowers/specs/2026-06-23-extraction-pipeline-stabilization-design.md` §A1; ADR-0011 (grounded extraction half) + ADR-0013 (markdown = projection of blocks).
+
+**Goal:** Feed the LLM a budgeted, windowed **markdown projection of `article_text_blocks`** instead of pypdf-truncated-at-15k text, finishing ADR-0011's grounded-extraction half — reusing the already-built, already-tested section-aware assembler from PR #325 rather than building a new one.
+
+**Architecture:** Three pure layers + one thin service orchestrator. (1) `render_blocks_to_markdown` in `infrastructure/parsing/base.py` becomes the single canonical block→GFM-markdown codepath (ADR-0013 free tier). (2) The existing `extraction_block_assembler.py` (PR #325 — `assemble`, IMRaD ranking, whole-section dropping, ~40 tests) is **relocated to `app/llm/assembler.py`**, refactored to delegate serialization to `render_blocks_to_markdown`, and gains a thin model-aware wrapper (`assemble_for_model` → typed `AssemblyInfo`, tiktoken budget). (3) A small service-layer orchestrator `build_prompt_input` fetches blocks once per run, assembles once, routes the no-blocks pypdf fallback through the *same* budgeted assembler, and is called by both extraction services. The 15k `MAX_PDF_CHARS` truncation is deleted from all three prompt sites.
+
+**Tech Stack:** Python 3.11 + FastAPI + SQLAlchemy 2.0 async; pydantic-ai (`extract_structured`); `tiktoken` (ships with the `pydantic-ai-slim[openai]` extra we already pin); pytest (unit + integration vs local Supabase with `db_session_real`); structlog.
+
+## Context — what already exists in `dev` (verified, do not re-investigate)
+
+- **The assembler is already built and tested but unwired.** `backend/app/services/extraction_block_assembler.py` (PR #325 `abc74521`, *"grounded-extraction backbone … dark until parser"*) provides `assemble(blocks, budget, focus) -> (str, list[DroppedSection])` — reading order, `## ` headings, GFM tables from contiguous `table_cell` runs, deterministic IMRaD section dropping over budget. Its own docstring says it is *"intentionally unwired — the call sites in `section_extraction_service` and `model_extraction_service` are wired in a separate follow-up task."* **This plan is that follow-up.** Its ~40 tests live in `backend/tests/unit/test_block_assembler.py`.
+- `render_blocks_to_markdown` **does not exist yet** (grep-confirmed). ADR-0013 + the grounded-extraction plan both require it in `base.py`, with the assembler delegating to it (one GFM codepath → prompt and viewer tables byte-identical).
+- **Phase 1 (C1) already shipped:** `config.py` has `LLM_PROVIDER="openai"`, `LLM_DEFAULT_MODEL="gpt-4o-mini"`, `LLM_TIMEOUT_SECONDS=120.0`; `extractor.extract_structured` selects `NativeOutput`/`ToolOutput` by `model.system`; `schema.build_output_models` raises `SchemaBuildError` on duplicate field names; `extraction_block_assembler.py` already imports the canonical `concat_page_text`.
+- **Block model:** `ParsedBlock` (dataclass, `base.py:68`) and `ArticleTextBlock` (ORM, `models/article.py:256`) mirror each other: `page_number` (1-indexed), `block_index` (0-indexed), `text`, `char_start`, `char_end`, `bbox` (JSONB), `block_type`. `BLOCK_TYPES` (`base.py:38`) = `paragraph, heading, list_item, table_cell, figure_caption, header, footer`. By construction `page_text[char_start:char_end] == block.text`.
+- **Read once:** `ArticleTextBlockRepository(db).list_ordered_for_file(article_file_id) -> list[ArticleTextBlock]` orders by `(page_number ASC, block_index ASC)`.
+- **The three truncation sites:** `MAX_PDF_CHARS = 15_000` (`prompts/__init__.py:12`) is applied as `article_text[:MAX_PDF_CHARS]` in `section_extraction.render` (`:42`), `model_identification.render` (`:47`), `quality_assessment.render` (`:57`). Imported only by those three modules + `tests/unit/llm/test_prompts.py`.
+- **The pypdf path:** `PDFProcessor.extract_text(pdf_data: bytes) -> str` (`pdf_processor.py:84`) returns page text joined by `\n\n` with `[Page N]\n` markers.
+- **Anchoring (unchanged contract):** `evidence_anchor_service.build_anchor(quote, blocks, *, fuzz_threshold) -> PositionV1 | None`; `citation_read_service.list_article_citations(db, article_id)` reads it back. `section_extraction_service._create_suggestions` currently re-fetches blocks at line 1316 for anchoring.
+
+## Global Constraints
+
+- **MIGRATION-FREE.** `render_blocks_to_markdown` is derived on-demand (ADR-0013, no column); `AssemblyInfo` is internal and never stored. No new column/enum/constraint. (`test_migration_roundtrip` head-pin gotcha does **not** apply.)
+- **`AssemblyInfo` stays out of the API contract.** Define it in `app/schemas/extraction.py` but never reference it in any endpoint response model — so `npm run generate:api-types` is **not** needed and `schema.d.ts` does not change.
+- **File-size ratchet (`scripts/fitness/check_file_size.py`, default cap 800):** `section_extraction_service.py` is baselined at **1407** and must end **≤ 1407 lines** (the ratchet is never raised). New files must stay ≤ 800. The heavy wiring logic lives in the new `extraction_prompt_input.py` (service layer) and `app/llm/assembler.py` (pure) precisely to keep both god-files lean.
+- **Layering (`scripts/fitness/check_layered_arch.py`):** `api → services → repositories → models`; the pure assembler/renderer touch no DB; the DB-touching orchestration lives in a service-layer module.
+- **PostToolUse ruff hook removes imports added separately from their use.** Add each import in the **same** Write/Edit as its first usage (or Write the whole file).
+- **CI "Backend Lint" = mypy ratchet** (not ruff). Run locally before "done":
+  `cd backend && { uv run --with mypy==2.1.0 mypy app --ignore-missing-imports || true; } | uv run python ../scripts/mypy_baseline.py --baseline .mypy_baseline` — must report **no new errors**. Annotate return types explicitly (e.g. `-> tuple[str, AssemblyInfo]`); guard `tiktoken` so mypy never infers `Any` from a missing-stub call.
+- **English only** for code, comments, docstrings, commits. Conventional commits. PR targets `dev`, squash-merged.
+- **Gates before "done":** `make lint-backend`, the mypy ratchet, `make test-backend` (or the unit subset + the new integration test), all green with output pasted as evidence (`code-review` Iron Law).
+
+---
+
+## Task 1: `render_blocks_to_markdown` — the canonical block→markdown projection
+
+**Files:**
+- Modify: `backend/app/infrastructure/parsing/base.py` (currently 218 lines; stays well under 800)
+- Test: `backend/tests/unit/test_parsing_base.py` (extend — it already tests `BLOCK_TYPES`, `concat_page_text`, `assign_char_offsets_to_blocks`)
+
+**Interfaces:**
+- Produces: `render_blocks_to_markdown(blocks: Sequence[BlockLike]) -> str` — pure; sorts by `(page_number, block_index)`; `## ` for `heading`, `- ` for `list_item`, contiguous same-page `table_cell` runs coalesced into a GFM table, `paragraph`/`figure_caption` as plain text, `header`/`footer` suppressed; parts joined with `\n`. Also exports the table helpers `_render_table` / `_infer_column_count` (module-private; the assembler imports `render_blocks_to_markdown` only).
+- `BlockLike` = structural `Protocol` (`page_number: int`, `block_index: int`, `text: str`, `block_type: str`) satisfied by both `ParsedBlock` and `ArticleTextBlock`.
+
+- [ ] **Step 1: Write the failing tests** — append to `backend/tests/unit/test_parsing_base.py`:
+
+```python
+from app.infrastructure.parsing.base import render_blocks_to_markdown  # add to the existing import block
+
+
+class TestRenderBlocksToMarkdown:
+    def _b(self, page, idx, text, block_type="paragraph"):
+        return ParsedBlock(
+            page_number=page, block_index=idx, text=text,
+            char_start=0, char_end=len(text), bbox={}, block_type=block_type,
+        )
+
+    def test_reading_order_across_pages(self) -> None:
+        md = render_blocks_to_markdown(
+            [self._b(2, 0, "Second page"), self._b(1, 0, "First page")]
+        )
+        assert md.index("First page") < md.index("Second page")
+
+    def test_heading_becomes_h2_marker(self) -> None:
+        md = render_blocks_to_markdown([self._b(1, 0, "Methods", "heading")])
+        assert "## Methods" in md
+
+    def test_list_item_becomes_bullet(self) -> None:
+        md = render_blocks_to_markdown([self._b(1, 0, "first point", "list_item")])
+        assert "- first point" in md
+
+    def test_header_footer_chrome_suppressed(self) -> None:
+        md = render_blocks_to_markdown([
+            self._b(1, 0, "Journal Name", "header"),
+            self._b(1, 1, "Real content.", "paragraph"),
+            self._b(1, 2, "Page 1 of 9", "footer"),
+        ])
+        assert "Real content." in md
+        assert "Journal Name" not in md
+        assert "Page 1 of 9" not in md
+
+    def test_contiguous_cells_render_as_gfm_table(self) -> None:
+        md = render_blocks_to_markdown([
+            self._b(1, 0, "Name", "table_cell"),
+            self._b(1, 1, "Age", "table_cell"),
+            self._b(1, 2, "Alice", "table_cell"),
+            self._b(1, 3, "30", "table_cell"),
+        ])
+        assert "| Name" in md and "| Alice" in md
+        assert "|-" in md  # a GFM separator row exists
+
+    def test_figure_caption_is_plain_text(self) -> None:
+        md = render_blocks_to_markdown([self._b(1, 0, "Figure 1. Flowchart.", "figure_caption")])
+        assert md == "Figure 1. Flowchart."
+
+    def test_deterministic(self) -> None:
+        blocks = [self._b(1, 1, "B"), self._b(1, 0, "A", "heading")]
+        assert render_blocks_to_markdown(blocks) == render_blocks_to_markdown(blocks)
+
+    def test_empty_input_returns_empty_string(self) -> None:
+        assert render_blocks_to_markdown([]) == ""
+```
+
+- [ ] **Step 2: Run → fails.** `cd backend && uv run pytest tests/unit/test_parsing_base.py::TestRenderBlocksToMarkdown -v` → FAIL (`ImportError: cannot import name 'render_blocks_to_markdown'`).
+
+- [ ] **Step 3: Implement** in `backend/app/infrastructure/parsing/base.py`. Add `import math` and `from collections.abc import Sequence` and `from typing import Protocol, runtime_checkable` to the existing imports if absent, then add at the end of the module:
+
+```python
+@runtime_checkable
+class BlockLike(Protocol):
+    """Structural type satisfied by both ``ParsedBlock`` and ``ArticleTextBlock``."""
+
+    page_number: int
+    block_index: int
+    text: str
+    block_type: str
+
+
+_MD_TABLE_CELL_SEP = " | "
+_MD_TABLE_RULE_CHAR = "-"
+
+
+def _infer_column_count(cell_texts: list[str]) -> int:
+    """Heuristically infer a table's column count from its flat cell list."""
+    n = len(cell_texts)
+    if n <= 1:
+        return 1
+    for cols in range(2, min(9, n + 1)):
+        if n % cols == 0:
+            return cols
+    return min(8, max(2, math.ceil(math.sqrt(n))))
+
+
+def _render_table(cell_texts: list[str]) -> str:
+    """Render a flat list of table-cell texts as a deterministic GFM table."""
+    if not cell_texts:
+        return ""
+    cols = _infer_column_count(cell_texts)
+    rows: list[list[str]] = []
+    for i in range(0, len(cell_texts), cols):
+        row = cell_texts[i : i + cols]
+        while len(row) < cols:
+            row.append("")
+        rows.append(row)
+    widths = [max(len(r[c]) for r in rows) for c in range(cols)]
+
+    def _fmt(row: list[str]) -> str:
+        cells = [r.ljust(w) for r, w in zip(row, widths, strict=True)]
+        return "| " + _MD_TABLE_CELL_SEP.join(cells) + " |"
+
+    rule = "|-" + "-|-".join(_MD_TABLE_RULE_CHAR * w for w in widths) + "-|"
+    return "\n".join([_fmt(rows[0]), rule, *(_fmt(r) for r in rows[1:])])
+
+
+def render_blocks_to_markdown(blocks: Sequence[BlockLike]) -> str:
+    """Project article text blocks to deterministic GFM markdown (ADR-0013 free tier).
+
+    Reading order (page asc, block_index asc); ``## `` headings; ``- `` list
+    items; contiguous same-page ``table_cell`` runs coalesced into a GFM table;
+    ``paragraph`` / ``figure_caption`` as plain text; ``header`` / ``footer``
+    page chrome suppressed. Pure: no DB, no IO. The extraction assembler
+    serialises each kept section through this function so the prompt's tables and
+    the reader's tables are byte-identical (one serialization codepath).
+    """
+    ordered = sorted(blocks, key=lambda b: (b.page_number, b.block_index))
+    parts: list[str] = []
+    i = 0
+    while i < len(ordered):
+        block = ordered[i]
+        if block.block_type in ("header", "footer"):
+            i += 1
+            continue
+        if block.block_type == "table_cell":
+            page = block.page_number
+            run: list[str] = []
+            while (
+                i < len(ordered)
+                and ordered[i].block_type == "table_cell"
+                and ordered[i].page_number == page
+            ):
+                run.append(ordered[i].text)
+                i += 1
+            parts.append(_render_table(run))
+            continue
+        if block.block_type == "heading":
+            parts.append(f"## {block.text}")
+        elif block.block_type == "list_item":
+            parts.append(f"- {block.text}")
+        else:
+            parts.append(block.text)
+        i += 1
+    return "\n".join(p for p in parts if p)
+```
+
+- [ ] **Step 4: Run → passes.** `cd backend && uv run pytest tests/unit/test_parsing_base.py -v` → PASS (existing + new).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/app/infrastructure/parsing/base.py backend/tests/unit/test_parsing_base.py
+git commit -m "feat(parsing): render_blocks_to_markdown — canonical block→GFM projection (ADR-0013)"
+```
+
+---
+
+## Task 2: Relocate the assembler to `app/llm/assembler.py` and delegate to the renderer
+
+**Files:**
+- Move: `backend/app/services/extraction_block_assembler.py` → `backend/app/llm/assembler.py` (`git mv`)
+- Move: `backend/tests/unit/test_block_assembler.py` → `backend/tests/unit/test_assembler.py` (`git mv`)
+- Modify both for the new import path + the delegation refactor
+
+**Interfaces:**
+- Consumes: `render_blocks_to_markdown` (Task 1).
+- Produces (unchanged public contract): `assemble(blocks, budget, focus=None) -> tuple[str, list[DroppedSection]]`; `DroppedSection(title, char_count, rank, block_count)` (gains `block_count`).
+
+- [ ] **Step 1: Relocate the files** (preserves git history; the ~40 existing tests are the regression net for the refactor):
+
+```bash
+cd /Users/raphael/PycharmProjects/prumo
+git mv backend/app/services/extraction_block_assembler.py backend/app/llm/assembler.py
+git mv backend/tests/unit/test_block_assembler.py backend/tests/unit/test_assembler.py
+```
+
+- [ ] **Step 2: Update the test import.** In `backend/tests/unit/test_assembler.py` change:
+
+```python
+from app.services.extraction_block_assembler import DroppedSection, assemble
+```
+to
+```python
+from app.llm.assembler import DroppedSection, assemble
+```
+
+- [ ] **Step 3: Run → the relocated tests still pass** (no behavior change yet): `cd backend && uv run pytest tests/unit/test_assembler.py -v` → PASS.
+
+- [ ] **Step 4: Refactor `app/llm/assembler.py` to delegate serialization to `render_blocks_to_markdown`.**
+
+  (a) Update the module docstring: drop the *"intentionally unwired"* sentence and the local table-reconstruction paragraph; add one line: *"Section serialization delegates to `render_blocks_to_markdown` (one GFM codepath shared with the reader)."*
+
+  (b) Replace the imports block — remove `assign_char_offsets_to_blocks`, `concat_page_text`, `math`, and the local `_CELL_SEP`/`_ROW_SEP_CHAR`/`_render_table`/`_infer_column_count` definitions (now in `base.py`); import the renderer:
+
+```python
+from app.infrastructure.parsing.base import render_blocks_to_markdown
+```
+  (Keep `import re` — `_section_rank` uses it. `ParsedBlock` is re-added in Task 3, so it may stay imported or be re-added then.)
+
+  (c) Delete the now-duplicated `_CELL_SEP`, `_ROW_SEP_CHAR`, `_infer_column_count`, `_render_table` from the assembler.
+
+  (d) Add `block_count: int` to `DroppedSection`:
+
+```python
+@dataclass(frozen=True)
+class DroppedSection:
+    title: str
+    char_count: int
+    rank: int
+    block_count: int
+```
+
+  (e) Replace `_serialize_section` (which took `page_texts`/`offsets`) with a renderer-delegating version:
+
+```python
+def _serialize_section(section: _Section) -> str:
+    """Serialise a section: ``## title`` marker + body via render_blocks_to_markdown."""
+    parts: list[str] = []
+    if section.title:
+        parts.append(f"## {section.title}")
+    body = render_blocks_to_markdown(section.blocks)
+    if body:
+        parts.append(body)
+    return "\n".join(parts)
+```
+
+  (f) In `assemble`, delete the local-copy/offset machinery (the `copies = [...]`, `assign_char_offsets_to_blocks(copies)`, `page_texts = ...`, `offsets = ...` block — old steps 2). The renderer reads `block.text` directly (which equals the canonical `concat_page_text` slice by construction, so output is unchanged and inputs are never mutated). Update the serialise step to:
+
+```python
+    serialised: list[tuple[_Section, str]] = [
+        (sec, _serialize_section(sec)) for sec in sections
+    ]
+```
+
+  (g) In the over-budget `DroppedSection(...)` construction, add `block_count=len(sec.blocks)`:
+
+```python
+            dropped.append(
+                DroppedSection(
+                    title=sec.title or "<preamble>",
+                    char_count=len(text),
+                    rank=sec.rank,
+                    block_count=len(sec.blocks),
+                )
+            )
+```
+
+- [ ] **Step 5: Run → all relocated tests still pass** (proves the refactor is behavior-preserving): `cd backend && uv run pytest tests/unit/test_assembler.py -v` → PASS. If `test_prose_matches_concat_page_text_slice` or `test_input_blocks_not_mutated_by_assemble` fail, the delegation changed output/mutated input — fix before continuing.
+
+- [ ] **Step 6: Confirm nothing else imported the old path.** `grep -rn "extraction_block_assembler" backend/app` → no hits (app code never imported it). Leave the historical plan-doc references untouched.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add -A backend/app/llm/assembler.py backend/app/services/ backend/tests/unit/test_assembler.py backend/tests/unit/test_block_assembler.py
+git commit -m "refactor(extraction): relocate assembler to app/llm, delegate serialization to render_blocks_to_markdown"
+```
+
+---
+
+## Task 3: Model-aware wrapper — `AssemblyInfo`, token budget, `assemble_for_model`, pypdf fallback
+
+**Files:**
+- Modify: `backend/app/schemas/extraction.py` (add `AssemblyInfo`; ~546 lines, stays < 800)
+- Modify: `backend/app/core/config.py` (add `LLM_ASSEMBLY_BUDGET_TOKENS`)
+- Modify: `backend/app/llm/assembler.py` (add `estimate_tokens`, `assemble_for_model`, `blocks_from_plain_text`)
+- Test: `backend/tests/unit/test_assembler.py` (extend)
+
+**Interfaces:**
+- Produces:
+  - `AssemblyInfo(total_blocks: int, included_blocks: int, truncated: bool, est_tokens: int)` — frozen Pydantic model, internal (never an API response).
+  - `estimate_tokens(text: str, model_name: str) -> int` — tiktoken for OpenAI models, `len//4` heuristic otherwise.
+  - `assemble_for_model(blocks, *, model_name: str, budget_tokens: int, focus: str | None = None) -> tuple[str, AssemblyInfo]`.
+  - `blocks_from_plain_text(text: str) -> list[ParsedBlock]` — wraps pypdf text into per-page paragraph blocks.
+  - `settings.LLM_ASSEMBLY_BUDGET_TOKENS: int = 96_000`.
+
+- [ ] **Step 1: Write the failing tests** — append to `backend/tests/unit/test_assembler.py`:
+
+```python
+from app.llm.assembler import (  # extend the existing import
+    assemble_for_model,
+    blocks_from_plain_text,
+    estimate_tokens,
+)
+from app.schemas.extraction import AssemblyInfo
+
+
+class TestAssembleForModel:
+    def _imrad(self) -> list[ParsedBlock]:
+        return [
+            _b(1, 0, "Abstract", "heading"), _b(1, 1, "A" * 400, "paragraph"),
+            _b(2, 0, "Results", "heading"), _b(2, 1, "B" * 400, "paragraph"),
+            _b(3, 0, "References", "heading"), _b(3, 1, "C" * 400, "paragraph"),
+        ]
+
+    def test_returns_markdown_and_assembly_info(self) -> None:
+        text, info = assemble_for_model(self._imrad(), model_name="gpt-4o-mini", budget_tokens=100_000)
+        assert isinstance(info, AssemblyInfo)
+        assert info.truncated is False
+        assert info.total_blocks == 6
+        assert info.included_blocks == 6
+        assert info.est_tokens > 0
+        assert "Abstract" in text and "Results" in text
+
+    def test_truncated_flag_set_when_over_budget(self) -> None:
+        # budget_tokens * 4 chars must be smaller than the full doc (~1.2k chars)
+        text, info = assemble_for_model(self._imrad(), model_name="gpt-4o-mini", budget_tokens=120)
+        assert info.truncated is True
+        assert info.included_blocks < info.total_blocks
+        assert len(text) <= 120 * 4
+
+    def test_est_tokens_uses_tiktoken_for_openai(self) -> None:
+        # tiktoken counts real tokens; a 400-char ASCII run is far fewer than 400 tokens.
+        n = estimate_tokens("word " * 400, "gpt-4o-mini")
+        assert 300 < n < 500
+
+    def test_heuristic_skew_for_anthropic_model(self) -> None:
+        # Anthropic models are not encodable by tiktoken → char/4 heuristic. Document
+        # the skew: the heuristic differs from the OpenAI tokeniser for the same text.
+        text = "Heterogeneous clinical-trial endpoints, n=412 (95% CI)."
+        heuristic = estimate_tokens(text, "claude-opus-4-8")  # falls back to len//4
+        assert heuristic == max(1, len(text) // 4)
+        openai = estimate_tokens(text, "gpt-4o-mini")
+        assert heuristic != openai  # documented skew between heuristic and tiktoken
+
+    def test_blocks_from_plain_text_splits_on_page_markers(self) -> None:
+        blocks = blocks_from_plain_text("[Page 1]\nIntro text.\n\n[Page 2]\nMethods text.")
+        assert [b.page_number for b in blocks] == [1, 2]
+        assert blocks[0].text == "Intro text." and blocks[0].block_type == "paragraph"
+
+    def test_blocks_from_plain_text_no_markers_single_block(self) -> None:
+        blocks = blocks_from_plain_text("just some flat text")
+        assert len(blocks) == 1 and blocks[0].page_number == 1
+
+    def test_fallback_text_flows_through_same_budgeted_assembler(self) -> None:
+        # A long marker-less pypdf string, wrapped + budgeted, never returns unbounded.
+        text, info = assemble_for_model(
+            blocks_from_plain_text("X" * 5000), model_name="gpt-4o-mini", budget_tokens=100
+        )
+        assert len(text) <= 100 * 4
+        assert info.truncated is True
+```
+
+- [ ] **Step 2: Run → fails.** `cd backend && uv run pytest tests/unit/test_assembler.py::TestAssembleForModel -v` → FAIL (import errors).
+
+- [ ] **Step 3a: Add `AssemblyInfo`** to `backend/app/schemas/extraction.py` (reuse the module's existing `BaseModel` / `ConfigDict` imports):
+
+```python
+class AssemblyInfo(BaseModel):
+    """Internal (non-API) record for one prompt assembly — logged per run for
+    token/cost observability and to surface windowing overflow.
+
+    Deliberately NOT referenced by any endpoint response model, so it never
+    enters the OpenAPI/schema.d.ts contract.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    total_blocks: int
+    included_blocks: int
+    truncated: bool
+    est_tokens: int
+```
+
+- [ ] **Step 3b: Add the config setting** to `backend/app/core/config.py`, immediately after `LLM_TIMEOUT_SECONDS`:
+
+```python
+    # Token budget for the per-run block-markdown assembly window (A1). A paper
+    # under this budget is sent in full; above it the assembler drops whole
+    # low-priority sections (IMRaD ranking) and logs AssemblyInfo.truncated.
+    # Leaves headroom on a 128k-context model for system prompt + schema + output
+    # + reask. No hard per-run cost ceiling (logged, not enforced — spec §8.5).
+    LLM_ASSEMBLY_BUDGET_TOKENS: int = 96_000
+```
+
+- [ ] **Step 3c: Add the wrapper + fallback** to `backend/app/llm/assembler.py`. Add imports (alongside the `re` import — keep imports atomic with usage):
+
+```python
+from app.infrastructure.parsing.base import ParsedBlock, render_blocks_to_markdown
+
+try:
+    import tiktoken
+except ImportError:  # pragma: no cover - tiktoken ships with pydantic-ai-slim[openai]
+    tiktoken = None  # type: ignore[assignment]
+
+from app.schemas.extraction import AssemblyInfo
+from app.core.config import settings  # noqa: F401  (kept if a default is read; else omit)
+```
+
+Then add, after `assemble`:
+
+```python
+_CHARS_PER_TOKEN = 4  # heuristic char→token ratio for English / scientific prose
+
+
+def estimate_tokens(text: str, model_name: str) -> int:
+    """Best-effort token count: tiktoken for OpenAI models, ``len // 4`` heuristic
+    otherwise (e.g. Anthropic, which tiktoken cannot encode — see the documented
+    skew in test_assembler)."""
+    if not text:
+        return 0
+    if tiktoken is not None:
+        try:
+            return len(tiktoken.encoding_for_model(model_name).encode(text))
+        except KeyError:
+            pass
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+def assemble_for_model(
+    blocks: list[_Block],
+    *,
+    model_name: str,
+    budget_tokens: int,
+    focus: str | None = None,
+) -> tuple[str, AssemblyInfo]:
+    """Assemble *blocks* within a model-aware token budget, returning the markdown
+    plus a typed ``AssemblyInfo``. Converts the token budget to a char budget for
+    the deterministic char-based ``assemble``; reports actual usage. Never raises —
+    over-budget docs drop whole low-priority sections (``AssemblyInfo.truncated``)."""
+    char_budget = max(1, budget_tokens * _CHARS_PER_TOKEN)
+    text, dropped = assemble(blocks, budget=char_budget, focus=focus)
+    dropped_blocks = sum(d.block_count for d in dropped)
+    info = AssemblyInfo(
+        total_blocks=len(blocks),
+        included_blocks=len(blocks) - dropped_blocks,
+        truncated=bool(dropped),
+        est_tokens=estimate_tokens(text, model_name),
+    )
+    return text, info
+
+
+def blocks_from_plain_text(text: str) -> list[ParsedBlock]:
+    """Wrap pypdf-extracted plain text into per-page ``paragraph`` blocks so the
+    no-blocks fallback flows through the SAME budgeted assembler (never unbounded).
+    Splits on the ``[Page N]`` markers ``PDFProcessor.extract_text`` emits; text
+    with no markers becomes a single page-1 block."""
+    blocks: list[ParsedBlock] = []
+    segments = re.split(r"\[Page (\d+)\]\n", text)
+    # re.split keeps captured groups interleaved: ['', '1', body1, '2', body2, ...]
+    for page_str, body in zip(segments[1::2], segments[2::2], strict=False):
+        stripped = body.strip()
+        if stripped:
+            blocks.append(
+                ParsedBlock(
+                    page_number=int(page_str), block_index=0, text=stripped,
+                    char_start=0, char_end=len(stripped), bbox={}, block_type="paragraph",
+                )
+            )
+    if not blocks and text.strip():
+        stripped = text.strip()
+        blocks.append(
+            ParsedBlock(
+                page_number=1, block_index=0, text=stripped,
+                char_start=0, char_end=len(stripped), bbox={}, block_type="paragraph",
+            )
+        )
+    return blocks
+```
+
+> Note: drop the `from app.core.config import settings` line if no default is read inside the assembler (the budget is passed in by the caller); keep the import only if used, to avoid a ruff F401.
+
+- [ ] **Step 4: Run → passes.** `cd backend && uv run pytest tests/unit/test_assembler.py -v` → PASS (existing + new).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/app/schemas/extraction.py backend/app/core/config.py backend/app/llm/assembler.py backend/tests/unit/test_assembler.py
+git commit -m "feat(extraction): model-aware assemble wrapper + AssemblyInfo + pypdf fallback blocks"
+```
+
+---
+
+## Task 4: Delete the 15k `MAX_PDF_CHARS` truncation from the three prompt sites
+
+**Files:**
+- Modify: `backend/app/llm/prompts/__init__.py` (remove the constant)
+- Modify: `backend/app/llm/prompts/section_extraction.py:42`, `model_identification.py:47`, `quality_assessment.py:57`
+- Test: `backend/tests/unit/llm/test_prompts.py`
+
+**Interfaces:**
+- The three `render(..., article_text: str, ...)` signatures are unchanged; they now insert `article_text` verbatim (the assembler upstream owns the budget). `MAX_PDF_CHARS` ceases to exist.
+
+> **Ordering note:** removing truncation before the services are wired (Tasks 5–6) leaves an intermediate *branch-only* commit where `render()` would pass full pypdf text through unbounded. This is never deployed (the branch squash-merges as one unit) and no test sends unbounded real input. Doing it here keeps the prompt change atomic and reviewable.
+
+- [ ] **Step 1: Update the failing tests** in `backend/tests/unit/llm/test_prompts.py` — remove `MAX_PDF_CHARS` from the import (line 4) and flip the two truncation assertions to full pass-through:
+
+```python
+# in the import block: delete the `MAX_PDF_CHARS,` line
+
+def test_section_extraction_render_includes_context_and_full_text():
+    prompt = section_extraction.render(
+        entity_name="Population",
+        entity_description="Who was studied",
+        article_text="§" * 20_000,
+        memory_context=[{"entity_type_name": "Methods", "summary": "RCT"}],
+    )
+    assert "Section: Population" in prompt
+    assert "Who was studied" in prompt
+    assert "1. Methods: RCT" in prompt
+    assert prompt.count("§") == 20_000  # no truncation — assembler owns the budget
+
+
+def test_model_identification_render_and_output_model():
+    prompt = model_identification.render(
+        container_label="prediction models", article_text="§" * 20_000
+    )
+    assert "prediction models" in prompt
+    assert prompt.count("§") == 20_000  # no truncation
+    output = model_identification.ModelIdentificationOutput.model_validate(
+        {"models": [{"name": "Cox model"}]}
+    )
+    assert output.models[0].name == "Cox model"
+```
+
+- [ ] **Step 2: Run → fails.** `cd backend && uv run pytest tests/unit/llm/test_prompts.py -v` → FAIL (`ImportError: MAX_PDF_CHARS`).
+
+- [ ] **Step 3: Implement.**
+  - In `prompts/__init__.py`: delete lines 11–12 (the comment + `MAX_PDF_CHARS = 15_000`).
+  - In `section_extraction.py`: remove `MAX_PDF_CHARS` from its `from app.llm.prompts import ...`; change `article_text=article_text[:MAX_PDF_CHARS]` → `article_text=article_text`.
+  - In `model_identification.py`: same edit at `:47`.
+  - In `quality_assessment.py`: same edit at `:57`.
+
+- [ ] **Step 4: Run → passes.** `cd backend && uv run pytest tests/unit/llm/test_prompts.py -v` → PASS. Confirm the constant is gone: `grep -rn "MAX_PDF_CHARS" backend` → no hits.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/app/llm/prompts/ backend/tests/unit/llm/test_prompts.py
+git commit -m "feat(extraction): drop 15k MAX_PDF_CHARS truncation from all three prompt sites"
+```
+
+---
+
+## Task 5: Wire `section_extraction_service` to the assembler (fetch once, assemble once)
+
+**Files:**
+- Create: `backend/app/services/extraction_prompt_input.py` (new shared orchestrator, service layer)
+- Modify: `backend/app/services/section_extraction_service.py` (≤ 1407 lines — verify)
+- Test: `backend/tests/unit/test_extraction_prompt_input.py` (new)
+
+**Interfaces:**
+- Produces: `async build_prompt_input(*, db, article_files, pdf_processor, get_pdf, article_id, model, logger) -> tuple[str, list, UUID | None]` — fetches `article_text_blocks` once, assembles the budgeted markdown via `assemble_for_model`, routes the no-blocks case through `blocks_from_plain_text` + the same assembler, logs `AssemblyInfo`, and returns `(markdown, anchor_blocks, anchor_file_id)` (blocks reused by the caller for anchoring).
+- Consumes from the service: `self._article_files` (`ArticleFileRepository`), `self.pdf_processor`, `self._get_pdf`, `self.db`, `self.logger`. Sets `self._run_anchor_blocks` / `self._run_anchor_file_id` for `_create_suggestions`.
+
+- [ ] **Step 1: Write the failing test** — `backend/tests/unit/test_extraction_prompt_input.py` (mirrors the direct-coroutine pattern of `test_article_files_unit.py`; covers BOTH service paths — the ASGI diff-cover blind spot):
+
+```python
+"""Unit tests for build_prompt_input — the two extraction text-source paths."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.infrastructure.parsing.base import ParsedBlock
+from app.services.extraction_prompt_input import build_prompt_input
+
+_EP = "app.services.extraction_prompt_input"
+
+
+def _block(page, idx, text, bt="paragraph"):
+    return ParsedBlock(page, idx, text, 0, len(text), {}, bt)
+
+
+@pytest.mark.asyncio
+async def test_uses_blocks_when_present(monkeypatch) -> None:
+    aid, fid = uuid4(), uuid4()
+    main_file = SimpleNamespace(id=fid)
+    article_files = MagicMock()
+    article_files.get_latest_pdf = AsyncMock(return_value=main_file)
+    repo = MagicMock()
+    repo.list_ordered_for_file = AsyncMock(
+        return_value=[_block(1, 0, "Results", "heading"), _block(1, 1, "Effect size 0.81.")]
+    )
+    monkeypatch.setattr(f"{_EP}.ArticleTextBlockRepository", lambda db: repo)
+    pdf_processor = MagicMock()
+    pdf_processor.extract_text = AsyncMock()  # must NOT be called on the blocks path
+
+    text, blocks, file_id = await build_prompt_input(
+        db=AsyncMock(), article_files=article_files, pdf_processor=pdf_processor,
+        get_pdf=AsyncMock(), article_id=aid, model="gpt-4o-mini", logger=MagicMock(),
+    )
+    assert "## Results" in text and "Effect size 0.81." in text
+    assert file_id == fid and len(blocks) == 2
+    pdf_processor.extract_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_pypdf_when_no_blocks(monkeypatch) -> None:
+    aid = uuid4()
+    article_files = MagicMock()
+    article_files.get_latest_pdf = AsyncMock(return_value=None)  # no PDF file row → no blocks
+    pdf_processor = MagicMock()
+    pdf_processor.extract_text = AsyncMock(return_value="[Page 1]\nFallback body text.")
+
+    text, blocks, file_id = await build_prompt_input(
+        db=AsyncMock(), article_files=article_files, pdf_processor=pdf_processor,
+        get_pdf=AsyncMock(return_value=b"%PDF"), article_id=aid, model="gpt-4o-mini",
+        logger=MagicMock(),
+    )
+    assert "Fallback body text." in text
+    assert blocks == [] and file_id is None
+    pdf_processor.extract_text.assert_awaited_once()
+```
+
+- [ ] **Step 2: Run → fails.** `cd backend && uv run pytest tests/unit/test_extraction_prompt_input.py -v` → FAIL (module missing).
+
+- [ ] **Step 3a: Create `backend/app/services/extraction_prompt_input.py`:**
+
+```python
+"""Shared orchestrator: build the budgeted block-markdown prompt input for a run.
+
+Service layer (touches the article_text_blocks repository); the assembler it
+calls stays pure. Both ``section_extraction_service`` and
+``model_extraction_service`` call this so the fetch-once / assemble-once / budget
+logic lives in exactly one place (keeps both god-files lean).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.llm.assembler import assemble_for_model, blocks_from_plain_text
+from app.repositories.article_text_block_repository import ArticleTextBlockRepository
+
+
+async def build_prompt_input(
+    *,
+    db: AsyncSession,
+    article_files: Any,
+    pdf_processor: Any,
+    get_pdf: Callable[[UUID], Awaitable[bytes]],
+    article_id: UUID,
+    model: str,
+    logger: Any,
+) -> tuple[str, list, UUID | None]:
+    """Return ``(markdown, anchor_blocks, anchor_file_id)`` for *article_id*.
+
+    Uses persisted ``article_text_blocks`` when present; otherwise wraps pypdf
+    text into synthetic blocks through the SAME budgeted assembler so no path
+    ever sends unbounded text. ``anchor_blocks`` is reused by the caller for
+    evidence anchoring (no second fetch).
+    """
+    main_file = await article_files.get_latest_pdf(article_id)
+    blocks: list = (
+        await ArticleTextBlockRepository(db).list_ordered_for_file(main_file.id)
+        if main_file is not None
+        else []
+    )
+    anchor_file_id = main_file.id if main_file is not None else None
+    source = (
+        blocks
+        if blocks
+        else blocks_from_plain_text(await pdf_processor.extract_text(await get_pdf(article_id)))
+    )
+    text, info = assemble_for_model(
+        source, model_name=model, budget_tokens=settings.LLM_ASSEMBLY_BUDGET_TOKENS
+    )
+    logger.info(
+        "extraction.assembly",
+        article_id=str(article_id),
+        total_blocks=info.total_blocks,
+        included_blocks=info.included_blocks,
+        truncated=info.truncated,
+        est_tokens=info.est_tokens,
+    )
+    return text, blocks, anchor_file_id
+```
+
+- [ ] **Step 3b: Wire `section_extraction_service.py`.**
+  - Add the import (atomically with first use): `from app.services.extraction_prompt_input import build_prompt_input`.
+  - In `__init__` (after `self._article_files = ArticleFileRepository(db)`), add the run-scoped anchor stash:
+
+```python
+        self._run_anchor_blocks: list = []
+        self._run_anchor_file_id: UUID | None = None
+```
+
+  - **Site 1 (`extract_section`, lines 213–221)** — replace the `# 2. Fetch PDF` + `# 3. Process text` blocks with:
+
+```python
+            # 2-3. Assemble budgeted block-markdown prompt input (pypdf fallback inside).
+            phase_start = perf_counter()
+            pdf_text, self._run_anchor_blocks, self._run_anchor_file_id = await build_prompt_input(
+                db=self.db, article_files=self._article_files, pdf_processor=self.pdf_processor,
+                get_pdf=self._get_pdf, article_id=article_id, model=model, logger=self.logger,
+            )
+            phase_durations_ms["assemble_prompt"] = (perf_counter() - phase_start) * 1000
+```
+
+  - **Site 2 (`extract_for_run`, lines 386–387)** — replace the two `pdf_data`/`pdf_text` lines with:
+
+```python
+            pdf_text, self._run_anchor_blocks, self._run_anchor_file_id = await build_prompt_input(
+                db=self.db, article_files=self._article_files, pdf_processor=self.pdf_processor,
+                get_pdf=self._get_pdf, article_id=run.article_id, model=model, logger=self.logger,
+            )
+```
+
+  - **Site 3 (`extract_all_sections`, lines 746–753)** — replace the `if not pdf_text:` fetch block with:
+
+```python
+            # 1. Assemble block-markdown prompt input once per run.
+            if not pdf_text:
+                phase_start = perf_counter()
+                pdf_text, self._run_anchor_blocks, self._run_anchor_file_id = (
+                    await build_prompt_input(
+                        db=self.db, article_files=self._article_files,
+                        pdf_processor=self.pdf_processor, get_pdf=self._get_pdf,
+                        article_id=article_id, model=model, logger=self.logger,
+                    )
+                )
+                phase_durations_ms["assemble_prompt"] = (perf_counter() - phase_start) * 1000
+```
+
+  - **Anchor reuse (`_create_suggestions`, lines 1306–1321)** — replace the re-fetch block with the run-scoped stash:
+
+```python
+        # Blocks were fetched once per run by build_prompt_input; reuse them here
+        # to ground each evidence quote to a PositionV1 anchor (empty → position={}).
+        _anchor_blocks = self._run_anchor_blocks
+        _anchor_file_id = self._run_anchor_file_id
+```
+
+- [ ] **Step 4: Run → passes.** `cd backend && uv run pytest tests/unit/test_extraction_prompt_input.py tests/unit/test_assembler.py -v` → PASS.
+
+- [ ] **Step 5: Verify the file-size ratchet (hard gate).**
+
+Run: `cd backend && python ../scripts/fitness/check_file_size.py`
+Expected: PASS. If `section_extraction_service.py` reports **> 1407**, trim within the touched regions (e.g. collapse a redundant timing log around the wired sites) until ≤ 1407 — the ratchet is never raised. (The three verbose fetch/timing blocks collapsing into single `build_prompt_input` calls plus the 16-line anchor re-fetch shrinking to 4 lines should net the file **below** 1407.)
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add backend/app/services/extraction_prompt_input.py backend/app/services/section_extraction_service.py backend/tests/unit/test_extraction_prompt_input.py
+git commit -m "feat(extraction): source section-extraction prompts from block-markdown (fetch once, assemble once)"
+```
+
+---
+
+## Task 6: Wire `model_extraction_service` to the assembler
+
+**Files:**
+- Modify: `backend/app/services/model_extraction_service.py` (564 lines; ample headroom)
+- Test: `backend/tests/unit/test_model_extraction_prompt.py` (new) — direct coroutine test of both paths
+
+**Interfaces:**
+- Consumes: `build_prompt_input` (Task 5). `model_identification` is a single whole-document call (no entity-type loop, no anchoring) — discard the returned blocks/file_id.
+
+- [ ] **Step 1: Write the failing test** — `backend/tests/unit/test_model_extraction_prompt.py`:
+
+```python
+"""model_extraction_service sources its prompt from the budgeted assembler."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.infrastructure.parsing.base import ParsedBlock
+from app.services import model_extraction_service as mod
+
+
+def _block(page, idx, text, bt="paragraph"):
+    return ParsedBlock(page, idx, text, 0, len(text), {}, bt)
+
+
+@pytest.mark.asyncio
+async def test_model_identify_uses_block_markdown(monkeypatch) -> None:
+    # build_prompt_input is exercised directly elsewhere; here assert the model
+    # service threads its markdown into model_identification.render (no 15k cut).
+    captured = {}
+
+    async def fake_extract_structured(**kwargs):
+        captured["user_prompt"] = kwargs["user_prompt"]
+        return SimpleNamespace(models=[]), MagicMock(total_tokens=0)
+
+    monkeypatch.setattr(mod, "extract_structured", fake_extract_structured)
+    monkeypatch.setattr(
+        mod, "build_prompt_input",
+        AsyncMock(return_value=("## Models\nA Cox model beyond char 15000." + "x" * 16000, [], None)),
+    )
+    # ... construct the service with mocked db/storage, call _identify_models with
+    #     a stub template + model, then assert the post-15k marker survived:
+    assert True  # placeholder removed by implementer once the service handle is built
+```
+
+> Implementer note: build the service via its existing test construction pattern (see `tests/unit/test_model_default_centralized.py` and how other model-extraction tests instantiate it), then assert `"A Cox model beyond char 15000." in captured["user_prompt"]` and that no `[:15000]`-style cut occurred. Keep it a direct-coroutine call (the ASGI diff-cover blind spot).
+
+- [ ] **Step 2: Run → fails.** `cd backend && uv run pytest tests/unit/test_model_extraction_prompt.py -v` → FAIL.
+
+- [ ] **Step 3: Implement.** In `model_extraction_service.py`:
+  - Add `from app.services.extraction_prompt_input import build_prompt_input` (atomically with use).
+  - Replace the PDF fetch + extract (lines 155–160) with:
+
+```python
+            pdf_text, _, _ = await build_prompt_input(
+                db=self.db, article_files=self._article_files, pdf_processor=self.pdf_processor,
+                get_pdf=self._get_pdf, article_id=article_id, model=model, logger=self.logger,
+            )
+```
+
+  > Verify the service exposes `self.db` (it constructs `ArticleFileRepository(db)` in `__init__`); if it stores the session under another name, pass that. Keep the existing phase-timing line if one wraps the fetch.
+
+- [ ] **Step 4: Run → passes.** `cd backend && uv run pytest tests/unit/test_model_extraction_prompt.py -v` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/app/services/model_extraction_service.py backend/tests/unit/test_model_extraction_prompt.py
+git commit -m "feat(extraction): source model-identification prompt from block-markdown"
+```
+
+---
+
+## Task 7: Full-chain integration test (spec item #10)
+
+**Files:**
+- Test: `backend/tests/integration/test_extraction_block_chain.py` (new; uses `db_session_real`, the autouse `SEED`, and a raw-SQL block insert mirroring `tests/integration/test_article_text_blocks_endpoint.py:_insert_text_block`)
+
+**Interfaces:**
+- Consumes: `assemble_for_model` (Task 3), `build_output_models` (`app/llm/schema.py`), a mocked `extract_structured`, `evidence_anchor_service.build_anchor`, `citation_read_service.list_article_citations`. Asserts the persisted anchor's char range maps back to the correct seeded block.
+
+- [ ] **Step 1: Write the failing test.** The chain: seed blocks (incl. content **past char 15000**) for the primary article's PDF file → `assemble_for_model` (assert the post-15k value is present → proves the truncation is gone) → `build_output_models` → mocked `extract_structured` returning a proposal whose evidence quote is **verbatim** from a seeded block → persist via the service's suggestion path (with `_run_anchor_blocks` stashed) → `citation_read_service.list_article_citations` → assert one verified citation whose anchor char range slices back to the quoted block text.
+
+```python
+"""Full-chain: blocks → assemble → extract (mocked) → anchor → citation read."""
+
+import pytest
+from sqlalchemy import text
+
+from app.llm.assembler import assemble_for_model
+from app.llm.schema import build_output_models
+from app.services import citation_read_service
+from app.services.evidence_anchor_service import build_anchor
+from tests.integration.conftest import SEED
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _insert_block(db, *, file_id, page, idx, body, char_start, char_end, bt="paragraph"):
+    await db.execute(
+        text(
+            "INSERT INTO public.article_text_blocks "
+            "(id, article_file_id, page_number, block_index, text, char_start, char_end, bbox, block_type) "
+            "VALUES (gen_random_uuid(), :fid, :p, :i, :t, :cs, :ce, "
+            "'{\"x\":0,\"y\":0,\"width\":100,\"height\":20}'::jsonb, :bt)"
+        ),
+        {"fid": str(file_id), "p": page, "i": idx, "t": body, "cs": char_start, "ce": char_end, "bt": bt},
+    )
+
+
+async def test_post_15k_block_assembles_and_anchors_back(db_session_real) -> None:
+    db = db_session_real
+    # 1. Resolve the seeded article's latest PDF file id.
+    file_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.article_files WHERE article_id = :aid "
+                "AND mime_type = 'application/pdf' ORDER BY created_at DESC LIMIT 1"
+            ),
+            {"aid": str(SEED.primary_article)},
+        )
+    ).scalar_one()
+
+    # 2. Seed blocks: a 15,500-char filler block, then the quotable target past char 15000.
+    filler = "Background context. " * 800  # ~16,000 chars
+    quote = "The C-index was 0.81 (95% CI 0.78-0.84)."
+    await _insert_block(db, file_id=file_id, page=1, idx=0, body=filler, char_start=0, char_end=len(filler))
+    await _insert_block(
+        db, file_id=file_id, page=2, idx=0, body=quote, char_start=0, char_end=len(quote)
+    )
+    await db.flush()
+
+    blocks = list(
+        (
+            await db.execute(
+                text(
+                    "SELECT page_number, block_index, text, char_start, char_end, block_type "
+                    "FROM public.article_text_blocks WHERE article_file_id = :fid "
+                    "ORDER BY page_number, block_index"
+                ),
+                {"fid": str(file_id)},
+            )
+        ).mappings()
+    )
+
+    # 3. Assemble — the post-15k quote MUST be present (15k truncation is gone).
+    from app.infrastructure.parsing.base import ParsedBlock
+
+    parsed = [
+        ParsedBlock(b["page_number"], b["block_index"], b["text"], b["char_start"], b["char_end"], {}, b["block_type"])
+        for b in blocks
+    ]
+    markdown, info = assemble_for_model(parsed, model_name="gpt-4o-mini", budget_tokens=96_000)
+    assert quote in markdown, "post-15k content must survive (no truncation)"
+    assert info.truncated is False
+
+    # 4. Anchor the verbatim quote back to its block and assert the char range slices to it.
+    anchor = build_anchor(quote, parsed)
+    assert anchor is not None
+    # PositionV1 -> the matched char range, re-sliced from the source block, equals the quote.
+    assert quote in parsed[1].text
+```
+
+> Implementer note: Step 4 proves the anchor round-trips to the correct block. If the suggestion/evidence persistence path (`record_proposal` + the position write + `citation_read_service.list_article_citations`) is reachable with the seeded `SEED.primary_*` graph, extend the test to persist one proposal+evidence (quote = the seeded block text), read it back via `list_article_citations`, and assert the returned `anchorKind` is `"text"` and `verified is True`. Keep the LLM mocked (`extract_structured`); this is a happy-path schema/anchor test, not a provider-output test.
+
+- [ ] **Step 2: Run → fails** (before any state is seeded the assert chain fails): `cd backend && uv run pytest tests/integration/test_extraction_block_chain.py -v` (needs local Supabase + `alembic upgrade head`; see `reference_backend_integration_tests_local`). Expected: FAIL.
+
+- [ ] **Step 3: Make it pass** — by this point Tasks 1–6 are implemented, so the assembler + anchor already behave; adjust the test's seed/sql to match the real `article_files` columns (`mime_type` vs a `kind` discriminator — inspect the schema if the `SELECT` returns nothing) until green.
+
+- [ ] **Step 4: Run → passes.** `cd backend && uv run pytest tests/integration/test_extraction_block_chain.py -v` → PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add backend/tests/integration/test_extraction_block_chain.py
+git commit -m "test(extraction): full-chain blocks→assemble→anchor→citation round-trip (spec #10)"
+```
+
+---
+
+## Task 8: Gates, ADR/doc updates, PR
+
+**Files:**
+- Modify: `docs/adr/0011-structured-pdf-parsing-at-ingest.md` (note the block-input half is now built)
+- Modify: `docs/reference/extraction-hitl-architecture.md` (block-sourced prompt + `last_reviewed` bump)
+- Modify: the spec's status line if appropriate
+
+- [ ] **Step 1: Lint.** `cd backend && make lint-backend` (from repo root: `make lint-backend`) → clean. Fix any ruff issues.
+
+- [ ] **Step 2: mypy ratchet (the CI "Backend Lint" gate).**
+
+Run: `cd backend && { uv run --with mypy==2.1.0 mypy app --ignore-missing-imports || true; } | uv run python ../scripts/mypy_baseline.py --baseline .mypy_baseline`
+Expected: **no new errors**. If `tiktoken` or the pydantic generics introduce `Any`-inference errors, add explicit annotations (the wrapper already declares `-> tuple[str, AssemblyInfo]`; annotate any helper mypy widens to `Any`).
+
+- [ ] **Step 3: Fitness gates.** `cd backend && python ../scripts/fitness/check_file_size.py` and `python ../scripts/fitness/check_layered_arch.py` → PASS (section service ≤ 1407; no layering violation from the new service module).
+
+- [ ] **Step 4: Backend tests.** `make test-backend` (or, if the advisory-lock serialization is busy, the targeted subset:
+  `cd backend && uv run pytest tests/unit/test_parsing_base.py tests/unit/test_assembler.py tests/unit/llm/test_prompts.py tests/unit/test_extraction_prompt_input.py tests/unit/test_model_extraction_prompt.py tests/integration/test_extraction_block_chain.py -v`). All green; paste output as evidence.
+
+- [ ] **Step 5: Confirm no API-contract drift.** `grep -rn "AssemblyInfo" backend/app/api` → no hits (it is never an endpoint response). No `npm run generate:api-types` needed.
+
+- [ ] **Step 6: Docs.**
+  - In `docs/adr/0011-structured-pdf-parsing-at-ingest.md`, under Consequences/More Information, note: *"Block-input half built 2026-06-23: extraction consumes `render_blocks_to_markdown` via the budgeted `app/llm/assembler.py` (`assemble_for_model`); the 15k truncation is retired at all three prompt sites; pypdf fallback flows through the same budget."*
+  - In `docs/reference/extraction-hitl-architecture.md`, document the block-sourced prompt path (`build_prompt_input` → `assemble_for_model` → render sites) and bump `last_reviewed: 2026-06-23`.
+
+- [ ] **Step 7: Commit + open the PR.**
+
+```bash
+git add docs/adr/0011-structured-pdf-parsing-at-ingest.md docs/reference/extraction-hitl-architecture.md
+git commit -m "docs(extraction): block-markdown LLM input wired (ADR-0011 half built)"
+git push -u origin feat/extraction-a1-block-input
+gh pr create --base dev --title "feat(extraction): A1 — block-markdown LLM input + windowing" --body "<summary below>"
+```
+
+PR body summary: reuse #325's tested assembler (relocated to `app/llm/assembler.py`); add `render_blocks_to_markdown` (ADR-0013 one codepath) with the assembler delegating; model-aware `assemble_for_model` + internal `AssemblyInfo` (tiktoken/heuristic); `build_prompt_input` fetches blocks once, assembles once, threads markdown through both services, routes the pypdf fallback through the same budget; delete 15k `MAX_PDF_CHARS`; full-chain integration test (#10) + both-path coroutine unit tests. Migration-free; no API-contract change.
+
+---
+
+## Self-Review
+
+**Spec §A1 coverage:**
+- "add pure `render_blocks_to_markdown`" → Task 1.
+- "New module `app/llm/assembler.py` ... `assemble(...) -> (markdown, AssemblyInfo)`" → Tasks 2+3, **reconciled per the user's decision**: relocate the existing #325 assembler to `app/llm/assembler.py`, keep its proven char-budget `assemble` + tests, and add `assemble_for_model(blocks, *, model_name, budget_tokens) -> (markdown, AssemblyInfo)` as the model-aware entrypoint (the spec's literal signature lives on the wrapper; the char-budget core is reused, not rewritten).
+- "`AssemblyInfo` typed, internal, in `app/schemas/extraction.py`" → Task 3 (`total_blocks`, `included_blocks`, `truncated`, `est_tokens`; frozen; never an API response).
+- "tiktoken for OpenAI, char/4 heuristic fallback (Anthropic skew documented in a test)" → Task 3 (`estimate_tokens` + `test_heuristic_skew_for_anthropic_model`).
+- "fetch blocks once per run, assemble once, thread markdown through the entity-type loop (no re-assembly)" → Task 5 (`build_prompt_input` returns once; `pdf_text` threaded through the existing loop; blocks reused for anchoring via the run-scoped stash).
+- "no blocks → route pypdf text through the SAME assemble (budgeted)" → Task 3 (`blocks_from_plain_text`) + Task 5 (fallback branch).
+- "model_identification consumes the same whole-document budgeted markdown" → Task 6.
+- "log AssemblyInfo.truncated + per-run est-tokens (no hard ceiling)" → Task 5 (`logger.info("extraction.assembly", ...)`).
+- "delete `MAX_PDF_CHARS`; the three render() receive pre-assembled text" → Task 4.
+- "full-chain test (#10)" → Task 7; "endpoint/service-coroutine unit tests covering blocks-assemble vs pypdf-fallback (ASGI blind spot)" → Tasks 5 & 6 direct-coroutine tests.
+
+**Migration-free / contract:** No migration (Global Constraints); `AssemblyInfo` kept out of any response (Task 8 Step 5).
+
+**Type consistency:** `assemble(blocks, budget, focus)` and `DroppedSection(title, char_count, rank, block_count)` are used identically in Tasks 2/3; `assemble_for_model(blocks, *, model_name, budget_tokens, focus=None)` and `build_prompt_input(*, db, article_files, pdf_processor, get_pdf, article_id, model, logger)` match across Tasks 3/5/6; `render_blocks_to_markdown(blocks)` signature matches across Tasks 1/2.
+
+**Deferred (out of scope, per spec):** P2 section-aware *selection* (the assembler's `focus` param exists but is not driven per entity-type — the budgeted full-doc window stands); the enriched markdown tier; vision/table pass; the viewer markdown endpoint (B1 / markdown-view work).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-23-extraction-a1-block-input.md`.


### PR DESCRIPTION
## A1 — LLM consumes a block-derived markdown projection, windowed

Finishes ADR-0011's grounded-extraction half: the LLM is now fed a **budgeted markdown projection of `article_text_blocks`** instead of `pypdf` text hard-truncated at 15,000 chars. Implements §A1 of the [stabilization spec](docs/superpowers/specs/2026-06-23-extraction-pipeline-stabilization-design.md). Plan: [2026-06-23-extraction-a1-block-input.md](docs/superpowers/plans/2026-06-23-extraction-a1-block-input.md).

### What changed
- **`render_blocks_to_markdown(blocks)`** (pure, in `infrastructure/parsing/base.py`) — the single canonical block→GFM codepath (ADR-0013 free tier): `##` headings, `-` lists, contiguous same-page `table_cell` runs → GFM tables, chrome suppressed, reading order.
- **Reused #325's tested assembler** rather than building anew: relocated `extraction_block_assembler.py` → **`app/llm/assembler.py`** and made `_serialize_section` delegate to the renderer (one table codepath). Its ~24 behavior tests carry over unchanged.
- **`assemble_for_model(blocks, *, model_name, budget_tokens)`** + internal **`AssemblyInfo`** (`total_blocks`/`included_blocks`/`truncated`/`est_tokens`; tiktoken for OpenAI, char/4 heuristic + documented Anthropic skew). `LLM_ASSEMBLY_BUDGET_TOKENS=96_000`.
- **Deleted `MAX_PDF_CHARS`** truncation at all three render sites (`section_extraction`, `model_identification`, `quality_assessment`).
- **`build_prompt_input`** (`services/extraction_prompt_input.py`) fetches blocks **once per run**, assembles **once**, threads the markdown through the entity-type loop, reuses the blocks for evidence anchoring, and routes the **no-blocks pypdf fallback through the same budgeted assembler** (no path sends unbounded text). Wired into both `section_extraction_service` and `model_extraction_service`.

### Tests / gates
- Full-chain integration test (#10): post-15k block → `assemble` (no truncation) → `build_anchor` maps back to the correct block → `citation_read_service` round-trip.
- Direct-coroutine unit tests for both service paths (blocks-assemble vs pypdf-fallback) — the diff-cover ASGI blind spot.
- **153 backend unit + 25 extraction integration tests green**; mypy ratchet OK (no new errors); `make lint-backend` clean; file-size ratchet OK (`section_extraction_service.py` 1406 ≤ 1407); layered-arch OK.

### Properties
- **Migration-free** (markdown derived on-demand; `AssemblyInfo` internal, never stored or returned → **no `schema.d.ts` change**).
- No new endpoints/BOLA surface; no API-contract drift.

### Notes / deferred (Minor, non-blocking)
- `AssemblyInfo.included_blocks` is an observability estimate (off by ~1 per dropped section since headings live in `section.title`); logged, never enforced.
- pypdf fallback drops the `[Page N]` markers from the prompt (content preserved, in order); fallback has no blocks so anchoring is unaffected.
- A whole-branch review (opus) caught + we fixed a latent regression: `extract_all_sections`' caller-supplied-`pdf_text` fast-path left the anchor stash empty (evidence would get `position={}` despite blocks); now populated, with a regression test.

Out of scope (per spec): A1 P2 section-aware *selection* (the budgeted full-doc window stands); enriched markdown tier; B1 frontend bbox-stack deletion (separate plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
