### PR TITLE
chore(workflow): agentic merge-train discipline + Dependabot anti-churn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       python-minor-patch:
         update-types: [minor, patch]
     open-pull-requests-limit: 5
+    # Don't auto-rebase on every base-branch commit (avoids CI re-run
+    # storms under concurrent merges). Unstick a stale PR via the native
+    # Update-branch button — never `@dependabot rebase` a grouped PR
+    # (it closes and recreates the PR under a new number + branch).
+    rebase-strategy: disabled
 
   - package-ecosystem: npm
     directory: /
@@ -19,6 +24,7 @@ updates:
       npm-minor-patch:
         update-types: [minor, patch]
     open-pull-requests-limit: 5
+    rebase-strategy: disabled
     ignore:
       # TypeScript 6.0.x is blocked: openapi-typescript (critical for
       # generate:api-types) peers on "^5.x" as of its latest 7.13.0.
@@ -34,4 +40,8 @@ updates:
       day: monday
     groups:
       actions:
-        update-types: [minor, patch, major]
+        # Minor/patch group (auto-merge-eligible). Majors open as
+        # individual PRs for human review — grouped majors were
+        # un-auto-mergeable and drove the rebase-recreation churn.
+        update-types: [minor, patch]
+    rebase-strategy: disabled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,3 +128,23 @@ Design rationale (the *why*):
 
 Path-scoped conventions live in `.claude/rules/` (`backend.md`,
 `frontend.md`) and load automatically when matching files are touched.
+
+## Branch & merge (agentic concurrency)
+
+Concurrent agents and worktrees make `dev` behave like a multi-dev
+branch. Fix throughput without weakening the gate:
+
+- **`dev` stays strict (up-to-date required).** It re-tests each PR
+  against the latest base, catching logical conflicts between two
+  individually-green PRs. Don't drop strict to go faster.
+- **One armed auto-merge at a time (merge-train).** Only one PR carries
+  `gh pr merge --auto --squash` into `dev` at once; arm the next only
+  after the current one lands. N concurrent armed PRs just go `BEHIND`
+  and invalidate each other.
+- **Unstick a `BEHIND` PR with Update-branch, never a hand rebase:**
+  `gh api -X PUT .../pulls/<n>/update-branch`. Never `@dependabot
+  rebase` a grouped PR — it closes and recreates it under a new number.
+- **Scope agents to non-overlapping paths/worktrees** so concurrent PRs
+  rarely conflict.
+- A GitHub merge queue is the real fix but needs an org (public repo →
+  a free org); revisit if concurrency outgrows the merge-train.


### PR DESCRIPTION
## Why

Under agentic engineering (N agents × N worktrees × N PRs), `dev` behaves like a **multi-dev** branch — the 2026-06-24 incident (manual `update-branch` nudges, `@dependabot rebase` close+recreate of #377→#397 / #384→#398) was exactly that. The fix is to **keep `dev` strict (safety) and remove the churn by process**, not by dropping the up-to-date gate (which under concurrency would let two individually-green PRs merge into a broken `dev`).

This adopts **Plan B**: stay on the personal account, serialize merges with a *merge-train* discipline (one armed auto-merge at a time).

## Changes

- **`CLAUDE.md`** — new "Branch & merge (agentic concurrency)" protocol:
  - `dev` stays `strict` (re-tests each PR against latest base → catches logical conflicts).
  - **One armed auto-merge at a time** (merge-train); arm the next only after the current lands.
  - Unstick a `BEHIND` PR via `update-branch`, never a hand rebase; never `@dependabot rebase` a grouped PR.
  - Scope agents to non-overlapping worktrees.
  - Merge queue noted as the real fix, gated on moving to a (free) GitHub org.
- **`.github/dependabot.yml`**:
  - `rebase-strategy: disabled` on all 3 ecosystems → stops the auto-rebase CI re-run storm.
  - GitHub Actions **majors split out of the group** (`update-types: [minor, patch]`) → majors open as individual review PRs instead of an un-auto-mergeable grouped major.
- **Repo setting** `delete_branch_on_merge=true` applied out-of-band → merged branches auto-prune (was the manual-cleanup half of the incident).

## Risk
Low. CI/config + docs only; no app code. `dependabot.yml` validated (YAML + schema), cspell clean. `docs-ci` is not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)