### PR TITLE
feat(extraction): citation P1 — multiple citations per value + export model transparency

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -25,6 +25,7 @@ docs/superpowers/plans/2026-06-23-extraction-stabilization-phase1.md
 docs/superpowers/plans/2026-06-23-consensus-view-fixes-phase-a.md
 docs/superpowers/plans/2026-06-23-extraction-a1-block-input.md
 docs/superpowers/plans/2026-06-24-markdown-ingestion-and-citation-highlight.md
+docs/superpowers/plans/2026-06-27-citation-p1-multi-evidence.md
 
 # Design specs — likewise snapshots
 docs/superpowers/specs/2026-*-design.md

--- a/backend/alembic/versions/0035_evidence_rank.py
+++ b/backend/alembic/versions/0035_evidence_rank.py
@@ -1,0 +1,29 @@
+"""evidence rank
+
+Revision ID: 0035_evidence_rank
+Revises: 0034_evidence_attr_label
+Create Date: 2026-06-27
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0035_evidence_rank"
+down_revision = "0034_evidence_attr_label"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "extraction_evidence",
+        sa.Column("rank", sa.Integer(), server_default="0", nullable=False),
+        schema="public",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("extraction_evidence", "rank", schema="public")

--- a/backend/app/llm/schema.py
+++ b/backend/app/llm/schema.py
@@ -1,11 +1,11 @@
 """extraction_fields rows → runtime Pydantic output models.
 
 Builds one Pydantic model per chunk of fields. OpenAI strict-mode schemas
-allow ~100 properties and each extraction field expands to ~7 (value,
-confidence, reasoning, evidence{text, page_number} + the container), so
-large UI-built templates are split into multiple calls and merged by the
-caller. DB field names are mapped through aliases so any template name —
-spaces, parentheses, leading digits — round-trips safely.
+allow ~100 properties and each extraction field expands to ~8 (value,
+confidence, reasoning, status, evidence list[{text, page_number}] + the
+container), so large UI-built templates are split into multiple calls and
+merged by the caller. DB field names are mapped through aliases so any
+template name — spaces, parentheses, leading digits — round-trips safely.
 """
 
 from typing import Any, Literal
@@ -104,8 +104,13 @@ def _field_result_model(field: Any, index: int) -> type[BaseModel]:
             Field(description="1-2 sentence justification for the value, null if none."),
         ),
         evidence=(
-            Evidence | None,
-            Field(description="Supporting quote from the article, null if none."),
+            list[Evidence],
+            Field(
+                description=(
+                    "Up to 3 short verbatim quotes from the article supporting the "
+                    "value, most direct first; [] when status is not_found."
+                ),
+            ),
         ),
         status=(
             Literal["found", "not_found", "ambiguous"],

--- a/backend/app/llm/validators.py
+++ b/backend/app/llm/validators.py
@@ -29,18 +29,18 @@ def evidence_is_plausible(output: Any) -> Any:
     for field_name, field_info in type(output).model_fields.items():
         label = field_info.alias or field_name
         field_result = getattr(output, field_name)
-        evidence = getattr(field_result, "evidence", None)
-        if evidence is None:
-            continue
-        if not evidence.text.strip():
-            raise ModelRetry(
-                f"Field '{label}': evidence.text must be a non-empty quote from the "
-                "article; return null evidence when there is no quote."
-            )
-        if evidence.page_number is not None and evidence.page_number < 1:
-            raise ModelRetry(
-                f"Field '{label}': evidence.page_number must be a 1-based page number or null."
-            )
+        evidence_list = getattr(field_result, "evidence", None) or []
+        for idx, evidence in enumerate(evidence_list):
+            if not evidence.text.strip():
+                raise ModelRetry(
+                    f"Field '{label}' evidence[{idx}]: evidence.text must be a "
+                    "non-empty quote; omit the entry when there is no quote."
+                )
+            if evidence.page_number is not None and evidence.page_number < 1:
+                raise ModelRetry(
+                    f"Field '{label}' evidence[{idx}]: page_number must be a "
+                    "1-based page number or null."
+                )
     return output
 
 

--- a/backend/app/models/extraction.py
+++ b/backend/app/models/extraction.py
@@ -517,6 +517,8 @@ class ExtractionEvidence(BaseModel):
     position: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default={}, nullable=True)
     text_content: Mapped[str | None] = mapped_column(Text, nullable=True)
     attribution_label: Mapped[str | None] = mapped_column(Text, nullable=True)
+    rank: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    # order of an evidence span within its proposal (0 = primary/first; LLM order)
 
     created_by: Mapped[UUID] = mapped_column(
         PG_UUID(as_uuid=True),

--- a/backend/app/schemas/extraction_suggestion.py
+++ b/backend/app/schemas/extraction_suggestion.py
@@ -20,6 +20,8 @@ class EvidenceResponse(BaseModel):
         alias="blockIds",
         description="block_index values for deterministic reader highlight",
     )
+    rank: int = 0
+    attribution_label: str | None = Field(default=None, alias="attributionLabel")
 
 
 class AISuggestionItem(BaseModel):
@@ -36,7 +38,7 @@ class AISuggestionItem(BaseModel):
     confidence_score: float | None
     rationale: str | None
     created_at: datetime
-    evidence: EvidenceResponse | None
+    evidence: list[EvidenceResponse]
     # Caller-scoped: 'accepted' | 'rejected' | 'pending'
     status: str
 
@@ -64,4 +66,4 @@ class AISuggestionHistoryItem(BaseModel):
     confidence_score: float | None
     rationale: str | None
     created_at: datetime
-    evidence: EvidenceResponse | None
+    evidence: list[EvidenceResponse]

--- a/backend/app/services/exports/extraction/ai_metadata.py
+++ b/backend/app/services/exports/extraction/ai_metadata.py
@@ -34,13 +34,17 @@ _HEADERS: tuple[str, ...] = (
     "Evidence text",
     "Evidence page(s)",
     "Proposed at",
+    "Model used",
     "Reviewer outcome",
     "Final value used",
 )
 #: 1-based column indices carrying resolved extraction values — rendered
 #: like matrix cells via the shared helper (number+unit / Yes survive).
-_VALUE_COLS: frozenset[int] = frozenset({5, 12})
-#: 1-based column index of the ``proposed_at`` timestamp.
+#: Col 5 = "AI proposed value"; col 13 = "Final value used" (shifted +1
+#: after the "Model used" column was inserted between "Proposed at" and
+#: "Reviewer outcome").
+_VALUE_COLS: frozenset[int] = frozenset({5, 13})
+#: 1-based column index of the ``proposed_at`` timestamp (unchanged).
 _TIMESTAMP_COL = 10
 _HEADER_STYLE = CellStyle(bold=True, align="center")
 _COL_WIDTH = 22.0

--- a/backend/app/services/extraction_export_service.py
+++ b/backend/app/services/extraction_export_service.py
@@ -210,6 +210,7 @@ class AIProposalRow:
     evidence_text: str  # joined with ' | ' when multiple
     evidence_pages: str  # joined with ', ' when multiple
     proposed_at: datetime
+    model_used: str  # resolved from run.parameters["model"]; "" when absent
     reviewer_outcome: str  # accepted | rejected | edited (best-effort) | pending | superseded
     final_value_used: Any  # None when not published
 
@@ -1740,6 +1741,19 @@ class ExtractionExportService(LoggerMixin):
         ).all()
         section_label_by_entity: dict[UUID, str] = dict(ent_label_rows)
 
+        # 6. Model per run — resolved from run.parameters["model"] (set at
+        # dispatch time). Falls back to "" for older runs without the key.
+        run_param_rows = (
+            await self.db.execute(
+                select(ExtractionRun.id, ExtractionRun.parameters).where(
+                    ExtractionRun.id.in_(run_ids)
+                )
+            )
+        ).all()
+        model_by_run: dict[UUID, str] = {
+            rid: (params or {}).get("model", "") for rid, params in run_param_rows
+        }
+
         # Field-label fallback when a field is not in the template snapshot
         # (rare; happens when the run was finalized on an older version).
         missing_field_ids = {
@@ -1796,6 +1810,7 @@ class ExtractionExportService(LoggerMixin):
                     )
                 ),
                 proposed_at=ts,
+                model_used=model_by_run.get(rid, ""),
                 reviewer_outcome=outcome,
                 final_value_used=final_value,
             )

--- a/backend/app/services/extraction_suggestion_read_service.py
+++ b/backend/app/services/extraction_suggestion_read_service.py
@@ -149,10 +149,12 @@ async def load_suggestions(
         .scalars()
         .all()
     )
-    evidence_by_proposal: dict[UUID, ExtractionEvidence] = {}
+    evidence_by_proposal: dict[UUID, list[ExtractionEvidence]] = {}
     for ev in evidence_rows:
-        if ev.proposal_record_id and ev.proposal_record_id not in evidence_by_proposal:
-            evidence_by_proposal[ev.proposal_record_id] = ev
+        if ev.proposal_record_id:
+            evidence_by_proposal.setdefault(ev.proposal_record_id, []).append(ev)
+    for rows in evidence_by_proposal.values():
+        rows.sort(key=lambda e: (e.rank, str(e.id)))
 
     # --- Step 4: load CALLER's reviewer_states → decisions (blind boundary) ---
     # NOTE: this query is intentionally NOT filtered by article — article scope is
@@ -188,17 +190,17 @@ async def load_suggestions(
     # --- Step 5: build response items ---
     items: list[AISuggestionItem] = []
     for p in deduped:
-        ev = evidence_by_proposal.get(p.id)
-        evidence_resp = (
+        evidence_list = [
             EvidenceResponse(
                 proposal_record_id=p.id,
                 text_content=ev.text_content,
                 page_number=ev.page_number,
                 blockIds=_extract_block_ids(ev),
+                rank=ev.rank,
+                attributionLabel=ev.attribution_label,
             )
-            if ev is not None
-            else None
-        )
+            for ev in evidence_by_proposal.get(p.id, [])
+        ]
         coord = (p.instance_id, p.field_id)
         status = _resolve_status(decision_by_coord.get(coord))
         items.append(
@@ -213,7 +215,7 @@ async def load_suggestions(
                 else None,
                 rationale=p.rationale,
                 created_at=p.created_at,
-                evidence=evidence_resp,
+                evidence=evidence_list,
                 status=status,
             )
         )
@@ -276,24 +278,26 @@ async def get_suggestion_history(
         .scalars()
         .all()
     )
-    evidence_by_proposal: dict[UUID, ExtractionEvidence] = {}
+    evidence_by_proposal: dict[UUID, list[ExtractionEvidence]] = {}
     for ev in evidence_rows:
-        if ev.proposal_record_id and ev.proposal_record_id not in evidence_by_proposal:
-            evidence_by_proposal[ev.proposal_record_id] = ev
+        if ev.proposal_record_id:
+            evidence_by_proposal.setdefault(ev.proposal_record_id, []).append(ev)
+    for rows in evidence_by_proposal.values():
+        rows.sort(key=lambda e: (e.rank, str(e.id)))
 
     items: list[AISuggestionHistoryItem] = []
     for p in proposals:
-        ev = evidence_by_proposal.get(p.id)
-        evidence_resp = (
+        evidence_list = [
             EvidenceResponse(
                 proposal_record_id=p.id,
                 text_content=ev.text_content,
                 page_number=ev.page_number,
                 blockIds=_extract_block_ids(ev),
+                rank=ev.rank,
+                attributionLabel=ev.attribution_label,
             )
-            if ev is not None
-            else None
-        )
+            for ev in evidence_by_proposal.get(p.id, [])
+        ]
         items.append(
             AISuggestionHistoryItem(
                 id=p.id,
@@ -306,7 +310,7 @@ async def get_suggestion_history(
                 else None,
                 rationale=p.rationale,
                 created_at=p.created_at,
-                evidence=evidence_resp,
+                evidence=evidence_list,
             )
         )
 

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -53,6 +53,9 @@ from app.services.extraction_prompt_input import build_prompt_input
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.run_lifecycle_service import RunLifecycleService
 
+# Maximum number of evidence rows written per extracted field.
+EVIDENCE_CAP = 3
+
 
 @dataclass
 class SectionExtractionResult:
@@ -1346,20 +1349,38 @@ class SectionExtractionService(LoggerMixin):
 
             confidence_score: float | None = None
             reasoning: str | None = None
-            evidence_meta: dict[str, Any] | None = None
 
             if isinstance(value, dict):
                 confidence_score = value.get("confidence")
                 reasoning = value.get("reasoning")
                 raw_evidence = value.get("evidence")
-                if isinstance(raw_evidence, dict) and raw_evidence.get("text"):
-                    evidence_meta = {
+                inner_value = value.get("value", value)
+            else:
+                raw_evidence = None
+                inner_value = value
+
+            # Build evidence_items list (cap at EVIDENCE_CAP).
+            # Supports both the new list shape (P1) and the legacy single-dict
+            # shape (P0) so old LLM responses continue to work.
+            evidence_items: list[dict[str, Any]] = []
+            if isinstance(raw_evidence, list):
+                for e in raw_evidence:
+                    if isinstance(e, dict) and (e.get("text") or "").strip():
+                        evidence_items.append(
+                            {
+                                "text": str(e["text"]).strip(),
+                                "page_number": e.get("page_number"),
+                            }
+                        )
+            elif isinstance(raw_evidence, dict) and (raw_evidence.get("text") or "").strip():
+                # LEGACY tolerance: old P0 shape was a single evidence dict → one row, rank 0.
+                evidence_items.append(
+                    {
                         "text": str(raw_evidence["text"]).strip(),
                         "page_number": raw_evidence.get("page_number"),
                     }
-                inner_value = value.get("value", value)
-            else:
-                inner_value = value
+                )
+            evidence_items = evidence_items[:EVIDENCE_CAP]
 
             # JSONB column on proposed_value is dict-typed; always wrap so
             # scalars/lists round-trip predictably and the frontend can read
@@ -1376,36 +1397,37 @@ class SectionExtractionService(LoggerMixin):
                 rationale=reasoning,
             )
 
-            if evidence_meta:
-                _quote = evidence_meta.get("text") or ""
-                _pos = build_anchor(_quote, _anchor_blocks) if _anchor_blocks and _quote else None
-                if _pos is not None:
-                    _position: dict = _pos.model_dump(by_alias=True, mode="json")
-                    _page_num = _pos.anchor.range.page
+            for rank, item in enumerate(evidence_items):
+                quote = item["text"]
+                pos = build_anchor(quote, _anchor_blocks) if _anchor_blocks and quote else None
+                if pos is not None:
+                    position: dict = pos.model_dump(by_alias=True, mode="json")
+                    page_num = pos.anchor.range.page
                 else:
-                    _position = {}
-                    _page_num = evidence_meta.get("page_number")
+                    position = {}
+                    page_num = item.get("page_number")
                 ev_row = ExtractionEvidence(
                     project_id=project_id,
                     article_id=article_id,
-                    article_file_id=_anchor_file_id if _pos is not None else None,
+                    article_file_id=_anchor_file_id if pos is not None else None,
                     run_id=run.id,
                     proposal_record_id=proposal.id,
-                    page_number=_page_num,
-                    text_content=evidence_meta.get("text"),
-                    position=_position,
+                    page_number=page_num,
+                    text_content=quote,
+                    position=position,
+                    rank=rank,
                     created_by=UUID(self.user_id),
                 )
                 self.db.add(ev_row)
 
                 # Queue for entailment gate: found fields with evidence only.
-                if isinstance(value, dict) and value.get("status") == "found" and _quote:
+                if isinstance(value, dict) and value.get("status") == "found" and quote:
                     _gate_specs.append(
                         GateSpec(
                             field_label=field_label_map.get(field_name, field_name),
                             value_str=str(inner_value),
-                            quote=_quote,
-                            pos=_pos,
+                            quote=quote,
+                            pos=pos,
                             anchor_blocks=_anchor_blocks,
                         )
                     )

--- a/backend/tests/integration/test_extraction_export_ai_outcome.py
+++ b/backend/tests/integration/test_extraction_export_ai_outcome.py
@@ -612,8 +612,7 @@ async def test_model_used_resolved_from_run_parameters(
 
     Two runs with different ``parameters["model"]`` values are each
     represented by one AI proposal. The AIProposalRow for each proposal
-    must carry the model from its run. A run without a "model" key must
-    yield an empty string (graceful degradation for older runs).
+    must carry the model from its OWN run, proving per-run isolation.
     """
     coord = await _coord(db_session)
     if coord is None:
@@ -631,6 +630,23 @@ async def test_model_used_resolved_from_run_parameters(
     run_a.parameters = {"model": "gpt-4o-mini"}
     await db_session.flush()
 
+    # Run B — cloned from run_a's metadata but with a different model.
+    # We insert directly to avoid _make_run deleting run_a.
+    run_b = ExtractionRun(
+        project_id=run_a.project_id,
+        article_id=run_a.article_id,
+        template_id=run_a.template_id,
+        kind=run_a.kind,
+        version_id=run_a.version_id,
+        hitl_config_snapshot=run_a.hitl_config_snapshot,
+        stage=run_a.stage,
+        status=run_a.status,
+        parameters={"model": "gpt-4o"},
+        created_by=run_a.created_by,
+    )
+    db_session.add(run_b)
+    await db_session.flush()
+
     proposal_a = uuid4()
     db_session.add(
         _ai_proposal(
@@ -641,9 +657,20 @@ async def test_model_used_resolved_from_run_parameters(
             value="value-a",
         )
     )
+    proposal_b = uuid4()
+    db_session.add(
+        _ai_proposal(
+            proposal_id=proposal_b,
+            run_id=run_b.id,
+            instance_id=instance_id,
+            field_id=field_id,
+            value="value-b",
+        )
+    )
     await db_session.flush()
 
-    rows = await _service(db_session, profile_id=profile_id)._load_ai_proposal_rows(
+    # Query run_a's proposals — must carry run_a's model.
+    rows_a = await _service(db_session, profile_id=profile_id)._load_ai_proposal_rows(
         articles=(
             _article(
                 article_id=article_id,
@@ -658,8 +685,27 @@ async def test_model_used_resolved_from_run_parameters(
         mode=ExportMode.CONSENSUS,
         target_reviewer_id=None,
     )
-    assert len(rows) == 1
-    assert rows[0].model_used == "gpt-4o-mini"
+    assert len(rows_a) == 1
+    assert rows_a[0].model_used == "gpt-4o-mini"
+
+    # Query run_b's proposals — must carry run_b's model.
+    rows_b = await _service(db_session, profile_id=profile_id)._load_ai_proposal_rows(
+        articles=(
+            _article(
+                article_id=article_id,
+                run_id=run_b.id,
+                run_stage=run_b.stage,
+                entity_type_id=entity_type_id,
+                instance_id=instance_id,
+            ),
+        ),
+        sections=(_section(entity_type_id=entity_type_id, field_id=field_id),),
+        value_map={},
+        mode=ExportMode.CONSENSUS,
+        target_reviewer_id=None,
+    )
+    assert len(rows_b) == 1
+    assert rows_b[0].model_used == "gpt-4o"
 
     await db_session.rollback()
 
@@ -713,7 +759,5 @@ async def test_model_used_empty_when_parameters_absent(
     )
     assert len(rows) == 1
     assert rows[0].model_used == ""
-
-    await db_session.rollback()
 
     await db_session.rollback()

--- a/backend/tests/integration/test_extraction_export_ai_outcome.py
+++ b/backend/tests/integration/test_extraction_export_ai_outcome.py
@@ -604,4 +604,116 @@ async def test_ai_evidence_ordered_and_deduped(
     # Text deduped and in page order.
     assert row.evidence_text == "two | nine | ten"
 
+
+async def test_model_used_resolved_from_run_parameters(
+    db_session: AsyncSession,
+) -> None:
+    """A7 — model_used is resolved from run.parameters["model"].
+
+    Two runs with different ``parameters["model"]`` values are each
+    represented by one AI proposal. The AIProposalRow for each proposal
+    must carry the model from its run. A run without a "model" key must
+    yield an empty string (graceful degradation for older runs).
+    """
+    coord = await _coord(db_session)
+    if coord is None:
+        pytest.skip("dev DB not seeded with an extraction instance")
+    project_id, article_id, template_id, profile_id, entity_type_id, instance_id, field_id = coord
+
+    # Run A — has parameters["model"] = "gpt-4o-mini".
+    run_a = await _make_run(
+        db_session,
+        project_id=project_id,
+        article_id=article_id,
+        template_id=template_id,
+        profile_id=profile_id,
+    )
+    run_a.parameters = {"model": "gpt-4o-mini"}
+    await db_session.flush()
+
+    proposal_a = uuid4()
+    db_session.add(
+        _ai_proposal(
+            proposal_id=proposal_a,
+            run_id=run_a.id,
+            instance_id=instance_id,
+            field_id=field_id,
+            value="value-a",
+        )
+    )
+    await db_session.flush()
+
+    rows = await _service(db_session, profile_id=profile_id)._load_ai_proposal_rows(
+        articles=(
+            _article(
+                article_id=article_id,
+                run_id=run_a.id,
+                run_stage=run_a.stage,
+                entity_type_id=entity_type_id,
+                instance_id=instance_id,
+            ),
+        ),
+        sections=(_section(entity_type_id=entity_type_id, field_id=field_id),),
+        value_map={},
+        mode=ExportMode.CONSENSUS,
+        target_reviewer_id=None,
+    )
+    assert len(rows) == 1
+    assert rows[0].model_used == "gpt-4o-mini"
+
+    await db_session.rollback()
+
+
+async def test_model_used_empty_when_parameters_absent(
+    db_session: AsyncSession,
+) -> None:
+    """A7b — run.parameters without "model" key yields model_used=""."""
+    coord = await _coord(db_session)
+    if coord is None:
+        pytest.skip("dev DB not seeded with an extraction instance")
+    project_id, article_id, template_id, profile_id, entity_type_id, instance_id, field_id = coord
+
+    run = await _make_run(
+        db_session,
+        project_id=project_id,
+        article_id=article_id,
+        template_id=template_id,
+        profile_id=profile_id,
+    )
+    # Leave run.parameters empty (no "model" key).
+    run.parameters = {}
+    await db_session.flush()
+
+    proposal_id = uuid4()
+    db_session.add(
+        _ai_proposal(
+            proposal_id=proposal_id,
+            run_id=run.id,
+            instance_id=instance_id,
+            field_id=field_id,
+            value="value",
+        )
+    )
+    await db_session.flush()
+
+    rows = await _service(db_session, profile_id=profile_id)._load_ai_proposal_rows(
+        articles=(
+            _article(
+                article_id=article_id,
+                run_id=run.id,
+                run_stage=run.stage,
+                entity_type_id=entity_type_id,
+                instance_id=instance_id,
+            ),
+        ),
+        sections=(_section(entity_type_id=entity_type_id, field_id=field_id),),
+        value_map={},
+        mode=ExportMode.CONSENSUS,
+        target_reviewer_id=None,
+    )
+    assert len(rows) == 1
+    assert rows[0].model_used == ""
+
+    await db_session.rollback()
+
     await db_session.rollback()

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -259,6 +259,37 @@ async def test_migration_0034_round_trip(db_session: AsyncSession) -> None:
     )
 
 
+_EVIDENCE_RANK_COL = text(
+    "SELECT 1 FROM information_schema.columns "
+    "WHERE table_schema = 'public' AND table_name = 'extraction_evidence' "
+    "AND column_name = 'rank'"
+)
+
+
+@pytest.mark.asyncio
+async def test_migration_0035_round_trip(db_session: AsyncSession) -> None:
+    """0035 adds extraction_evidence.rank (server_default '0', backfilling
+    legacy rows to 0). Downgrade to the explicit parent 0034_evidence_attr_label
+    drops it; upgrade head restores it. Backfill is proven by the server_default
+    at the column level (no data: SEED seeds no evidence rows and a raw INSERT
+    would violate the NOT NULL FKs + workflow_target_present CHECK)."""
+    assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() == 1, "rank must exist at HEAD"
+
+    _run_alembic("downgrade", "0034_evidence_attr_label")
+    try:
+        await db_session.commit()
+        assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() is None, (
+            "downgrade must drop rank"
+        )
+    finally:
+        _run_alembic("upgrade", "head")
+
+    await db_session.commit()
+    assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() == 1, (
+        "upgrade head must restore rank"
+    )
+
+
 @pytest.mark.asyncio
 async def test_alembic_head_is_expected_revision() -> None:
     """Pin the head revision id. If a future migration is added without
@@ -267,9 +298,7 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0034_evidence_attr_label" in out, (
-        f"Expected head revision '0034_evidence_attr_label', got:\n{out}"
-    )
+    assert "0035_evidence_rank" in out, f"Expected head revision '0035_evidence_rank', got:\n{out}"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_section_extraction_evidence.py
+++ b/backend/tests/integration/test_section_extraction_evidence.py
@@ -1,0 +1,373 @@
+"""Integration tests: multi-evidence persistence per field (Task 4).
+
+Drives ``_create_suggestions`` directly — bypasses ``_assemble_prompt_text``
+and ``_extract_with_llm`` which require real PDF files and real LLM calls.
+
+Assertions:
+  (a) A field with a 2-item evidence list → 2 ExtractionEvidence rows
+      with rank 0 and 1.
+  (b) A field with a single-dict evidence (legacy P0 shape) → 1 row at rank 0.
+  (c) Cap: a field with 5 evidence items → exactly 3 rows (rank 0–2).
+  (d) Abstention (status "not_found") → 0 evidence rows, 0 proposals.
+
+Patches:
+  - ``app.llm.entailment.gate_evidence`` → deterministic async stub
+    returning ``"entailed"`` (no real LLM call).
+  - ``section_extraction_service.build_model`` → no-op (gate stub bypasses it
+    but it must not raise MissingLLMKeyError on the build call).
+
+Uses ``db_session_real`` because ``_create_suggestions`` calls ``flush()`` and
+we need to SELECT the flushed evidence rows in the same transaction context.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.llm.entailment as entailment_mod
+from app.infrastructure.parsing.base import ParsedBlock
+from app.models.extraction import ExtractionEvidence, ExtractionRunStage
+from app.services import section_extraction_service as ses
+from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
+
+_BBOX = {"x": 0.0, "y": 0.0, "width": 400.0, "height": 12.0}
+
+# Evidence quotes seeded into ParsedBlocks so build_anchor() can resolve them.
+_QUOTE_A = "The mean sample size was 142 participants across all studies."
+_QUOTE_B = "Trials enrolled between 100 and 184 subjects on average."
+_QUOTE_C = "A total of 142 participants were enrolled."
+_QUOTE_D = "Participant count: one hundred and forty-two."
+_QUOTE_E = "Sample: 142 subjects total."
+
+
+async def _build_run_in_extract(db: AsyncSession) -> Any:
+    """Create a run advanced to EXTRACT and return it."""
+    lifecycle = RunLifecycleService(db)
+    run = await lifecycle.create_run(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        project_template_id=SEED.primary_template,
+        user_id=SEED.primary_profile,
+    )
+    run = await lifecycle.advance_stage(
+        run_id=run.id,
+        target_stage=ExtractionRunStage.EXTRACT,
+        user_id=SEED.primary_profile,
+    )
+    await db.flush()
+    return run
+
+
+def _make_service(
+    db: AsyncSession, trace_id: str = "test-evidence"
+) -> ses.SectionExtractionService:
+    """Return a minimally-wired service instance (no real storage needed)."""
+    storage = MagicMock()
+    return ses.SectionExtractionService(
+        db=db,
+        user_id=str(SEED.primary_profile),
+        storage=storage,
+        trace_id=trace_id,
+        openai_api_key=None,
+    )
+
+
+def _make_parsed_blocks(*quotes: str) -> list[ParsedBlock]:
+    """Return ParsedBlocks for each quote so build_anchor resolves them."""
+    blocks = []
+    offset = 0
+    for i, quote in enumerate(quotes):
+        blocks.append(
+            ParsedBlock(
+                page_number=1,
+                block_index=i,
+                text=quote,
+                char_start=offset,
+                char_end=offset + len(quote),
+                bbox=_BBOX,
+                block_type="paragraph",
+            )
+        )
+        offset += len(quote) + 1
+    return blocks
+
+
+async def _cleanup_runs(db: AsyncSession, run_ids: list[str]) -> None:
+    """Delete test run data in dependency order."""
+    await db.commit()
+    await db.execute(
+        text("DELETE FROM public.extraction_evidence WHERE run_id = ANY(:ids)"),
+        {"ids": run_ids},
+    )
+    await db.execute(
+        text("DELETE FROM public.extraction_proposal_records WHERE run_id = ANY(:ids)"),
+        {"ids": run_ids},
+    )
+    await db.execute(
+        text("DELETE FROM public.extraction_runs WHERE id = ANY(:ids)"),
+        {"ids": run_ids},
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_two_ranked_rows(
+    db_session_real: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A field with a 2-item evidence list writes 2 ExtractionEvidence rows, rank 0 and 1."""
+
+    async def _stub_gate(**_kwargs: Any) -> str:
+        return "entailed"
+
+    monkeypatch.setattr(entailment_mod, "gate_evidence", _stub_gate)
+    monkeypatch.setattr(ses, "build_model", lambda *_a, **_kw: MagicMock())
+
+    run = await _build_run_in_extract(db_session_real)
+
+    service = _make_service(db_session_real)
+    service._run_anchor_blocks = _make_parsed_blocks(_QUOTE_A, _QUOTE_B)
+    service._run_anchor_file_id = None
+
+    extracted_data: dict[str, Any] = {
+        "sample_size": {
+            "value": 142,
+            "confidence": 0.95,
+            "reasoning": "Stated in two places.",
+            "evidence": [
+                {"text": _QUOTE_A, "page_number": 1},
+                {"text": _QUOTE_B, "page_number": 1},
+            ],
+            "status": "found",
+        },
+    }
+
+    count = await service._create_suggestions(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        entity_type_id=SEED.primary_entity_type,
+        parent_instance_id=None,
+        extracted_data=extracted_data,
+        run=run,
+        model="gpt-4o-mini",
+    )
+    await db_session_real.flush()
+
+    rows = (
+        (
+            await db_session_real.execute(
+                select(ExtractionEvidence)
+                .where(ExtractionEvidence.run_id == run.id)
+                .order_by(ExtractionEvidence.rank)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert count == 1, f"Expected 1 proposal written, got {count}"
+    assert len(rows) == 2, f"Expected 2 evidence rows, got {len(rows)}"
+    assert rows[0].rank == 0, f"Expected rank 0, got {rows[0].rank}"
+    assert rows[1].rank == 1, f"Expected rank 1, got {rows[1].rank}"
+    assert rows[0].text_content == _QUOTE_A
+    assert rows[1].text_content == _QUOTE_B
+
+    await _cleanup_runs(db_session_real, [str(run.id)])
+
+
+@pytest.mark.asyncio
+async def test_legacy_single_dict(
+    db_session_real: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy single-dict evidence shape (P0) writes exactly 1 row at rank 0."""
+
+    async def _stub_gate(**_kwargs: Any) -> str:
+        return "entailed"
+
+    monkeypatch.setattr(entailment_mod, "gate_evidence", _stub_gate)
+    monkeypatch.setattr(ses, "build_model", lambda *_a, **_kw: MagicMock())
+
+    run = await _build_run_in_extract(db_session_real)
+
+    service = _make_service(db_session_real, trace_id="test-legacy")
+    service._run_anchor_blocks = _make_parsed_blocks(_QUOTE_A)
+    service._run_anchor_file_id = None
+
+    # Legacy P0 shape: evidence is a plain dict, NOT a list.
+    extracted_data: dict[str, Any] = {
+        "sample_size": {
+            "value": 142,
+            "confidence": 0.9,
+            "reasoning": "Stated in abstract.",
+            "evidence": {"text": _QUOTE_A, "page_number": 1},  # single dict (P0 shape)
+            "status": "found",
+        },
+    }
+
+    count = await service._create_suggestions(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        entity_type_id=SEED.primary_entity_type,
+        parent_instance_id=None,
+        extracted_data=extracted_data,
+        run=run,
+        model="gpt-4o-mini",
+    )
+    await db_session_real.flush()
+
+    rows = (
+        (
+            await db_session_real.execute(
+                select(ExtractionEvidence).where(ExtractionEvidence.run_id == run.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert count == 1, f"Expected 1 proposal, got {count}"
+    assert len(rows) == 1, f"Expected 1 evidence row for legacy dict, got {len(rows)}"
+    assert rows[0].rank == 0, f"Expected rank 0, got {rows[0].rank}"
+    assert rows[0].text_content == _QUOTE_A
+
+    await _cleanup_runs(db_session_real, [str(run.id)])
+
+
+@pytest.mark.asyncio
+async def test_abstention_no_rows(
+    db_session_real: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A not_found field writes 0 evidence rows and 0 proposals."""
+
+    async def _stub_gate(**_kwargs: Any) -> str:
+        return "entailed"
+
+    monkeypatch.setattr(entailment_mod, "gate_evidence", _stub_gate)
+    monkeypatch.setattr(ses, "build_model", lambda *_a, **_kw: MagicMock())
+
+    run = await _build_run_in_extract(db_session_real)
+
+    service = _make_service(db_session_real, trace_id="test-abstention")
+    service._run_anchor_blocks = []
+    service._run_anchor_file_id = None
+
+    extracted_data: dict[str, Any] = {
+        "sample_size": {
+            "value": None,
+            "confidence": None,
+            "reasoning": "Not mentioned.",
+            "evidence": None,
+            "status": "not_found",
+        },
+    }
+
+    count = await service._create_suggestions(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        entity_type_id=SEED.primary_entity_type,
+        parent_instance_id=None,
+        extracted_data=extracted_data,
+        run=run,
+        model="gpt-4o-mini",
+    )
+    await db_session_real.flush()
+
+    evidence_count = (
+        await db_session_real.execute(
+            text("SELECT COUNT(*) FROM public.extraction_evidence WHERE run_id = :rid"),
+            {"rid": str(run.id)},
+        )
+    ).scalar()
+
+    proposal_count = (
+        await db_session_real.execute(
+            text("SELECT COUNT(*) FROM public.extraction_proposal_records WHERE run_id = :rid"),
+            {"rid": str(run.id)},
+        )
+    ).scalar()
+
+    assert count == 0, f"Expected 0 proposals for not_found, got {count}"
+    assert evidence_count == 0, f"Expected 0 evidence rows, got {evidence_count}"
+    assert proposal_count == 0, f"Expected 0 proposal records, got {proposal_count}"
+
+    await _cleanup_runs(db_session_real, [str(run.id)])
+
+
+@pytest.mark.asyncio
+async def test_caps_at_three(
+    db_session_real: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A field with 5 evidence items writes exactly 3 rows (rank 0–2), cap enforced."""
+
+    async def _stub_gate(**_kwargs: Any) -> str:
+        return "entailed"
+
+    monkeypatch.setattr(entailment_mod, "gate_evidence", _stub_gate)
+    monkeypatch.setattr(ses, "build_model", lambda *_a, **_kw: MagicMock())
+
+    run = await _build_run_in_extract(db_session_real)
+
+    service = _make_service(db_session_real, trace_id="test-cap")
+    service._run_anchor_blocks = _make_parsed_blocks(
+        _QUOTE_A, _QUOTE_B, _QUOTE_C, _QUOTE_D, _QUOTE_E
+    )
+    service._run_anchor_file_id = None
+
+    extracted_data: dict[str, Any] = {
+        "sample_size": {
+            "value": 142,
+            "confidence": 0.9,
+            "reasoning": "Multiple sources.",
+            "evidence": [
+                {"text": _QUOTE_A, "page_number": 1},
+                {"text": _QUOTE_B, "page_number": 1},
+                {"text": _QUOTE_C, "page_number": 2},
+                {"text": _QUOTE_D, "page_number": 2},
+                {"text": _QUOTE_E, "page_number": 3},
+            ],
+            "status": "found",
+        },
+    }
+
+    count = await service._create_suggestions(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        entity_type_id=SEED.primary_entity_type,
+        parent_instance_id=None,
+        extracted_data=extracted_data,
+        run=run,
+        model="gpt-4o-mini",
+    )
+    await db_session_real.flush()
+
+    rows = (
+        (
+            await db_session_real.execute(
+                select(ExtractionEvidence)
+                .where(ExtractionEvidence.run_id == run.id)
+                .order_by(ExtractionEvidence.rank)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert count == 1, f"Expected 1 proposal, got {count}"
+    assert len(rows) == 3, f"Expected 3 evidence rows (cap=3), got {len(rows)}"
+    assert [r.rank for r in rows] == [0, 1, 2], (
+        f"Expected ranks [0,1,2], got {[r.rank for r in rows]}"
+    )
+    assert rows[0].text_content == _QUOTE_A
+    assert rows[1].text_content == _QUOTE_B
+    assert rows[2].text_content == _QUOTE_C
+
+    await _cleanup_runs(db_session_real, [str(run.id)])

--- a/backend/tests/integration/test_suggestion_read.py
+++ b/backend/tests/integration/test_suggestion_read.py
@@ -843,12 +843,12 @@ async def test_load_suggestions_evidence_block_ids_populated(
     suggestion = next(
         s for s in result.suggestions if s.proposed_value == {"value": "BLOCK-ID-TEST"}
     )
-    assert suggestion.evidence is not None
-    assert suggestion.evidence.block_ids == [2], (
-        f"Expected evidence.block_ids == [2], got {suggestion.evidence.block_ids}"
+    assert isinstance(suggestion.evidence, list) and len(suggestion.evidence) >= 1
+    assert suggestion.evidence[0].block_ids == [2], (
+        f"Expected evidence[0].block_ids == [2], got {suggestion.evidence[0].block_ids}"
     )
     # Alias round-trip: model_dump(by_alias=True) must emit blockIds
-    dumped = suggestion.evidence.model_dump(by_alias=True)
+    dumped = suggestion.evidence[0].model_dump(by_alias=True)
     assert dumped["blockIds"] == [2], f"blockIds alias missing from serialized evidence: {dumped}"
 
 
@@ -921,11 +921,11 @@ async def test_get_suggestion_history_evidence_block_ids_populated(
         None,
     )
     assert matched is not None, "Expected proposal not found in history"
-    assert matched.evidence is not None
-    assert matched.evidence.block_ids == [2], (
-        f"Expected evidence.block_ids == [2], got {matched.evidence.block_ids}"
+    assert isinstance(matched.evidence, list) and len(matched.evidence) >= 1
+    assert matched.evidence[0].block_ids == [2], (
+        f"Expected evidence[0].block_ids == [2], got {matched.evidence[0].block_ids}"
     )
-    dumped = matched.evidence.model_dump(by_alias=True)
+    dumped = matched.evidence[0].model_dump(by_alias=True)
     assert dumped["blockIds"] == [2], f"blockIds alias missing from serialized evidence: {dumped}"
 
 
@@ -990,7 +990,199 @@ async def test_load_suggestions_evidence_block_ids_empty_when_no_position(
     suggestion = next(
         s for s in result.suggestions if s.proposed_value == {"value": "NO-POSITION-TEST"}
     )
-    assert suggestion.evidence is not None
-    assert suggestion.evidence.block_ids == [], (
-        f"Expected evidence.block_ids == [] for no-position evidence, got {suggestion.evidence.block_ids}"
+    assert isinstance(suggestion.evidence, list) and len(suggestion.evidence) >= 1
+    assert suggestion.evidence[0].block_ids == [], (
+        f"Expected evidence[0].block_ids == [] for no-position evidence, got {suggestion.evidence[0].block_ids}"
     )
+
+
+# ---------------------------------------------------------------------------
+# ORDERED EVIDENCE LIST TESTS (Task 5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_evidence_ordered_list(
+    db_session: AsyncSession,
+) -> None:
+    """load_suggestions returns evidence as an ordered list (rank asc) with rank + attribution_label.
+
+    Seed a proposal with two evidence rows:
+      - rank=1, attribution_label='entailed', text='rank-1'
+      - rank=0, attribution_label=None, text='rank-0'
+    Assert evidence is a length-2 list, ordered rank-0 then rank-1, with
+    attribution_label preserved.
+    """
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+    manager_id = SEED.primary_profile
+
+    lifecycle = RunLifecycleService(db_session)
+    run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.EXTRACT, user_id=manager_id
+    )
+
+    proposal_svc = ExtractionProposalService(db_session)
+    proposal = await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": "ORDERED-EVIDENCE-TEST"},
+    )
+    await db_session.flush()
+
+    # rank=1 row inserted first, rank=0 second — service must order by rank asc
+    db_session.add(
+        ExtractionEvidence(
+            id=uuid4(),
+            project_id=project_id,
+            article_id=article_id,
+            run_id=run.id,
+            proposal_record_id=proposal.id,
+            page_number=2,
+            text_content="rank-1",
+            created_by=manager_id,
+            position=None,
+            rank=1,
+            attribution_label="entailed",
+        )
+    )
+    db_session.add(
+        ExtractionEvidence(
+            id=uuid4(),
+            project_id=project_id,
+            article_id=article_id,
+            run_id=run.id,
+            proposal_record_id=proposal.id,
+            page_number=1,
+            text_content="rank-0",
+            created_by=manager_id,
+            position=None,
+            rank=0,
+            attribution_label=None,
+        )
+    )
+    await db_session.flush()
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=article_id,
+        caller_id=manager_id,
+        run_id=run.id,
+    )
+
+    suggestion = next(
+        (s for s in result.suggestions if s.proposed_value == {"value": "ORDERED-EVIDENCE-TEST"}),
+        None,
+    )
+    assert suggestion is not None, "Expected proposal not found"
+
+    # evidence must be a list now (not EvidenceResponse | None)
+    assert isinstance(suggestion.evidence, list), (
+        f"evidence should be a list, got {type(suggestion.evidence)}"
+    )
+    assert len(suggestion.evidence) == 2, (
+        f"Expected 2 evidence items, got {len(suggestion.evidence)}"
+    )
+
+    # ordered by rank ascending: rank-0 first, rank-1 second
+    assert suggestion.evidence[0].rank == 0, (
+        f"First evidence item should have rank=0, got {suggestion.evidence[0].rank}"
+    )
+    assert suggestion.evidence[0].text_content == "rank-0"
+    assert suggestion.evidence[0].attribution_label is None
+
+    assert suggestion.evidence[1].rank == 1, (
+        f"Second evidence item should have rank=1, got {suggestion.evidence[1].rank}"
+    )
+    assert suggestion.evidence[1].text_content == "rank-1"
+    assert suggestion.evidence[1].attribution_label == "entailed"
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_evidence_legacy_length_one(
+    db_session: AsyncSession,
+) -> None:
+    """Backward-compat: a proposal with a single evidence row returns a length-1 list.
+
+    rank=0, attribution_label=None (legacy defaults).
+    """
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+    manager_id = SEED.primary_profile
+
+    lifecycle = RunLifecycleService(db_session)
+    run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.EXTRACT, user_id=manager_id
+    )
+
+    proposal_svc = ExtractionProposalService(db_session)
+    proposal = await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": "LEGACY-SINGLE-EVIDENCE"},
+    )
+    await db_session.flush()
+
+    db_session.add(
+        ExtractionEvidence(
+            id=uuid4(),
+            project_id=project_id,
+            article_id=article_id,
+            run_id=run.id,
+            proposal_record_id=proposal.id,
+            page_number=1,
+            text_content="legacy single evidence",
+            created_by=manager_id,
+            position=None,
+            rank=0,
+            attribution_label=None,
+        )
+    )
+    await db_session.flush()
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=article_id,
+        caller_id=manager_id,
+        run_id=run.id,
+    )
+
+    suggestion = next(
+        (s for s in result.suggestions if s.proposed_value == {"value": "LEGACY-SINGLE-EVIDENCE"}),
+        None,
+    )
+    assert suggestion is not None, "Expected proposal not found"
+
+    # backward-compat: single evidence row → length-1 list
+    assert isinstance(suggestion.evidence, list), (
+        f"evidence should be a list, got {type(suggestion.evidence)}"
+    )
+    assert len(suggestion.evidence) == 1, (
+        f"Expected 1 evidence item, got {len(suggestion.evidence)}"
+    )
+    assert suggestion.evidence[0].rank == 0
+    assert suggestion.evidence[0].attribution_label is None

--- a/backend/tests/unit/llm/test_schema.py
+++ b/backend/tests/unit/llm/test_schema.py
@@ -60,7 +60,7 @@ def test_text_field_round_trip():
                 "value": "adults with sepsis",
                 "confidence": 0.9,
                 "reasoning": "stated in methods",
-                "evidence": {"text": "We enrolled adults...", "page_number": 3},
+                "evidence": [{"text": "We enrolled adults...", "page_number": 3}],
                 "status": "found",
             }
         }
@@ -68,7 +68,7 @@ def test_text_field_round_trip():
     data = dump_extraction(instance)
     assert data["population"]["value"] == "adults with sepsis"
     assert data["population"]["confidence"] == 0.9
-    assert data["population"]["evidence"]["page_number"] == 3
+    assert data["population"]["evidence"][0]["page_number"] == 3
 
 
 def test_value_may_be_null_when_not_found():
@@ -79,7 +79,7 @@ def test_value_may_be_null_when_not_found():
                 "value": None,
                 "confidence": 0.0,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "not_found",
             }
         }
@@ -101,7 +101,7 @@ def test_select_field_rejects_out_of_enum_value():
                     "value": "Medium",
                     "confidence": 0.5,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 }
             }
@@ -112,7 +112,7 @@ def test_select_field_rejects_out_of_enum_value():
                 "value": "Low",
                 "confidence": 0.5,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "found",
             }
         }
@@ -133,7 +133,7 @@ def test_multiselect_field_is_list_of_enum():
                 "value": ["mortality"],
                 "confidence": 0.8,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "found",
             }
         }
@@ -146,7 +146,7 @@ def test_multiselect_field_is_list_of_enum():
                     "value": ["weird"],
                     "confidence": 0.8,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 }
             }
@@ -162,7 +162,7 @@ def test_confidence_out_of_range_rejected():
                     "value": "x",
                     "confidence": 1.2,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 }
             }
@@ -181,14 +181,14 @@ def test_number_and_boolean_types():
                 "value": 412,
                 "confidence": 1.0,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "found",
             },
             "multicentre": {
                 "value": True,
                 "confidence": 1.0,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "found",
             },
         }
@@ -206,7 +206,7 @@ def test_field_name_with_spaces_round_trips_via_alias():
                 "value": "412",
                 "confidence": 1.0,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "found",
             }
         }
@@ -234,14 +234,14 @@ def test_extra_fields_forbidden():
                     "value": "x",
                     "confidence": 0.5,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 },
                 "hallucinated": {
                     "value": "y",
                     "confidence": 0.5,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 },
             }
@@ -302,14 +302,14 @@ def test_integer_and_bare_list_type_mappings():
                 "value": 17,
                 "confidence": 1.0,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "found",
             },
             "keywords": {
                 "value": ["sepsis", "icu"],
                 "confidence": 0.9,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "found",
             },
         }
@@ -328,7 +328,7 @@ def test_empty_allowed_values_falls_back_to_scalar():
                 "value": "anything goes",
                 "confidence": 0.5,
                 "reasoning": None,
-                "evidence": None,
+                "evidence": [],
                 "status": "found",
             }
         }
@@ -341,3 +341,71 @@ def test_llm_description_preferred_when_both_set():
     [model] = build_output_models(_entity_type([field]))
     prop = model.model_json_schema(by_alias=True)["properties"]["population"]
     assert prop["description"] == "llm hint"
+
+
+# ---------------------------------------------------------------------------
+# Task 1: evidence is list[Evidence]
+# ---------------------------------------------------------------------------
+
+from typing import get_args, get_origin
+
+from app.llm.schema import Evidence, _field_result_model
+
+
+def _field_bare(name="primary_outcome", field_type="text", required=True):
+    class _F:  # minimal duck-typed extraction_fields row
+        pass
+
+    f = _F()
+    f.name = name
+    f.label = name
+    f.field_type = field_type
+    f.allowed_values = None
+    f.is_required = required
+    f.llm_description = None
+    f.description = None
+    return f
+
+
+def test_field_result_evidence_is_list_of_evidence():
+    model = _field_result_model(_field_bare(), index=0)
+    ann = model.model_fields["evidence"].annotation
+    assert get_origin(ann) is list, f"evidence must be a list, got {ann!r}"
+    assert get_args(ann) == (Evidence,), f"list item must be Evidence, got {get_args(ann)!r}"
+
+
+def test_field_result_keeps_status_field():
+    model = _field_result_model(_field_bare(), index=0)
+    assert "status" in model.model_fields, "P0 status field must be preserved"
+
+
+def _entity_with_one_field():
+    class _E:
+        pass
+
+    e = _E()
+    e.id = "et-1"
+    e.fields = [_field_bare()]
+    return e
+
+
+def test_dump_extraction_emits_evidence_list():
+    [model] = build_output_models(_entity_with_one_field())
+    instance = model.model_validate(
+        {
+            "primary_outcome": {
+                "value": "OS",
+                "confidence": 0.9,
+                "reasoning": "stated",
+                "status": "found",
+                "evidence": [
+                    {"text": "overall survival", "page_number": 3},
+                    {"text": "OS was the primary endpoint", "page_number": 3},
+                ],
+            }
+        }
+    )
+    dumped = dump_extraction(instance)
+    ev = dumped["primary_outcome"]["evidence"]
+    assert isinstance(ev, list) and len(ev) == 2
+    assert ev[0]["text"] == "overall survival"

--- a/backend/tests/unit/llm/test_schema.py
+++ b/backend/tests/unit/llm/test_schema.py
@@ -1,6 +1,7 @@
 """Unit tests for the runtime schema builder (DB field rows → Pydantic models)."""
 
 from types import SimpleNamespace
+from typing import get_args, get_origin
 
 import pytest
 from pydantic import ValidationError
@@ -8,7 +9,9 @@ from pydantic import ValidationError
 from app.llm.schema import (
     _PROPERTIES_PER_FIELD,
     OPENAI_STRICT_PROPERTY_BUDGET,
+    Evidence,
     SchemaBuildError,
+    _field_result_model,
     build_output_models,
     dump_extraction,
 )
@@ -346,10 +349,6 @@ def test_llm_description_preferred_when_both_set():
 # ---------------------------------------------------------------------------
 # Task 1: evidence is list[Evidence]
 # ---------------------------------------------------------------------------
-
-from typing import get_args, get_origin
-
-from app.llm.schema import Evidence, _field_result_model
 
 
 def _field_bare(name="primary_outcome", field_type="text", required=True):

--- a/backend/tests/unit/llm/test_validators.py
+++ b/backend/tests/unit/llm/test_validators.py
@@ -9,7 +9,8 @@ from app.llm.schema import build_output_models
 from app.llm.validators import evidence_is_plausible
 
 
-def _instance(evidence):
+def _instance(evidence_list):
+    """Build a validated output model with evidence as a list[Evidence]."""
     field = SimpleNamespace(
         name="population",
         field_type="text",
@@ -25,28 +26,41 @@ def _instance(evidence):
                 "value": "x",
                 "confidence": 0.5,
                 "reasoning": None,
-                "evidence": evidence,
+                "evidence": evidence_list,
                 "status": "found",
             }
         }
     )
 
 
-def test_passes_with_no_evidence():
-    output = _instance(None)
+def test_passes_with_empty_evidence_list():
+    output = _instance([])
     assert evidence_is_plausible(output) is output
 
 
 def test_passes_with_plausible_evidence():
-    output = _instance({"text": "We enrolled adults.", "page_number": 2})
+    output = _instance([{"text": "We enrolled adults.", "page_number": 2}])
     assert evidence_is_plausible(output) is output
 
 
 def test_rejects_blank_evidence_text():
     with pytest.raises(ModelRetry, match="population"):
-        evidence_is_plausible(_instance({"text": "   ", "page_number": 2}))
+        evidence_is_plausible(_instance([{"text": "   ", "page_number": 2}]))
 
 
 def test_rejects_non_positive_page_number():
     with pytest.raises(ModelRetry, match="page_number"):
-        evidence_is_plausible(_instance({"text": "quote", "page_number": 0}))
+        evidence_is_plausible(_instance([{"text": "quote", "page_number": 0}]))
+
+
+def test_plausible_rejects_blank_quote_in_list():
+    """A blank quote in the second list item must be rejected."""
+    out = _instance([{"text": "ok", "page_number": 1}, {"text": "  ", "page_number": 1}])
+    with pytest.raises(ModelRetry):
+        evidence_is_plausible(out)
+
+
+def test_plausible_accepts_empty_evidence_list():
+    """An empty evidence list is abstention — must pass."""
+    out = _instance([])
+    assert evidence_is_plausible(out) is out

--- a/backend/tests/unit/test_extraction_ai_metadata_builder.py
+++ b/backend/tests/unit/test_extraction_ai_metadata_builder.py
@@ -42,6 +42,7 @@ def _proposal(**over: object) -> AIProposalRow:
         "evidence_text": "evidence",
         "evidence_pages": "4",
         "proposed_at": datetime(2026, 5, 23, 10, 0, 0, tzinfo=UTC),
+        "model_used": "gpt-4o",
         "reviewer_outcome": "accepted",
         "final_value_used": "Yes",
     }
@@ -59,7 +60,9 @@ def test_header_and_placeholder_when_no_rows() -> None:
     assert spec.title == "AI metadata"
     assert spec.rows[0][0].value == "Article"
     assert spec.rows[0][4].value == "AI proposed value"
-    assert spec.rows[0][11].value == "Final value used"
+    # "Model used" now at 0-based index 10; "Final value used" shifted to 12.
+    assert spec.rows[0][10].value == "Model used"
+    assert spec.rows[0][12].value == "Final value used"
     assert spec.rows[1][0].value == "(No AI proposals recorded for the selected articles.)"
 
 
@@ -70,9 +73,21 @@ def test_one_row_per_proposal_in_canonical_order() -> None:
     assert row[0].value == "Gaca, 2011"
     assert row[2].value == 1
     assert row[3].value == "1.1 Dose"
-    # Value columns (E/L) render via the shared format helper.
+    # Value columns (E/M) render via the shared format helper.
     assert row[4].value == "5 mg"
-    assert row[11].value == "Yes"
-    # Timestamp is ISO-8601 text (SheetSpec IR is scalar-only).
+    # Timestamp unchanged at 0-based index 9.
     assert row[9].value == "2026-05-23T10:00:00+00:00"
-    assert row[10].value == "accepted"
+    # "Model used" at 0-based index 10 (NEW).
+    assert row[10].value == "gpt-4o"
+    # "Reviewer outcome" shifted to 0-based index 11.
+    assert row[11].value == "accepted"
+    # "Final value used" shifted to 0-based index 12.
+    assert row[12].value == "Yes"
+
+
+def test_model_used_empty_string_when_not_set() -> None:
+    """model_used defaults to empty string when the run has no parameters["model"]."""
+    spec = build_ai_metadata(_layout(include_ai_metadata=True, rows=(_proposal(model_used=""),)))
+    assert spec is not None
+    row = spec.rows[1]
+    assert row[10].value == ""

--- a/backend/tests/unit/test_extraction_export_determinism.py
+++ b/backend/tests/unit/test_extraction_export_determinism.py
@@ -211,6 +211,7 @@ def test_build_workbook_ai_metadata_path_is_deterministic():
             evidence_text="excerpt",
             evidence_pages="4",
             proposed_at=datetime(2026, 5, 23, 10, 0, 0, tzinfo=UTC),
+            model_used="gpt-4o-mini",
             reviewer_outcome="accepted",
             final_value_used="Existing registry",
         ),
@@ -290,9 +291,9 @@ async def test_load_ai_proposal_rows_populates_final_value_for_all_users_mode() 
     # ALL_USERS value_map: consensus column uses (run_id, inst_id, field_id, None).
     value_map = {(run_id, inst_id, field_id, None): "Existing registry"}
 
-    # Mock the five DB execute calls in _load_ai_proposal_rows order:
+    # Mock the six DB execute calls in _load_ai_proposal_rows order:
     #   1. instance query, 2. proposal query, 3. evidence query,
-    #   4. decision query, 5. entity-type label query.
+    #   4. decision query, 5. entity-type label query, 6. run params query.
     def _result(rows):
         r = MagicMock()
         r.all.return_value = rows
@@ -321,6 +322,7 @@ async def test_load_ai_proposal_rows_populates_final_value_for_all_users_mode() 
                 [(run_id, inst_id, field_id, uuid4(), "accept_proposal", pid)]
             ),  # decisions (reviewer-tagged)
             _result([(entity_type_id, "1. Source of data")]),  # entity labels
+            _result([(run_id, {})]),  # run params
         ]
     )
 

--- a/backend/tests/unit/test_extraction_export_service.py
+++ b/backend/tests/unit/test_extraction_export_service.py
@@ -844,6 +844,8 @@ class TestLoadAiProposalRows:
                 _rows_result([]),
                 # 5. ent_label_rows
                 _rows_result([ent_label_row]),
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
                 # (no field fallback — field_id is in field_label_by_id from sections)
             ]
         )
@@ -912,6 +914,9 @@ class TestLoadAiProposalRows:
                 _rows_result(evidence_rows),
                 _rows_result([]),  # decisions
                 _rows_result([(entity_type_id, "Sec")]),
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field fallback (sections=())
                 _rows_result([(field_id, "Fld")]),
             ]
         )
@@ -972,7 +977,9 @@ class TestLoadAiProposalRows:
                 _rows_result([]),  # no evidence
                 _rows_result([decision_row]),
                 _rows_result([(entity_type_id, "Section Label")]),
-                # 6th query: field label fallback (field_id not in sections=())
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field label fallback (field_id not in sections=())
                 _rows_result([(field_id, "Field Label")]),
             ]
         )
@@ -1027,7 +1034,9 @@ class TestLoadAiProposalRows:
                 _rows_result([]),
                 _rows_result([]),
                 _rows_result([(entity_type_id, "Section")]),
-                # 6th: field fallback (field_id not in sections=())
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field fallback (field_id not in sections=())
                 _rows_result([(field_id, "Field Label")]),
             ]
         )
@@ -1079,7 +1088,9 @@ class TestLoadAiProposalRows:
                 _rows_result([]),
                 _rows_result([]),
                 _rows_result([(entity_type_id, "Section")]),
-                # 6th: field fallback (field_id not in sections=())
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field fallback (field_id not in sections=())
                 _rows_result([(field_id, "Field Label")]),
             ]
         )
@@ -1139,6 +1150,9 @@ class TestLoadAiProposalRows:
                 _rows_result([]),
                 _rows_result([target_reject]),  # query filtered to target reviewer
                 _rows_result([(entity_type_id, "Sec")]),
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field fallback (sections=())
                 _rows_result([(field_id, "Fld")]),
             ]
         )
@@ -1182,7 +1196,9 @@ class TestLoadAiProposalRows:
                 _rows_result([]),
                 # ent_label_rows provides fallback label
                 _rows_result([(entity_type_id, "Fallback Section Label")]),
-                # 6th: field fallback (field_id not in sections=())
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field fallback (field_id not in sections=())
                 _rows_result([(field_id, "Field Label")]),
             ]
         )
@@ -1225,7 +1241,9 @@ class TestLoadAiProposalRows:
                 _rows_result([]),
                 _rows_result([]),
                 _rows_result([(entity_type_id, "Section Label")]),
-                # 6th query: field label fallback
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field label fallback
                 _rows_result([(field_id, "Fallback Field Label")]),
             ]
         )
@@ -1287,6 +1305,9 @@ class TestLoadAiProposalRows:
                 _rows_result([]),  # evidence
                 _rows_result([decision_a, decision_b]),  # decisions (reviewer-tagged)
                 _rows_result([(entity_type_id, "Sec")]),
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field fallback (sections=())
                 _rows_result([(field_id, "Fld")]),
             ]
         )
@@ -2436,7 +2457,10 @@ class TestAiProposalRowsModelInstances:
                 _rows_result([]),
                 _rows_result([]),
                 _rows_result([(entity_type_id, "Model Section")]),
-                _rows_result([(field_id, "Field")]),  # field fallback
+                # 6. run_param_rows
+                _rows_result([(run_id, {})]),
+                # 7. field fallback
+                _rows_result([(field_id, "Field")]),
             ]
         )
 

--- a/backend/tests/unit/test_extraction_models.py
+++ b/backend/tests/unit/test_extraction_models.py
@@ -1,0 +1,16 @@
+from app.models.extraction import ExtractionEvidence
+
+
+def test_evidence_has_rank_column():
+    cols = ExtractionEvidence.__table__.c
+    assert "rank" in cols
+    # A bare-string server_default's .arg is the string itself (no .text).
+    assert cols["rank"].server_default.arg == "0"
+    assert cols["rank"].nullable is False
+
+
+def test_rank_default_backfills_legacy_rows_to_zero():
+    # server_default "0" is what backfills pre-existing rows at migration time;
+    # asserting it here is the backfill contract (SEED seeds no evidence; a raw
+    # INSERT can't satisfy the FKs + workflow_target_present CHECK).
+    assert ExtractionEvidence.__table__.c["rank"].server_default.arg == "0"

--- a/backend/tests/unit/test_extraction_xlsx_builder.py
+++ b/backend/tests/unit/test_extraction_xlsx_builder.py
@@ -448,6 +448,7 @@ def test_ai_metadata_sheet_writes_proposal_rows_in_canonical_order():
         evidence_text="Patients were enrolled from the registry.",
         evidence_pages="4",
         proposed_at=datetime(2026, 5, 23, 10, 0, 0, tzinfo=UTC),
+        model_used="gpt-4o-mini",
         reviewer_outcome="accepted",
         final_value_used="Existing registry",
     )
@@ -478,10 +479,11 @@ def test_ai_metadata_sheet_writes_proposal_rows_in_canonical_order():
     assert ws.cell(row=2, column=7).value == "LLM reasoning here"
     assert ws.cell(row=2, column=8).value == "Patients were enrolled from the registry."
     assert ws.cell(row=2, column=9).value == "4"
-    # column 10 is the timestamp — openpyxl stores it as a datetime
+    # column 10: timestamp; column 11: model_used (NEW); column 12: reviewer outcome (shifted)
     assert ws.cell(row=2, column=10).value is not None
-    assert ws.cell(row=2, column=11).value == "accepted"
-    assert ws.cell(row=2, column=12).value == "Existing registry"
+    assert ws.cell(row=2, column=11).value == "gpt-4o-mini"
+    assert ws.cell(row=2, column=12).value == "accepted"
+    assert ws.cell(row=2, column=13).value == "Existing registry"
 
 
 def test_ai_metadata_value_columns_render_via_shared_helper():
@@ -501,6 +503,7 @@ def test_ai_metadata_value_columns_render_via_shared_helper():
         evidence_text="evidence",
         evidence_pages="2",
         proposed_at=datetime(2026, 6, 14, 10, 0, 0, tzinfo=UTC),
+        model_used="gpt-4o",
         reviewer_outcome="accepted",
         final_value_used="Yes",
     )
@@ -520,9 +523,9 @@ def test_ai_metadata_value_columns_render_via_shared_helper():
         ai_proposal_rows=(proposal,),
     )
     ws = _open(build_workbook(layout))["AI metadata"]
-    # E2 = "AI proposed value", L2 = "Final value used".
+    # E2 = "AI proposed value" (col 5), M2 = "Final value used" (col 13, shifted +1).
     assert ws.cell(row=2, column=5).value == "5 mg"
-    assert ws.cell(row=2, column=12).value == "Yes"
+    assert ws.cell(row=2, column=13).value == "Yes"
 
 
 def test_xlsx_safe_raises_on_dict() -> None:

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -1832,14 +1832,14 @@ class TestExtractWithLlmWiring:
                     "value": "150",
                     "confidence": 0.9,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 },
                 "field_1": {
                     "value": "RCT",
                     "confidence": 0.8,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 },
             }
@@ -1873,7 +1873,7 @@ class TestExtractWithLlmWiring:
                         "value": "v",
                         "confidence": 0.5,
                         "reasoning": None,
-                        "evidence": None,
+                        "evidence": [],
                         "status": "found",
                     }
                     for info in model_cls.model_fields.values()
@@ -1908,7 +1908,7 @@ class TestExtractWithLlmWiring:
                     "value": "v",
                     "confidence": 0.5,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 }
             }
@@ -1944,7 +1944,7 @@ class TestExtractWithLlmWiring:
                     "value": "Low",
                     "confidence": 0.5,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 }
             }
@@ -1993,7 +1993,7 @@ class TestExtractWithLlmWiring:
                     "value": "v",
                     "confidence": 0.5,
                     "reasoning": None,
-                    "evidence": None,
+                    "evidence": [],
                     "status": "found",
                 }
             }

--- a/docs/reference/extraction-hitl-architecture.md
+++ b/docs/reference/extraction-hitl-architecture.md
@@ -106,7 +106,7 @@ and `extraction_instance_status` enum were dropped in HITL Phase 3 (migration
 ## 3. Database — final schema
 
 All tables live in the `public` schema with RLS enabled. Migration head:
-`0034_evidence_attr_label` (post-squash numbering; run
+`0035_evidence_rank` (post-squash numbering; run
 `ls backend/alembic/versions/` for the current head — and bump this line
 in any PR that adds an `extraction_*` migration).
 

--- a/docs/superpowers/plans/2026-06-27-citation-p1-multi-evidence.md
+++ b/docs/superpowers/plans/2026-06-27-citation-p1-multi-evidence.md
@@ -1,0 +1,808 @@
+---
+status: draft
+last_reviewed: 2026-06-27
+owner: '@raphaelfh'
+---
+
+# Citation P1 — Multiple Citations per Extracted Value (Prose) Implementation Plan
+
+> **Note for the agentic worker:** Execute one `- [ ]` step at a time, in order.
+> Each step is a bite-sized TDD loop: write the failing test exactly as given,
+> run the verify command and read its output (RED), then write the minimum
+> implementation to make it pass and re-run (GREEN). Never batch steps. Never
+> mark a step done without running its verify command and reading the output.
+> Stop and report if a verify command behaves differently than the step
+> predicts — do not "fix forward" past an unexpected signal. All paths are
+> relative to the repo root unless prefixed with `backend/`. Backend commands
+> run from `backend/` (`cd backend && uv run ...`); frontend commands run from
+> the **repo root** (`npm run ...`). The worktree is
+> `/Users/raphael/PycharmProjects/prumo/.claude/worktrees/condescending-einstein-c5c778`
+> on branch `claude/citation-p1-multi-evidence` (off `dev`, P0 already merged).
+
+## Goal
+
+Turn per-field AI evidence from a single optional `Evidence` into a **list**
+(cap ~3 primary spans, corroboration deferred), persist N `ExtractionEvidence`
+rows per proposal ordered by `rank`, and flow that list to the UI **through the
+suggestion read path the frontend already uses** (`load_suggestions` /
+`get_suggestion_history` → `AISuggestionService`), rendering a multi-citation
+list with an entailment-aware green/amber state. Also surface the resolved model
+(`run.parameters["model"]`) as a "Model used" column in the Excel AI-metadata
+export for extraction **and** QA.
+
+Scope is **prose only** (§4.2 / §4.4 / §4.8 / §5 of
+`docs/superpowers/specs/2026-06-27-citation-provenance-design.md`). Corroboration
+is **primary-only in v1** — the LLM may emit up to ~3 spans, ordered by `rank`;
+there is NO deterministic corroboration pass.
+
+**Deferred to focused follow-ups (NOT in P1):**
+- The per-project **selectable-default model** mechanism (settings service +
+  manager-gated endpoint + FE model selector). P1 ships only the export
+  transparency column reading whatever model the run already snapshotted.
+- `evidence_role` / `evidence_kind` / `match_method` provenance columns (always
+  constant in primary-only P1) — defer to corroboration / P3 / P4.
+- A standalone `GET /articles/{id}/citations` endpoint — the read-side P0
+  `list_article_citations` service stays untouched in P1; the UI consumes the
+  suggestion path instead, so no new endpoint is added.
+- `block_id` injection, table cell grids, figures, CSS highlight — P2–P4.
+
+## Architecture
+
+The data path for one AI extraction call:
+
+```
+LLM (NativeOutput)                build_output_models / _field_result_model
+  evidence: list[Evidence]   ─────────────────────────────────────────────┐
+                                                                           │
+dump_extraction → {field: {value, confidence, reasoning, evidence:[...],   │
+                            status}}                                        │
+                                                                           ▼
+section_extraction_service._create_suggestions
+  for field:                                                  evidence_is_plausible
+    record_proposal(...)                                      (list-aware validator)
+    for rank, item in enumerate(evidence_items[:3]):  ┌── ExtractionEvidence row ──┐
+      build_anchor(quote) → position                  │ rank = 0..n (LLM order)    │
+      ExtractionEvidence(rank=rank, ...)              │ attribution_label (P0 gate)│
+    (legacy single-dict tolerance → one row, rank=0)  └────────────────────────────┘
+  run_entailment_gate(specs) → labels  (one spec per found row)
+                                                                           ▼
+extraction_suggestion_read_service.load_suggestions / get_suggestion_history
+  group evidence by proposal_record_id → ORDERED list[EvidenceResponse]
+    (order by rank, then id)                  ┌── EvidenceResponse ──┐
+                                              │ text_content,page_num│
+                                              │ blockIds, rank       │
+                                              │ attributionLabel (P0)│
+                                              └──────────────────────┘
+                                                                           ▼
+AISuggestionItem.evidence: list[EvidenceResponse]   (length-1 for legacy proposals)
+  → generate:api-types → schema.d.ts  (FE type becomes a list)
+                                                                           ▼
+aiSuggestionService → AISuggestion.evidence: EvidenceCitation[]  (length-1 legacy)
+                                                                           ▼
+AISuggestionEvidence.tsx  (primary first + "also cited (n)"; green=entailed,
+                           amber=weak/unsupported; each row Locate-able)
+
+Export transparency (orthogonal):
+AIProposalRow.model_used ← run.parameters["model"] per proposal (extraction + QA)
+  → "Model used" column in the AI-metadata Excel sheet
+```
+
+`extraction_evidence` is **already** 1:N per proposal (`proposal_record_id` FK,
+no uniqueness). P1 adds **one** column (`rank`) + one Alembic migration, changes
+the **write loop** from one row to N rows, and the **read grouping** from
+first-row-wins to an ordered list.
+
+## Tech Stack
+
+- **Backend:** Python 3.11+, FastAPI, SQLAlchemy 2.0 async, Alembic, Pydantic
+  v2, pydantic-ai (NativeOutput), structlog. Tests: pytest (integration against
+  local Supabase Postgres; LLM via pydantic-ai `FunctionModel`).
+- **Frontend:** TypeScript strict, React 19 + Vite (React Compiler,
+  `panicThreshold: all_errors`), TanStack Query (key factory), shadcn/Radix,
+  in-house i18n `frontend/lib/copy/`. Tests: Vitest + MSW.
+- **Default model:** `gpt-4o-mini` (`settings.LLM_DEFAULT_MODEL`); per-project
+  selection deferred (see Goal).
+
+## Global Constraints
+
+These are prumo invariants. Violating any one fails CI or review. Copy them into
+your working memory before each task.
+
+- **App schema = Alembic only.** Revision id **≤ 32 chars**
+  (`alembic_version.version_num` is `varchar(32)`). A migration touching
+  `extraction_*` ⇒ in the **same change** update the migration-head line +
+  `last_reviewed` in `docs/reference/extraction-hitl-architecture.md` (head line
+  at ~L109) **and** the `test_migration_roundtrip` head-pin (currently
+  `0034_evidence_attr_label` at `tests/integration/test_migration_roundtrip.py`
+  L270) **and** add a per-migration round-trip test that **downgrades to the
+  explicit parent** `0034_evidence_attr_label` (never `downgrade -1`). Never
+  apply app-schema DDL via the Supabase MCP. Backfill legacy rows via
+  `server_default`.
+- **No raw INSERT of evidence in tests.** `extraction_evidence` has NOT NULL FKs
+  (`project_id`, `article_id`, `run_id`, `created_by`) and the
+  `workflow_target_present` CHECK (one of proposal/reviewer/consensus). The SEED
+  graph does **not** seed any evidence/proposal rows (verified: SEED stops at
+  instance). So migration backfill is proven via the `server_default` at the
+  schema/columnar level — not a data row — exactly as `test_migration_0034_round_trip`
+  does (column presence, no data). Evidence rows in service/read tests are created
+  through `_create_suggestions` / `record_proposal`, never hand-INSERTed.
+- **Typed responses, no `dict`.** Pydantic response models stay typed
+  (`EvidenceResponse`, `AISuggestionItem`) — never `dict[str, Any]` payloads.
+- **Backend tests integration-over-mocks** against local Supabase Postgres (RLS,
+  CHECK constraints, deferred triggers are invisible to mocks). LLM calls use
+  pydantic-ai **`FunctionModel`** (NOT `TestModel` — it bypasses NativeOutput).
+- **Frontend / React Compiler.** NO `try/finally`/`throw` in component or hook
+  bodies (IO goes through `frontend/services/*` returning `ErrorResult`/`toResult`).
+  ALL user-facing copy via `frontend/lib/copy/` (no hardcoded strings). ALL
+  TanStack query keys via the factory in `frontend/lib/query-keys/extraction.ts`.
+  Import API shapes from `frontend/types/api/schema.d.ts` (regenerate with
+  `npm run generate:api-types` after any schema change and commit the diff — the
+  FE `evidence` type only becomes a list once `schema.d.ts` is regenerated;
+  skipping it fails `tsc --noEmit`).
+- **pydantic-ai NativeOutput;** default model `gpt-4o-mini`.
+- **Backward-compat single→list** across the read service / reader: always return
+  a list (**length 1** for legacy proposals with a single evidence row). A legacy
+  single-evidence proposal must render and resolve identically to before.
+- **English only.** Conventional commits.
+- **At harden, run the FULL backend unit suite** (`cd backend && uv run pytest
+  tests/unit -q`), not a subset — a prior phase's `status` field broke wiring
+  that only the full suite caught.
+
+---
+
+### Task 1 — Evidence list in the LLM contract (`schema.py`)
+
+Make the LLM emit `evidence: list[Evidence]` (cap enforced by prompt + a hard
+slice downstream, not by the schema), keep the P0 `status` field, and keep
+`dump_extraction` shape stable (the list flows through `model_dump(by_alias=True)`
+unchanged).
+
+**Files**
+- `backend/app/llm/schema.py` (modify `_field_result_model`; adjust the
+  `_PROPERTIES_PER_FIELD` doc/budget comment)
+- `backend/tests/unit/llm/test_schema.py` (existing)
+
+**Interfaces**
+```python
+# _field_result_model: evidence field becomes a list (was Evidence | None)
+evidence=(
+    list[Evidence],
+    Field(
+        description=(
+            "Up to 3 short verbatim quotes from the article supporting the "
+            "value, most direct first; [] when status is not_found."
+        ),
+    ),
+),
+```
+`Evidence` itself is unchanged (`text: str`, `page_number: int | None`). Keep
+`_PROPERTIES_PER_FIELD = 8` (value, confidence, reasoning, status, evidence +
+Evidence{text,page} ≈ unchanged); verify the budget math in the test.
+
+- [ ] **RED — evidence is a list of Evidence.** Add to
+  `backend/tests/unit/llm/test_schema.py`:
+  ```python
+  from typing import get_args, get_origin
+  from app.llm.schema import Evidence, _field_result_model
+
+
+  def _field(name="primary_outcome", field_type="text", required=True):
+      class _F:  # minimal duck-typed extraction_fields row
+          pass
+      f = _F()
+      f.name = name
+      f.label = name
+      f.field_type = field_type
+      f.allowed_values = None
+      f.is_required = required
+      f.llm_description = None
+      f.description = None
+      return f
+
+
+  def test_field_result_evidence_is_list_of_evidence():
+      model = _field_result_model(_field(), index=0)
+      ann = model.model_fields["evidence"].annotation
+      assert get_origin(ann) is list, f"evidence must be a list, got {ann!r}"
+      assert get_args(ann) == (Evidence,), f"list item must be Evidence, got {get_args(ann)!r}"
+
+
+  def test_field_result_keeps_status_field():
+      model = _field_result_model(_field(), index=0)
+      assert "status" in model.model_fields, "P0 status field must be preserved"
+  ```
+  Verify (expect FAIL — evidence is currently `Evidence | None`):
+  `cd backend && uv run pytest tests/unit/llm/test_schema.py -q -k "evidence_is_list or keeps_status"`
+- [ ] **GREEN — make evidence a list.** In `backend/app/llm/schema.py`
+  `_field_result_model`, replace the `evidence=(Evidence | None, Field(...))`
+  tuple with the `list[Evidence]` interface above. Update the module docstring
+  line that says `evidence{text, page_number}` to note it is now a list, and the
+  `_PROPERTIES_PER_FIELD` comment to mention `status` + list evidence. Re-run the
+  same command (expect PASS).
+- [ ] **RED — dump_extraction round-trips a list.** Add to the same file:
+  ```python
+  from app.llm.schema import build_output_models, dump_extraction
+
+
+  def _entity_with_one_field():
+      class _E:
+          pass
+      e = _E()
+      e.id = "et-1"
+      e.fields = [_field()]
+      return e
+
+
+  def test_dump_extraction_emits_evidence_list():
+      [model] = build_output_models(_entity_with_one_field())
+      instance = model.model_validate(
+          {
+              "primary_outcome": {
+                  "value": "OS",
+                  "confidence": 0.9,
+                  "reasoning": "stated",
+                  "status": "found",
+                  "evidence": [
+                      {"text": "overall survival", "page_number": 3},
+                      {"text": "OS was the primary endpoint", "page_number": 3},
+                  ],
+              }
+          }
+      )
+      dumped = dump_extraction(instance)
+      ev = dumped["primary_outcome"]["evidence"]
+      assert isinstance(ev, list) and len(ev) == 2
+      assert ev[0]["text"] == "overall survival"
+  ```
+  Verify:
+  `cd backend && uv run pytest tests/unit/llm/test_schema.py -q -k dump_extraction_emits_evidence_list`
+
+### Task 2 — List-aware extraction validator (`validators.py`)
+
+`evidence_is_plausible` iterates each field's `.evidence` as a single object and
+calls `evidence.text` — it will break on a list. Make it iterate the list and
+keep abstention valid (`[]` is fine). **Lands before the persistence task.**
+
+**Files**
+- `backend/app/llm/validators.py` (`evidence_is_plausible` only)
+- `backend/tests/unit/llm/test_validators.py` (existing)
+
+**Interfaces**
+```python
+def evidence_is_plausible(output: Any) -> Any:
+    for field_name, field_info in type(output).model_fields.items():
+        label = field_info.alias or field_name
+        field_result = getattr(output, field_name)
+        evidence_list = getattr(field_result, "evidence", None) or []
+        for idx, evidence in enumerate(evidence_list):
+            if not evidence.text.strip():
+                raise ModelRetry(
+                    f"Field '{label}' evidence[{idx}]: evidence.text must be a "
+                    "non-empty quote; omit the entry when there is no quote."
+                )
+            if evidence.page_number is not None and evidence.page_number < 1:
+                raise ModelRetry(
+                    f"Field '{label}' evidence[{idx}]: page_number must be a "
+                    "1-based page number or null."
+                )
+    return output
+```
+
+- [ ] **RED — empty quote inside the list is rejected; empty list is OK.** Add to
+  `backend/tests/unit/llm/test_validators.py` (reuse a `_field` helper — import
+  from `test_schema` or duplicate the small factory):
+  ```python
+  import pytest
+  from pydantic import ConfigDict, create_model
+  from pydantic_ai import ModelRetry
+  from app.llm.schema import _field_result_model
+  from app.llm.validators import evidence_is_plausible
+
+
+  def _output_with_evidence(ev_list):
+      Field0 = _field_result_model(_field(), index=0)  # _field from Task 1
+      Container = create_model(
+          "C", __config__=ConfigDict(extra="forbid"),
+          primary_outcome=(Field0, ...),
+      )
+      return Container.model_validate(
+          {"primary_outcome": {"value": "x", "confidence": 1.0,
+                               "reasoning": "r", "status": "found",
+                               "evidence": ev_list}}
+      )
+
+
+  def test_plausible_rejects_blank_quote_in_list():
+      out = _output_with_evidence([{"text": "ok", "page_number": 1},
+                                   {"text": "  ", "page_number": 1}])
+      with pytest.raises(ModelRetry):
+          evidence_is_plausible(out)
+
+
+  def test_plausible_accepts_empty_evidence_list():
+      out = _output_with_evidence([])  # abstention
+      assert evidence_is_plausible(out) is out
+  ```
+  Verify (expect FAIL — current code does `evidence.text` on a list):
+  `cd backend && uv run pytest tests/unit/llm/test_validators.py -q -k "blank_quote_in_list or empty_evidence_list"`
+- [ ] **GREEN — iterate the list.** Apply the `evidence_is_plausible` interface
+  above. Re-run (expect PASS).
+
+### Task 3 — Alembic migration: `extraction_evidence.rank`
+
+Add a single `rank` column (Integer, `server_default "0"`) to
+`extraction_evidence`, backfilling legacy rows to 0. Mirror the model. Update the
+arch-doc head line + `last_reviewed`, bump the roundtrip head-pin, add a
+round-trip test downgrading to the explicit parent `0034_evidence_attr_label`.
+
+**Files**
+- `backend/alembic/versions/0035_evidence_rank.py` (new — id `0035_evidence_rank`,
+  18 chars, ≤ 32 OK)
+- `backend/app/models/extraction.py` (`ExtractionEvidence`)
+- `backend/tests/unit/test_extraction_models.py` (new)
+- `backend/tests/integration/test_migration_roundtrip.py` (head-pin + new test)
+- `docs/reference/extraction-hitl-architecture.md` (head line ~L109 +
+  `last_reviewed` frontmatter)
+
+**Interfaces**
+```python
+# ExtractionEvidence — new column (after attribution_label)
+rank: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+# order of an evidence span within its proposal (0 = primary/first; LLM order)
+```
+
+- [ ] **RED — model declares `rank` with the right default.** Create
+  `backend/tests/unit/test_extraction_models.py`:
+  ```python
+  from app.models.extraction import ExtractionEvidence
+
+
+  def test_evidence_has_rank_column():
+      cols = ExtractionEvidence.__table__.c
+      assert "rank" in cols
+      # A bare-string server_default's .arg is the string itself (no .text).
+      assert cols["rank"].server_default.arg == "0"
+      assert cols["rank"].nullable is False
+  ```
+  Verify (expect FAIL):
+  `cd backend && uv run pytest tests/unit/test_extraction_models.py -q -k rank_column`
+- [ ] **GREEN — add the column to the model.** Insert the `rank` `mapped_column`
+  into `ExtractionEvidence` (right after `attribution_label`). Re-run (PASS).
+- [ ] **GREEN — autogenerate + hand-verify the migration.** Run
+  `cd backend && uv run alembic revision --autogenerate -m "evidence rank"`,
+  then **rename** the generated file to `0035_evidence_rank.py` and set inside it
+  `revision = "0035_evidence_rank"` and
+  `down_revision = "0034_evidence_attr_label"`. Confirm `upgrade()` is a single
+  `op.add_column("extraction_evidence", sa.Column("rank", sa.Integer(),
+  nullable=False, server_default="0"), schema="public")` and `downgrade()` drops
+  it. Verify offline SQL compiles (also catches the ≤32-char id):
+  `cd backend && uv run alembic upgrade 0034_evidence_attr_label:0035_evidence_rank --sql >/dev/null && echo OK`
+- [ ] **RED — round-trip integration test + head-pin bump.** Append to
+  `tests/integration/test_migration_roundtrip.py` (mirror
+  `test_migration_0034_round_trip`):
+  ```python
+  _EVIDENCE_RANK_COL = text(
+      "SELECT 1 FROM information_schema.columns "
+      "WHERE table_schema = 'public' AND table_name = 'extraction_evidence' "
+      "AND column_name = 'rank'"
+  )
+
+
+  @pytest.mark.asyncio
+  async def test_migration_0035_round_trip(db_session: AsyncSession) -> None:
+      """0035 adds extraction_evidence.rank (server_default '0', backfilling
+      legacy rows to 0). Downgrade to the explicit parent 0034_evidence_attr_label
+      drops it; upgrade head restores it. Backfill is proven by the server_default
+      at the column level (no data: SEED seeds no evidence rows and a raw INSERT
+      would violate the NOT NULL FKs + workflow_target_present CHECK)."""
+      assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() == 1, (
+          "rank must exist at HEAD"
+      )
+
+      _run_alembic("downgrade", "0034_evidence_attr_label")
+      try:
+          await db_session.commit()
+          assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() is None, (
+              "downgrade must drop rank"
+          )
+      finally:
+          _run_alembic("upgrade", "head")
+
+      await db_session.commit()
+      assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() == 1, (
+          "upgrade head must restore rank"
+      )
+  ```
+  Also bump the head-pin assertion (L270) from `0034_evidence_attr_label` to
+  `0035_evidence_rank`. Verify (needs local Supabase up + `alembic upgrade head`):
+  `cd backend && uv run pytest tests/integration/test_migration_roundtrip.py -q -k "0035 or head_is_expected"`
+- [ ] **GREEN — column-level default backfill assertion + docs.** Add to
+  `test_extraction_models.py` an explicit assertion that the default backfills
+  legacy rows (column-level, no data):
+  ```python
+  def test_rank_default_backfills_legacy_rows_to_zero():
+      # server_default "0" is what backfills pre-existing rows at migration time;
+      # asserting it here is the backfill contract (SEED seeds no evidence; a raw
+      # INSERT can't satisfy the FKs + workflow_target_present CHECK).
+      assert ExtractionEvidence.__table__.c["rank"].server_default.arg == "0"
+  ```
+  Then update `docs/reference/extraction-hitl-architecture.md`: change the head
+  line (~L109) to `0035_evidence_rank` and set `last_reviewed: 2026-06-27`.
+  Verify:
+  `cd backend && uv run pytest tests/unit/test_extraction_models.py -q && grep -n "0035_evidence_rank" ../docs/reference/extraction-hitl-architecture.md`
+
+### Task 4 — Persist N evidence rows per proposal (`section_extraction_service.py`)
+
+Change the write loop in `_create_suggestions` from one `ExtractionEvidence` to
+one per evidence entry (cap 3), assigning `rank` 0..n in LLM order, **keeping a
+legacy single-dict tolerance branch**, and feeding **each** found-with-quote row
+to the entailment gate (P0 `run_entailment_gate`).
+
+**Files**
+- `backend/app/services/section_extraction_service.py` (`_create_suggestions`
+  field loop ~L1349–1414; the `evidence_meta` block becomes a list build)
+- `backend/tests/integration/test_section_extraction_evidence.py` (verify with
+  `ls backend/tests/integration | grep -i section_extraction`; create if absent)
+
+**Interfaces**
+```python
+EVIDENCE_CAP = 3  # module constant near the top of the service
+
+# inside the field loop, replacing the single evidence_meta block:
+raw_evidence = value.get("evidence") if isinstance(value, dict) else None
+evidence_items: list[dict[str, Any]] = []
+if isinstance(raw_evidence, list):
+    for e in raw_evidence:
+        if isinstance(e, dict) and (e.get("text") or "").strip():
+            evidence_items.append(
+                {"text": str(e["text"]).strip(), "page_number": e.get("page_number")}
+            )
+elif isinstance(raw_evidence, dict) and (raw_evidence.get("text") or "").strip():
+    # LEGACY tolerance: old P0 shape was a single evidence dict → one row, rank 0.
+    evidence_items.append(
+        {"text": str(raw_evidence["text"]).strip(),
+         "page_number": raw_evidence.get("page_number")}
+    )
+evidence_items = evidence_items[:EVIDENCE_CAP]
+
+for rank, item in enumerate(evidence_items):
+    quote = item["text"]
+    pos = build_anchor(quote, _anchor_blocks) if _anchor_blocks and quote else None
+    position = pos.model_dump(by_alias=True, mode="json") if pos is not None else {}
+    page_num = pos.anchor.range.page if pos is not None else item.get("page_number")
+    ev_row = ExtractionEvidence(
+        project_id=project_id,
+        article_id=article_id,
+        article_file_id=_anchor_file_id if pos is not None else None,
+        run_id=run.id,
+        proposal_record_id=proposal.id,
+        page_number=page_num,
+        text_content=quote,
+        position=position,
+        rank=rank,
+        created_by=UUID(self.user_id),
+    )
+    self.db.add(ev_row)
+    if isinstance(value, dict) and value.get("status") == "found":
+        _gate_specs.append(GateSpec(
+            field_label=field_label_map.get(field_name, field_name),
+            value_str=str(inner_value), quote=quote, pos=pos,
+            anchor_blocks=_anchor_blocks,
+        ))
+        _gate_rows.append(ev_row)
+```
+The gate fan-out + `zip(_gate_rows, labels, strict=True)` block stays as-is — it
+now assigns labels across all rows.
+
+- [ ] **RED — two evidence entries write two ranked rows.** Add an integration
+  test that drives `_create_suggestions` (or the public `extract_section` path
+  with a `FunctionModel` returning two evidence quotes) and asserts two
+  `ExtractionEvidence` rows exist for the proposal with `rank` 0 and 1. Mirror the
+  fixture style of the existing section-extraction integration tests (autouse
+  `SEED`, scope by `project_id`). Verify (expect FAIL — current loop writes one
+  row):
+  `cd backend && uv run pytest tests/integration/test_section_extraction_evidence.py -q -k two_ranked_rows`
+- [ ] **GREEN — loop over evidence_items.** Apply the interface above to
+  `_create_suggestions`, adding the `EVIDENCE_CAP` constant. Re-run (PASS).
+- [ ] **RED — legacy single-dict shape writes one row at rank 0.** Add a test that
+  feeds `value["evidence"]` as a **single dict** (the old P0 shape, not a list)
+  and asserts exactly one `ExtractionEvidence` row with `rank == 0`. Verify
+  (expect PASS only with the legacy branch present — this guards it):
+  `cd backend && uv run pytest tests/integration/test_section_extraction_evidence.py -q -k legacy_single_dict`
+- [ ] **RED — abstention writes zero rows; cap caps at 3.** Add two cases: a
+  `not_found` field writes no evidence rows; a field with 5 quotes writes exactly
+  3 (`rank` 0–2). Verify:
+  `cd backend && uv run pytest tests/integration/test_section_extraction_evidence.py -q -k "abstention_no_rows or caps_at_three"`
+- [ ] **GREEN — confirm cap + abstention.** The `[:EVIDENCE_CAP]` slice and the
+  existing status skip satisfy both. Re-run (expect PASS).
+
+### Task 5 — Suggestion read path returns an ordered evidence list
+
+Update the suggestion read service (the path the UI actually uses) to group
+evidence by `proposal_record_id` into an **ordered** `list[EvidenceResponse]`
+(order by `rank`, then `id`) instead of taking only the first row, and widen the
+schema. Add `rank` + `attributionLabel` (from P0) to `EvidenceResponse`. Legacy
+proposals with a single evidence row yield a length-1 list.
+
+**Files**
+- `backend/app/services/extraction_suggestion_read_service.py` (`load_suggestions`
+  step 3 + step 5; `get_suggestion_history` evidence grouping + item build)
+- `backend/app/schemas/extraction_suggestion.py` (`EvidenceResponse`,
+  `AISuggestionItem.evidence`, `AISuggestionHistoryItem.evidence`)
+- `backend/tests/integration/test_suggestion_read.py` (existing — verify with
+  `ls backend/tests/integration | grep -i suggestion`)
+
+**Interfaces**
+```python
+# app/schemas/extraction_suggestion.py — EvidenceResponse gains rank + label
+class EvidenceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+    proposal_record_id: UUID | None
+    text_content: str | None
+    page_number: int | None
+    block_ids: list[int] = Field(default_factory=list, alias="blockIds", ...)
+    rank: int = 0
+    attribution_label: str | None = Field(default=None, alias="attributionLabel")
+
+# AISuggestionItem + AISuggestionHistoryItem
+    evidence: list[EvidenceResponse]  # was EvidenceResponse | None; [] when none
+```
+```python
+# extraction_suggestion_read_service.py — group into an ordered list
+# (replaces evidence_by_proposal: dict[UUID, ExtractionEvidence] taking first row)
+evidence_by_proposal: dict[UUID, list[ExtractionEvidence]] = {}
+for ev in evidence_rows:
+    if ev.proposal_record_id:
+        evidence_by_proposal.setdefault(ev.proposal_record_id, []).append(ev)
+for rows in evidence_by_proposal.values():
+    rows.sort(key=lambda e: (e.rank, str(e.id)))
+
+# item build (both load_suggestions and get_suggestion_history):
+evidence_list = [
+    EvidenceResponse(
+        proposal_record_id=p.id,
+        text_content=ev.text_content,
+        page_number=ev.page_number,
+        blockIds=_extract_block_ids(ev),
+        rank=ev.rank,
+        attributionLabel=ev.attribution_label,
+    )
+    for ev in evidence_by_proposal.get(p.id, [])
+]
+# ...AISuggestionItem(..., evidence=evidence_list, ...)
+```
+
+- [ ] **RED — load_suggestions returns ordered list with rank + label.** In
+  `test_suggestion_read.py`, seed (via `_create_suggestions` / `record_proposal`,
+  never raw INSERT) a proposal with two evidence rows (rank 1 then 0, one labelled
+  `entailed`), call `load_suggestions`, and assert the item's `evidence` is a
+  length-2 list ordered rank 0 then 1, with `attribution_label` preserved. Verify
+  (expect FAIL — service returns a single `EvidenceResponse | None`):
+  `cd backend && uv run pytest tests/integration/test_suggestion_read.py -q -k ordered_list`
+- [ ] **GREEN — group + widen schema.** Apply both interfaces (schema +
+  service, in `load_suggestions` and `get_suggestion_history`). Re-run (PASS).
+- [ ] **RED — legacy single-evidence proposal → length-1 list.** Seed a proposal
+  with one evidence row (default `rank=0`, NULL `attribution_label`) and assert
+  `evidence` is a length-1 list with `rank == 0` and `attribution_label is None`.
+  Verify (locks backward-compat):
+  `cd backend && uv run pytest tests/integration/test_suggestion_read.py -q -k legacy_length_one`
+- [ ] **GREEN — regenerate API types (FE list type).** From repo root run
+  `npm run generate:api-types` and commit the `frontend/types/api/{openapi.json,
+  schema.d.ts}` diff. The FE `AISuggestionItem.evidence` must now be a list —
+  verify:
+  `grep -n "EvidenceResponse" frontend/types/api/schema.d.ts && git -C .. diff --stat frontend/types/api/`
+
+### Task 6 — Frontend: multi-citation render (primary first + "also cited (n)")
+
+Change `AISuggestion.evidence` from a single object to a list, map it in the
+service from the new server list, and render the list in `AISuggestionEvidence.tsx`
+with green (entailed) vs **amber** (weak/unsupported) state per row and per-row
+Locate. Length-1 for legacy.
+
+**Files**
+- `frontend/types/ai-extraction.ts` (`AISuggestion.evidence` → list type)
+- `frontend/services/aiSuggestionService.ts` (map server list → `EvidenceCitation[]`)
+- `frontend/components/extraction/ai/AISuggestionEvidence.tsx` (render list +
+  amber/green)
+- `frontend/lib/copy/extraction.ts` (verify path; add copy keys
+  `evidenceAlsoCited`, `attributionWeak`, `attributionUnsupported`,
+  `attributionEntailed`)
+- Tests: `frontend/components/extraction/ai/AISuggestionEvidence.test.tsx`
+  (new/extend), `frontend/services/aiSuggestionService.test.ts` (extend)
+
+**Interfaces**
+```ts
+// types/ai-extraction.ts
+export interface EvidenceCitation {
+  text: string;
+  pageNumber?: number | null;
+  blockIds: number[];
+  attributionLabel?: 'entailed' | 'weak' | 'unsupported' | null;
+  rank: number;
+}
+export interface AISuggestion {
+  // ...unchanged fields...
+  evidence?: EvidenceCitation[];  // [] / undefined when none; length-1 for legacy
+}
+```
+`aiSuggestionService.ts`: `item.evidence` is now a server **list**; map it to
+`EvidenceCitation[]` sorted by `rank` (fall back to `[]` when empty/absent).
+`AISuggestionEvidence.tsx`: accept `evidence: EvidenceCitation[]`; render the
+first (lowest-`rank`) item as the primary block (existing layout), and when
+`length > 1` render the rest collapsed under a
+`t('extraction','evidenceAlsoCited').replace('{{n}}', String(length-1))` toggle.
+Per item, choose the left-border + badge tone: `attributionLabel === 'entailed'`
+→ green; `weak`/`unsupported` → **amber** (with the matching copy key);
+`null`/legacy → existing neutral primary tone. No `try/finally`/`throw` — keep the
+existing clipboard `.then/.catch`. `onLocate?: (rank: number) => void` so each row
+locates its own span.
+
+- [ ] **RED — service maps a citation list.** In `aiSuggestionService.test.ts`,
+  feed a server item whose `evidence` is the new list shape (two entries, ranks
+  0/1, labels `entailed`/`weak`) and assert `mapItemToSuggestion` returns
+  `evidence` as a length-2 array, primary first, with `attributionLabel`
+  preserved; feed an item with `evidence: []` and assert `evidence` is `[]`.
+  Verify (expect FAIL — mapper builds a single object from `item.evidence.text_content`):
+  `npm run test:run -- aiSuggestionService`
+- [ ] **GREEN — map to list.** Update `mapItemToSuggestion` /
+  `mapHistoryItemToSuggestion` to build `EvidenceCitation[]` from the server
+  evidence list (sorted by `rank`). Update the `AISuggestion.evidence` type and
+  add the `EvidenceCitation` export. Re-run (expect PASS).
+- [ ] **RED — component renders primary + "also cited" + amber + legacy.** In
+  `AISuggestionEvidence.test.tsx` render with two citations (one `entailed`, one
+  `weak`); assert the primary quote is visible, an "also cited (1)" affordance is
+  present, and the weak row carries the amber attribution copy
+  (`t('extraction','attributionWeak')`). Add a legacy case: a length-1 list with
+  `attributionLabel: null` renders exactly the old single-block layout (no "also
+  cited"). Verify (expect FAIL — component takes a single `evidence` object):
+  `npm run test:run -- AISuggestionEvidence`
+- [ ] **GREEN — render the list + tones + copy.** Add the copy keys to
+  `frontend/lib/copy/extraction.ts`, and rewrite `AISuggestionEvidence` per the
+  interface. Update all call sites passing the old single-object prop to pass the
+  list (search: `grep -rn "AISuggestionEvidence" frontend/components frontend/pages`).
+  Re-run (expect PASS).
+- [ ] **GREEN — typecheck + lint clean (React Compiler gate).** Verify:
+  `npm run lint && npx tsc --noEmit`
+
+### Task 7 — Export transparency: "Model used" column (extraction + QA)
+
+Add a `model_used` field to `AIProposalRow` (resolved from
+`run.parameters["model"]` per proposal) and a "Model used" header to the
+AI-metadata sheet, for extraction **and** QA exports. (Per-project model
+*selection* is deferred — this task only surfaces whatever model the run already
+snapshotted.)
+
+**Files**
+- `backend/app/services/extraction_export_service.py` (`AIProposalRow` dataclass
+  ~L195; `_resolve_ai_proposal_rows` row build ~L1783 — needs run→model lookup)
+- `backend/app/services/exports/extraction/ai_metadata.py` (`_HEADERS` ~L26;
+  `_VALUE_COLS` / `_TIMESTAMP_COL` 1-based index constants)
+- `backend/tests/unit/test_extraction_ai_metadata_builder.py` (existing — its
+  assertions use 0-based tuple indices: `row[9]`=timestamp, `row[10]`=outcome,
+  `row[11]`=final value; these SHIFT when "Model used" is inserted)
+- `backend/tests/integration/test_extraction_export*.py` (extend the AI-metadata
+  case)
+
+**Interfaces**
+```python
+# AIProposalRow — insert model_used AFTER proposed_at, BEFORE reviewer_outcome
+# (keeps "Final value used" last; field order == header order via astuple):
+    proposed_at: datetime
+    model_used: str          # resolved run.parameters["model"], "" if absent
+    reviewer_outcome: str
+    final_value_used: Any
+```
+```python
+# ai_metadata.py _HEADERS — insert "Model used" between "Proposed at" (col 10)
+# and "Reviewer outcome". Resulting 1-based columns:
+#   10 = "Proposed at"; 11 = "Model used"; 12 = "Reviewer outcome";
+#   13 = "Final value used".
+_VALUE_COLS = frozenset({5, 13})   # AI proposed value + Final value used
+_TIMESTAMP_COL = 10                # unchanged
+```
+In `_resolve_ai_proposal_rows`, build `model_by_run: dict[UUID, str]` from the
+in-scope runs (`run.parameters.get("model", "")`) and set
+`model_used=model_by_run.get(rid, "")` on each row. The builder is `kind`-agnostic,
+so QA gets the column for free — assert it.
+
+- [ ] **RED — header + row carry the model (pure builder).** In
+  `test_extraction_ai_metadata_builder.py`: add `"model_used": "gpt-4o"` to the
+  `_proposal` factory's base dict, then update the existing 0-based index
+  assertions for the shifted layout and add the new column. After the insert the
+  AI-metadata headers are (0-based): 0 Article … 9 "Proposed at",
+  10 "Model used", 11 "Reviewer outcome", 12 "Final value used". So assert:
+  ```python
+  # no-rows / header case:
+  assert spec.rows[0][10].value == "Model used"
+  assert spec.rows[0][12].value == "Final value used"
+  # one-row case:
+  assert row[9].value == "2026-05-23T10:00:00+00:00"   # timestamp unchanged
+  assert row[10].value == "gpt-4o"                       # NEW
+  assert row[11].value == "accepted"                     # was row[10]
+  assert row[12].value == "Yes"                          # was row[11]
+  ```
+  Verify (expect FAIL — field absent, indices off):
+  `cd backend && uv run pytest tests/unit/test_extraction_ai_metadata_builder.py -q`
+- [ ] **GREEN — add field + header + index shift.** Add `model_used` to
+  `AIProposalRow` (after `proposed_at`), insert `"Model used"` into `_HEADERS`
+  (between "Proposed at" and "Reviewer outcome"), and update `_VALUE_COLS` to
+  `{5, 13}`. Re-run (expect PASS).
+- [ ] **RED — resolver fills model from run.parameters (extraction + QA).**
+  Extend the export integration test: an extraction run with
+  `parameters["model"]="gpt-4o-mini"` and a QA run with
+  `parameters["model"]="gpt-4o"` both surface their model in the AI-metadata
+  sheet's "Model used" column. Verify (expect FAIL — `_resolve_ai_proposal_rows`
+  doesn't set it):
+  `cd backend && uv run pytest "tests/integration/test_extraction_export*.py" -q -k model_used`
+- [ ] **GREEN — wire model_by_run.** Build `model_by_run` in
+  `_resolve_ai_proposal_rows` and set `model_used` on every `AIProposalRow`.
+  Re-run (expect PASS).
+
+### Task 8 — Harden & verify (whole-phase gate)
+
+- [ ] **Full backend unit suite (the wiring guard).** A prior phase's `status`
+  field broke wiring only the full suite caught — run all unit tests, not a
+  subset. Verify:
+  `cd backend && uv run pytest tests/unit -q`
+- [ ] **Backend integration suite (DB-backed).** Local Supabase up + `alembic
+  upgrade head` first (advisory-lock: never run concurrently). Verify:
+  `cd backend && uv run alembic upgrade head && uv run pytest tests/integration -q`
+- [ ] **Backend lint/format.** Verify:
+  `make lint-backend`
+- [ ] **Frontend tests + lint + typecheck.** From repo root. Verify:
+  `npm run test:run && npm run lint && npx tsc --noEmit`
+- [ ] **API contract is committed.** The widened `EvidenceResponse` /
+  `AISuggestionItem.evidence` list landed in the generated schema. Verify
+  (expect no diff):
+  `npm run generate:api-types && git -C .. diff --exit-code frontend/types/api/`
+- [ ] **Migration head is consistent everywhere.** Confirm the head-pin, the
+  arch-doc head line, and the actual head agree. Verify:
+  `cd backend && uv run alembic heads && grep -n "0035_evidence_rank" tests/integration/test_migration_roundtrip.py ../docs/reference/extraction-hitl-architecture.md`
+- [ ] **Manual smoke (optional, evidence-backed).** Run the local stack, open a
+  run with an AI proposal that produced ≥2 evidence spans, and confirm the
+  suggestion shows the primary quote + an "also cited (n)" toggle, an amber row
+  for a weak label, and that the Excel export's AI-metadata sheet has a populated
+  "Model used" column. Capture a screenshot or the cell value as evidence.
+
+---
+
+## Self-Review
+
+Before opening a PR, confirm each of these against **run output**, not memory:
+
+- **TDD discipline.** Every implementation step was preceded by a RED run whose
+  failure you read, and followed by a GREEN run whose pass you read. No step was
+  marked done on assertion alone (`verification-before-completion`).
+- **Migration invariants (Task 3).** Revision id `0035_evidence_rank` is ≤ 32
+  chars; `down_revision = "0034_evidence_attr_label"`; the round-trip test
+  downgrades to that **explicit parent** (not `-1`); the head-pin (L270), the
+  arch-doc head line (~L109), and `last_reviewed` were all bumped in the same
+  change; `rank` backfills via `server_default "0"` (asserted at the column level
+  — `.server_default.arg == "0"`, NOT `.arg.text`); no data migration and no raw
+  evidence INSERT (NOT NULL FKs + `workflow_target_present` CHECK; SEED seeds no
+  evidence).
+- **No new endpoint.** P0's `list_article_citations` is untouched; the evidence
+  list reaches the UI through `extraction_suggestion_read_service` — the path the
+  frontend already consumes. No BOLA/typed-anchor/`ProjectNotFoundError` surface
+  was added.
+- **LLM testing.** Any test exercising the extraction call uses pydantic-ai
+  `FunctionModel`, never `TestModel`.
+- **Legacy single-dict + single-row compatibility.** The persistence loop keeps a
+  single-dict tolerance branch (Task 4 has a `legacy_single_dict` test asserting
+  one row at rank 0); the read service returns a **length-1** list for a
+  single-evidence proposal (Task 5 `legacy_length_one`); the component renders a
+  length-1 list as the old single-block layout (Task 6 legacy case).
+- **API types regenerated + committed.** The FE `evidence` type is a list because
+  `schema.d.ts` was regenerated (Task 5 GREEN); `tsc --noEmit` is clean.
+- **Frontend constraints.** No `try/finally`/`throw` in component/hook bodies;
+  all new copy lives in `frontend/lib/copy/`; query keys (if any added) come from
+  the factory; API shapes imported from `schema.d.ts`; `npm run lint` and
+  `tsc --noEmit` clean (React Compiler `all_errors` gate).
+- **Scope honesty.** One migration column (`rank`) only — `evidence_role` /
+  `evidence_kind` / `match_method` deferred. Per-project model **selection**
+  (settings service + endpoint + FE selector) deferred; only the export
+  transparency column ships. No `block_id`, table, figure, or highlight work.
+- **Whole-suite harden.** The FULL backend unit suite ran green (Task 8), not a
+  per-task subset.
+- **Layering.** Services touch models/repositories only (no `api` imports, no HTTP
+  objects); the read service returns typed Pydantic models, never ORM rows.

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -28,7 +28,8 @@ interface AISuggestionDisplayProps {
 
 function hasSuggestionDetails(suggestion: AISuggestion): boolean {
   const hasReasoning = !!suggestion.reasoning?.trim();
-  const hasEvidence = !!suggestion.evidence?.text?.trim();
+  const hasEvidence =
+    (suggestion.evidence?.length ?? 0) > 0 && !!suggestion.evidence?.[0]?.text?.trim();
   return hasReasoning || hasEvidence;
 }
 

--- a/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
@@ -2,12 +2,13 @@
  * Tests for AISuggestionEvidence (presentational component).
  *
  * Scenarios:
- *  (a) onLocate provided → a "Locate in document" button renders and calls it
+ *  (a) onLocate provided → a "Locate in document" button renders and calls it with the rank
  *  (b) no onLocate → no locate button (backward compatible; quote + page badge)
  *  (c) handleCopy — setCopied(true) only fires on clipboard success
- *
- * The component is purely presentational: no viewer-store access. (Tooltip
- * still needs TooltipProvider — a Radix requirement, not a viewer requirement.)
+ *  (d) multi-citation list → primary shown, "also cited (n)" toggle present
+ *  (e) amber / green attribution badges render with correct copy key
+ *  (f) legacy length-1 list with null attributionLabel → old single-block layout
+ *  (g) empty list → renders nothing
  */
 
 import {render, screen} from '@testing-library/react';
@@ -21,17 +22,25 @@ vi.mock('@/lib/copy', () => ({
 
 import {AISuggestionEvidence} from './AISuggestionEvidence';
 import {TooltipProvider} from '@/components/ui/tooltip';
+import type {EvidenceCitation} from '@/types/ai-extraction';
 
 function Wrapper({children}: {children: ReactNode}) {
   return <TooltipProvider>{children}</TooltipProvider>;
 }
 
-const evidence = {text: 'some evidence text', pageNumber: 3};
+const singleCitation: EvidenceCitation[] = [
+  {text: 'some evidence text', pageNumber: 3, blockIds: [], attributionLabel: null, rank: 0},
+];
+
+const twoCitations: EvidenceCitation[] = [
+  {text: 'primary evidence', pageNumber: 2, blockIds: [1], attributionLabel: 'entailed', rank: 0},
+  {text: 'secondary evidence', pageNumber: 5, blockIds: [10], attributionLabel: 'weak', rank: 1},
+];
 
 describe('AISuggestionEvidence', () => {
   describe('(a) onLocate provided', () => {
     it('renders a locate button', () => {
-      render(<AISuggestionEvidence evidence={evidence} onLocate={vi.fn()} />, {
+      render(<AISuggestionEvidence evidence={singleCitation} onLocate={vi.fn()} />, {
         wrapper: Wrapper,
       });
       expect(
@@ -39,39 +48,43 @@ describe('AISuggestionEvidence', () => {
       ).toBeInTheDocument();
     });
 
-    it('calls onLocate when the locate button is clicked', async () => {
+    it('calls onLocate with rank 0 when the locate button is clicked', async () => {
       const user = userEvent.setup();
       const onLocate = vi.fn();
-      render(<AISuggestionEvidence evidence={evidence} onLocate={onLocate} />, {
+      render(<AISuggestionEvidence evidence={singleCitation} onLocate={onLocate} />, {
         wrapper: Wrapper,
       });
       await user.click(screen.getByRole('button', {name: 'evidenceLocate'}));
       expect(onLocate).toHaveBeenCalledOnce();
+      expect(onLocate).toHaveBeenCalledWith(0);
     });
   });
 
   describe('(b) no onLocate — backward compat', () => {
     it('renders the quote text', () => {
-      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      render(<AISuggestionEvidence evidence={singleCitation} />, {wrapper: Wrapper});
       expect(screen.getByText(/some evidence text/)).toBeInTheDocument();
     });
 
     it('renders the page badge', () => {
-      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      render(<AISuggestionEvidence evidence={singleCitation} />, {wrapper: Wrapper});
       expect(screen.getByText('pageLabel')).toBeInTheDocument();
     });
 
     it('does NOT render a locate button', () => {
-      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      render(<AISuggestionEvidence evidence={singleCitation} />, {wrapper: Wrapper});
       expect(
         screen.queryByRole('button', {name: 'evidenceLocate'}),
       ).not.toBeInTheDocument();
     });
 
     it('renders without crashing when no locate (no viewer state needed)', () => {
-      const {unmount} = render(<AISuggestionEvidence evidence={{text: 'safe'}} />, {
-        wrapper: Wrapper,
-      });
+      const {unmount} = render(
+        <AISuggestionEvidence
+          evidence={[{text: 'safe', pageNumber: null, blockIds: [], attributionLabel: null, rank: 0}]}
+        />,
+        {wrapper: Wrapper},
+      );
       expect(screen.getByText(/safe/)).toBeInTheDocument();
       unmount();
     });
@@ -81,7 +94,7 @@ describe('AISuggestionEvidence', () => {
     it('sets copied=true when clipboard write succeeds', async () => {
       const spy = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
       const user = userEvent.setup();
-      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      render(<AISuggestionEvidence evidence={singleCitation} />, {wrapper: Wrapper});
       const copyBtn = screen.getByRole('button', {name: 'copySnippet'});
 
       await user.click(copyBtn);
@@ -94,13 +107,91 @@ describe('AISuggestionEvidence', () => {
         new Error('permission denied'),
       );
       const user = userEvent.setup();
-      render(<AISuggestionEvidence evidence={evidence} />, {wrapper: Wrapper});
+      render(<AISuggestionEvidence evidence={singleCitation} />, {wrapper: Wrapper});
       const copyBtn = screen.getByRole('button', {name: 'copySnippet'});
 
       await user.click(copyBtn);
       expect(screen.queryByRole('button', {name: 'copyCopied'})).not.toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'copySnippet'})).toBeInTheDocument();
       spy.mockRestore();
+    });
+  });
+
+  describe('(d) multi-citation list — primary + "also cited" toggle', () => {
+    it('renders the primary quote immediately', () => {
+      render(<AISuggestionEvidence evidence={twoCitations} />, {wrapper: Wrapper});
+      expect(screen.getByText(/primary evidence/)).toBeInTheDocument();
+    });
+
+    it('renders the "evidenceAlsoCited" toggle button', () => {
+      render(<AISuggestionEvidence evidence={twoCitations} />, {wrapper: Wrapper});
+      expect(screen.getByText('evidenceAlsoCited')).toBeInTheDocument();
+    });
+
+    it('does NOT render the secondary quote before expansion', () => {
+      render(<AISuggestionEvidence evidence={twoCitations} />, {wrapper: Wrapper});
+      expect(screen.queryByText(/secondary evidence/)).not.toBeInTheDocument();
+    });
+
+    it('reveals secondary quote after clicking the toggle', async () => {
+      const user = userEvent.setup();
+      render(<AISuggestionEvidence evidence={twoCitations} />, {wrapper: Wrapper});
+      await user.click(screen.getByText('evidenceAlsoCited'));
+      expect(screen.getByText(/secondary evidence/)).toBeInTheDocument();
+    });
+  });
+
+  describe('(e) attribution badges — green (entailed) vs amber (weak)', () => {
+    it('shows green badge for entailed primary citation', () => {
+      render(<AISuggestionEvidence evidence={twoCitations} />, {wrapper: Wrapper});
+      // 'attributionEntailed' is the copy key for the green badge
+      expect(screen.getByText('attributionEntailed')).toBeInTheDocument();
+    });
+
+    it('shows amber badge for weak secondary citation after expansion', async () => {
+      const user = userEvent.setup();
+      render(<AISuggestionEvidence evidence={twoCitations} />, {wrapper: Wrapper});
+      await user.click(screen.getByText('evidenceAlsoCited'));
+      expect(screen.getByText('attributionWeak')).toBeInTheDocument();
+    });
+
+    it('shows amber badge for unsupported citation', () => {
+      const unsupportedCitation: EvidenceCitation[] = [
+        {
+          text: 'unsupported text',
+          pageNumber: 1,
+          blockIds: [],
+          attributionLabel: 'unsupported',
+          rank: 0,
+        },
+      ];
+      render(<AISuggestionEvidence evidence={unsupportedCitation} />, {wrapper: Wrapper});
+      expect(screen.getByText('attributionUnsupported')).toBeInTheDocument();
+    });
+
+    it('does NOT show any badge when attributionLabel is null', () => {
+      render(<AISuggestionEvidence evidence={singleCitation} />, {wrapper: Wrapper});
+      expect(screen.queryByText('attributionEntailed')).not.toBeInTheDocument();
+      expect(screen.queryByText('attributionWeak')).not.toBeInTheDocument();
+      expect(screen.queryByText('attributionUnsupported')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('(f) legacy — length-1 list with null attributionLabel', () => {
+    it('renders the single citation without any "also cited" toggle', () => {
+      render(<AISuggestionEvidence evidence={singleCitation} />, {wrapper: Wrapper});
+      expect(screen.getByText(/some evidence text/)).toBeInTheDocument();
+      expect(screen.queryByText('evidenceAlsoCited')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('(g) empty evidence list', () => {
+    it('renders nothing when evidence is an empty array', () => {
+      const {container} = render(
+        <AISuggestionEvidence evidence={[]} />,
+        {wrapper: Wrapper},
+      );
+      expect(container.firstChild).toBeNull();
     });
   });
 });

--- a/frontend/components/extraction/ai/AISuggestionEvidence.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.tsx
@@ -1,67 +1,109 @@
 /**
  * Component to display AI suggestion evidence
  *
- * Shows the text passage cited by the LLM as evidence for extraction,
- * including page number (if available).
+ * Accepts a list of `EvidenceCitation` items (ordered by rank — rank 0 is
+ * primary). The primary citation is shown prominently; additional citations
+ * are revealed under a collapsible "Also cited (n)" toggle.
  *
- * Optional markdown-first locate: when an `onLocate` callback is provided (by a
- * parent inside a ViewerProvider), the evidence block gains a "Locate in
- * document" button that switches the reader to the cited passage and flashes
- * it. When `onLocate` is absent the component renders exactly as before —
- * backward compatible, safe to use outside a ViewerProvider.
+ * Each citation row shows:
+ * - A left-border + badge in the attribution tone:
+ *   GREEN  → `attributionLabel === 'entailed'`
+ *   AMBER  → `'weak' | 'unsupported'`
+ *   neutral → null / legacy
+ * - A "Locate in document" button when `onLocate` is provided (passed per
+ *   citation as `onLocate(rank)` so each row targets its own span).
+ * - A copy-to-clipboard button.
+ *
+ * Legacy compatibility: a length-1 array with `attributionLabel: null`
+ * renders exactly the old single-block layout with no toggle.
  *
  * @component
  */
 
-import {Check, Copy, FileText, MapPin} from 'lucide-react';
+import {Check, ChevronDown, ChevronUp, Copy, FileText, MapPin} from 'lucide-react';
 import {Button} from '@/components/ui/button';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {useState} from 'react';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
+import type {EvidenceCitation} from '@/types/ai-extraction';
 
 // =================== INTERFACES ===================
 
 interface AISuggestionEvidenceProps {
-  evidence: {
-    text: string;
-    pageNumber?: number | null;
-  };
+  evidence: EvidenceCitation[];
   className?: string;
   showCopyButton?: boolean;
-  /** Locate this evidence in the document reader. Provided by a parent inside a
-   *  ViewerProvider; absent → the locate button is not rendered. */
-  onLocate?: () => void;
+  /**
+   * Called with the rank of the citation the user clicked "Locate" on.
+   * When absent the locate button is not rendered (backward compatible).
+   */
+  onLocate?: (rank: number) => void;
 }
 
-// =================== COMPONENT ===================
+// =================== CITATION ROW ===================
 
-export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
-  const {evidence, className, showCopyButton = true, onLocate} = props;
+interface CitationRowProps {
+  citation: EvidenceCitation;
+  showCopyButton: boolean;
+  onLocate?: (rank: number) => void;
+  isPrimary?: boolean;
+}
+
+function CitationRow({citation, showCopyButton, onLocate, isPrimary}: CitationRowProps) {
   const [copied, setCopied] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const handleCopy = async () => {
-    const ok = await navigator.clipboard.writeText(evidence.text).then(() => true).catch((err: unknown) => {
-      console.error('Failed to copy evidence text:', err);
-      return false;
-    });
-    if (ok) {
+  const handleCopy = () => {
+    navigator.clipboard.writeText(citation.text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    }
+    }).catch((err: unknown) => {
+      console.error('Failed to copy evidence text:', err);
+    });
   };
 
+  const label = citation.attributionLabel;
+  const isEntailed = label === 'entailed';
+  const isAmber = label === 'weak' || label === 'unsupported';
+
+  const badgeCopy =
+    isEntailed
+      ? t('extraction', 'attributionEntailed')
+      : label === 'weak'
+        ? t('extraction', 'attributionWeak')
+        : label === 'unsupported'
+          ? t('extraction', 'attributionUnsupported')
+          : null;
+
+  const borderClass = isEntailed
+    ? 'border-l-green-500'
+    : isAmber
+      ? 'border-l-amber-500'
+      : 'border-l-primary/20';
+
   return (
-    <div className={cn('flex flex-col gap-4 p-4 bg-muted/50 rounded-lg border', className)}>
-      {/* Header with icon and page */}
+    <div className={cn(isPrimary ? 'flex flex-col gap-4' : 'flex flex-col gap-3')}>
+      {/* Row header: icon + page + attribution badge + actions */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
         <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap">
           <FileText className="h-4 w-4 shrink-0" />
           <span className="font-medium">{t('extraction', 'evidenceCited')}</span>
-          {evidence.pageNumber !== null && evidence.pageNumber !== undefined && (
+          {citation.pageNumber !== null && citation.pageNumber !== undefined && (
             <span className="px-2 py-1 bg-background rounded text-xs shrink-0">
-              {t('extraction', 'pageLabel').replace('{{n}}', String(evidence.pageNumber))}
+              {t('extraction', 'pageLabel').replace('{{n}}', String(citation.pageNumber))}
+            </span>
+          )}
+          {badgeCopy !== null && (
+            <span
+              className={cn(
+                'px-2 py-0.5 rounded text-xs font-medium shrink-0',
+                isEntailed
+                  ? 'bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300'
+                  : 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300',
+              )}
+            >
+              {badgeCopy}
             </span>
           )}
         </div>
@@ -76,7 +118,7 @@ export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
                   className="h-8 w-8 p-0 hover:bg-muted"
                   onClick={(e) => {
                     e.stopPropagation();
-                    onLocate();
+                    onLocate(citation.rank);
                   }}
                   aria-label={t('extraction', 'evidenceLocate')}
                 >
@@ -121,9 +163,71 @@ export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
       </div>
 
       {/* Cited passage */}
-      <blockquote className="text-sm text-foreground/90 italic pl-3 sm:pl-5 border-l-2 border-primary/20 whitespace-pre-wrap break-words leading-relaxed">
-        "{evidence.text}"
+      <blockquote
+        className={cn(
+          'text-sm text-foreground/90 italic pl-3 sm:pl-5 border-l-2 whitespace-pre-wrap break-words leading-relaxed',
+          borderClass,
+        )}
+      >
+        "{citation.text}"
       </blockquote>
+    </div>
+  );
+}
+
+// =================== COMPONENT ===================
+
+export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
+  const {evidence, className, showCopyButton = true, onLocate} = props;
+  const [expanded, setExpanded] = useState(false);
+
+  if (evidence.length === 0) return null;
+
+  const [primary, ...rest] = evidence;
+  const hasExtra = rest.length > 0;
+
+  return (
+    <div className={cn('flex flex-col gap-4 p-4 bg-muted/50 rounded-lg border', className)}>
+      <CitationRow
+        citation={primary}
+        showCopyButton={showCopyButton}
+        onLocate={onLocate}
+        isPrimary
+      />
+
+      {hasExtra && (
+        <>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-fit gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded((prev) => !prev);
+            }}
+          >
+            {expanded ? (
+              <ChevronUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" />
+            )}
+            {t('extraction', 'evidenceAlsoCited').replace('{{n}}', String(rest.length))}
+          </Button>
+
+          {expanded && (
+            <div className="flex flex-col gap-4 border-t pt-4">
+              {rest.map((citation) => (
+                <CitationRow
+                  key={citation.rank}
+                  citation={citation}
+                  showCopyButton={showCopyButton}
+                  onLocate={onLocate}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/components/extraction/ai/shared/AISuggestionConfidence.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionConfidence.tsx
@@ -28,7 +28,8 @@ export function AISuggestionConfidence({
 }: AISuggestionConfidenceProps) {
   const confidencePercent = calculateConfidencePercent(suggestion.confidence);
   const hasReasoning = !!suggestion.reasoning?.trim();
-  const hasEvidence = !!suggestion.evidence?.text?.trim();
+  const hasEvidence =
+    (suggestion.evidence?.length ?? 0) > 0 && !!suggestion.evidence?.[0]?.text?.trim();
   const hasDetails = hasReasoning || hasEvidence;
 
     // When used as part of trigger (value + % clickable), only render the %

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
@@ -38,7 +38,7 @@ const suggestion = {
   confidence: 0.9,
   reasoning: 'Because of this evidence.',
   timestamp: new Date('2024-01-01T00:00:00Z'),
-  evidence: {text: 'test evidence', pageNumber: 2, blockIds: [5]},
+  evidence: [{text: 'test evidence', pageNumber: 2, blockIds: [5], rank: 0, attributionLabel: null}],
 };
 
 function Wrapper({children}: {children: ReactNode}) {

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
@@ -18,7 +18,7 @@ import {
 import {Sparkles} from 'lucide-react';
 import {AISuggestionEvidence} from '../AISuggestionEvidence';
 import {t} from '@/lib/copy';
-import type {AISuggestion} from '@/hooks/extraction/ai/useAISuggestions';
+import type {AISuggestion, EvidenceCitation} from '@/types/ai-extraction';
 import {useReaderLocate} from '@/hooks/extraction/useReaderLocate';
 
 // -----------------------------------------------------------------------------
@@ -27,7 +27,7 @@ import {useReaderLocate} from '@/hooks/extraction/useReaderLocate';
 
 function hasSuggestionDetails(suggestion: AISuggestion): boolean {
   const hasReasoning = !!suggestion.reasoning?.trim();
-  const hasEvidence = !!suggestion.evidence?.text?.trim();
+  const hasEvidence = (suggestion.evidence?.length ?? 0) > 0 && !!suggestion.evidence?.[0]?.text?.trim();
   return hasReasoning || hasEvidence;
 }
 
@@ -45,18 +45,19 @@ interface AISuggestionDetailsPopoverProps {
 // -----------------------------------------------------------------------------
 
 interface EvidenceSectionProps {
-  evidence: {text: string; pageNumber?: number | null; blockIds?: number[]};
+  evidence: EvidenceCitation[];
   onClose: () => void;
 }
 
 function EvidenceSection({evidence, onClose}: EvidenceSectionProps) {
   const {locate, isAvailable} = useReaderLocate();
 
-  // Locate in the document reader, then close the popover so the (still
-  // visible) viewer shows the flash unobstructed.
+  // Per-citation locate: finds the matching citation by rank, then locates it
+  // in the reader. Closes the popover so the flash is unobstructed.
   const onLocate = isAvailable
-    ? () => {
-        locate(evidence.text, evidence.pageNumber ?? null, evidence.blockIds ?? []);
+    ? (rank: number) => {
+        const citation = evidence.find((e) => e.rank === rank) ?? evidence[0];
+        locate(citation.text, citation.pageNumber ?? null, citation.blockIds ?? []);
         onClose();
       }
     : undefined;
@@ -64,7 +65,7 @@ function EvidenceSection({evidence, onClose}: EvidenceSectionProps) {
   return (
     <section className="space-y-2" aria-label={t('extraction', 'evidenceCitedAria')}>
       <AISuggestionEvidence
-        evidence={{text: evidence.text, pageNumber: evidence.pageNumber ?? null}}
+        evidence={evidence}
         onLocate={onLocate}
       />
     </section>
@@ -115,9 +116,9 @@ export function AISuggestionDetailsPopover({
             </section>
           )}
 
-          {evidence?.text?.trim() && (
+          {evidence && evidence.length > 0 && evidence[0]?.text?.trim() && (
             <EvidenceSection
-              evidence={{text: evidence.text, pageNumber: evidence.pageNumber ?? null, blockIds: evidence.blockIds ?? []}}
+              evidence={evidence}
               onClose={() => setOpen(false)}
             />
           )}

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -846,6 +846,11 @@ export const extraction = {
     aiRationaleLabel: 'Rationale',
     // AISuggestionEvidence – markdown-first citation locate
     evidenceLocate: 'Locate in document',
+    // AISuggestionEvidence – multi-citation list + attribution badges
+    evidenceAlsoCited: 'Also cited ({{n}})',
+    attributionEntailed: 'Verified',
+    attributionWeak: 'Weak match',
+    attributionUnsupported: 'Not supported',
 } as const;
 
 export type ExtractionCopy = typeof extraction;

--- a/frontend/services/aiSuggestionService.ts
+++ b/frontend/services/aiSuggestionService.ts
@@ -14,6 +14,7 @@ import { ExtractionValueService } from '@/services/extractionValueService';
 import type {
   AISuggestion,
   AISuggestionHistoryItem,
+  EvidenceCitation,
   LoadSuggestionsResult,
 } from '@/types/ai-extraction';
 import { getSuggestionKey } from '@/types/ai-extraction';
@@ -23,6 +24,22 @@ import type { components } from '@/types/api/schema';
 type AISuggestionItem = components['schemas']['AISuggestionItem'];
 type AISuggestionHistoryItemServer = components['schemas']['AISuggestionHistoryItem'];
 type AISuggestionsResponse = components['schemas']['AISuggestionsResponse'];
+
+type ServerEvidenceItem = components['schemas']['EvidenceResponse'];
+
+function mapEvidenceList(
+  list: ServerEvidenceItem[] | null | undefined,
+): EvidenceCitation[] | undefined {
+  if (!list || list.length === 0) return undefined;
+  const sorted = [...list].sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+  return sorted.map((e) => ({
+    text: e.text_content ?? '',
+    pageNumber: e.page_number ?? null,
+    blockIds: e.blockIds ?? [],
+    attributionLabel: (e.attributionLabel as EvidenceCitation['attributionLabel']) ?? null,
+    rank: e.rank ?? 0,
+  }));
+}
 
 function unwrapValue(raw: { [key: string]: unknown } | null | undefined): unknown {
   if (raw === null || raw === undefined) return '';
@@ -39,13 +56,7 @@ function mapItemToSuggestion(item: AISuggestionItem): AISuggestion {
     reasoning: item.rationale ?? '',
     status: (item.status ?? 'pending') as AISuggestion['status'],
     timestamp: new Date(item.created_at),
-    evidence: item.evidence?.text_content
-      ? {
-          text: item.evidence.text_content,
-          pageNumber: item.evidence.page_number ?? null,
-          blockIds: item.evidence.blockIds ?? [],
-        }
-      : undefined,
+    evidence: mapEvidenceList(item.evidence),
   };
 }
 
@@ -61,13 +72,7 @@ function mapHistoryItemToSuggestion(
     // History items have no server-side status (raw proposal trail)
     status: 'pending',
     timestamp: new Date(item.created_at),
-    evidence: item.evidence?.text_content
-      ? {
-          text: item.evidence.text_content,
-          pageNumber: item.evidence.page_number ?? null,
-          blockIds: item.evidence.blockIds ?? [],
-        }
-      : undefined,
+    evidence: mapEvidenceList(item.evidence),
   };
 }
 

--- a/frontend/test/services/aiSuggestionService.test.ts
+++ b/frontend/test/services/aiSuggestionService.test.ts
@@ -200,25 +200,83 @@ describe('AISuggestionService.loadSuggestions', () => {
     expect(sug.evidence).toBeUndefined(); // evidence=null → undefined
   });
 
-  it('maps evidence when present', async () => {
+  it('maps evidence list when present (single item)', async () => {
     (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       suggestions: [
         makeItem({
-          evidence: {
-            text_content: 'verbatim quote',
-            page_number: 3,
-            proposal_record_id: 'p-1',
-          },
+          evidence: [
+            {
+              text_content: 'verbatim quote',
+              page_number: 3,
+              proposal_record_id: 'p-1',
+              rank: 0,
+              attributionLabel: null,
+              blockIds: [],
+            },
+          ],
         }),
       ],
       count: 1,
     });
     const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
-    expect(result.suggestions['inst-1_f-1'].evidence).toEqual({
-      text: 'verbatim quote',
-      pageNumber: 3,
-      blockIds: [],
+    expect(result.suggestions['inst-1_f-1'].evidence).toEqual([
+      {text: 'verbatim quote', pageNumber: 3, blockIds: [], attributionLabel: null, rank: 0},
+    ]);
+  });
+
+  it('maps multi-citation evidence list sorted by rank with attributionLabel', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [
+        makeItem({
+          evidence: [
+            {
+              text_content: 'secondary quote',
+              page_number: 5,
+              proposal_record_id: 'p-1',
+              rank: 1,
+              attributionLabel: 'weak',
+              blockIds: [10],
+            },
+            {
+              text_content: 'primary quote',
+              page_number: 2,
+              proposal_record_id: 'p-1',
+              rank: 0,
+              attributionLabel: 'entailed',
+              blockIds: [1, 2],
+            },
+          ],
+        }),
+      ],
+      count: 1,
     });
+    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    const evidence = result.suggestions['inst-1_f-1'].evidence;
+    expect(evidence).toHaveLength(2);
+    // rank 0 must be first
+    expect(evidence![0]).toEqual({
+      text: 'primary quote',
+      pageNumber: 2,
+      blockIds: [1, 2],
+      attributionLabel: 'entailed',
+      rank: 0,
+    });
+    expect(evidence![1]).toEqual({
+      text: 'secondary quote',
+      pageNumber: 5,
+      blockIds: [10],
+      attributionLabel: 'weak',
+      rank: 1,
+    });
+  });
+
+  it('returns undefined evidence when evidence list is empty', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [makeItem({evidence: []})],
+      count: 1,
+    });
+    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    expect(result.suggestions['inst-1_f-1'].evidence).toBeUndefined();
   });
 
   it("uses server-provided status='accepted'", async () => {
@@ -285,7 +343,7 @@ describe('AISuggestionService.getHistory', () => {
     expect(path).toContain('limit=10');
   });
 
-  it('returns mapped history items with evidence', async () => {
+  it('returns mapped history items with evidence (array shape)', async () => {
     (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       {
         id: 'p-1',
@@ -296,16 +354,23 @@ describe('AISuggestionService.getHistory', () => {
         confidence_score: 0.8,
         rationale: null,
         created_at: '2026-04-28T10:00:00Z',
-        evidence: {
-          text_content: 'quote',
-          page_number: 2,
-          proposal_record_id: 'p-1',
-        },
+        evidence: [
+          {
+            text_content: 'quote',
+            page_number: 2,
+            proposal_record_id: 'p-1',
+            rank: 0,
+            attributionLabel: null,
+            blockIds: [],
+          },
+        ],
       },
     ]);
     const result = await AISuggestionService.getHistory('art-1', 'inst-1', 'f-1');
     expect(result).toHaveLength(1);
-    expect(result[0].evidence).toEqual({ text: 'quote', pageNumber: 2, blockIds: [] });
+    expect(result[0].evidence).toEqual([
+      {text: 'quote', pageNumber: 2, blockIds: [], attributionLabel: null, rank: 0},
+    ]);
     expect(result[0].value).toBe('V');
     expect(result[0].runId).toBe('run-A');
     // History items have no server status — default to 'pending'

--- a/frontend/types/ai-extraction.ts
+++ b/frontend/types/ai-extraction.ts
@@ -26,6 +26,18 @@ export type SupportedAIModel = 'gpt-4o-mini' | 'gpt-4o' | 'gpt-5';
 // =================== AI SUGGESTIONS (presentation shape) ===================
 
 /**
+ * A single cited evidence passage attached to an AI proposal.
+ * Ordered by `rank` (0 = primary, lowest confidence-distance to the proposal).
+ */
+export interface EvidenceCitation {
+  text: string;
+  pageNumber?: number | null;
+  blockIds: number[];
+  attributionLabel?: 'entailed' | 'weak' | 'unsupported' | null;
+  rank: number;
+}
+
+/**
  * Presentation shape an extraction-UI consumer renders. There's no longer
  * a backing `ai_suggestions` table — the equivalent rows live in
  * `extraction_proposal_records` (filtered by `source='ai'`) and are
@@ -39,11 +51,8 @@ export interface AISuggestion {
   reasoning: string; // empty string when null
   status: SuggestionStatus;
   timestamp: Date; // proposal created_at parsed
-  evidence?: {
-    text: string;
-    pageNumber?: number | null;
-    blockIds: number[];
-  };
+  /** Ordered by rank (0 = primary). Empty array when no evidence. */
+  evidence?: EvidenceCitation[];
 }
 
 /**

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -21,14 +21,11 @@
             "type": "string"
           },
           "evidence": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/EvidenceResponse"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "items": {
+              "$ref": "#/components/schemas/EvidenceResponse"
+            },
+            "title": "Evidence",
+            "type": "array"
           },
           "field_id": {
             "format": "uuid",
@@ -101,14 +98,11 @@
             "type": "string"
           },
           "evidence": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/EvidenceResponse"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "items": {
+              "$ref": "#/components/schemas/EvidenceResponse"
+            },
+            "title": "Evidence",
+            "type": "array"
           },
           "field_id": {
             "format": "uuid",
@@ -3195,6 +3189,17 @@
       "EvidenceResponse": {
         "description": "Evidence snippet attached to a proposal record.",
         "properties": {
+          "attributionLabel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attributionlabel"
+          },
           "blockIds": {
             "description": "block_index values for deterministic reader highlight",
             "items": {
@@ -3225,6 +3230,11 @@
               }
             ],
             "title": "Proposal Record Id"
+          },
+          "rank": {
+            "default": 0,
+            "title": "Rank",
+            "type": "integer"
           },
           "text_content": {
             "anyOf": [

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -1013,7 +1013,8 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
-            evidence: components["schemas"]["EvidenceResponse"] | null;
+            /** Evidence */
+            evidence: components["schemas"]["EvidenceResponse"][];
             /**
              * Field Id
              * Format: uuid
@@ -1053,7 +1054,8 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
-            evidence: components["schemas"]["EvidenceResponse"] | null;
+            /** Evidence */
+            evidence: components["schemas"]["EvidenceResponse"][];
             /**
              * Field Id
              * Format: uuid
@@ -2305,6 +2307,8 @@ export interface components {
          * @description Evidence snippet attached to a proposal record.
          */
         EvidenceResponse: {
+            /** Attributionlabel */
+            attributionLabel?: string | null;
             /**
              * Blockids
              * @description block_index values for deterministic reader highlight
@@ -2314,6 +2318,11 @@ export interface components {
             page_number: number | null;
             /** Proposal Record Id */
             proposal_record_id: string | null;
+            /**
+             * Rank
+             * @default 0
+             */
+            rank: number;
             /** Text Content */
             text_content: string | null;
         };

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -1,10 +1,10 @@
 # file-size ratchet baseline — oversized files frozen at current size.
 # May shrink (re-run --update-baseline to tighten), never grow. Cleanup is a separate effort.
 backend/app/seed.py:1941
-backend/app/services/extraction_export_service.py:2237
-backend/app/services/section_extraction_service.py:1443
+backend/app/services/extraction_export_service.py:2252
+backend/app/services/section_extraction_service.py:1456
 frontend/components/articles/ArticleForm.tsx:1272
 frontend/components/articles/ArticlesList.tsx:1360
 frontend/components/extraction/ArticleExtractionTable.tsx:1130
-frontend/lib/copy/extraction.ts:855
-frontend/pages/ExtractionFullScreen.tsx:1286
+frontend/lib/copy/extraction.ts:856
+frontend/pages/ExtractionFullScreen.tsx:1279


### PR DESCRIPTION
## Citation/provenance — Phase 1 (multiple citations, prose)

Second slice of the citation/provenance redesign (builds on P0 #410). Plan:
`docs/superpowers/plans/2026-06-27-citation-p1-multi-evidence.md`.

- **Evidence is now a list** end-to-end: LLM contract `evidence: list[Evidence]`; list-aware `evidence_is_plausible`; `_create_suggestions` persists **N ranked rows per field** (cap 3, `rank` 0..n, legacy single-dict tolerance), each gated per-row (degrade-on-error preserved).
- **`rank` column** on `extraction_evidence` (Alembic `0035_evidence_rank`).
- **Suggestion read path returns an ordered evidence list** (`EvidenceResponse` gains `rank` + `attributionLabel`; `AISuggestionItem.evidence` → list; API types regenerated).
- **Frontend multi-citation render**: primary + "also cited (n)", green/amber verification badge by `attributionLabel`, per-citation locate.
- **Export transparency**: "Model used" column in the AI-metadata sheet (extraction + QA), resolved from `run.parameters["model"]`.

**Scope/deferred:** per-project model-selection UI (settings service + manager-gated endpoint + selector) deferred to a focused follow-up — this ships the run-level model + export transparency. Deterministic corroboration stays primary-only (the gate already labels weak/unsupported from P0).

**Evidence:** full backend suite 2186 passed; architectural fitness OK; frontend typecheck + lint clean; vitest 810 passed. Subagent-driven per-task reviews (incl. an opus review of the hot-path persistence) + adversarial 5-lens plan panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)