### PR TITLE
promote: float-noise %<->fraction citation fix (#425) to main

### DIFF
--- a/backend/app/llm/value_support.py
+++ b/backend/app/llm/value_support.py
@@ -82,8 +82,11 @@ def _candidates(value: str) -> set[str]:
                 f = float(n)
             except ValueError:
                 continue
-            out.add(_canon(str(f / 100)))  # 12.5 -> 0.125
-            out.add(_canon(str(f * 100)))  # 0.125 -> 12.5
+            # `.12g` keeps 12 significant digits without leaking binary float
+            # noise (`str(11.8 / 100)` -> "0.11800000000000001"), so the clean
+            # decimal in the source text still matches.
+            out.add(_canon(format(f / 100, ".12g")))  # 12.5 -> 0.125
+            out.add(_canon(format(f * 100, ".12g")))  # 0.125 -> 12.5
     return {c for c in out if c}
 
 

--- a/backend/tests/unit/test_value_support.py
+++ b/backend/tests/unit/test_value_support.py
@@ -43,3 +43,30 @@ def test_comma_decimal_not_misread_as_grouping():
     # Locale comma-decimal ("11,8" == 11.8) must read as a decimal, not 118.
     assert numeric_value_supported("11,8", "increased by 11.8 points")
     assert not numeric_value_supported("11,8", "a total of 118 events")
+
+
+def test_percent_fraction_forms_match_despite_float_noise():
+    """Regression: the %<->fraction candidates must not leak binary float noise.
+
+    ``11.8 / 100`` reprs as ``0.11800000000000001`` and ``0.118 * 100`` as
+    ``11.799999999999999``; the raw ``str()`` candidate never matched the clean
+    decimal in the source text, so a valid citation was marked unsupported.
+    """
+    # percent value, fraction in the source text
+    assert numeric_value_supported("11.8%", "the incidence was 0.118 overall")
+    assert numeric_value_supported("0.7%", "occurred in 0.007 of cases")
+    assert numeric_value_supported("2.9%", "a rate of 0.029")
+    # fraction value, percent in the source text (reverse direction)
+    assert numeric_value_supported("0.118", "a rate of 11.8%")
+
+
+def test_integer_percent_candidate_not_mangled():
+    """The fraction->percent candidate of an integer must stay intact.
+
+    Guards against a tempting wrong fix (unconditional ``rstrip`` after a
+    ``.12g`` format) that would turn the candidate ``"500"`` into ``"5"``;
+    ``_canon`` only strips when a decimal point is present.
+    """
+    # "5" read as a fraction -> 500%; source states the percent form
+    assert numeric_value_supported("5", "rose to 500% of baseline")
+    assert numeric_value_supported("2", "exactly 200% increase")


### PR DESCRIPTION
Promotion of `dev` -> `main` (production).

## Contents

- #425 — `fix(extraction): format %<->fraction candidates with .12g to avoid float-repr noise`

Single, self-contained bugfix. The entailment gate's deterministic numeric check was building percentage/fraction equivalence candidates with `str(f / 100)` / `str(f * 100)`, leaking binary float noise (`str(11.8 / 100)` -> `"0.11800000000000001"`) so a valid numeric citation was marked `unsupported` when the value and source used opposite forms. Conservative — only false negatives, never a false verification.

## Risk

Low. Pure function in `backend/app/llm/value_support.py`, no schema/migration, no API contract change. Already green on `dev` CI. Merging to `main` triggers the Railway prod deploy.

## Evidence

- Backend unit suite 1657 passed; ruff clean; regression test red->green (on #425).
- Full `dev` required-check suite passed (PR #425 auto-merged on green).