### PR TITLE
Promote: async-extraction corrections → prod

### DIFF
--- a/backend/app/api/v1/endpoints/section_extraction.py
+++ b/backend/app/api/v1/endpoints/section_extraction.py
@@ -24,6 +24,7 @@ from app.core.deps import CurrentUser, DbSession
 from app.core.logging import get_logger
 from app.schemas.common import ApiResponse
 from app.schemas.extraction import (
+    ExtractionErrorCode,
     ExtractionJobResult,
     ExtractionJobStartedResponse,
     ExtractionJobStatusResponse,
@@ -85,6 +86,24 @@ def _lookup_job_owner(job_id: str) -> str | None:
     if isinstance(raw, bytes):
         return raw.decode("utf-8", errors="replace")
     return str(raw)
+
+
+def _failure_error_code(exc: object) -> ExtractionErrorCode:
+    """Recover the failure's machine-readable code from the AsyncResult.
+
+    ``run_section_extraction_task`` raises ``ExtractionTaskError`` carrying a
+    string ``error_code`` (it survives the Celery JSON round-trip via the
+    exception args). Read it duck-typed and coerce to the enum, defaulting any
+    missing / unknown code to ``EXTRACTION_FAILED`` so serialization never
+    fails on a future or untyped error.
+    """
+    raw = getattr(exc, "error_code", None)
+    if isinstance(raw, str):
+        try:
+            return ExtractionErrorCode(raw)
+        except ValueError:
+            return ExtractionErrorCode.EXTRACTION_FAILED
+    return ExtractionErrorCode.EXTRACTION_FAILED
 
 
 # ----------------------------------------------------------------------
@@ -249,11 +268,13 @@ async def get_section_extraction_status(
             trace_id=trace_id,
         )
     if state == "FAILURE":
+        exc = result.result
         return ApiResponse.success(
             data=ExtractionJobStatusResponse(
                 job_id=job_id,
                 status="failed",
-                error=str(result.result) if result.result else "Task failed.",
+                error=str(exc) if exc else "Task failed.",
+                error_code=_failure_error_code(exc),
             ),
             trace_id=trace_id,
         )

--- a/backend/app/llm/value_support.py
+++ b/backend/app/llm/value_support.py
@@ -8,39 +8,84 @@ from __future__ import annotations
 import re
 import unicodedata
 
-_NUM = re.compile(r"-?\d+(?:[.,]\d+)?")
+# A numeric token: optional sign, digits, then any run of `,`/`.` groups so
+# grouped numbers like "1,234.5" or "24,077" are captured as a single token.
+_NUM = re.compile(r"-?\d+(?:[.,]\d+)*")
 
 
 def _norm(s: str) -> str:
     return unicodedata.normalize("NFKC", s).casefold()
 
 
+def _canon(n: str) -> str:
+    """Canonicalize an en-form numeric string (`.` decimal, no grouping)."""
+    return n.rstrip("0").rstrip(".") if "." in n else n
+
+
 def is_numeric_like(value: str) -> bool:
     return bool(_NUM.search(value or ""))
+
+
+def _looks_grouped(token: str) -> bool:
+    """True if *token* (digits + `,` only) reads as N,NNN,NNN thousands groups.
+
+    Guards the grouping interpretation so a locale comma-decimal like "11,8"
+    (== 11.8) is never mistaken for the integer 118.
+    """
+    parts = token.lstrip("-").split(",")
+    if len(parts) < 2:
+        return False
+    return (
+        1 <= len(parts[0]) <= 3
+        and all(len(p) == 3 for p in parts[1:])
+        and all(p.isdigit() for p in parts)
+    )
+
+
+def _raw_forms(token: str) -> set[str]:
+    """Locale-aware interpretations of one numeric token as canonical strings.
+
+    - both `,` and `.`: the rightmost separator is the decimal point, the rest
+      group thousands ("1,234.5" -> "1234.5").
+    - only `,`: ambiguous -> a decimal reading ("24,077" -> "24.077") plus, when
+      it looks like thousands groups, an integer reading ("24,077" -> "24077").
+    - only `.` (or none): `.` is the decimal point, so "11.8" never yields 118.
+    """
+    has_comma = "," in token
+    has_dot = "." in token
+    if has_comma and has_dot:
+        dec = max(token.rfind(","), token.rfind("."))
+        int_part = token[:dec].replace(",", "").replace(".", "")
+        return {_canon(f"{int_part}.{token[dec + 1 :]}")}
+    if has_comma:
+        forms = {_canon(token.replace(",", "."))}
+        if _looks_grouped(token):
+            forms.add(_canon(token.replace(",", "")))
+        return forms
+    return {_canon(token)}
+
+
+def _text_forms(text: str) -> set[str]:
+    out: set[str] = set()
+    for tok in _NUM.findall(_norm(text)):
+        out |= _raw_forms(tok)
+    return {c for c in out if c}
 
 
 def _candidates(value: str) -> set[str]:
     """Normalized numeric forms a value may appear as (raw, %<->fraction)."""
     out: set[str] = set()
-    for m in _NUM.findall(_norm(value)):
-        n = m.replace(",", ".")
-        out.add(n.rstrip("0").rstrip(".") if "." in n else n)
-        try:
-            f = float(n)
-            out.add(str(f / 100).rstrip("0").rstrip("."))  # 12.5 -> 0.125
-            out.add(str(f * 100).rstrip("0").rstrip("."))  # 0.125 -> 12.5
-        except ValueError:
-            pass
+    for tok in _NUM.findall(_norm(value)):
+        for n in _raw_forms(tok):
+            out.add(n)
+            try:
+                f = float(n)
+            except ValueError:
+                continue
+            out.add(_canon(str(f / 100)))  # 12.5 -> 0.125
+            out.add(_canon(str(f * 100)))  # 0.125 -> 12.5
     return {c for c in out if c}
 
 
 def numeric_value_supported(value: str, text: str) -> bool:
-    text_nums = {
-        (
-            m.replace(",", ".").rstrip("0").rstrip(".")
-            if "." in m.replace(",", ".")
-            else m.replace(",", ".")
-        )
-        for m in _NUM.findall(_norm(text))
-    }
-    return bool(_candidates(value) & text_nums)
+    return bool(_candidates(value) & _text_forms(text))

--- a/backend/app/schemas/extraction.py
+++ b/backend/app/schemas/extraction.py
@@ -5,6 +5,7 @@ Schemas Pydantic for extraction de data de articles cientificos.
 """
 
 from datetime import datetime
+from enum import Enum
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
@@ -453,6 +454,24 @@ class ReviewSuggestionRequest(BaseModel):
 # =================== ASYNC SECTION EXTRACTION JOB SCHEMAS ===================
 
 
+class ExtractionErrorCode(str, Enum):
+    """Stable, machine-readable code for a terminal extraction failure.
+
+    Carried on ``ExtractionJobStatusResponse.error_code`` so the frontend can
+    pick specific, actionable toast copy without parsing the human ``error``
+    string. Only modes the backend genuinely raises are represented — each
+    value has a real emitter in ``classify_extraction_error``:
+
+    - ``PDF_NOT_FOUND``    — the article has no stored PDF (``FileNotFoundError``).
+    - ``MISSING_API_KEY``  — no usable LLM key, BYOK or global (``MissingLLMKeyError``).
+    - ``EXTRACTION_FAILED``— generic catch-all for everything else.
+    """
+
+    PDF_NOT_FOUND = "PDF_NOT_FOUND"
+    MISSING_API_KEY = "MISSING_API_KEY"
+    EXTRACTION_FAILED = "EXTRACTION_FAILED"
+
+
 class ExtractionJobStartedResponse(BaseModel):
     """202 payload returned when an extraction job is queued."""
 
@@ -491,6 +510,10 @@ class ExtractionJobStatusResponse(BaseModel):
     status: str = Field(..., description="pending | running | completed | failed | cancelled")
     result: ExtractionJobResult | None = None
     error: str | None = None
+    # Machine-readable failure classification, set only when ``status`` is
+    # ``failed``. Lets the frontend map to specific copy without parsing
+    # ``error``. See ``ExtractionErrorCode`` / ``classify_extraction_error``.
+    error_code: ExtractionErrorCode | None = Field(default=None, alias="errorCode")
 
 
 # =================== CITATION ANCHOR (extraction_evidence.position v1) ===================

--- a/backend/app/services/extraction_errors.py
+++ b/backend/app/services/extraction_errors.py
@@ -1,0 +1,63 @@
+"""Error-code taxonomy for async section extraction.
+
+The Celery extraction task can fail in a few distinct ways the frontend wants
+to surface differently (missing PDF, missing LLM key, everything else). This
+module turns the *exception types* the pipeline raises into a stable
+``ExtractionErrorCode`` and wraps them in ``ExtractionTaskError`` so the code
+survives the Celery JSON result boundary — the status endpoint reads it back
+without parsing the exception repr.
+"""
+
+from __future__ import annotations
+
+from app.schemas.extraction import ExtractionErrorCode
+
+# Default human message when a generic failure carries no usable text of its own.
+_GENERIC_MESSAGE = "Section extraction failed."
+
+
+class ExtractionTaskError(Exception):
+    """Terminal extraction failure carrying a machine-readable code.
+
+    Celery's result backend serializes exceptions as JSON (it stores
+    ``exc.args``) and reconstructs them with ``cls(*args)``. Keeping the code
+    as the first positional arg — and rebuilding ``error_code`` from it in
+    ``__init__`` — lets the status endpoint recover the code after the
+    worker→web round-trip, with no exception-repr parsing.
+    """
+
+    def __init__(self, error_code: ExtractionErrorCode | str, message: str = "") -> None:
+        # Store the plain string value (not the enum) so the JSON-serialized
+        # args stay primitive and the reconstruction is exact.
+        self.error_code: str = (
+            error_code.value if isinstance(error_code, ExtractionErrorCode) else str(error_code)
+        )
+        self.message: str = message
+        super().__init__(self.error_code, message)
+
+    def __str__(self) -> str:
+        # The human-facing message, never the (code, message) tuple repr.
+        return self.message or self.error_code
+
+
+def classify_extraction_error(exc: BaseException) -> tuple[ExtractionErrorCode, str]:
+    """Map a raised exception to ``(code, human_message)``.
+
+    Type-based — never string-matches the exception repr. Anything without a
+    known type maps to ``EXTRACTION_FAILED`` with its own message.
+    """
+    # Lazy import: ``app.llm.provider`` pulls in pydantic-ai model classes, and
+    # this module is imported on the API process too (only for the enum/type).
+    from app.llm.provider import MissingLLMKeyError
+
+    if isinstance(exc, MissingLLMKeyError):
+        # The provider message already tells the user how to fix it (BYOK key
+        # or env var) — keep it verbatim.
+        return ExtractionErrorCode.MISSING_API_KEY, str(exc).strip() or _GENERIC_MESSAGE
+
+    if isinstance(exc, FileNotFoundError):
+        # The raw message is "No PDF for article <uuid>"; surface the friendly,
+        # actionable copy the pre-async endpoint used instead.
+        return ExtractionErrorCode.PDF_NOT_FOUND, "PDF not found. Upload a PDF first."
+
+    return ExtractionErrorCode.EXTRACTION_FAILED, str(exc).strip() or _GENERIC_MESSAGE

--- a/backend/app/worker/tasks/extraction_tasks.py
+++ b/backend/app/worker/tasks/extraction_tasks.py
@@ -17,6 +17,7 @@ from celery import Task
 
 from app.core.config import settings
 from app.llm.errors import is_transient_llm_error
+from app.services.extraction_errors import ExtractionTaskError, classify_extraction_error
 from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
 
@@ -323,9 +324,14 @@ def run_section_extraction_task(
     try:
         return run_task(run)
     except Exception as exc:
-        if not is_transient_llm_error(exc):
-            raise  # permanent: fail fast, no retry
-        raise self.retry(exc=exc, countdown=_retry_countdown(self.request.retries))
+        if is_transient_llm_error(exc) and self.request.retries < self.max_retries:
+            # Transient and retries remain — back off and retry.
+            raise self.retry(exc=exc, countdown=_retry_countdown(self.request.retries))
+        # Terminal failure (permanent, or transient with retries exhausted):
+        # attach a stable, machine-readable code so the status endpoint can
+        # surface specific frontend copy instead of parsing the exception repr.
+        code, message = classify_extraction_error(exc)
+        raise ExtractionTaskError(code, message) from exc
 
 
 @celery_app.task(

--- a/backend/tests/unit/test_extraction_errors.py
+++ b/backend/tests/unit/test_extraction_errors.py
@@ -1,0 +1,76 @@
+"""Unit tests for the extraction error-code taxonomy.
+
+``classify_extraction_error`` maps the *types* the extraction pipeline can
+raise to a stable ``ExtractionErrorCode`` (no exception-repr parsing), and
+``ExtractionTaskError`` carries that code across the Celery JSON result
+boundary so the status endpoint can surface specific frontend copy.
+"""
+
+from __future__ import annotations
+
+from app.llm.provider import MissingLLMKeyError
+from app.schemas.extraction import ExtractionErrorCode
+from app.services.extraction_errors import (
+    ExtractionTaskError,
+    classify_extraction_error,
+)
+
+
+class TestClassifyExtractionError:
+    def test_file_not_found_maps_to_pdf_not_found(self) -> None:
+        code, message = classify_extraction_error(FileNotFoundError("No PDF for article 1234"))
+        assert code is ExtractionErrorCode.PDF_NOT_FOUND
+        # Friendly, actionable copy — not the raw "No PDF for article <uuid>".
+        assert message == "PDF not found. Upload a PDF first."
+
+    def test_missing_llm_key_maps_to_missing_api_key(self) -> None:
+        code, message = classify_extraction_error(
+            MissingLLMKeyError("No OpenAI API key available: pass a BYOK key.")
+        )
+        assert code is ExtractionErrorCode.MISSING_API_KEY
+        # The provider message is already actionable — pass it through.
+        assert message == "No OpenAI API key available: pass a BYOK key."
+
+    def test_unknown_error_maps_to_generic(self) -> None:
+        code, message = classify_extraction_error(RuntimeError("llm exploded"))
+        assert code is ExtractionErrorCode.EXTRACTION_FAILED
+        assert message == "llm exploded"
+
+    def test_blank_message_falls_back_to_default(self) -> None:
+        code, message = classify_extraction_error(ValueError("   "))
+        assert code is ExtractionErrorCode.EXTRACTION_FAILED
+        assert message == "Section extraction failed."
+
+
+class TestExtractionTaskError:
+    def test_carries_code_and_message(self) -> None:
+        err = ExtractionTaskError(ExtractionErrorCode.PDF_NOT_FOUND, "PDF not found.")
+        # error_code is a plain string (enum value) so JSON args stay clean.
+        assert err.error_code == "PDF_NOT_FOUND"
+        assert err.message == "PDF not found."
+        # str() is the human message, never the (code, message) tuple repr.
+        assert str(err) == "PDF not found."
+
+    def test_accepts_plain_string_code(self) -> None:
+        err = ExtractionTaskError("MISSING_API_KEY", "no key")
+        assert err.error_code == "MISSING_API_KEY"
+        assert str(err) == "no key"
+
+    def test_survives_celery_json_round_trip(self) -> None:
+        """The Celery result backend serializes exceptions as JSON (exc.args)
+        and reconstructs them via ``cls(*args)``. The code must survive that
+        round-trip so the status endpoint can read it after worker→web."""
+        from celery.backends.base import Backend
+
+        from app.worker.celery_app import celery_app
+
+        backend = Backend(app=celery_app, serializer="json")
+        original = ExtractionTaskError(
+            ExtractionErrorCode.MISSING_API_KEY, "No OpenAI API key available."
+        )
+
+        rebuilt = backend.exception_to_python(backend.prepare_exception(original))
+
+        assert isinstance(rebuilt, ExtractionTaskError)
+        assert rebuilt.error_code == "MISSING_API_KEY"
+        assert str(rebuilt) == "No OpenAI API key available."

--- a/backend/tests/unit/test_run_section_extraction_task.py
+++ b/backend/tests/unit/test_run_section_extraction_task.py
@@ -19,6 +19,9 @@ from uuid import uuid4
 
 import pytest
 
+from app.llm.provider import MissingLLMKeyError
+from app.schemas.extraction import ExtractionErrorCode
+from app.services.extraction_errors import ExtractionTaskError
 from app.services.section_extraction_service import (
     BatchAllSectionsFailed,
     BatchExtractionResult,
@@ -245,7 +248,10 @@ class TestRunSectionExtractionTaskBatch:
 
 
 class TestRunSectionExtractionTaskRollback:
-    def test_rolls_back_and_reraises_on_exception(self):
+    def test_rolls_back_and_raises_coded_error_on_exception(self):
+        """An unknown failure rolls back and surfaces as a coded
+        ``ExtractionTaskError`` (generic code) instead of leaking the raw
+        exception type — so the status endpoint always has a code to read."""
         user_id = str(uuid4())
         payload_dict = {
             "projectId": str(uuid4()),
@@ -269,10 +275,12 @@ class TestRunSectionExtractionTaskRollback:
             patch("app.core.factories.create_storage_adapter", return_value=MagicMock()),
             patch("app.core.deps.get_supabase_client", return_value=MagicMock()),
             patch("app.worker._session.worker_session", new=_session_factory(session)),
-            pytest.raises(RuntimeError, match="llm exploded"),
+            pytest.raises(ExtractionTaskError) as exc_info,
         ):
             _apply(payload_dict, user_id)
 
+        assert exc_info.value.error_code == ExtractionErrorCode.EXTRACTION_FAILED.value
+        assert str(exc_info.value) == "llm exploded"
         session.rollback.assert_awaited_once()
         session.commit.assert_not_awaited()
 
@@ -281,8 +289,8 @@ class TestRunSectionExtractionTaskAllFailed:
     def test_commits_failed_status_on_batch_all_sections_failed(self):
         """When the service raises BatchAllSectionsFailed it has already marked the
         run FAILED (rollback_and_fail); the task must COMMIT that terminal status
-        (not roll it back) and re-raise, so the failed run is visible to status
-        polls — mirrors the pre-async endpoint's handling."""
+        (not roll it back) and surface a coded error, so the failed run is visible
+        to status polls — mirrors the pre-async endpoint's handling."""
         user_id = str(uuid4())
         payload_dict = {
             "projectId": str(uuid4()),
@@ -308,9 +316,58 @@ class TestRunSectionExtractionTaskAllFailed:
             patch("app.core.factories.create_storage_adapter", return_value=MagicMock()),
             patch("app.core.deps.get_supabase_client", return_value=MagicMock()),
             patch("app.worker._session.worker_session", new=_session_factory(session)),
-            pytest.raises(BatchAllSectionsFailed, match="all 3 sections failed"),
+            pytest.raises(ExtractionTaskError) as exc_info,
         ):
             _apply(payload_dict, user_id)
 
+        assert exc_info.value.error_code == ExtractionErrorCode.EXTRACTION_FAILED.value
+        assert str(exc_info.value) == "all 3 sections failed"
         session.commit.assert_awaited_once()
         session.rollback.assert_not_awaited()
+
+
+class TestRunSectionExtractionTaskErrorCode:
+    """The task attaches a stable ``ExtractionErrorCode`` for the failure modes
+    the pipeline raises by type, so the status endpoint can surface specific
+    frontend copy without parsing the exception repr."""
+
+    def _run_with_side_effect(self, exc: Exception) -> ExtractionTaskError:
+        user_id = str(uuid4())
+        payload_dict = {
+            "projectId": str(uuid4()),
+            "articleId": str(uuid4()),
+            "templateId": str(uuid4()),
+            "entityTypeId": str(uuid4()),
+        }
+
+        session = _FakeSession()
+        fake_service = MagicMock()
+        fake_service.run_from_request = AsyncMock(side_effect=exc)
+        fake_api_key = MagicMock()
+        fake_api_key.get_key_for_provider = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "app.services.section_extraction_service.SectionExtractionService",
+                return_value=fake_service,
+            ),
+            patch("app.services.api_key_service.APIKeyService", return_value=fake_api_key),
+            patch("app.core.factories.create_storage_adapter", return_value=MagicMock()),
+            patch("app.core.deps.get_supabase_client", return_value=MagicMock()),
+            patch("app.worker._session.worker_session", new=_session_factory(session)),
+            pytest.raises(ExtractionTaskError) as exc_info,
+        ):
+            _apply(payload_dict, user_id)
+        return exc_info.value
+
+    def test_missing_pdf_carries_pdf_not_found_code(self):
+        err = self._run_with_side_effect(FileNotFoundError("No PDF for article abc"))
+        assert err.error_code == ExtractionErrorCode.PDF_NOT_FOUND.value
+        assert str(err) == "PDF not found. Upload a PDF first."
+
+    def test_missing_llm_key_carries_missing_api_key_code(self):
+        err = self._run_with_side_effect(
+            MissingLLMKeyError("No OpenAI API key available: pass a BYOK key.")
+        )
+        assert err.error_code == ExtractionErrorCode.MISSING_API_KEY.value
+        assert str(err) == "No OpenAI API key available: pass a BYOK key."

--- a/backend/tests/unit/test_section_extraction_endpoint.py
+++ b/backend/tests/unit/test_section_extraction_endpoint.py
@@ -28,7 +28,8 @@ from app.api.v1.endpoints import section_extraction as se
 from app.core.deps import get_db, get_supabase
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
-from app.schemas.extraction import SectionExtractionRequest
+from app.schemas.extraction import ExtractionErrorCode, SectionExtractionRequest
+from app.services.extraction_errors import ExtractionTaskError
 
 CALLER_USER_ID = str(uuid4())
 OTHER_USER_ID = str(uuid4())
@@ -379,6 +380,7 @@ class TestGetSectionExtractionStatus:
 
     @pytest.mark.asyncio
     async def test_failure_state_returns_failed_with_error(self, client: AsyncClient) -> None:
+        """An untyped exception (no error_code attr) → generic EXTRACTION_FAILED."""
         mock_result = MagicMock()
         mock_result.state = "FAILURE"
         mock_result.result = RuntimeError("llm timed out")
@@ -396,6 +398,60 @@ class TestGetSectionExtractionStatus:
         assert body["ok"] is True
         assert body["data"]["status"] == "failed"
         assert "llm timed out" in body["data"]["error"]
+        assert body["data"]["errorCode"] == ExtractionErrorCode.EXTRACTION_FAILED.value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("code", "message"),
+        [
+            (ExtractionErrorCode.PDF_NOT_FOUND, "PDF not found. Upload a PDF first."),
+            (ExtractionErrorCode.MISSING_API_KEY, "No OpenAI API key available."),
+        ],
+    )
+    async def test_failure_state_surfaces_typed_error_code(
+        self, client: AsyncClient, code: ExtractionErrorCode, message: str
+    ) -> None:
+        """A coded ExtractionTaskError → its error_code + human message reach
+        the API envelope (the worker→web JSON round-trip is exercised by
+        ExtractionTaskError directly in test_extraction_errors)."""
+        mock_result = MagicMock()
+        mock_result.state = "FAILURE"
+        mock_result.result = ExtractionTaskError(code, message)
+
+        with (
+            patch("celery.result.AsyncResult", return_value=mock_result),
+            patch(
+                "app.api.v1.endpoints.section_extraction._lookup_job_owner",
+                return_value=CALLER_USER_ID,
+            ),
+        ):
+            res = await client.get(_status_url(str(uuid4())))
+
+        body = res.json()
+        assert body["data"]["status"] == "failed"
+        assert body["data"]["errorCode"] == code.value
+        assert body["data"]["error"] == message
+
+    @pytest.mark.asyncio
+    async def test_failure_state_coerces_unknown_code_to_generic(self, client: AsyncClient) -> None:
+        """A failure whose error_code isn't a known enum value must not crash
+        serialization — it falls back to EXTRACTION_FAILED."""
+        mock_result = MagicMock()
+        mock_result.state = "FAILURE"
+        mock_result.result = ExtractionTaskError("SOME_FUTURE_CODE", "boom")
+
+        with (
+            patch("celery.result.AsyncResult", return_value=mock_result),
+            patch(
+                "app.api.v1.endpoints.section_extraction._lookup_job_owner",
+                return_value=CALLER_USER_ID,
+            ),
+        ):
+            res = await client.get(_status_url(str(uuid4())))
+
+        body = res.json()
+        assert body["data"]["status"] == "failed"
+        assert body["data"]["errorCode"] == ExtractionErrorCode.EXTRACTION_FAILED.value
 
     @pytest.mark.asyncio
     async def test_success_single_result_parsed(self, client: AsyncClient) -> None:

--- a/backend/tests/unit/test_value_support.py
+++ b/backend/tests/unit/test_value_support.py
@@ -10,3 +10,36 @@ def test_percent_forms_match():
 def test_is_numeric_like():
     assert is_numeric_like("12.5%")
     assert not is_numeric_like("metformin")
+
+
+def test_thousands_separator_integer_matches():
+    # Reported bug: a US thousands-grouped source number ("24,077") must
+    # support an integer value 24077 (both directions).
+    assert numeric_value_supported(
+        "24077",
+        "We identify a total of 24,077 cancer patients eligible for the study",
+    )
+    assert numeric_value_supported("24,077", "the cohort had 24077 patients")
+
+
+def test_grouping_plus_decimal_matches():
+    # Mixed grouping + decimal: comma groups, dot is the decimal point.
+    assert numeric_value_supported("1,234.5", "a mean of 1234.5 person-years")
+    assert numeric_value_supported("1234.5", "reported as 1,234.5 overall")
+
+
+def test_percent_fraction_still_matches():
+    # The %<->fraction path must keep working after the grouping change.
+    assert numeric_value_supported("0.125", "a fraction of 12.5%")
+
+
+def test_real_decimal_not_confused_with_grouping():
+    # "11.8" is a genuine decimal; it must NOT spuriously match 118.
+    assert numeric_value_supported("11.8", "increased by 11.8 points")
+    assert not numeric_value_supported("11.8", "a total of 118 events")
+
+
+def test_comma_decimal_not_misread_as_grouping():
+    # Locale comma-decimal ("11,8" == 11.8) must read as a decimal, not 118.
+    assert numeric_value_supported("11,8", "increased by 11.8 points")
+    assert not numeric_value_supported("11,8", "a total of 118 events")

--- a/frontend/e2e/extraction-observability.e2e.ts
+++ b/frontend/e2e/extraction-observability.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { APIRequestContext, expect, test } from "@playwright/test";
 
 type RequiredEnvKey =
   | "E2E_USER_EMAIL"
@@ -52,6 +52,47 @@ async function fetchRunFromSupabase(runId: string) {
     error_message: string | null;
   }>;
   return rows[0] ?? null;
+}
+
+type SectionJobStatus = {
+  status: string;
+  result?: { extractionRunId?: string } | null;
+  error?: string | null;
+};
+
+// Section extraction is async: POST returns 202 + { job_id }; poll
+// GET /extraction/sections/status/{job_id} until the job reaches a terminal
+// state. Mirrors the extraction-export poll helper.
+async function pollSectionJob(
+  request: APIRequestContext,
+  apiBase: string,
+  jobId: string,
+  authToken: string,
+  traceId: string
+): Promise<SectionJobStatus> {
+  const inflight = new Set(["pending", "running"]);
+  const maxIters = 90; // ~180s at 2s intervals — matches the old sync timeout budget
+  for (let idx = 0; idx < maxIters; idx += 1) {
+    const res = await request.get(
+      `${apiBase}/api/v1/extraction/sections/status/${jobId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+          "X-Trace-Id": traceId,
+        },
+      }
+    );
+    const body = (await res.json()) as {
+      ok?: boolean;
+      data?: SectionJobStatus;
+    };
+    const data = body.data;
+    if (data?.status && !inflight.has(data.status)) {
+      return data;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  return { status: "timeout" };
 }
 
 test.describe("Extraction E2E Observability", () => {
@@ -142,6 +183,8 @@ test.describe("Extraction E2E Observability", () => {
       model: process.env.E2E_MODEL_NAME || "gpt-4o-mini",
     };
 
+    // Section extraction is async: POST dispatches a Celery job (202 + job_id);
+    // the run id is read from the completed job status, not the POST response.
     const sectionStart = Date.now();
     const sectionResponse = await request.post(
       `${apiBase}/api/v1/extraction/sections`,
@@ -152,18 +195,37 @@ test.describe("Extraction E2E Observability", () => {
           "X-Trace-Id": traceId,
           "Content-Type": "application/json",
         },
-        timeout: 180000,
       }
     );
-    const sectionDurationMs = Date.now() - sectionStart;
+    const sectionDispatchMs = Date.now() - sectionStart;
 
-    const sectionBody = (await sectionResponse.json()) as {
+    const sectionDispatchBody = (await sectionResponse.json()) as {
       ok?: boolean;
-      data?: { extractionRunId?: string; durationMs?: number };
+      data?: { job_id?: string };
       detail?: string;
       error?: { message?: string };
     };
-    const sectionRunId = sectionBody.data?.extractionRunId;
+    const sectionJobId = sectionDispatchBody.data?.job_id;
+
+    expect(
+      sectionResponse.status(),
+      `section dispatch failed: status=${sectionResponse.status()} detail=${sectionDispatchBody.detail || sectionDispatchBody.error?.message || "n/a"}`
+    ).toBe(202);
+    expect(sectionDispatchBody.ok).toBeTruthy();
+    expect(sectionJobId).toBeTruthy();
+
+    const pollStart = Date.now();
+    const sectionJob: SectionJobStatus = sectionJobId
+      ? await pollSectionJob(request, apiBase, sectionJobId, authToken!, traceId)
+      : { status: "no-job" };
+    const sectionPollMs = Date.now() - pollStart;
+
+    expect(
+      sectionJob.status,
+      `section job did not complete: ${sectionJob.error ?? "n/a"}`
+    ).toBe("completed");
+    const sectionRunId = sectionJob.result?.extractionRunId;
+    expect(sectionRunId).toBeTruthy();
 
     const modelRun = modelRunId ? await fetchRunFromSupabase(modelRunId) : null;
     const sectionRun = sectionRunId ? await fetchRunFromSupabase(sectionRunId) : null;
@@ -184,20 +246,13 @@ test.describe("Extraction E2E Observability", () => {
     expect(modelBody.ok).toBeTruthy();
     expect(modelRunId).toBeTruthy();
 
-    expect(
-      sectionResponse.ok(),
-      `section extraction failed: status=${sectionResponse.status()} detail=${sectionBody.detail || sectionBody.error?.message || "n/a"}`
-    ).toBeTruthy();
-    expect(sectionBody.ok).toBeTruthy();
-    expect(sectionRunId).toBeTruthy();
-
     test.info().annotations.push({
       type: "timing",
-      description: `model_api_ms=${modelDurationMs}, model_status=${modelResponse.status()}, section_api_ms=${sectionDurationMs}, section_status=${sectionResponse.status()}, trace_id=${traceId}`,
+      description: `model_api_ms=${modelDurationMs}, model_status=${modelResponse.status()}, section_dispatch_ms=${sectionDispatchMs}, section_poll_ms=${sectionPollMs}, section_status=${sectionResponse.status()}, trace_id=${traceId}`,
     });
 
     console.warn(
-      `[E2E extraction baseline] trace_id=${traceId} model_status=${modelResponse.status()} model_api_ms=${modelDurationMs} section_status=${sectionResponse.status()} section_api_ms=${sectionDurationMs}`
+      `[E2E extraction baseline] trace_id=${traceId} model_status=${modelResponse.status()} model_api_ms=${modelDurationMs} section_status=${sectionResponse.status()} section_dispatch_ms=${sectionDispatchMs} section_poll_ms=${sectionPollMs}`
     );
   });
 });

--- a/frontend/e2e/flows/extraction.e2e.ts
+++ b/frontend/e2e/flows/extraction.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { APIRequestContext, expect, test } from "@playwright/test";
 
 import { loginViaUi, resolveAuthToken } from "../_fixtures/auth";
 import { authHeaders, parseEnvelope } from "../_fixtures/api";
@@ -7,6 +7,40 @@ import {
   resolveActiveExtractionTemplateId,
   resolveStudySectionEntityTypeId,
 } from "../_fixtures/supabase-admin";
+
+// Section extraction is async: POST returns 202 + { job_id }; the result is
+// fetched by polling GET /extraction/sections/status/{job_id}. Mirrors the
+// extraction-export poll helper (flows/extraction-export.e2e.ts).
+type SectionJobStatus = {
+  status: string;
+  result?: { extractionRunId?: string } | null;
+  error?: string | null;
+};
+
+async function pollSectionJob(input: {
+  request: APIRequestContext;
+  apiUrl: string;
+  jobId: string;
+  token: string;
+  traceId: string;
+}): Promise<SectionJobStatus> {
+  const inflight = new Set(["pending", "running"]);
+  const maxIters = 90; // ~180s at 2s intervals — matches the old sync timeout budget
+  for (let idx = 0; idx < maxIters; idx += 1) {
+    const res = await input.request.get(
+      `${input.apiUrl}/api/v1/extraction/sections/status/${input.jobId}`,
+      { headers: authHeaders(input.token, input.traceId) },
+    );
+    expect(res.ok()).toBeTruthy();
+    const body = await parseEnvelope<SectionJobStatus>(res);
+    expect(body.ok).toBeTruthy();
+    if (!inflight.has(body.data.status)) {
+      return body.data;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  return { status: "timeout" };
+}
 
 test.describe("Extraction flow (UI + API)", () => {
   test("opens extraction fullscreen route", async ({ page }) => {
@@ -60,12 +94,24 @@ test.describe("Extraction flow (UI + API)", () => {
         extractAllSections: false,
         model: process.env.E2E_MODEL_NAME || "gpt-4o-mini",
       },
-      timeout: 180000,
     });
-    expect(sectionResponse.ok()).toBeTruthy();
-    const sectionBody = await parseEnvelope<{ extractionRunId: string }>(sectionResponse);
-    expect(sectionBody.ok).toBeTruthy();
-    expect(sectionBody.data.extractionRunId).toBeTruthy();
+    expect(sectionResponse.status()).toBe(202);
+    const sectionDispatch = await parseEnvelope<{ job_id: string }>(sectionResponse);
+    expect(sectionDispatch.ok).toBeTruthy();
+    expect(sectionDispatch.data.job_id).toBeTruthy();
+
+    const sectionJob = await pollSectionJob({
+      request,
+      apiUrl: env.apiUrl,
+      jobId: sectionDispatch.data.job_id,
+      token,
+      traceId,
+    });
+    expect(
+      sectionJob.status,
+      `section job did not complete: ${sectionJob.error ?? "n/a"}`,
+    ).toBe("completed");
+    expect(sectionJob.result?.extractionRunId).toBeTruthy();
   });
 
   test("section extraction enqueues an async job (202) or 503 when the queue is down", async ({

--- a/frontend/e2e/remote/smoke-remote.e2e.ts
+++ b/frontend/e2e/remote/smoke-remote.e2e.ts
@@ -1,8 +1,42 @@
-import { expect, test } from "@playwright/test";
+import { APIRequestContext, expect, test } from "@playwright/test";
 
 import { loginViaUi, resolveAuthToken } from "../_fixtures/auth";
 import { authHeaders, parseEnvelope } from "../_fixtures/api";
 import { createTraceId, loadE2EEnv, missingEnvKeys } from "../_fixtures/env";
+
+// Section extraction is async: POST returns 202 + { job_id }; the result is
+// fetched by polling GET /extraction/sections/status/{job_id}. Mirrors the
+// extraction-export poll helper (flows/extraction-export.e2e.ts).
+type SectionJobStatus = {
+  status: string;
+  result?: { extractionRunId?: string } | null;
+  error?: string | null;
+};
+
+async function pollSectionJob(input: {
+  request: APIRequestContext;
+  apiUrl: string;
+  jobId: string;
+  token: string;
+  traceId: string;
+}): Promise<SectionJobStatus> {
+  const inflight = new Set(["pending", "running"]);
+  const maxIters = 90; // ~180s at 2s intervals — matches the old sync timeout budget
+  for (let idx = 0; idx < maxIters; idx += 1) {
+    const res = await input.request.get(
+      `${input.apiUrl}/api/v1/extraction/sections/status/${input.jobId}`,
+      { headers: authHeaders(input.token, input.traceId) },
+    );
+    expect(res.ok()).toBeTruthy();
+    const body = await parseEnvelope<SectionJobStatus>(res);
+    expect(body.ok).toBeTruthy();
+    if (!inflight.has(body.data.status)) {
+      return body.data;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  return { status: "timeout" };
+}
 
 test.describe("Remote smoke", () => {
   test("auth + extraction + unified queue smoke", async ({ page, request }) => {
@@ -32,11 +66,24 @@ test.describe("Remote smoke", () => {
         entityTypeId: env.entityTypeId,
         extractAllSections: false,
       },
-      timeout: 180000,
     });
-    expect(extractionResponse.ok()).toBeTruthy();
-    const extractionBody = await parseEnvelope<{ extractionRunId: string }>(extractionResponse);
-    expect(extractionBody.ok).toBeTruthy();
+    expect(extractionResponse.status()).toBe(202);
+    const extractionDispatch = await parseEnvelope<{ job_id: string }>(extractionResponse);
+    expect(extractionDispatch.ok).toBeTruthy();
+    expect(extractionDispatch.data.job_id).toBeTruthy();
+
+    const extractionJob = await pollSectionJob({
+      request,
+      apiUrl: env.apiUrl,
+      jobId: extractionDispatch.data.job_id,
+      token,
+      traceId,
+    });
+    expect(
+      extractionJob.status,
+      `section job did not complete: ${extractionJob.error ?? "n/a"}`,
+    ).toBe("completed");
+    expect(extractionJob.result?.extractionRunId).toBeTruthy();
 
     // /api/v1/review-queue was 008-only and was deleted along with the
     // evaluation_* endpoints. The new HITL flow exposes per-Run state via

--- a/frontend/hooks/extraction/ai/useRunAIExtraction.ts
+++ b/frontend/hooks/extraction/ai/useRunAIExtraction.ts
@@ -22,6 +22,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {toast} from 'sonner';
 
 import {t} from '@/lib/copy';
+import {jobErrorToast} from '@/lib/ai-extraction/jobErrorToast';
 import {extractionKeys} from '@/lib/query-keys';
 import {
   extractForRun as extractForRunService,
@@ -59,6 +60,7 @@ export function useRunAIExtraction(options?: {
   const jobStatus = jobQuery.data?.status;
   const jobResult = jobQuery.data?.result as ExtractionJobResult | null | undefined;
   const jobError = jobQuery.data?.error;
+  const jobErrorCode = jobQuery.data?.errorCode;
 
   // React to terminal job state. setState is placed inside async callbacks
   // (Promise.resolve().then()) to satisfy the react-hooks/set-state-in-effect rule.
@@ -89,10 +91,20 @@ export function useRunAIExtraction(options?: {
 
     if (jobStatus === 'failed') {
       const msg = jobError ?? t('extraction', 'extractionJobFailedTitle');
-      toast.error(t('extraction', 'extractionJobFailedTitle'), {
-        description: msg,
-        duration: 8000,
-      });
+      // A classified backend code gets specific copy; otherwise fall back to
+      // the generic "AI extraction failed" toast.
+      const specific = jobErrorToast(jobErrorCode, msg);
+      if (specific) {
+        toast.error(specific.title, {
+          description: specific.description,
+          duration: specific.duration,
+        });
+      } else {
+        toast.error(t('extraction', 'extractionJobFailedTitle'), {
+          description: msg,
+          duration: 8000,
+        });
+      }
       void Promise.resolve().then(() => {
         setError(msg);
         setJobId(null);

--- a/frontend/hooks/extraction/useSectionExtraction.ts
+++ b/frontend/hooks/extraction/useSectionExtraction.ts
@@ -18,6 +18,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {toast} from 'sonner';
 
 import {t} from '@/lib/copy';
+import {jobErrorToast} from '@/lib/ai-extraction/jobErrorToast';
 import {extractionKeys} from '@/lib/query-keys';
 import {
   extractSectionAsync,
@@ -58,6 +59,7 @@ export function useSectionExtraction(options?: {
   const jobStatus = jobQuery.data?.status;
   const jobResult = jobQuery.data?.result as ExtractionJobResult | null | undefined;
   const jobError = jobQuery.data?.error;
+  const jobErrorCode = jobQuery.data?.errorCode;
 
   // React to terminal job state. setState is placed inside async callbacks
   // (Promise.resolve().then()) to satisfy the react-hooks/set-state-in-effect rule.
@@ -99,10 +101,20 @@ export function useSectionExtraction(options?: {
 
     if (jobStatus === 'failed') {
       const msg = jobError ?? t('extraction', 'extractionJobFailedTitle');
-      toast.error(t('extraction', 'sectionExtractionErrorTitle'), {
-        description: msg,
-        duration: 8000,
-      });
+      // A classified backend code gets specific copy; otherwise fall back to
+      // the generic error toast.
+      const specific = jobErrorToast(jobErrorCode, msg);
+      if (specific) {
+        toast.error(specific.title, {
+          description: specific.description,
+          duration: specific.duration,
+        });
+      } else {
+        toast.error(t('extraction', 'sectionExtractionErrorTitle'), {
+          description: msg,
+          duration: 8000,
+        });
+      }
       void Promise.resolve().then(() => {
         setError(msg);
         setJobId(null);

--- a/frontend/lib/ai-extraction/jobErrorToast.test.ts
+++ b/frontend/lib/ai-extraction/jobErrorToast.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it, vi} from 'vitest';
+
+// `t` is mocked to echo the copy key so assertions read the key directly.
+vi.mock('@/lib/copy', () => ({
+  t: (_ns: string, key: string) => key,
+}));
+
+import {jobErrorToast} from '@/lib/ai-extraction/jobErrorToast';
+
+describe('jobErrorToast', () => {
+  it('maps MISSING_API_KEY to the auth title + the backend message', () => {
+    expect(jobErrorToast('MISSING_API_KEY', 'No OpenAI API key available.')).toEqual({
+      title: 'sectionExtractionErrorAuth',
+      description: 'No OpenAI API key available.',
+      duration: 8000,
+    });
+  });
+
+  it('maps PDF_NOT_FOUND to the generic error title + the backend message', () => {
+    expect(jobErrorToast('PDF_NOT_FOUND', 'PDF not found. Upload a PDF first.')).toEqual({
+      title: 'sectionExtractionErrorTitle',
+      description: 'PDF not found. Upload a PDF first.',
+      duration: 8000,
+    });
+  });
+
+  it('returns null for the generic code so the caller uses its own fallback', () => {
+    expect(jobErrorToast('EXTRACTION_FAILED', 'something broke')).toBeNull();
+  });
+
+  it('returns null for a missing or unknown code', () => {
+    expect(jobErrorToast(null, 'x')).toBeNull();
+    expect(jobErrorToast(undefined, 'x')).toBeNull();
+  });
+});

--- a/frontend/lib/ai-extraction/jobErrorToast.ts
+++ b/frontend/lib/ai-extraction/jobErrorToast.ts
@@ -1,0 +1,44 @@
+/**
+ * Map a failed async-extraction job's machine-readable error code to a
+ * specific toast.
+ *
+ * The backend (``run_section_extraction_task`` / the status endpoint) attaches
+ * a stable ``ExtractionErrorCode`` to failures it can classify by type. Only
+ * the codes that warrant *distinct* copy are handled here — anything else
+ * (the generic ``EXTRACTION_FAILED``, or a missing/unknown code) returns
+ * ``null`` so the calling hook falls back to its own generic toast.
+ *
+ * Pure function — no IO, no toast side effect — so the hooks stay
+ * React-Compiler-clean and this mapping is unit-testable on its own.
+ */
+import {t} from '@/lib/copy';
+import type {components} from '@/types/api/schema';
+
+type ExtractionErrorCode = components['schemas']['ExtractionErrorCode'];
+
+export interface JobErrorToast {
+  title: string;
+  description?: string;
+  duration?: number;
+}
+
+export function jobErrorToast(
+  code: ExtractionErrorCode | null | undefined,
+  message: string,
+): JobErrorToast | null {
+  // Actionable failures hold the toast as long as the generic failure (8 s)
+  // so the user can read the remediation. Owning the duration here keeps both
+  // hooks consistent (no per-hook fallback drift).
+  const duration = 8000;
+  switch (code) {
+    case 'MISSING_API_KEY':
+      // No usable LLM key. "Authentication error" title; the backend message
+      // is already actionable (BYOK key / env var), so surface it verbatim.
+      return {title: t('extraction', 'sectionExtractionErrorAuth'), description: message, duration};
+    case 'PDF_NOT_FOUND':
+      // Missing PDF. Generic title + the actionable "Upload a PDF first" message.
+      return {title: t('extraction', 'sectionExtractionErrorTitle'), description: message, duration};
+    default:
+      return null;
+  }
+}

--- a/frontend/test/hooks/useRunAIExtraction.test.tsx
+++ b/frontend/test/hooks/useRunAIExtraction.test.tsx
@@ -228,6 +228,34 @@ describe('useRunAIExtraction (async job)', () => {
     expect(result.current.loading).toBe(false);
   });
 
+  it('maps a MISSING_API_KEY failure code to the specific auth toast copy', async () => {
+    apiClientMock.mockResolvedValueOnce({job_id: 'job-1'});
+    statusMock.mockResolvedValue({
+      ok: true,
+      data: makeStatus('failed', {
+        error: 'No OpenAI API key available.',
+        errorCode: 'MISSING_API_KEY',
+      }),
+    });
+
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(() => useRunAIExtraction(), {wrapper});
+
+    await act(async () => {
+      await result.current.extractForRun(PARAMS);
+    });
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(toast.error).toHaveBeenCalledWith(
+      'sectionExtractionErrorAuth',
+      expect.objectContaining({
+        description: 'No OpenAI API key available.',
+        duration: 8000,
+      }),
+    );
+    expect(result.current.loading).toBe(false);
+  });
+
   it('loading is true while kickoff is in flight', async () => {
     let resolvePost!: (v: unknown) => void;
     apiClientMock.mockReturnValueOnce(

--- a/frontend/test/hooks/useSectionExtraction.test.tsx
+++ b/frontend/test/hooks/useSectionExtraction.test.tsx
@@ -236,4 +236,31 @@ describe('useSectionExtraction (async job)', () => {
     );
     expect(result.current.loading).toBe(false);
   });
+
+  it('maps a MISSING_API_KEY failure code to the specific auth toast copy', async () => {
+    apiClientMock.mockResolvedValueOnce({job_id: 'job-sec-1'});
+    statusMock.mockResolvedValue({
+      ok: true,
+      data: makeStatus('failed', {
+        error: 'No OpenAI API key available.',
+        errorCode: 'MISSING_API_KEY',
+      }),
+    });
+
+    const {wrapper} = createWrapper();
+    const {result} = renderHook(() => useSectionExtraction(), {wrapper});
+
+    await act(async () => {
+      await result.current.extractSection(PARAMS);
+    });
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(toast.error).toHaveBeenCalledWith(
+      'sectionExtractionErrorAuth',
+      expect.objectContaining({
+        description: 'No OpenAI API key available.',
+        duration: 8000,
+      }),
+    );
+  });
 });

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -3351,6 +3351,16 @@
         "title": "ExtractionArticleScope",
         "type": "string"
       },
+      "ExtractionErrorCode": {
+        "description": "Stable, machine-readable code for a terminal extraction failure.\n\nCarried on ``ExtractionJobStatusResponse.error_code`` so the frontend can\npick specific, actionable toast copy without parsing the human ``error``\nstring. Only modes the backend genuinely raises are represented \u2014 each\nvalue has a real emitter in ``classify_extraction_error``:\n\n- ``PDF_NOT_FOUND``    \u2014 the article has no stored PDF (``FileNotFoundError``).\n- ``MISSING_API_KEY``  \u2014 no usable LLM key, BYOK or global (``MissingLLMKeyError``).\n- ``EXTRACTION_FAILED``\u2014 generic catch-all for everything else.",
+        "enum": [
+          "PDF_NOT_FOUND",
+          "MISSING_API_KEY",
+          "EXTRACTION_FAILED"
+        ],
+        "title": "ExtractionErrorCode",
+        "type": "string"
+      },
       "ExtractionExportCancelResponse": {
         "description": "Cancel endpoint payload.",
         "properties": {
@@ -3602,6 +3612,16 @@
               }
             ],
             "title": "Error"
+          },
+          "errorCode": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ExtractionErrorCode"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "jobId": {
             "title": "Jobid",

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -2405,6 +2405,21 @@ export interface components {
          */
         ExtractionArticleScope: "current_list" | "selected_only";
         /**
+         * ExtractionErrorCode
+         * @description Stable, machine-readable code for a terminal extraction failure.
+         *
+         *     Carried on ``ExtractionJobStatusResponse.error_code`` so the frontend can
+         *     pick specific, actionable toast copy without parsing the human ``error``
+         *     string. Only modes the backend genuinely raises are represented — each
+         *     value has a real emitter in ``classify_extraction_error``:
+         *
+         *     - ``PDF_NOT_FOUND``    — the article has no stored PDF (``FileNotFoundError``).
+         *     - ``MISSING_API_KEY``  — no usable LLM key, BYOK or global (``MissingLLMKeyError``).
+         *     - ``EXTRACTION_FAILED``— generic catch-all for everything else.
+         * @enum {string}
+         */
+        ExtractionErrorCode: "PDF_NOT_FOUND" | "MISSING_API_KEY" | "EXTRACTION_FAILED";
+        /**
          * ExtractionExportCancelResponse
          * @description Cancel endpoint payload.
          */
@@ -2515,6 +2530,7 @@ export interface components {
         ExtractionJobStatusResponse: {
             /** Error */
             error?: string | null;
+            errorCode?: components["schemas"]["ExtractionErrorCode"] | null;
             /** Jobid */
             jobId: string;
             result?: components["schemas"]["ExtractionJobResult"] | null;


### PR DESCRIPTION
## Promotion dev → main (merge-commit)

Carries the post-Part-B corrections:

- **#416** fix(extraction): locale-aware thousands separators in numeric value-support
- **#421** test(e2e): migrate section-extraction specs to async 202 + status poll
- **#422** feat(extraction): restore granular error codes for async section extraction

## What ships

- **Thousands-separator fix**: `"24,077"` in the source now matches the value `24077` → numeric evidence is correctly labeled (Verified/entailed) instead of falsely "unsupported".
- **Granular async error codes**: `ExtractionErrorCode` carried task→status-endpoint→frontend (survives the Celery JSON round-trip, adversarially verified); the async path surfaces specific toasts (PDF-not-found, auth) instead of a single generic one. Failed-status-commit invariant + BOLA preserved.
- **E2E specs** migrated to the async contract (202 + poll-to-terminal).

No new migrations. Both feature PRs adversarially reviewed (APPROVED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)