### PR TITLE
fix(parsing): disable OCR in Docling parser (RapidOCR PP-OCRv6 crash)

### DIFF
--- a/backend/app/infrastructure/parsing/docling_parser.py
+++ b/backend/app/infrastructure/parsing/docling_parser.py
@@ -5,6 +5,14 @@ lazy-imported inside parse() so app boot and non-parsing tests stay light.
 Maps docling DocItem labels onto the closed block_type set, reads bbox from
 each item's prov, and emits ParsedBlock with char offsets as 0 placeholders
 (DocumentParsingService assigns real offsets).
+
+OCR is disabled: our inputs are born-digital scientific PDFs with an embedded
+text layer, so OCR adds nothing. docling's default ``do_ocr=True`` loads
+RapidOCR, whose torch backend crashes on the PP-OCRv6 default it adopted in
+3.9 ("Unsupported configuration: torch.PP-OCRv6.det.small") when onnxruntime
+is absent. Disabling OCR skips the RapidOCR import entirely. Table structure
+stays on (FAST + cell matching: cell text comes verbatim from the PDF text
+layer) since scientific tables are load-bearing for extraction.
 """
 
 from __future__ import annotations
@@ -30,18 +38,50 @@ _LABEL_MAP = {
 }
 
 
+def _pdf_pipeline_options():
+    """Build the PDF pipeline options for the self-hosted parser.
+
+    OCR off (born-digital text layer; avoids the RapidOCR/PP-OCRv6/torch crash),
+    table structure on in FAST mode with cell matching, accelerator pinned to
+    CPU (the worker has no GPU). Lazy-imports docling to keep app boot light.
+    """
+    from docling.datamodel.accelerator_options import (
+        AcceleratorDevice,
+        AcceleratorOptions,
+    )
+    from docling.datamodel.pipeline_options import PdfPipelineOptions, TableFormerMode
+
+    options = PdfPipelineOptions()
+    options.do_ocr = False
+    options.do_table_structure = True
+    options.table_structure_options.mode = TableFormerMode.FAST
+    options.table_structure_options.do_cell_matching = True
+    options.accelerator_options = AcceleratorOptions(device=AcceleratorDevice.CPU)
+    return options
+
+
 class DoclingParser(DocumentParser):
     """Self-hosted layout parser. Implements the DocumentParser port."""
 
     def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:
-        from docling.document_converter import DocumentConverter
+        from docling.datamodel.base_models import InputFormat
+        from docling.document_converter import (
+            DocumentConverter,
+            PdfFormatOption,
+        )
         from docling_core.types.doc import TableItem
+
+        converter = DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(pipeline_options=_pdf_pipeline_options())
+            }
+        )
 
         # docling reads from a path; write the bytes to a temp file.
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
             tmp.write(pdf_bytes)
             tmp.flush()
-            doc = DocumentConverter().convert(tmp.name).document
+            doc = converter.convert(tmp.name).document
 
         blocks: list[ParsedBlock] = []
         per_page_index: dict[int, int] = {}

--- a/backend/app/infrastructure/parsing/docling_parser.py
+++ b/backend/app/infrastructure/parsing/docling_parser.py
@@ -18,12 +18,16 @@ layer) since scientific tables are load-bearing for extraction.
 from __future__ import annotations
 
 import tempfile
+from typing import TYPE_CHECKING
 
 from app.infrastructure.parsing.base import (
     DocumentParser,
     ParsedBlock,
     normalize_block_type,
 )
+
+if TYPE_CHECKING:
+    from docling.datamodel.pipeline_options import PdfPipelineOptions
 
 # docling label.value -> our closed block_type
 _LABEL_MAP = {
@@ -38,7 +42,7 @@ _LABEL_MAP = {
 }
 
 
-def _pdf_pipeline_options():
+def _pdf_pipeline_options() -> PdfPipelineOptions:
     """Build the PDF pipeline options for the self-hosted parser.
 
     OCR off (born-digital text layer; avoids the RapidOCR/PP-OCRv6/torch crash),
@@ -49,13 +53,19 @@ def _pdf_pipeline_options():
         AcceleratorDevice,
         AcceleratorOptions,
     )
-    from docling.datamodel.pipeline_options import PdfPipelineOptions, TableFormerMode
+    from docling.datamodel.pipeline_options import (
+        PdfPipelineOptions,
+        TableFormerMode,
+        TableStructureOptions,
+    )
 
     options = PdfPipelineOptions()
     options.do_ocr = False
     options.do_table_structure = True
-    options.table_structure_options.mode = TableFormerMode.FAST
-    options.table_structure_options.do_cell_matching = True
+    options.table_structure_options = TableStructureOptions(
+        mode=TableFormerMode.FAST,
+        do_cell_matching=True,
+    )
     options.accelerator_options = AcceleratorOptions(device=AcceleratorDevice.CPU)
     return options
 

--- a/backend/tests/unit/test_docling_parser_options.py
+++ b/backend/tests/unit/test_docling_parser_options.py
@@ -1,0 +1,41 @@
+"""Unit test for the DoclingParser pipeline configuration.
+
+The self-hosted Docling parser must run with OCR DISABLED. Docling's default is
+``do_ocr=True``, which loads RapidOCR; RapidOCR 3.9+ promoted a PP-OCRv6 model
+the torch backend can't resolve (no ``onnxruntime`` on the slim worker), raising
+``Unsupported configuration: torch.PP-OCRv6.det.small`` at pipeline init. Our
+inputs are born-digital scientific PDFs with an embedded text layer, so OCR is
+unnecessary; disabling it skips the RapidOCR import entirely and neutralises the
+transitive-version drift.
+
+Skipped when docling is not installed (dev machines without torch); the CI image
+and the worker image install docling so it runs there.
+"""
+
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("docling") is None,
+    reason="docling not installed in this environment",
+)
+
+
+def test_pdf_pipeline_options_disable_ocr_keep_tables_on_cpu():
+    from docling.datamodel.accelerator_options import AcceleratorDevice
+    from docling.datamodel.pipeline_options import TableFormerMode
+
+    from app.infrastructure.parsing.docling_parser import _pdf_pipeline_options
+
+    opts = _pdf_pipeline_options()
+
+    # The bug: OCR on -> RapidOCR/PP-OCRv6/torch crash. Must be off.
+    assert opts.do_ocr is False
+    # Tables are load-bearing for scientific extraction: keep structure on,
+    # FAST mode for CPU cost, cell text matched verbatim from the PDF text layer.
+    assert opts.do_table_structure is True
+    assert opts.table_structure_options.mode == TableFormerMode.FAST
+    assert opts.table_structure_options.do_cell_matching is True
+    # The worker has no GPU; pin the accelerator to CPU explicitly.
+    assert opts.accelerator_options.device == AcceleratorDevice.CPU


### PR DESCRIPTION
## Why

The self-hosted **Docling** fallback parser crashes on **every** PDF that reaches it with `ValueError: Unsupported configuration: torch.PP-OCRv6.det.small`. Three prod `article_files` are stuck at `parse_failed` (most recent today 12:15 UTC), retrying every minute.

Root cause: docling's default `do_ocr=True` loads RapidOCR. **RapidOCR 3.9** (released ~2026-06-23 — matches the first failure at 06-23 19:26) promoted a **PP-OCRv6** detection model whose **torch** backend has no registered model URL. The slim worker ships **no `onnxruntime`**, so RapidOCR falls back to its torch engine and raises at pipeline init, before any page is read. `pyproject` pins `docling>=2.0.0` and the Dockerfile installs via `uv pip install -e .` (ignores `uv.lock`), so the transitive rapidocr drifted to 3.9 on a rebuild — which is why prod broke while local (rapidocr 3.8.4 → PP-OCRv4) still works.

## What changed

- `backend/app/infrastructure/parsing/docling_parser.py`: new `_pdf_pipeline_options()` builds the converter with **`do_ocr=False`**, `do_table_structure=True` (`TableFormerMode.FAST` + `do_cell_matching=True`), and the accelerator pinned to CPU. `parse()` now builds the `DocumentConverter` from these options instead of a bare `DocumentConverter()`.
- `backend/tests/unit/test_docling_parser_options.py`: regression test asserting OCR is off, tables stay on (FAST + cell matching), CPU accelerator.

Why `do_ocr=False` is correct and sufficient: born-digital scientific PDFs carry an embedded text layer, so OCR adds nothing. Confirmed from docling source that `from rapidocr import RapidOCR` lives inside `if self.enabled:` — with OCR off, **RapidOCR is never imported**, so the rapidocr version drift can't crash us regardless of which version a rebuild resolves. bbox + table structure are preserved (layout + TableFormer stay on), so evidence-anchoring/hybrid citations and table extraction are unaffected.

## Risk

Low, isolated to the Docling adapter (no endpoint / DB / migration / API-envelope surface). Behavioural change: a genuinely **scanned** (image-only) PDF hitting the self-hosted path now yields no text → `parse_failed` (the *same* terminal state as today, since it currently crashes for everyone). Default path is LlamaParse cloud; Docling is the fallback.

## Test plan

- [x] New regression test red→green (`tests/unit/test_docling_parser_options.py`)
- [x] `tests/integration/test_docling_parser.py` passes (real parse, OCR off)
- [x] Confirmed `rapidocr` not in `sys.modules` after a `DoclingParser().parse(...)`
- [x] Full unit suite: 1580 passed
- [x] `ruff check app tests` clean; `ruff format --check` clean
- [ ] Full `make test-backend` integration suite — deferred to CI (needs local Supabase Docker; change has no DB surface)

## Out of scope (follow-up: "harden next")

Build reproducibility + cost: switch Dockerfile to `uv sync --frozen` (honor the lock), pin torch/torchvision to the PyTorch **CPU** index (drops ~1GB+ of CUDA wheels — 74 nvidia refs in the lock), and prefetch only layout+TableFormer models at build time with `DOCLING_ARTIFACTS_PATH` + `HF_HUB_OFFLINE` (no runtime downloads). Tracked for PR 2.

## Post-deploy

After dev→main promotion + Railway redeploy, re-parse the 3 `parse_failed` files (and the pending backlog) via the existing re-parse affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)