### PR TITLE
fix(extraction): format %<->fraction candidates with .12g to avoid float-repr noise

### DIFF
--- a/backend/app/llm/value_support.py
+++ b/backend/app/llm/value_support.py
@@ -82,8 +82,11 @@ def _candidates(value: str) -> set[str]:
                 f = float(n)
             except ValueError:
                 continue
-            out.add(_canon(str(f / 100)))  # 12.5 -> 0.125
-            out.add(_canon(str(f * 100)))  # 0.125 -> 12.5
+            # `.12g` keeps 12 significant digits without leaking binary float
+            # noise (`str(11.8 / 100)` -> "0.11800000000000001"), so the clean
+            # decimal in the source text still matches.
+            out.add(_canon(format(f / 100, ".12g")))  # 12.5 -> 0.125
+            out.add(_canon(format(f * 100, ".12g")))  # 0.125 -> 12.5
     return {c for c in out if c}
 
 

--- a/backend/tests/unit/test_value_support.py
+++ b/backend/tests/unit/test_value_support.py
@@ -43,3 +43,30 @@ def test_comma_decimal_not_misread_as_grouping():
     # Locale comma-decimal ("11,8" == 11.8) must read as a decimal, not 118.
     assert numeric_value_supported("11,8", "increased by 11.8 points")
     assert not numeric_value_supported("11,8", "a total of 118 events")
+
+
+def test_percent_fraction_forms_match_despite_float_noise():
+    """Regression: the %<->fraction candidates must not leak binary float noise.
+
+    ``11.8 / 100`` reprs as ``0.11800000000000001`` and ``0.118 * 100`` as
+    ``11.799999999999999``; the raw ``str()`` candidate never matched the clean
+    decimal in the source text, so a valid citation was marked unsupported.
+    """
+    # percent value, fraction in the source text
+    assert numeric_value_supported("11.8%", "the incidence was 0.118 overall")
+    assert numeric_value_supported("0.7%", "occurred in 0.007 of cases")
+    assert numeric_value_supported("2.9%", "a rate of 0.029")
+    # fraction value, percent in the source text (reverse direction)
+    assert numeric_value_supported("0.118", "a rate of 11.8%")
+
+
+def test_integer_percent_candidate_not_mangled():
+    """The fraction->percent candidate of an integer must stay intact.
+
+    Guards against a tempting wrong fix (unconditional ``rstrip`` after a
+    ``.12g`` format) that would turn the candidate ``"500"`` into ``"5"``;
+    ``_canon`` only strips when a decimal point is present.
+    """
+    # "5" read as a fraction -> 500%; source states the percent form
+    assert numeric_value_supported("5", "rose to 500% of baseline")
+    assert numeric_value_supported("2", "exactly 200% increase")


### PR DESCRIPTION
## Why

The entailment gate's deterministic numeric check (`backend/app/llm/value_support.py`) marks legitimate numeric citations as `unsupported` (yellow) whenever the extracted value and the source text use opposite percentage/fraction forms — e.g. value `11.8%` vs source `0.118`. Root cause: the `%<->fraction` equivalence candidates are built with `str(f / 100)` / `str(f * 100)`, and Python's default float repr leaks binary noise:

- `str(11.8 / 100)` -> `"0.11800000000000001"` (not `"0.118"`)
- `str(0.118 * 100)` -> `"11.799999999999999"` (not `"11.8"`)

The noisy candidate never matches the clean decimal in the text, so the gate returns `False`. Conservative failure mode — only **false negatives** (a valid citation suppressed), never a false verification.

## What changed

- [value_support.py:85](backend/app/llm/value_support.py#L85): build the `%<->fraction` candidates with `format(f, ".12g")` instead of `str(f)`. 12 significant digits drops the binary tail (`0.118`, `0.007`, `11.8`) while `_canon` stays the *conditional* strip (`if "." in n`) so an integer candidate like `"500"` is not mangled to `"5"`.
- [test_value_support.py](backend/tests/unit/test_value_support.py): regression test for both directions of the float-noise bug, plus a guard test pinning the conditional-strip behavior.

## Risk

Low. Pure function, no IO, no schema/migration. The change only *adds* matches that should always have matched (cleaner candidate strings); it cannot create a false positive because the deterministic check is one half of the entailment gate (the LLM judge still runs). Pre-existing bug since #416 — **not** a regression of the thousands-separator work, whose tests stay green.

## Test plan

- [x] `make lint-backend` clean (ruff check + format, all 497 backend files)
- [x] Backend unit suite: `uv run pytest tests/unit/` — 1657 passed
- [x] New regression test fails on `dev`, passes after the fix (verified red->green)
- [ ] CI runs the full integration suite

## Out of scope

None.