### PR TITLE
chore(parsing): CPU-only torch + prefetched Docling models + lean image build

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,17 @@
+# Keep the build context small and secret-free. The Dockerfile only needs
+# pyproject.toml, uv.lock, README.md, app/, alembic/, alembic.ini.
+.venv
+venv
+.env
+.env.*
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+tests/
+.git/
+*.egg-info/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,20 +12,27 @@ RUN pip install --no-cache-dir uv
 COPY pyproject.toml README.md ./
 COPY app ./app
 
-# Install dependencies (editable so the runtime stage can reuse site-packages)
-RUN uv pip install --system --no-cache -e .
+# Install dependencies into the system prefix (the runtime stage copies it).
+# --torch-backend=cpu makes uv resolve torch/torchvision from the PyTorch CPU
+# wheel index, dropping the ~1GB CUDA stack (nvidia-*/triton) that is dead
+# weight on the CPU-only worker.
+RUN uv pip install --system --no-cache --torch-backend=cpu -e .
+
+# Prefetch ONLY the models the OCR-disabled standard pipeline needs (layout +
+# TableFormer) into the image, so the worker NEVER downloads at runtime. OCR
+# (RapidOCR) is disabled in the parser, and the code-formula / picture models
+# are unused — skip them to keep the image lean.
+RUN python -c "from pathlib import Path; from docling.utils.model_downloader import download_models; download_models(output_dir=Path('/opt/docling-models'), with_layout=True, with_tableformer=True, with_code_formula=False, with_picture_classifier=False, with_rapidocr=False, with_easyocr=False)"
 
 # =================== RUNTIME STAGE ===================
 FROM python:3.12-slim as runtime
 
 WORKDIR /app
 
-# System libraries for the self-hosted Docling fallback parser. Docling pulls
-# opencv (via rapidocr/docling-ibm-models), which dlopens libGL/libxcb/glib at
-# `import cv2`. The slim base ships none of these, so the fallback otherwise
-# crashes with "libxcb.so.1: cannot open shared object file". The default
-# (cloud LlamaParse) path is pure HTTP and does not need these, but the
-# fallback must not be a guaranteed crash.
+# System libraries for the self-hosted Docling parser. docling-ibm-models /
+# opencv historically dlopen libGL/libxcb/glib at import; the slim base ships
+# none of these. Kept conservatively even though OCR is now disabled — removing
+# them is a separate, tested cleanup once cv2 is confirmed unreachable.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libgl1 libglib2.0-0 libxcb1 libxext6 libsm6 libxrender1 \
@@ -38,13 +45,22 @@ RUN adduser --disabled-password --gecos "" appuser
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
+# Copy the prefetched Docling models
+COPY --from=builder /opt/docling-models /opt/docling-models
+
 # Copy application code and Alembic migration files
 COPY app ./app
 COPY alembic ./alembic
 COPY alembic.ini ./alembic.ini
 
+# Serve Docling models from the prefetched dir and forbid any runtime model
+# download (fail fast instead of hanging the worker offline).
+ENV DOCLING_ARTIFACTS_PATH=/opt/docling-models \
+    HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1
+
 # Change ownership
-RUN chown -R appuser:appuser /app
+RUN chown -R appuser:appuser /app /opt/docling-models
 
 # Switch to non-root user
 USER appuser
@@ -60,4 +76,3 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
 
 # Run migrations then start application
 CMD ["sh", "-c", "alembic upgrade head && gunicorn -k uvicorn.workers.UvicornWorker -w 1 -t 120 -b 0.0.0.0:${PORT:-8000} app.main:app"]
-

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,7 +38,11 @@ dependencies = [
     "logfire[fastapi,celery]>=3.0.0",
     # PDF Processing
     "pypdf>=5.0.0",
-    "docling>=2.0.0",
+    # Pinned: the parser stack is drift-sensitive — an unpinned rapidocr bump to
+    # 3.9 (PP-OCRv6) broke prod via docling's OCR default. OCR is now disabled in
+    # DoclingParser so rapidocr drift is harmless, but pinning docling itself
+    # stops its own API/model drift. Bump deliberately and re-test.
+    "docling==2.104.0",
     # Observability
     "structlog>=24.0.0",
     # Rate Limiting

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -4188,7 +4188,7 @@ requires-dist = [
     { name = "celery-types", marker = "extra == 'dev'", specifier = ">=0.22.0" },
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=10.0" },
-    { name = "docling", specifier = ">=2.0.0" },
+    { name = "docling", specifier = "==2.104.0" },
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "greenlet", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Why

Follow-up hardening to [#391](https://github.com/raphaelfh/prumo/pull/391) (which disabled OCR to fix the RapidOCR PP-OCRv6 crash). Two cost/reliability problems remained in the worker image:

1. The CPU-only worker pulled the **full CUDA torch stack** (~1GB of `nvidia-*`/`triton`) as dead weight — 74 nvidia refs in the resolution.
2. Docling downloaded its models from HF Hub at **first parse** (slow, network-fragile on the worker).

## What changed (`backend/Dockerfile`, `pyproject.toml`, `uv.lock`, `.dockerignore`)

- **CPU-only torch**: `uv pip install --torch-backend=cpu` resolves torch/torchvision from the PyTorch CPU index → `torch 2.12.1+cpu`, dropping the entire CUDA stack.
- **Build-time model prefetch**: download *only* layout + TableFormer into `/opt/docling-models` (skip OCR + the ~500MB code-formula model), then `DOCLING_ARTIFACTS_PATH` + `HF_HUB_OFFLINE=1` + `TRANSFORMERS_OFFLINE=1` so the worker **never** downloads at runtime.
- **Pin `docling==2.104.0`**: the parser stack is drift-sensitive (an unpinned rapidocr 3.9/PP-OCRv6 bump broke prod). OCR is disabled in #391 so rapidocr drift is moot, but pinning docling stops its own API/model drift.
- **`backend/.dockerignore`**: smaller, secret-free build context.

## Risk

Build-system only; no app code changes. Image build is the risk surface — validated below. Must deploy **with or after #391** (this image prefetches no OCR models and forbids runtime downloads; OCR-on code would fail offline). Both go to `main` in the same promotion.

## Test plan / evidence (validated locally on `linux/amd64`, Railway's arch)

- [x] `docker build --platform linux/amd64` succeeds (image 1.62GB)
- [x] `torch 2.12.1+cpu`, `torchvision 0.27.1+cpu`, **zero** nvidia/triton packages in the image
- [x] **Offline parse** (`docker run --network none`) succeeds from prefetched models with `do_ocr=False` — 4 blocks, text present
- [x] `uv lock --check` consistent; `ruff check` clean
- [ ] CI **Backend Docker Build** rebuilds the committed files (authoritative gate)

## Out of scope / notes

- **Full `uv sync --frozen` deferred**: uv 0.10.9 cannot combine a frozen lock with CPU-torch selection (`--torch-backend` is `uv pip install`-only; `uv lock`/`uv sync` ignore it and mis-resolve torchvision to a wheel-less local build). docling is pinned as the targeted drift guard; #391 already fixes the rapidocr drift that caused the outage.
- The `apt-get install libgl1 libxcb1 …` block is kept conservatively; with OCR off it is likely removable, but only as a separate tested cleanup (confirm no dep imports `cv2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)