### PR TITLE
Promote: Docling OCR-crash fix + CPU-torch/offline build hardening (#391, #394)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,17 @@
+# Keep the build context small and secret-free. The Dockerfile only needs
+# pyproject.toml, uv.lock, README.md, app/, alembic/, alembic.ini.
+.venv
+venv
+.env
+.env.*
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+tests/
+.git/
+*.egg-info/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,20 +12,27 @@ RUN pip install --no-cache-dir uv
 COPY pyproject.toml README.md ./
 COPY app ./app
 
-# Install dependencies (editable so the runtime stage can reuse site-packages)
-RUN uv pip install --system --no-cache -e .
+# Install dependencies into the system prefix (the runtime stage copies it).
+# --torch-backend=cpu makes uv resolve torch/torchvision from the PyTorch CPU
+# wheel index, dropping the ~1GB CUDA stack (nvidia-*/triton) that is dead
+# weight on the CPU-only worker.
+RUN uv pip install --system --no-cache --torch-backend=cpu -e .
+
+# Prefetch ONLY the models the OCR-disabled standard pipeline needs (layout +
+# TableFormer) into the image, so the worker NEVER downloads at runtime. OCR
+# (RapidOCR) is disabled in the parser, and the code-formula / picture models
+# are unused — skip them to keep the image lean.
+RUN python -c "from pathlib import Path; from docling.utils.model_downloader import download_models; download_models(output_dir=Path('/opt/docling-models'), with_layout=True, with_tableformer=True, with_code_formula=False, with_picture_classifier=False, with_rapidocr=False, with_easyocr=False)"
 
 # =================== RUNTIME STAGE ===================
 FROM python:3.12-slim as runtime
 
 WORKDIR /app
 
-# System libraries for the self-hosted Docling fallback parser. Docling pulls
-# opencv (via rapidocr/docling-ibm-models), which dlopens libGL/libxcb/glib at
-# `import cv2`. The slim base ships none of these, so the fallback otherwise
-# crashes with "libxcb.so.1: cannot open shared object file". The default
-# (cloud LlamaParse) path is pure HTTP and does not need these, but the
-# fallback must not be a guaranteed crash.
+# System libraries for the self-hosted Docling parser. docling-ibm-models /
+# opencv historically dlopen libGL/libxcb/glib at import; the slim base ships
+# none of these. Kept conservatively even though OCR is now disabled — removing
+# them is a separate, tested cleanup once cv2 is confirmed unreachable.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libgl1 libglib2.0-0 libxcb1 libxext6 libsm6 libxrender1 \
@@ -38,13 +45,22 @@ RUN adduser --disabled-password --gecos "" appuser
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
+# Copy the prefetched Docling models
+COPY --from=builder /opt/docling-models /opt/docling-models
+
 # Copy application code and Alembic migration files
 COPY app ./app
 COPY alembic ./alembic
 COPY alembic.ini ./alembic.ini
 
+# Serve Docling models from the prefetched dir and forbid any runtime model
+# download (fail fast instead of hanging the worker offline).
+ENV DOCLING_ARTIFACTS_PATH=/opt/docling-models \
+    HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1
+
 # Change ownership
-RUN chown -R appuser:appuser /app
+RUN chown -R appuser:appuser /app /opt/docling-models
 
 # Switch to non-root user
 USER appuser
@@ -60,4 +76,3 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
 
 # Run migrations then start application
 CMD ["sh", "-c", "alembic upgrade head && gunicorn -k uvicorn.workers.UvicornWorker -w 1 -t 120 -b 0.0.0.0:${PORT:-8000} app.main:app"]
-

--- a/backend/app/infrastructure/parsing/docling_parser.py
+++ b/backend/app/infrastructure/parsing/docling_parser.py
@@ -5,17 +5,29 @@ lazy-imported inside parse() so app boot and non-parsing tests stay light.
 Maps docling DocItem labels onto the closed block_type set, reads bbox from
 each item's prov, and emits ParsedBlock with char offsets as 0 placeholders
 (DocumentParsingService assigns real offsets).
+
+OCR is disabled: our inputs are born-digital scientific PDFs with an embedded
+text layer, so OCR adds nothing. docling's default ``do_ocr=True`` loads
+RapidOCR, whose torch backend crashes on the PP-OCRv6 default it adopted in
+3.9 ("Unsupported configuration: torch.PP-OCRv6.det.small") when onnxruntime
+is absent. Disabling OCR skips the RapidOCR import entirely. Table structure
+stays on (FAST + cell matching: cell text comes verbatim from the PDF text
+layer) since scientific tables are load-bearing for extraction.
 """
 
 from __future__ import annotations
 
 import tempfile
+from typing import TYPE_CHECKING
 
 from app.infrastructure.parsing.base import (
     DocumentParser,
     ParsedBlock,
     normalize_block_type,
 )
+
+if TYPE_CHECKING:
+    from docling.datamodel.pipeline_options import PdfPipelineOptions
 
 # docling label.value -> our closed block_type
 _LABEL_MAP = {
@@ -30,18 +42,56 @@ _LABEL_MAP = {
 }
 
 
+def _pdf_pipeline_options() -> PdfPipelineOptions:
+    """Build the PDF pipeline options for the self-hosted parser.
+
+    OCR off (born-digital text layer; avoids the RapidOCR/PP-OCRv6/torch crash),
+    table structure on in FAST mode with cell matching, accelerator pinned to
+    CPU (the worker has no GPU). Lazy-imports docling to keep app boot light.
+    """
+    from docling.datamodel.accelerator_options import (
+        AcceleratorDevice,
+        AcceleratorOptions,
+    )
+    from docling.datamodel.pipeline_options import (
+        PdfPipelineOptions,
+        TableFormerMode,
+        TableStructureOptions,
+    )
+
+    options = PdfPipelineOptions()
+    options.do_ocr = False
+    options.do_table_structure = True
+    options.table_structure_options = TableStructureOptions(
+        mode=TableFormerMode.FAST,
+        do_cell_matching=True,
+    )
+    options.accelerator_options = AcceleratorOptions(device=AcceleratorDevice.CPU)
+    return options
+
+
 class DoclingParser(DocumentParser):
     """Self-hosted layout parser. Implements the DocumentParser port."""
 
     def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:
-        from docling.document_converter import DocumentConverter
+        from docling.datamodel.base_models import InputFormat
+        from docling.document_converter import (
+            DocumentConverter,
+            PdfFormatOption,
+        )
         from docling_core.types.doc import TableItem
+
+        converter = DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(pipeline_options=_pdf_pipeline_options())
+            }
+        )
 
         # docling reads from a path; write the bytes to a temp file.
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
             tmp.write(pdf_bytes)
             tmp.flush()
-            doc = DocumentConverter().convert(tmp.name).document
+            doc = converter.convert(tmp.name).document
 
         blocks: list[ParsedBlock] = []
         per_page_index: dict[int, int] = {}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,7 +38,11 @@ dependencies = [
     "logfire[fastapi,celery]>=3.0.0",
     # PDF Processing
     "pypdf>=5.0.0",
-    "docling>=2.0.0",
+    # Pinned: the parser stack is drift-sensitive — an unpinned rapidocr bump to
+    # 3.9 (PP-OCRv6) broke prod via docling's OCR default. OCR is now disabled in
+    # DoclingParser so rapidocr drift is harmless, but pinning docling itself
+    # stops its own API/model drift. Bump deliberately and re-test.
+    "docling==2.104.0",
     # Observability
     "structlog>=24.0.0",
     # Rate Limiting

--- a/backend/tests/unit/test_docling_parser_options.py
+++ b/backend/tests/unit/test_docling_parser_options.py
@@ -1,0 +1,41 @@
+"""Unit test for the DoclingParser pipeline configuration.
+
+The self-hosted Docling parser must run with OCR DISABLED. Docling's default is
+``do_ocr=True``, which loads RapidOCR; RapidOCR 3.9+ promoted a PP-OCRv6 model
+the torch backend can't resolve (no ``onnxruntime`` on the slim worker), raising
+``Unsupported configuration: torch.PP-OCRv6.det.small`` at pipeline init. Our
+inputs are born-digital scientific PDFs with an embedded text layer, so OCR is
+unnecessary; disabling it skips the RapidOCR import entirely and neutralises the
+transitive-version drift.
+
+Skipped when docling is not installed (dev machines without torch); the CI image
+and the worker image install docling so it runs there.
+"""
+
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("docling") is None,
+    reason="docling not installed in this environment",
+)
+
+
+def test_pdf_pipeline_options_disable_ocr_keep_tables_on_cpu():
+    from docling.datamodel.accelerator_options import AcceleratorDevice
+    from docling.datamodel.pipeline_options import TableFormerMode
+
+    from app.infrastructure.parsing.docling_parser import _pdf_pipeline_options
+
+    opts = _pdf_pipeline_options()
+
+    # The bug: OCR on -> RapidOCR/PP-OCRv6/torch crash. Must be off.
+    assert opts.do_ocr is False
+    # Tables are load-bearing for scientific extraction: keep structure on,
+    # FAST mode for CPU cost, cell text matched verbatim from the PDF text layer.
+    assert opts.do_table_structure is True
+    assert opts.table_structure_options.mode == TableFormerMode.FAST
+    assert opts.table_structure_options.do_cell_matching is True
+    # The worker has no GPU; pin the accelerator to CPU explicitly.
+    assert opts.accelerator_options.device == AcceleratorDevice.CPU

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -4188,7 +4188,7 @@ requires-dist = [
     { name = "celery-types", marker = "extra == 'dev'", specifier = ">=0.22.0" },
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "diff-cover", marker = "extra == 'dev'", specifier = ">=10.0" },
-    { name = "docling", specifier = ">=2.0.0" },
+    { name = "docling", specifier = "==2.104.0" },
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "greenlet", specifier = ">=3.0.0" },


### PR DESCRIPTION
Promotes `dev` → `main` (Railway deploys from main). Scope is exactly two reviewed, CI-green PRs:

- **#391** — `fix(parsing)`: disable OCR in the Docling parser. Fixes the prod crash `ValueError: Unsupported configuration: torch.PP-OCRv6.det.small` (RapidOCR 3.9/PP-OCRv6 torch backend + no onnxruntime). OCR is unnecessary for born-digital scientific PDFs and disabling it skips the RapidOCR import entirely.
- **#394** — `chore(parsing)`: CPU-only torch (drops the ~1GB CUDA stack), build-time prefetch of layout+TableFormer models + `HF_HUB_OFFLINE` (no runtime downloads), `docling==2.104.0` pin, and a `.dockerignore`. Validated on linux/amd64: builds, `torch 2.12.1+cpu`, offline parse works.

## Post-deploy
Re-parse the 3 `parse_failed` article_files (recovery affordance) so they pick up the OCR-disabled parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)