### PR TITLE
docs: repo+memory consistency sweep + add /ship-spec pipeline

### DIFF
--- a/.claude/commands/ship-spec.md
+++ b/.claude/commands/ship-spec.md
@@ -1,0 +1,215 @@
+---
+description: Drive a spec from brainstorm to a chosen ceiling — dev (PR open + auto-merge armed) or prod (promote to main) — through plan → adversarial review → TDD execution → harden → ship, gated on green evidence. The ceiling is chosen once at invocation; prod never promotes on a red signal.
+argument-hint: "<spec-ref or description> [--to dev|prod] [--from-plan <path>] [--no-worktree] [--no-automerge] [--confirm-promote] [--dry-run]"
+allowed-tools:
+  - Task
+  - Read
+  - Edit
+  - Write
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - Bash(git:*)
+  - Bash(gh:*)
+  - Bash(make:*)
+  - Bash(npm run*)
+  - Bash(uv run*)
+  - Bash(cd backend*)
+  - Bash(curl:*)
+  - Bash(railway:*)
+  - mcp__Claude_Preview__preview_start
+  - mcp__Claude_Preview__preview_screenshot
+  - mcp__Claude_Preview__preview_snapshot
+---
+
+# /ship-spec — spec → chosen ceiling
+
+User-supplied arguments: `$ARGUMENTS`
+
+You are running prumo's **spec-to-ship pipeline**. You do not own any
+methodology yourself — you are the *orchestrator* that composes the
+project's existing skills in order, injects the prumo-specific gotchas,
+and enforces two things the individual skills do not:
+
+1. **The autonomy ceiling** — `dev` or `prod`, chosen once below and
+   then a hard guard, not a reminder. A `dev` run physically cannot
+   touch `main`.
+2. **Evidence gates** — every promotion proceeds only on fresh green
+   evidence you captured and read. A red or unknown signal HALTS the
+   run; it never promotes on a bad signal.
+
+> Iron law (`verification-before-completion`): no "done", "passing", or
+> "safe to ship" without fresh output you ran and read. A described gate
+> is not a passed gate.
+
+Create one todo per phase below before you start, and a sub-todo per
+task in Phase 3.
+
+---
+
+## Phase 0 — Parse arguments and lock the ceiling
+
+From `$ARGUMENTS` compute:
+
+- **subject** — the first non-flag token(s): a path to a written spec
+  (`docs/.../spec.md`) or an inline description. Required. If absent,
+  ask the user what to build, then stop.
+- **TARGET** — `prod` if `--to prod` is present, else `dev`. **If
+  `--to` is absent, ask once with `AskUserQuestion`** (options: `dev`
+  — recommended, stop at PR; `prod` — promote to main). Default is
+  `dev`.
+- `--from-plan <path>` — an approved plan already exists; skip Phases 1
+  and the plan-writing half of 2, start the panel review on that plan.
+- `--no-worktree` — work in the current checkout (default: isolate).
+- `--no-automerge` — open the dev PR but do not arm auto-merge.
+- `--confirm-promote` — even on all-green evidence, pause for one human
+  OK right before `dev → main` (default: green evidence auto-proceeds).
+- `--dry-run` — run every read-only gate and print what *would* happen
+  at each write/promote step, but make no commit, push, PR, or deploy.
+
+**Announce the locked plan in one line**, e.g.:
+
+> Ceiling = prod · subject = ADR-0013 stored-markdown tier · worktree on · auto-merge armed · evidence-gated.
+
+`TARGET` is now immutable for the rest of the run. Treat any later
+instinct to "just also merge to main" on a `dev` run as a bug.
+
+## Phase 1 — Frame (skip if `--from-plan`)
+
+- If **subject** is not already a written, agreed spec, run
+  `superpowers:brainstorming` to turn it into one. Surface ambiguous
+  requirements — do not choose silently (CLAUDE.md working principle).
+- Unless `--no-worktree`, create an isolated workspace with
+  `superpowers:using-git-worktrees`. Remember the worktree gotchas:
+  install deps from the **parent** checkout (a worktree-local
+  `node_modules` duplicates React); frontend tooling runs from the
+  **repo root** (no `frontend/package.json`).
+- Decide slicing: one PR, or a phased stack? State the checkable goal
+  and the verify step for each slice. If phased, this run ships slice 1;
+  the rest queue.
+
+## Phase 2 — Plan, then survive an adversarial panel
+
+1. Run `superpowers:writing-plans`. Every step must carry its own
+   failing test + verify step (no step is "do X" without "prove X").
+2. **Adversarial multi-lens review.** Dispatch parallel `Task`
+   sub-agents (`subagent_type: general-purpose`) in a single message —
+   one per lens, each handed the plan and told to find what kills it:
+   - **constitution / layering** — typed boundaries, no layer leak
+     (`docs/reference/constitution.md`).
+   - **security / RLS / BOLA** — project-membership scoping, run-state
+     TOCTOU, the recurring incident classes in `code-review`.
+   - **migration-safety** — any SQLAlchemy model change ⇒ Alembic
+     migration; revision id ≤ 32 chars; the `test_migration_roundtrip`
+     head-pin + `downgrade -1` guards break when a migration is added.
+   - **simplicity / YAGNI** — could 200 lines be 50? cut speculation.
+   - **test-coverage** — diff-cover 80; the **ASGI blind spot** (endpoint
+     handler lines via httpx ASGITransport don't register — needs direct
+     endpoint-coroutine unit tests, not just integration).
+   Reconcile the verdicts, revise the plan, and only proceed when the
+   panel has no blocking objection. State what changed.
+
+## Phase 3 — Execute (loop per task, test-first)
+
+For **each** task in the plan, in order:
+
+- Load the right domain skill: `backend-development` (FastAPI /
+  SQLAlchemy / Alembic / Celery / RLS), `frontend-development`
+  (components / hooks / TanStack / stores / forms), `ui-styling` +
+  `frontend-ux` (visual), `web-testing` (test patterns).
+- **TDD-first** (`superpowers:test-driven-development`): write the
+  failing test for this task *first*, at the right layer. Interleave
+  tests at every layer — **never batch them at the end** (this is an
+  explicit, repeated project correction).
+- Implement the minimum that makes it pass (YAGNI).
+- **Clean in the code you touch** — no new legacy grandfathered; flag
+  (don't delete) unrelated dead code. If you touch a model, generate the
+  Alembic migration now and bump the roundtrip head-pin in the same
+  change.
+- Per-task checkpoint: `superpowers:requesting-code-review` on that
+  task's diff. If it's a frontend screen, also run `/design-review`.
+
+Respect the React Compiler rule throughout: no `try/finally` / `throw`
+in component bodies; IO errors go through `ErrorResult`/`toResult`; all
+copy through `frontend/lib/copy/`.
+
+## Phase 4 — Harden the whole diff (the Iron Law gate)
+
+1. `/simplify` — reuse, dedupe, altitude cleanups (quality only).
+2. `architectural-quality-loop` on the touched slice — drift + legacy
+   eviction, **verified**, not a vibe. Zero legacy left for later.
+3. `code-review` (full prumo checklist: BOLA, run-state TOCTOU, error
+   swallowing, schema drift, ApiResponse envelope drift, stale TanStack
+   cache) + `/security-review` on risk-sensitive paths.
+4. `superpowers:verification-before-completion`: run the real gate and
+   **read the output** —
+   ```
+   make quality-scan        # lint + typecheck + tests + arch fitness
+   ```
+   plus the backend / frontend suites the diff touches. Diff-cover 80
+   ⇒ add the direct endpoint-coroutine unit tests if the diff is an
+   endpoint (ASGI blind spot). **Any red here HALTS the run** — fix and
+   re-verify; do not proceed on "should pass".
+
+## Phase 5 — Ship to dev
+
+- Commit (conventional commit) and `git push origin <branch>`. Open the
+  PR → `dev`: `gh pr create --base dev ...`.
+- Wait for the **8 required checks**. Unless `--no-automerge`, arm
+  `gh pr merge --auto --squash`.
+- **Ceiling guard:** if `TARGET == dev`, **STOP**. Report the PR URL,
+  the CI state, and whether auto-merge is armed. The run is complete;
+  you do **not** continue to Phase 6. (`--dry-run`: print the PR/commit
+  you would create and stop here regardless of ceiling.)
+
+## Phase 6 — Promote to prod (only if `TARGET == prod`)
+
+1. Wait for the dev PR to actually squash-merge and `dev` to go green.
+2. Run `/preflight` (read-only: Vercel, Supabase advisors, Railway
+   health, local gate). **Evidence gate:** if the verdict is anything
+   other than GREEN (any FAIL / UNKNOWN), **HALT and report** — do not
+   promote. `--dry-run` also stops here after preflight.
+3. If `--confirm-promote`, ask the user once before promoting. Otherwise
+   green evidence auto-proceeds — the unattended `--to prod` you opted
+   into at invocation.
+4. **Promote — merge-commit PR (auto).** Only on a GREEN preflight (any
+   red already HALTED in step 2), run the promotion directly:
+
+   ```bash
+   gh pr create --base main --head dev --title "Promote dev to main"
+   gh pr merge <n> --auto --merge   # merge commit — NOT squash, NOT fast-forward
+   ```
+
+   `dev → main` cannot fast-forward (`main` carries merge commits dev
+   lacks), so it is always a merge-commit PR — never `git push origin
+   dev:main`. Then watch the Railway deploy: it waits for the **full**
+   Actions suite (CI **and** docs-ci); on a SKIPPED-SHA wedge recover per
+   the `deploy-release` skill (push a newer commit, or `railway up` from
+   the repo root). `deploy-release` stays the source of truth for the
+   recovery + rollback nuances; only the promotion command is inlined
+   here so the `--to prod` run completes unattended.
+
+## Phase 7 — Verify in prod (only if promoted)
+
+Evidence, not assertion:
+
+- `curl -fsS -o /dev/null -w "%{http_code}" https://web-production-48b398.up.railway.app/health` → expect 200.
+- Confirm `post-deploy-smoke` is green (health + frontend + CORS
+  preflight from the prod origin).
+- Run the Playwright E2E smoke against the deployed flow for the feature
+  you shipped (`web-testing`), and a `/design-review` pass on the
+  user-facing surface if one changed.
+
+## Phase 8 — Verdict
+
+End with one block:
+
+- `## RESULT: SHIPPED TO DEV` — PR URL + CI state + auto-merge status; or
+- `## RESULT: SHIPPED TO PROD` — main SHA + Railway/Vercel deploy state +
+  `/health` code + E2E result; or
+- `## RESULT: HALTED AT <phase>` — the red/unknown evidence verbatim and
+  exactly what to fix to resume.
+
+Report faithfully: if a step was skipped, say so; if a gate failed, show
+the output. Never assert a green you did not capture. If the work was a
+phased slice, name the next slice.

--- a/.claude/skills/backend-development/references/alembic.md
+++ b/.claude/skills/backend-development/references/alembic.md
@@ -134,18 +134,7 @@ For larger backfills, prefer a one-off script outside Alembic (run it manually a
 
 ## Squashing
 
-Squash when:
-- The version chain is hard to read (we squashed 18 → `0001_baseline_v1` in April 2026).
-- Local `alembic upgrade head` from scratch takes > 30 seconds.
-- Several migrations contradict each other (added, modified, then dropped a column).
-
-Squash by:
-1. Generating a fresh schema dump from a clean DB.
-2. Reset the chain to a single baseline file.
-3. Move the old chain to `alembic/versions/archive/`.
-4. Document the squash in `CLAUDE.md` recent changes and in `docs/reference/migrations.md`.
-
-Never squash if production has any of the squashed migrations applied but doesn't have the new baseline yet — production must be ahead of the squash point.
+Authoritative in `docs/reference/migrations.md` (§When to squash) — the rule of thumb, the don't-squash conditions, and the squash recipe. Don't re-derive it here.
 
 ## Running
 
@@ -163,6 +152,27 @@ Local: `make reset-db` wipes the DB cleanly so you can re-run from baseline. CI 
 ## Startup safety net
 
 `app/main.py::check_pending_migrations()` blocks app start if `alembic heads ≠ DB current`. This catches "forgot to run upgrade" in dev and "deployment skipped migrations" in prod.
+
+## CI gotchas (the versioned home for these)
+
+- **Revision id ≤ 32 chars** (see `docs/reference/migrations.md` §Naming
+  + ordering) — `alembic_version.version_num` overflows at *apply* time,
+  so an over-long id breaks the CI Backend Tests "apply migrations" step
+  and the Railway `alembic upgrade head` deploy, and `--sql` offline
+  doesn't catch it. Renaming one means updating the `revision`/docstring,
+  any child `down_revision`, the filename, and `test_migration_roundtrip.py`
+  (it pins the head id).
+- **`op.create_check_constraint` is mangled by the naming convention.**
+  `MetaData` in `app/models/base.py` sets `"ck": "ck_%(table_name)s_%(constraint_name)s"`,
+  so `op.create_check_constraint("user_api_keys_provider_check", ...)`
+  emits `ck_user_api_keys_user_api_keys_provider_check` — a silent rename
+  that breaks the downgrade. Baseline constraints use literal, un-prefixed
+  names, so to DROP+recreate one use raw `op.execute("ALTER TABLE ... ADD
+  CONSTRAINT <literal_name> CHECK (...)")` and verify with offline `--sql`
+  in both directions before trusting it.
+- **Adding a migration trips `test_migration_roundtrip`.** It pins the
+  head id and runs `downgrade -1`; bump the pin to the new head and set
+  the new file's `down_revision` to the explicit parent.
 
 ## AI-assistant pitfalls (read `docs/reference/migrations.md` for full list)
 

--- a/.claude/skills/deploy-release/SKILL.md
+++ b/.claude/skills/deploy-release/SKILL.md
@@ -18,10 +18,18 @@ frontend `https://prumoai.vercel.app`.
    required checks.
 2. Pre-deploy gate: run `/preflight` (read-only; probes Vercel,
    Supabase advisors, Railway health).
-3. Promote: `git push origin dev:main` (fast-forward). `main` branch
-   protection requires the 8 check contexts on the SHA — the dev push
-   run already attached them, so a green dev HEAD promotes cleanly;
-   an unverified SHA is rejected.
+3. Promote via a **merge-commit PR** — `dev → main` cannot fast-forward
+   (`main` carries the `Merge pull request #NNN from raphaelfh/dev`
+   commits dev lacks, so `git push origin dev:main` is rejected as
+   non-fast-forward):
+
+   ```bash
+   gh pr create --base main --head dev --title "Promote dev to main"
+   gh pr merge <n> --auto --merge   # merge commit — NOT squash, NOT fast-forward
+   ```
+
+   `main` branch protection requires the 8 check contexts green on the
+   head before the merge completes; the dev HEAD already carries them.
 4. Railway (GitHub App) waits for the full Actions suite — **CI and
    docs-ci** — on the main push, then builds web + worker. The web
    container runs `alembic upgrade head` before gunicorn, so app-schema

--- a/.claude/skills/web-testing/SKILL.md
+++ b/.claude/skills/web-testing/SKILL.md
@@ -36,7 +36,7 @@ Is the bug a race / timing / fixture leak?          -> read references/flakiness
 | Full backend suite                                | `make test-backend`                                                                    |
 | One backend test                                  | `cd backend && pytest tests/integration/test_run_lifecycle_service.py -k advance_pending` |
 | Run backend tests with stdout                     | `cd backend && pytest -s -vv tests/path/to/test.py::test_name`                         |
-| Full frontend unit suite                          | `npm test`                                                                             |
+| Full frontend unit suite                          | `npm run test:run`                                                                     |
 | One Vitest file                                   | `npx vitest run frontend/test/ConsensusPanel.test.tsx -t "renders"`                    |
 | Vitest watch (TDD)                                | `npx vitest frontend/test/...`                                                         |
 | Playwright (all projects)                         | `npx playwright test`                                                                  |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_reviewed: 2026-06-20
+last_reviewed: 2026-06-27
 owner: '@raphaelfh'
 ---
 
@@ -8,9 +8,11 @@ owner: '@raphaelfh'
 
 ## Current focus
 
-- See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the active cycle. As of
-  2026-06-20: structured PDF parsing / grounded extraction (ADR-0011, ADR-0013).
-  The extraction data-path consolidation **shipped** (#228, #324) — not active.
+- See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the live cycle — the
+  source of truth; don't re-pin a date here. Now: grounded extraction on
+  stored markdown (ADR-0013 **shipped**, #400; ADR-0011 still
+  **proposed**). The *extraction* read-path consolidation shipped (#228,
+  #324); other app-schema reads still use PostgREST.
 - Project history lives in `git log` and `docs/adr/` — do not append
   changelogs to this file. Keep this section to ≤ 5 lines.
 

--- a/docs/adr/0004-hosting-render-to-railway.md
+++ b/docs/adr/0004-hosting-render-to-railway.md
@@ -25,7 +25,9 @@ Redis plugin.
 - Both `web` and `worker` build from `backend/Dockerfile`.
 - IaC committed as `railway.toml`.
 - Deploys are GitHub-App driven from `main`, gated by **Wait for CI**.
-- Fallback when CI is red: `railway up backend --path-as-root --service <name>`.
+- Fallback when CI is red: `railway up` from the repo root (the older
+  `backend --path-as-root` form is broken and bash-guard-blocked — see
+  `docs/reference/deployment.md` / the deploy-release skill).
 
 ## Consequences
 

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -1,14 +1,12 @@
 ---
 status: stable
-last_reviewed: 2026-06-20
+last_reviewed: 2026-06-27
 owner: '@raphaelfh'
 ---
 
-> **Status:** Stable · Last reviewed: 2026-05-31 · Owner: @raphaelfh
+> **Status:** Stable · Owner: @raphaelfh
 
 # Deployment
-
-Last updated: 2026-05-31 (Vercel ↔ Supabase integration + frontend env-var rules).
 
 ## Topology
 
@@ -90,7 +88,7 @@ There is no tracked env template — env files match `.gitignore` line 21 (`.env
 | `DATABASE_URL` | Supabase pooler (used for app traffic) |
 | `DIRECT_DATABASE_URL` | Supabase direct (used by Alembic at boot) |
 | `OPENAI_API_KEY` | OpenAI dashboard |
-| `OPENAI_DEFAULT_MODEL` | `gpt-4o-mini` |
+| `LLM_DEFAULT_MODEL` | `gpt-4o-mini` — set with `LLM_PROVIDER`; the former `OPENAI_DEFAULT_MODEL` was defined but never read at runtime |
 | `DEBUG` | `false` |
 | `RATE_LIMIT_PER_MINUTE` | `60` |
 | `PROJECT_NAME` | `Prumo API` |
@@ -182,7 +180,7 @@ The worker does NOT run Alembic — it boots after the web service via Celery st
 
 1. Create it locally: `cd backend && alembic revision --autogenerate -m "description"`.
 2. Test locally: `alembic upgrade head` against the local stack.
-3. Open a PR, merge to `main`. Railway will autodeploy `web`, which runs Alembic before booting gunicorn.
+3. Open a PR to `dev`. Once merged, promote `dev → main` via a merge-commit PR, not a fast-forward push (see the deploy-release skill runbook for the commands). Railway then deploys `web`, which runs Alembic before booting gunicorn.
 
 Auth/storage migrations still go through Supabase CLI (see `docs/reference/migrations.md`).
 
@@ -207,7 +205,9 @@ on the head commit passes).
   deployment is marked `SKIPPED` and stays pending until a newer
   commit's CI goes green.
 - Push to `dev` → no deploy. Use `dev` for staging-style integration;
-  promote to `main` to ship.
+  promote `dev → main` to ship — via a merge-commit PR, not a
+  fast-forward push (`main` carries merge commits dev lacks). See the
+  deploy-release skill for the commands + runbook.
 
 ### What CI gates the deploy on
 
@@ -239,6 +239,16 @@ head commit. As of 2026-05-24 the relevant ones for backend code:
 5. **`backend-build`** — Docker image build.
 6. **`frontend-lint`** + **`frontend-build`** + the E2E gates when the
    corresponding secrets are configured.
+7. **`docs-ci`** — runs on the same push. Railway's "Wait for CI" waits
+   for the **full** Actions suite (CI **and** `docs-ci`), so a `docs-ci`
+   that reports SKIPPED (path-filtered) can wedge the deploy — recover
+   per the deploy-release skill (push a newer commit, or `railway up`
+   from the repo root).
+
+After a deploy, the `post-deploy-smoke` workflow (push-triggered +
+hourly) re-checks `/health`, the frontend, and a CORS preflight from the
+prod origin; a failure emails the owner. It is the deploy safety net,
+not a gate.
 
 Override the env-driven thresholds via repo variables
 (`PRUMO_DIFF_COVERAGE_MIN`, `PRUMO_CRITICAL_COVERAGE_MIN`) when
@@ -251,8 +261,10 @@ where coverage temporarily dips while the spec is in flight — manual
 deploys remain available:
 
 ```bash
-railway up backend --path-as-root --service web --detach -m "<msg>"
-railway up backend --path-as-root --service worker --detach -m "<msg>"
+# run from the repo ROOT — the older `backend --path-as-root` form is
+# broken and bash-guard-blocked (see the deploy-release skill)
+railway up --service web --detach -m "<msg>"
+railway up --service worker --detach -m "<msg>"
 ```
 
 Use this sparingly. Manual deploys bypass the gates; if you are

--- a/docs/reference/migrations.md
+++ b/docs/reference/migrations.md
@@ -45,15 +45,15 @@ Every migration file follows this shape:
 ```python
 """<one-line imperative summary>
 
-Revision ID: YYYYMMDD_NNNN
-Revises: YYYYMMDD_NNNN-1
+Revision ID: 0034_<short_kebab_summary>
+Revises: 0033_article_markdown_cols
 Create Date: YYYY-MM-DD
 """
 
 from alembic import op
 
-revision = "YYYYMMDD_NNNN"
-down_revision = "YYYYMMDD_NNNN-1"
+revision = "0034_<short_kebab_summary>"
+down_revision = "0033_article_markdown_cols"
 
 
 def upgrade() -> None:
@@ -83,10 +83,15 @@ every line, rewrite the docstring, split into one-change-per-file.
 
 ## Naming + ordering
 
-- File name: `YYYYMMDD_NNNN_<short_kebab_summary>.py`. Date is the day
-  the migration was *written*; NNNN is the next sequential number across
-  the whole repo (no per-day reset).
-- `revision` matches the date+number prefix.
+- File name: `00NN_<short_kebab_summary>.py` — `NN` is the next
+  sequential number after the current head (post-squash the chain
+  restarted at `0001_baseline_v1`; the legacy `YYYYMMDD_NNNN` form
+  survives only in `versions/archive/`).
+- `revision` matches the `00NN_<summary>` filename prefix, and **must be
+  ≤ 32 chars** (`alembic_version.version_num` is `character varying(32)`; an
+  over-long id fails at *apply* time — breaking CI Backend Tests and the
+  Railway `alembic upgrade head` deploy, and `--sql` offline does not
+  catch it). `.claude/rules/backend.md` enforces this.
 - `down_revision` points at the previous head — never branch.
 
 ## When to squash


### PR DESCRIPTION
## What

A consistency sweep across docs, skills, CLAUDE.md, and the agent memory, anchored in a read-only multi-agent audit (23 findings, 8 high all git-verified).

**Headline correction:** git history proves every `dev → main` promotion is a **merge-commit PR**, but `deploy-release/SKILL.md` prescribed `git push origin dev:main` (fast-forward) — which is *impossible* here (`main` is not an ancestor of `dev`). The memory was right; the skill was wrong. Fixed across **all** loci.

## Commits

- `docs(deploy)` — promotion → merge-commit PR (deploy-release SKILL, deployment.md, ADR-0004); `railway up` fallback from repo root (the `--path-as-root` form is broken); add docs-ci + post-deploy-smoke to the gate section; dead `OPENAI_DEFAULT_MODEL` → `LLM_DEFAULT_MODEL`; drop drifted body dates.
- `docs(migrations)` — revision convention `YYYYMMDD_NNNN` → `00NN_` (all 33 live migrations); ≤32-char rule; fold scattered alembic CI-gotchas into the versioned ref.
- `docs(focus)` — CLAUDE.md points at ROADMAP as the live source (no pinned date); ADR-0013 shipped vs ADR-0011 proposed; `npm test` → `npm run test:run`.
- `chore(commands)` — new `/ship-spec` pipeline (spec → dev|prod ceiling, evidence-gated; `--to prod` auto-promotes via merge-commit PR only on green preflight).

## Done alongside (local, not in this PR)

- **Agent memory** consolidated 54 → 44 files (8 closed-project narratives pruned with fact-harvest; 3 worktree memories + 4 promotion restatements collapsed to one SSOT each). Backed up first; index verified 44=44.
- **17 MB** of stale `.claude/worktrees` reclaimed (branch refs preserved).

## Notes

- `/ship-spec` is **untested** — no RED baseline pressure-scenario yet (writing-skills Iron Law). Lands as a usable draft; pressure-test before trusting `--to prod` unattended.
- Verified locally: cspell + markdownlint + frontmatter check all green; `/simplify` pass applied (fixed a fabricated cross-ref + de-duplicated the promotion command and the ≤32 rule to single sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)