### PR TITLE
refactor(extraction): remove dead _get_pdf helper

### DIFF
--- a/backend/app/services/model_extraction_service.py
+++ b/backend/app/services/model_extraction_service.py
@@ -262,15 +262,6 @@ class ModelExtractionService(LoggerMixin):
             )
             raise
 
-    async def _get_pdf(self, article_id: UUID) -> bytes:
-        """Fetch and download article PDF via Storage Adapter."""
-        pdf_file = await self._article_files.get_latest_pdf(article_id)
-
-        if not pdf_file:
-            raise FileNotFoundError(f"PDF not found for article {article_id}")
-
-        return await self.storage.download("articles", pdf_file.storage_key)
-
     async def _get_template(self, template_id: UUID) -> Any:
         """
         Fetch template with entity types.

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -347,7 +347,7 @@ class SectionExtractionService(LoggerMixin):
         that opens a Run via the HITL session service before asking the
         LLM to fill it in). Reuses the same building blocks as
         ``extract_section`` / ``_extract_section_with_memory``:
-        ``_get_pdf``, ``_extract_with_llm``,
+        ``_extract_with_llm``,
         ``_create_suggestions``.
 
         Stage rules:
@@ -1061,15 +1061,6 @@ class SectionExtractionService(LoggerMixin):
             return summary[: MAX_SUMMARY_LENGTH - 3] + "..."
 
         return summary
-
-    async def _get_pdf(self, article_id: UUID) -> bytes:
-        """Fetch and download PDF via storage adapter."""
-        pdf_file = await self._article_files.get_latest_pdf(article_id)
-
-        if not pdf_file:
-            raise FileNotFoundError(f"PDF not found for article {article_id}")
-
-        return await self.storage.download("articles", pdf_file.storage_key)
 
     async def _get_entity_type(self, entity_type_id: UUID) -> Any:
         """Fetch entity type with fields."""

--- a/backend/tests/unit/test_model_extraction_service.py
+++ b/backend/tests/unit/test_model_extraction_service.py
@@ -103,45 +103,6 @@ def service(mock_db, mock_storage):
         yield svc
 
 
-class TestModelExtractionPDF:
-    """Tests for PDF fetch and download."""
-
-    @pytest.mark.asyncio
-    async def test_get_pdf_success(self, service, mock_storage):
-        """Test successful PDF fetch."""
-        article_id = uuid4()
-        pdf_content = b"%PDF-1.4 test content"
-
-        # Mock article_files repository
-        mock_file = MagicMock()
-        mock_file.storage_key = "test-project/article.pdf"
-        service._article_files.get_latest_pdf = AsyncMock(return_value=mock_file)
-
-        # Mock storage adapter - note: takes (bucket, key)
-        mock_storage.download = AsyncMock(return_value=pdf_content)
-
-        result = await service._get_pdf(article_id)
-
-        assert result == pdf_content
-        service._article_files.get_latest_pdf.assert_called_once_with(article_id)
-        mock_storage.download.assert_called_once_with("articles", "test-project/article.pdf")
-
-    @pytest.mark.asyncio
-    async def test_get_pdf_not_found(
-        self,
-        service,
-        mock_storage,  # noqa: ARG002
-    ):
-        """Test error when PDF not found."""
-        article_id = uuid4()
-
-        # Mock article_files repository returns None
-        service._article_files.get_latest_pdf = AsyncMock(return_value=None)
-
-        with pytest.raises(FileNotFoundError, match="PDF not found"):
-            await service._get_pdf(article_id)
-
-
 class TestModelExtractionTemplate:
     """Tests for template lookup."""
 
@@ -336,7 +297,7 @@ class TestFullExtractionFlow:
         run_id = uuid4()
         entity_type_id = uuid4()
 
-        # Mock _get_pdf
+        # Mock PDF storage + article-file lookup
         pdf_content = b"%PDF test"
         mock_storage.download = AsyncMock(return_value=pdf_content)
 
@@ -547,7 +508,7 @@ class TestFullExtractionFlow:
         template_id = uuid4()
         run_id = uuid4()
 
-        # Mock _get_pdf
+        # Mock PDF storage + article-file lookup
         pdf_content = b"%PDF test"
         mock_storage.download = AsyncMock(return_value=pdf_content)
 

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -111,45 +111,6 @@ def service(mock_db, mock_storage):
         return svc
 
 
-class TestSectionExtractionPDF:
-    """Testes de processamento de PDFs."""
-
-    @pytest.mark.asyncio
-    async def test_get_pdf_success(self, service, mock_storage):
-        """Testa busca de PDF com sucesso."""
-        article_id = uuid4()
-        pdf_content = b"%PDF-1.4 test content"
-
-        # Mock article_files repository
-        mock_file = MagicMock()
-        mock_file.storage_key = "project-1/article-1/paper.pdf"
-        service._article_files.get_latest_pdf = AsyncMock(return_value=mock_file)
-
-        # Mock storage adapter - note: takes (bucket, key)
-        mock_storage.download = AsyncMock(return_value=pdf_content)
-
-        result = await service._get_pdf(article_id)
-
-        assert result == pdf_content
-        service._article_files.get_latest_pdf.assert_called_once_with(article_id)
-        mock_storage.download.assert_called_once_with("articles", "project-1/article-1/paper.pdf")
-
-    @pytest.mark.asyncio
-    async def test_get_pdf_not_found(
-        self,
-        service,
-        mock_storage,  # noqa: ARG002
-    ):
-        """Testa erro quando PDF não encontrado."""
-        article_id = uuid4()
-
-        # Mock article_files repository returns None
-        service._article_files.get_latest_pdf = AsyncMock(return_value=None)
-
-        with pytest.raises(FileNotFoundError, match="PDF not found"):
-            await service._get_pdf(article_id)
-
-
 class TestSectionExtractionEntityTypes:
     """Testes de busca de entity types."""
 
@@ -231,7 +192,7 @@ class TestSectionExtractionFullFlow:
         entity_type_id = uuid4()
         run_id = uuid4()
 
-        # Mock _get_pdf
+        # Mock PDF storage + article-file lookup
         pdf_content = b"%PDF-1.4 test"
         mock_storage.download = AsyncMock(return_value=pdf_content)
 


### PR DESCRIPTION
## Dead-code cleanup: remove `_get_pdf`

Follow-up to the stored-markdown ingestion work (#400). After that change, `build_prompt_input` owns PDF fetching (via `DocumentParsingService` for the on-demand parse), leaving the per-service `_get_pdf()` helpers with **no app callers** — only direct unit tests kept them alive.

Removed:
- `ModelExtractionService._get_pdf` + `SectionExtractionService._get_pdf`
- Their dedicated test classes `TestModelExtractionPDF` / `TestSectionExtractionPDF`
- A stale `_get_pdf` mention in a docstring
- Corrected misleading `# Mock _get_pdf` comments (the underlying storage / article-file mocks stay — `build_prompt_input` uses them)

No behavior change. Verified locally: ruff clean, mypy ratchet OK (no new errors), **2153 backend tests pass**.

> Note: the other two follow-ups I'd flagged (narrow the `_extract_block_ids` except, add the `findBlockByIndex` page=null test) were already shipped in `3bfe75a` — this PR is just the remaining dead-code removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
