### PR TITLE
Promote dev → main: consensus Phase B (optional rationale + full-envelope agreement)

### DIFF
--- a/backend/alembic/versions/0032_optional_consensus_rationale.py
+++ b/backend/alembic/versions/0032_optional_consensus_rationale.py
@@ -1,0 +1,44 @@
+"""Relax consensus manual_override CHECK: rationale optional
+
+Revision ID: 0032_optional_rationale
+Revises: 0031_unique_atb_idx
+Create Date: 2026-06-24
+
+Phase B (decision F) of the consensus-view rework: a consensus
+``manual_override`` needs only a ``value`` — the ``rationale`` becomes
+optional. Relaxes the DB CHECK ``manual_override_complete`` on
+``public.extraction_consensus_decisions`` from
+``value IS NOT NULL AND rationale IS NOT NULL`` to ``value IS NOT NULL``.
+
+Autogenerate does not detect CHECK-constraint *expression* changes, so this
+migration is hand-written. The service guard in ``ExtractionConsensusService``
+is relaxed in lockstep so the two enforcement points stay identical.
+
+Reversibility caveat: ``downgrade`` recreates the stricter constraint. If any
+``manual_override`` rows were written with ``rationale IS NULL`` after this
+migration, recreating the strict CHECK will fail (those rows violate it). That
+is the expected, documented limitation of relaxing a constraint — backfill or
+delete the NULL-rationale rows before downgrading in production.
+"""
+
+from alembic import op
+
+revision = "0032_optional_rationale"
+down_revision = "0031_unique_atb_idx"
+branch_labels = None
+depends_on = None
+
+_TABLE = "extraction_consensus_decisions"
+_CONSTRAINT = "manual_override_complete"
+_NEW_EXPR = "mode <> 'manual_override' OR value IS NOT NULL"
+_OLD_EXPR = "mode <> 'manual_override' OR (value IS NOT NULL AND rationale IS NOT NULL)"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check", schema="public")
+    op.create_check_constraint(_CONSTRAINT, _TABLE, _NEW_EXPR, schema="public")
+
+
+def downgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check", schema="public")
+    op.create_check_constraint(_CONSTRAINT, _TABLE, _OLD_EXPR, schema="public")

--- a/backend/app/models/extraction_workflow.py
+++ b/backend/app/models/extraction_workflow.py
@@ -359,7 +359,9 @@ class ExtractionConsensusDecision(BaseModel):
             name="select_existing_has_decision",
         ),
         CheckConstraint(
-            "mode <> 'manual_override' OR (value IS NOT NULL AND rationale IS NOT NULL)",
+            # Rationale is optional (Phase B, decision F) — only the value is
+            # required for a manual override. See alembic 0032.
+            "mode <> 'manual_override' OR value IS NOT NULL",
             name="manual_override_complete",
         ),
         {"schema": "public"},

--- a/backend/app/services/extraction_consensus_service.py
+++ b/backend/app/services/extraction_consensus_service.py
@@ -76,8 +76,11 @@ class ExtractionConsensusService:
 
         if mode_value == "select_existing" and selected_decision_id is None:
             raise InvalidConsensusError("mode='select_existing' requires selected_decision_id")
-        if mode_value == "manual_override" and (value is None or rationale is None):
-            raise InvalidConsensusError("mode='manual_override' requires both value and rationale")
+        # Rationale is optional (Phase B, decision F): only the value is required.
+        # The DB CHECK ``manual_override_complete`` is relaxed in lockstep
+        # (alembic 0032) so the two guards stay identical.
+        if mode_value == "manual_override" and value is None:
+            raise InvalidConsensusError("mode='manual_override' requires a value")
 
         # Resolve value to publish: from selected reviewer decision or from manual override
         if mode_value == "select_existing":

--- a/backend/app/services/run_lifecycle_service.py
+++ b/backend/app/services/run_lifecycle_service.py
@@ -309,12 +309,14 @@ class RunLifecycleService:
         """Per existing-instance × field coord with NO ``PublishedState`` yet: the single
         agreed value envelope to publish, plus the coords that still diverge unresolved.
 
-        Distinctness is compared on the UNWRAPPED scalar (so ``{"value": "x"}`` from two
-        reviewers counts as agreement), but the ORIGINAL envelope is published — it goes
-        straight into ``PublishedState.value``. Mirrors ``_filled_coords`` resolution
-        (``reject`` skipped; ``accept_proposal`` resolves through the referenced
-        proposal). One distinct value → publishable; ≥2 → unresolved divergence; coords
-        already carrying a ``PublishedState`` (manager-resolved) are skipped.
+        Distinctness is compared on the FULL value envelope (Phase B, decision G):
+        ``{"value":"5","unit":"mg"}`` and ``{"value":"5","unit":"g"}`` are a conflict, not
+        agreement — keying on the unit-stripped scalar used to publish one unit silently.
+        The original envelope is published verbatim into ``PublishedState.value``. Mirrors
+        ``_filled_coords`` resolution (``reject`` skipped; ``accept_proposal`` resolves
+        through the referenced proposal). One distinct envelope → publishable; ≥2 →
+        unresolved divergence; coords already carrying a ``PublishedState``
+        (manager-resolved) are skipped.
         """
         published_coords = {
             (instance_id, field_id)
@@ -330,7 +332,8 @@ class RunLifecycleService:
 
         # One pass over each reviewer's current value: first distinct value per
         # unpublished coord is the publish candidate; a second DIFFERENT value
-        # (compared on the unwrapped scalar) demotes the coord to unresolved.
+        # (compared on the FULL envelope, so a unit/structured difference counts)
+        # demotes the coord to unresolved.
         to_publish: dict[tuple[UUID, UUID], Any] = {}
         seen_key: dict[tuple[UUID, UUID], str] = {}
         unresolved: set[tuple[UUID, UUID]] = set()
@@ -338,7 +341,7 @@ class RunLifecycleService:
             coord = (instance_id, field_id)
             if coord in published_coords or coord in unresolved:
                 continue
-            key = json.dumps(_unwrap_value(resolved), sort_keys=True, default=str)
+            key = json.dumps(resolved, sort_keys=True, default=str)
             if coord not in seen_key:
                 seen_key[coord] = key
                 to_publish[coord] = resolved

--- a/backend/tests/integration/test_extraction_consensus_service.py
+++ b/backend/tests/integration/test_extraction_consensus_service.py
@@ -156,9 +156,11 @@ async def test_select_existing_requires_decision_id(
 
 
 @pytest.mark.asyncio
-async def test_manual_override_requires_value_and_rationale(
+async def test_manual_override_requires_value(
     db_session: AsyncSession,
 ) -> None:
+    """A ``manual_override`` with no value is still rejected (Phase B relaxed
+    only the rationale requirement, not the value)."""
     fx = await _setup_consensus_run(db_session)
     if fx is None:
         pytest.skip("Missing fixtures.")
@@ -175,6 +177,41 @@ async def test_manual_override_requires_value_and_rationale(
             value=None,
             rationale=None,
         )
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_manual_override_allows_null_rationale(
+    db_session: AsyncSession,
+) -> None:
+    """Phase B (decision F): the consensus rationale is OPTIONAL.
+
+    A ``manual_override`` with a value but ``rationale=None`` is accepted —
+    both the DB CHECK ``manual_override_complete`` (relaxed in alembic 0032)
+    and the service guard now require only ``value``. The PublishedState is
+    written exactly as for a rationale-bearing override. This rides the real
+    Postgres CHECK constraint, which is invisible to the mock-driven unit
+    twin, so it must live here.
+    """
+    fx = await _setup_consensus_run(db_session)
+    if fx is None:
+        pytest.skip("Missing fixtures.")
+    run_id, instance_id, field_id, profile_id, _ = fx
+
+    service = ExtractionConsensusService(db_session)
+    consensus, published = await service.record_consensus(
+        run_id=run_id,
+        instance_id=instance_id,
+        field_id=field_id,
+        consensus_user_id=profile_id,
+        mode=ExtractionConsensusMode.MANUAL_OVERRIDE,
+        value={"value": "5", "unit": "mg"},
+        rationale=None,
+    )
+    assert consensus.mode == "manual_override"
+    assert consensus.rationale is None
+    assert published.version == 1
+    assert published.value == {"value": "5", "unit": "mg"}
     await db_session.rollback()
 
 

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -141,6 +141,53 @@ async def test_migration_0030_round_trip(db_session: AsyncSession) -> None:
     )
 
 
+# Identify the manual_override CHECK by its CONTENT (it references the
+# 'manual_override' mode), not its name: SQLAlchemy's naming convention
+# prefixes the declared name to ``ck_extraction_consensus_decisions_*``, and we
+# don't want the test coupled to that. The sibling select_existing CHECK does
+# not mention 'manual_override', so this match is unambiguous in both states.
+_OVERRIDE_CHECK_DEF = text(
+    "SELECT pg_get_constraintdef(c.oid) "
+    "FROM pg_constraint c "
+    "JOIN pg_class t ON t.oid = c.conrelid "
+    "JOIN pg_namespace n ON n.oid = t.relnamespace "
+    "WHERE t.relname = 'extraction_consensus_decisions' "
+    "AND n.nspname = 'public' "
+    "AND c.contype = 'c' "
+    "AND pg_get_constraintdef(c.oid) LIKE '%manual_override%'"
+)
+
+
+@pytest.mark.asyncio
+async def test_migration_0032_round_trip(db_session: AsyncSession) -> None:
+    """``0032_optional_rationale`` relaxes the CHECK ``manual_override_complete``
+    to require only ``value`` (rationale optional). At head the constraint no
+    longer mentions ``rationale``; downgrading to the explicit parent ``0031``
+    restores the stricter expression; ``upgrade head`` relaxes it again.
+    Downgrades to the explicit parent (not ``-1``) so the test stays correct as
+    later migrations stack on top."""
+    def_at_head = (await db_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
+    assert def_at_head is not None and "rationale" not in def_at_head, (
+        f"manual_override_complete must not require rationale at HEAD, got: {def_at_head}"
+    )
+
+    _run_alembic("downgrade", "0031_unique_atb_idx")
+    try:
+        await db_session.commit()
+        def_down = (await db_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
+        assert def_down is not None and "rationale" in def_down, (
+            f"downgrade must restore the rationale requirement, got: {def_down}"
+        )
+    finally:
+        _run_alembic("upgrade", "head")
+
+    await db_session.commit()
+    def_after = (await db_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
+    assert def_after is not None and "rationale" not in def_after, (
+        f"upgrade head must re-relax the constraint, got: {def_after}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_alembic_head_is_expected_revision() -> None:
     """Pin the head revision id. If a future migration is added without
@@ -149,8 +196,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0031_unique_atb_idx" in out, (
-        f"Expected head revision '0031_unique_atb_idx', got:\n{out}"
+    assert "0032_optional_rationale" in out, (
+        f"Expected head revision '0032_optional_rationale', got:\n{out}"
     )
 
 

--- a/backend/tests/integration/test_qa_publish_flow.py
+++ b/backend/tests/integration/test_qa_publish_flow.py
@@ -571,7 +571,7 @@ async def test_finalize_rejected_from_wrong_stage(
     assert "cannot transition" in res.json()["error"]["message"].lower()
 
 
-# ===================== Manual override requires rationale =====================
+# ===================== Manual override requires only a value =====================
 
 
 @pytest.mark.asyncio
@@ -579,10 +579,10 @@ async def test_finalize_rejected_from_wrong_stage(
     ("value_payload", "rationale", "expected_status", "ids"),
     [
         ({"value": "Y"}, "with rationale", 201, "happy-path"),
-        ({"value": "Y"}, None, 400, "missing-rationale"),
+        ({"value": "Y"}, None, 201, "optional-rationale"),
         (None, "rationale alone", 400, "missing-value"),
     ],
-    ids=["happy-path", "missing-rationale", "missing-value"],
+    ids=["happy-path", "optional-rationale", "missing-value"],
 )
 async def test_manual_override_payload_validation(
     db_client: AsyncClient,
@@ -593,9 +593,9 @@ async def test_manual_override_payload_validation(
     expected_status: int,
     ids: str,  # noqa: ARG001
 ) -> None:
-    """manual_override requires both ``value`` and ``rationale``. Either
-    being absent rejects the request before any DB write, so the run is
-    untouched and republish can retry cleanly."""
+    """manual_override requires only a ``value``; the ``rationale`` is optional
+    (Phase B, decision F). A missing value still rejects the request before any
+    DB write, so the run is untouched and republish can retry cleanly."""
     article = await _pick_article(db_session)
     global_template_id = await _pick_qa_global_template(db_session)
     if article is None or global_template_id is None:

--- a/backend/tests/integration/test_run_lifecycle_service.py
+++ b/backend/tests/integration/test_run_lifecycle_service.py
@@ -757,3 +757,204 @@ async def test_approve_and_finalize_rejects_unresolved_divergence(
     with pytest.raises(InvalidStageTransitionError, match="diverge"):
         await svc.approve_and_finalize(run_id=run.id, user_id=profile_id)
     await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_approve_and_finalize_treats_unit_difference_as_divergence(
+    db_session: AsyncSession,
+) -> None:
+    """Phase B (decision G) — comparison contract: agreement is keyed on the FULL
+    stored envelope, not the unit-stripped scalar. This feeds the ``{value, unit}``
+    shape directly (the value remaining after one ``{value: …}`` peel): the old key
+    ``_unwrap_value(resolved)`` collapsed it to ``"5"`` and FALSELY agreed on
+    ``5 mg`` vs ``5 g``; the full-envelope key keeps the unit, so the coord is a
+    conflict and approve_and_finalize must REJECT. (The form double-wraps unit
+    values as ``{value: {value, unit}}`` — see the production-fidelity test below —
+    so this synthetic shape isolates the one-level-peel behaviour the fix targets.)"""
+    from app.services.extraction_review_service import ExtractionReviewService
+
+    fx = await _fixtures(db_session)
+    if fx is None:
+        pytest.skip("Missing fixtures.")
+    project_id, article_id, template_id, profile_id = fx
+    reviewer_id = SEED.reviewer_profile
+
+    await db_session.execute(
+        text(
+            "DELETE FROM public.extraction_runs WHERE project_id = :p "
+            "AND article_id = :a AND template_id = :t"
+        ),
+        {"p": str(project_id), "a": str(article_id), "t": str(template_id)},
+    )
+    svc = RunLifecycleService(db_session)
+    run = await svc.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=profile_id,
+    )
+    await svc.advance_stage(run_id=run.id, target_stage="extract", user_id=profile_id)
+    review = ExtractionReviewService(db_session)
+    await review.record_decision(
+        run_id=run.id,
+        instance_id=SEED.primary_instance,
+        field_id=SEED.primary_field,
+        reviewer_id=profile_id,
+        decision="edit",
+        value={"value": "5", "unit": "mg"},
+    )
+    await review.record_decision(
+        run_id=run.id,
+        instance_id=SEED.primary_instance,
+        field_id=SEED.primary_field,
+        reviewer_id=reviewer_id,
+        decision="edit",
+        value={"value": "5", "unit": "g"},
+    )
+    await svc.advance_stage(run_id=run.id, target_stage="consensus", user_id=profile_id)
+
+    with pytest.raises(InvalidStageTransitionError, match="diverge"):
+        await svc.approve_and_finalize(run_id=run.id, user_id=profile_id)
+
+    # Nothing was auto-published — the conflict must be resolved by the manager.
+    published = (
+        await db_session.execute(
+            text("SELECT count(*) FROM public.extraction_published_states WHERE run_id = :r"),
+            {"r": str(run.id)},
+        )
+    ).scalar()
+    assert published == 0
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_approve_and_finalize_publishes_identical_full_envelope(
+    db_session: AsyncSession,
+) -> None:
+    """Phase B (decision G) guardrail: when two reviewers submit the SAME full
+    envelope (value AND unit), it is still agreement — approve_and_finalize
+    publishes the single value and finalizes. The envelope is published verbatim
+    (unit preserved), not the unwrapped scalar. A single-key ``{value: X}`` must
+    likewise keep agreeing across reviewers — only differing siblings diverge."""
+    from app.services.extraction_review_service import ExtractionReviewService
+
+    fx = await _fixtures(db_session)
+    if fx is None:
+        pytest.skip("Missing fixtures.")
+    project_id, article_id, template_id, profile_id = fx
+    reviewer_id = SEED.reviewer_profile
+
+    await db_session.execute(
+        text(
+            "DELETE FROM public.extraction_runs WHERE project_id = :p "
+            "AND article_id = :a AND template_id = :t"
+        ),
+        {"p": str(project_id), "a": str(article_id), "t": str(template_id)},
+    )
+    svc = RunLifecycleService(db_session)
+    run = await svc.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=profile_id,
+    )
+    await svc.advance_stage(run_id=run.id, target_stage="extract", user_id=profile_id)
+    review = ExtractionReviewService(db_session)
+    envelope = {"value": "5", "unit": "mg"}
+    await review.record_decision(
+        run_id=run.id,
+        instance_id=SEED.primary_instance,
+        field_id=SEED.primary_field,
+        reviewer_id=profile_id,
+        decision="edit",
+        value=dict(envelope),
+    )
+    await review.record_decision(
+        run_id=run.id,
+        instance_id=SEED.primary_instance,
+        field_id=SEED.primary_field,
+        reviewer_id=reviewer_id,
+        decision="edit",
+        value=dict(envelope),
+    )
+    await svc.advance_stage(run_id=run.id, target_stage="consensus", user_id=profile_id)
+
+    finalized, published_count = await svc.approve_and_finalize(run_id=run.id, user_id=profile_id)
+    assert finalized.stage == ExtractionRunStage.FINALIZED.value
+    assert published_count == 1
+
+    published_value = (
+        await db_session.execute(
+            text("SELECT value FROM public.extraction_published_states WHERE run_id = :r"),
+            {"r": str(run.id)},
+        )
+    ).scalar()
+    assert published_value == envelope  # full envelope preserved, unit intact
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_approve_and_finalize_real_form_double_wrapped_unit_diverges(
+    db_session: AsyncSession,
+) -> None:
+    """Phase B (decision G) — production fidelity. The form does NOT store a bare
+    ``{value, unit}``: the autosave builds ``{value, unit}`` and ``writeRunFieldValue``
+    wraps it again, so the reviewer decision value is ``{value: {value, unit}}``
+    (frontend/services/extractionRunService.ts). This test feeds that exact stored
+    shape — ``{value: {value:"5", unit:"mg"}}`` vs ``{value: {value:"5", unit:"g"}}`` —
+    and confirms approve_and_finalize REJECTS and publishes nothing. (With this
+    double-wrapped shape the old one-level ``_unwrap_value`` already kept the unit,
+    so this guards that the full-envelope key does not regress the real path.)"""
+    from app.services.extraction_review_service import ExtractionReviewService
+
+    fx = await _fixtures(db_session)
+    if fx is None:
+        pytest.skip("Missing fixtures.")
+    project_id, article_id, template_id, profile_id = fx
+    reviewer_id = SEED.reviewer_profile
+
+    await db_session.execute(
+        text(
+            "DELETE FROM public.extraction_runs WHERE project_id = :p "
+            "AND article_id = :a AND template_id = :t"
+        ),
+        {"p": str(project_id), "a": str(article_id), "t": str(template_id)},
+    )
+    svc = RunLifecycleService(db_session)
+    run = await svc.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=profile_id,
+    )
+    await svc.advance_stage(run_id=run.id, target_stage="extract", user_id=profile_id)
+    review = ExtractionReviewService(db_session)
+    await review.record_decision(
+        run_id=run.id,
+        instance_id=SEED.primary_instance,
+        field_id=SEED.primary_field,
+        reviewer_id=profile_id,
+        decision="edit",
+        value={"value": {"value": "5", "unit": "mg"}},
+    )
+    await review.record_decision(
+        run_id=run.id,
+        instance_id=SEED.primary_instance,
+        field_id=SEED.primary_field,
+        reviewer_id=reviewer_id,
+        decision="edit",
+        value={"value": {"value": "5", "unit": "g"}},
+    )
+    await svc.advance_stage(run_id=run.id, target_stage="consensus", user_id=profile_id)
+
+    with pytest.raises(InvalidStageTransitionError, match="diverge"):
+        await svc.approve_and_finalize(run_id=run.id, user_id=profile_id)
+
+    published = (
+        await db_session.execute(
+            text("SELECT count(*) FROM public.extraction_published_states WHERE run_id = :r"),
+            {"r": str(run.id)},
+        )
+    ).scalar()
+    assert published == 0
+    await db_session.rollback()

--- a/backend/tests/unit/test_extraction_consensus_service.py
+++ b/backend/tests/unit/test_extraction_consensus_service.py
@@ -209,20 +209,22 @@ async def test_select_existing_requires_decision_id() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("value", "rationale"),
-    [(None, "r"), ({"v": "x"}, None), (None, None)],
-    ids=["missing-value", "missing-rationale", "both-missing"],
+    [(None, "r"), (None, None)],
+    ids=["missing-value-with-rationale", "missing-value-no-rationale"],
 )
-async def test_manual_override_requires_value_and_rationale(
+async def test_manual_override_requires_value(
     value: dict | None,
     rationale: str | None,
 ) -> None:
+    """A ``manual_override`` still requires a value; rationale is optional
+    (Phase B, decision F), so the only rejected case is a missing value."""
     service = _make_service()
     load_p, coh_p, repo_p = _patch_helpers(run=_make_run())
     with (
         load_p,
         coh_p,
         repo_p,
-        pytest.raises(InvalidConsensusError, match="requires both value and rationale"),
+        pytest.raises(InvalidConsensusError, match="requires a value"),
     ):
         await service.record_consensus(
             run_id=uuid4(),
@@ -233,6 +235,29 @@ async def test_manual_override_requires_value_and_rationale(
             value=value,
             rationale=rationale,
         )
+
+
+@pytest.mark.asyncio
+async def test_manual_override_allows_null_rationale() -> None:
+    """Phase B (decision F): a ``manual_override`` with a value but no rationale
+    is accepted — the service guard requires only ``value``. (The DB CHECK is
+    relaxed in lockstep; that half is covered by the integration twin.)"""
+    service = _make_service()
+    service._published.insert_first_if_absent.return_value = _make_published(version=1)
+    load_p, coh_p, repo_p = _patch_helpers(run=_make_run())
+    with load_p, coh_p, repo_p:
+        consensus, published = await service.record_consensus(
+            run_id=uuid4(),
+            instance_id=uuid4(),
+            field_id=uuid4(),
+            consensus_user_id=uuid4(),
+            mode=ExtractionConsensusMode.MANUAL_OVERRIDE,
+            value={"value": "5", "unit": "mg"},
+            rationale=None,
+        )
+    assert consensus.mode == "manual_override"
+    assert consensus.rationale is None
+    assert published.version == 1
 
 
 # =================== record_consensus: select_existing resolution ===================

--- a/docs/reference/extraction-hitl-architecture.md
+++ b/docs/reference/extraction-hitl-architecture.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_reviewed: 2026-06-23
+last_reviewed: 2026-06-24
 owner: '@raphaelfh'
 ---
 
@@ -106,7 +106,7 @@ and `extraction_instance_status` enum were dropped in HITL Phase 3 (migration
 ## 3. Database — final schema
 
 All tables live in the `public` schema with RLS enabled. Migration head:
-`0030_drop_instance_status` (post-squash numbering; run
+`0032_optional_rationale` (post-squash numbering; run
 `ls backend/alembic/versions/` for the current head — and bump this line
 in any PR that adds an `extraction_*` migration).
 
@@ -119,7 +119,7 @@ in any PR that adds an `extraction_*` migration).
 | `extraction_proposal_records` | **Yes** | One row per proposed value for a `(run, instance, field)` triplet. Source: `ai` / `human` / `system`. CHECK: `human` requires `source_user_id`. Append-only of *changes*: `ExtractionProposalService.record_proposal` no-ops when the value is identical to the latest row for the same coord+source(+user), so a client replaying an unchanged value (form remount, retry) doesn't grow a duplicate. |
 | `extraction_reviewer_decisions` | **Yes** | One row per reviewer decision: `accept_proposal` / `reject` / `edit`. CHECKs enforce that `accept_proposal` carries a `proposal_record_id` and `edit` carries a `value`. Same idempotent-re-record rule as proposals: an unchanged decision replay (same decision+value+proposal) is a no-op. |
 | `extraction_reviewer_states` | Materialized | Current `decision_id` per `(run, reviewer, instance, field)`. Upserted alongside each decision so reads are O(1). Unique `(run_id, reviewer_id, instance_id, field_id)`. |
-| `extraction_consensus_decisions` | **Yes** | Conflict resolution: `select_existing` (arbitrator picks a reviewer decision) or `manual_override` (writes value + rationale directly). |
+| `extraction_consensus_decisions` | **Yes** | Conflict resolution: `select_existing` (arbitrator picks a reviewer decision) or `manual_override` (writes a value directly; rationale optional since `0032_optional_rationale`). CHECK `manual_override_complete` requires only `value` for an override. |
 | `extraction_published_states` | Mutable with version | Canonical value per `(run, instance, field)` with optimistic concurrency. Update uses `WHERE version = :expected` so 0 rows = 409 conflict. |
 | `extraction_reviewer_ready` | Upsert | Per-`(run, reviewer)` advisory "I'm done extracting" flag (`is_ready`, `marked_ready_at`). Unique `(run_id, reviewer_id)`. Does **not** gate any stage transition; surfaces the "N/M reviewers ready" hint. Added `0029` (HITL Phase 2). |
 
@@ -415,7 +415,7 @@ publish, AI), keep it in the page-specific component.
   alongside every new decision.
 - **ConsensusDecision** — Append-only resolution when reviewers diverge.
   `select_existing` (arbitrator picks a reviewer decision) or
-  `manual_override` (writes value + rationale).
+  `manual_override` (writes a value directly; rationale optional).
 - **PublishedState** — Canonical published value per `(run, instance,
   field)`, with an integer `version` for optimistic concurrency.
 - **Evidence** — Polymorphic — points at a PDF (article_file_id, page,

--- a/frontend/components/runs/ConsensusPanel.tsx
+++ b/frontend/components/runs/ConsensusPanel.tsx
@@ -382,11 +382,9 @@ function CoordRow({
                   </Button>
                   <Button
                     size="sm"
-                    disabled={
-                      disabled ||
-                      overrideValue.trim() === "" ||
-                      overrideRationale.trim() === ""
-                    }
+                    // Rationale is optional (Phase B, decision F): only a
+                    // non-empty value gates the publish.
+                    disabled={disabled || overrideValue.trim() === ""}
                     onClick={async () => {
                       let parsed: unknown;
                       try {

--- a/frontend/hooks/runs/useReviewerSummary.ts
+++ b/frontend/hooks/runs/useReviewerSummary.ts
@@ -69,9 +69,31 @@ function reviewerKey(
 }
 
 /**
- * Equality check that is permissive about wrapping (`{value: X}` vs `X`)
- * and uses JSON canonicalization for deeper structures. Rejects compare
- * equal to each other; "edit X" and "edit Y" don't.
+ * Canonical JSON with object keys sorted recursively — matches the backend's
+ * `json.dumps(value, sort_keys=True)` so the two agreement checks stay in lock
+ * step (Phase B finding F1). Key order never affects equality; a differing
+ * sibling key (e.g. `unit`) does.
+ *
+ * Caveat: JS has no int/float distinction, so `5` and `5.0` both stringify to
+ * `"5"` here while the backend keeps `5` vs `5.0`. Harmless in practice — form
+ * values are stored as strings (`"5"`), never bare JSON numbers — so a numeric
+ * mismatch would only arise from a non-form writer, which is out of scope.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+/**
+ * Agreement check on the FULL value envelope (Phase B, decision G): two
+ * reviewers agree only when their whole stored value matches, so `5 mg` vs
+ * `5 g` (`{value, unit}` differing on `unit`) is divergence — not the false
+ * agreement the old unit-stripped `unwrap` produced. A single-key `{value: X}`
+ * still compares equal across reviewers. Rejects compare equal to each other;
+ * a reject vs a non-reject never does.
  */
 function decisionsAgree(
   a: ReviewerDecisionResponse,
@@ -80,14 +102,14 @@ function decisionsAgree(
   if (a.decision === "reject" && b.decision === "reject") return true;
   if (a.decision === "reject" || b.decision === "reject") return false;
 
-  const av = unwrap(a.value);
-  const bv = unwrap(b.value);
-  return JSON.stringify(av) === JSON.stringify(bv);
+  return stableStringify(a.value) === stableStringify(b.value);
 }
 
 /**
- * Peel one `{value: X}` envelope. Exported so RunReviewerComparison renders
- * values the exact way this summary aggregates/compares them (one peel rule).
+ * Peel one `{value: X}` envelope for DISPLAY. Exported so RunReviewerComparison
+ * renders values the same way this summary aggregates them. Agreement is no
+ * longer decided by peeling — `decisionsAgree` compares the full envelope
+ * (Phase B, decision G).
  */
 export function unwrap(raw: unknown): unknown {
   if (

--- a/frontend/lib/copy/consensus.ts
+++ b/frontend/lib/copy/consensus.ts
@@ -93,7 +93,7 @@ export const consensus = {
     panelOverrideWithCustom: 'Override with custom value',
     panelCustomValueLabel: 'Custom value (JSON; use a string for free-text fields)',
     panelCustomValuePlaceholder: '"Low" or {"text": "..."}',
-    panelRationaleLabel: 'Rationale (required)',
+    panelRationaleLabel: 'Rationale (optional)',
     panelRationalePlaceholder:
         'Why publish a value none of the reviewers picked?',
     panelPublishOverride: 'Publish override',

--- a/frontend/test/ConsensusPanel.test.tsx
+++ b/frontend/test/ConsensusPanel.test.tsx
@@ -388,6 +388,47 @@ describe("ConsensusPanel", () => {
     });
   });
 
+  it("enables the override submit with an empty rationale and labels it optional (Phase B)", async () => {
+    const { runDetail, summary } = makeFixtures();
+    const onManualOverride = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ConsensusPanel
+        runDetail={runDetail}
+        summary={summary}
+        requiredCoords={[]}
+        peersRevealed={true}
+        onSelectExisting={vi.fn()}
+        onManualOverride={onManualOverride}
+        onFinalize={vi.fn()}
+        showFinalize={false}
+      />,
+    );
+
+    await user.click(
+      screen.getByTestId("consensus-override-toggle-inst-1::field-1"),
+    );
+
+    // Rationale label now reads "(optional)" — never "(required)".
+    expect(screen.getByText(/Rationale \(optional\)/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Rationale \(required\)/i)).toBeNull();
+
+    // Type only a value, leave the rationale empty.
+    await user.type(screen.getByLabelText(/Custom value/i), '"Maybe"');
+
+    const submit = screen.getByTestId("consensus-override-submit-inst-1::field-1");
+    expect(submit).toBeEnabled();
+
+    await user.click(submit);
+    expect(onManualOverride).toHaveBeenCalledWith({
+      instanceId: "inst-1",
+      fieldId: "field-1",
+      value: "Maybe",
+      rationale: "",
+    });
+  });
+
   it("shows the published custom value + rationale + a Change button when resolved", async () => {
     const { runDetail, summary } = makeFixtures(); // divergent inst-1::field-1
     const resolved = consensusDecision({

--- a/frontend/test/useReviewerSummary.test.ts
+++ b/frontend/test/useReviewerSummary.test.ts
@@ -164,6 +164,112 @@ describe("useReviewerSummary", () => {
     expect(result.current.divergentCoords.has("i1::f2")).toBe(false);
   });
 
+  it("compares the full value envelope: a differing unit is divergence, an identical envelope is agreement", () => {
+    // Phase B (decision G): agreement is decided on the whole stored value, not
+    // the unit-stripped scalar. `5 mg` vs `5 g` agree on the number but differ
+    // on the unit → divergence; the same full envelope from both → agreement.
+    const { result } = renderHook(() =>
+      useReviewerSummary(
+        runDetail({
+          decisions: [
+            decision({
+              reviewer_id: "user-a",
+              instance_id: "i1",
+              field_id: "f1",
+              value: { value: "5", unit: "mg" },
+            }),
+            decision({
+              reviewer_id: "user-b",
+              instance_id: "i1",
+              field_id: "f1",
+              value: { value: "5", unit: "g" },
+            }),
+            decision({
+              reviewer_id: "user-a",
+              instance_id: "i1",
+              field_id: "f2",
+              value: { value: "5", unit: "mg" },
+            }),
+            decision({
+              reviewer_id: "user-b",
+              instance_id: "i1",
+              field_id: "f2",
+              value: { value: "5", unit: "mg" },
+            }),
+          ],
+        }),
+      ),
+    );
+    expect(result.current.divergentCoords.has("i1::f1")).toBe(true);
+    expect(result.current.divergentCoords.has("i1::f2")).toBe(false);
+  });
+
+  it("production-fidelity: real double-wrapped form shape diverges on unit, agrees when identical", () => {
+    // The form stores unit values double-wrapped: useAutoSaveProposals builds
+    // {value, unit}, then writeRunFieldValue wraps again → decision.value =
+    // {value: {value, unit}} (extractionRunService.ts). Confirm decisionsAgree
+    // (via divergentCoords) handles that real shape: unit differs → divergence;
+    // identical double-wrapped envelope → agreement.
+    const { result } = renderHook(() =>
+      useReviewerSummary(
+        runDetail({
+          decisions: [
+            decision({
+              reviewer_id: "user-a",
+              instance_id: "i1",
+              field_id: "f1",
+              value: { value: { value: "5", unit: "mg" } },
+            }),
+            decision({
+              reviewer_id: "user-b",
+              instance_id: "i1",
+              field_id: "f1",
+              value: { value: { value: "5", unit: "g" } },
+            }),
+            decision({
+              reviewer_id: "user-a",
+              instance_id: "i1",
+              field_id: "f2",
+              value: { value: { value: "5", unit: "mg" } },
+            }),
+            decision({
+              reviewer_id: "user-b",
+              instance_id: "i1",
+              field_id: "f2",
+              value: { value: { value: "5", unit: "mg" } },
+            }),
+          ],
+        }),
+      ),
+    );
+    expect(result.current.divergentCoords.has("i1::f1")).toBe(true);
+    expect(result.current.divergentCoords.has("i1::f2")).toBe(false);
+  });
+
+  it("ignores object key order when comparing envelopes (canonical, matches backend sort_keys)", () => {
+    const { result } = renderHook(() =>
+      useReviewerSummary(
+        runDetail({
+          decisions: [
+            decision({
+              reviewer_id: "user-a",
+              instance_id: "i1",
+              field_id: "f1",
+              value: { value: "5", unit: "mg" },
+            }),
+            decision({
+              reviewer_id: "user-b",
+              instance_id: "i1",
+              field_id: "f1",
+              value: { unit: "mg", value: "5" },
+            }),
+          ],
+        }),
+      ),
+    );
+    expect(result.current.divergentCoords.has("i1::f1")).toBe(false);
+  });
+
   it("treats reject as not equal to a positive value but equal to another reject", () => {
     const { result } = renderHook(() =>
       useReviewerSummary(


### PR DESCRIPTION
Promotion of [#392](https://github.com/raphaelfh/prumo/pull/392) (consensus-view rework **Phase B**) from `dev` to `main` for production deploy (Railway deploys from `main`).

Single change being promoted:
- **F** — consensus `manual_override` rationale optional (DB CHECK relaxed via alembic `0032_optional_rationale`; service guard + model CHECK + frontend in lockstep).
- **G** — agreement compared on the full value envelope (backend `_agreed_unpublished_values` + frontend `decisionsAgree`), fixing the FE/BE canonicalization asymmetry. Safe hardening (never less conservative than the prior compare).

Green in `dev`: Backend Tests, Frontend Tests, Frontend E2E, API Contract, lint, CodeQL, Architectural Fitness, Backend Docker Build all passed on #392.

Merge-commit promotion (not squash/ff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)