### PR TITLE
Promote dev to main: LlamaParse hang fix (#430) + find-in-document (#428)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -116,6 +116,14 @@ class Settings(BaseSettings):
     # Optional global LlamaCloud key; per-user BYOK (APIKeyService) takes
     # precedence over this global fallback.
     LLAMA_CLOUD_API_KEY: str | None = None
+    # Cap the blocking LlamaParse parse() call. The SDK's own default is
+    # 7200s (2h); left uncapped, a slow/stuck cloud job pins a worker slot
+    # and leaves the ArticleFile at "pending" forever. On timeout the parser
+    # degrades to the local PyMuPDF backend (see FallbackDocumentParser).
+    # 240s gives the (slow) agentic tier a realistic window without disabling
+    # it via constant fallback; tune against measured agentic latency. The
+    # per-task Celery time limits (parsing_tasks) must stay above 2x this.
+    LLAMA_PARSE_TIMEOUT_SECONDS: float = 240.0
 
     # =================== EVALUATION ===================
     EVALUATION_EVIDENCE_BUCKET: str = "articles"

--- a/backend/app/core/factories.py
+++ b/backend/app/core/factories.py
@@ -57,6 +57,7 @@ def create_document_parser(
     # import time. PymupdfParser is light (base fitz) so it can import eagerly,
     # but keep it lazy for symmetry.
     from app.infrastructure.parsing.docling_parser import DoclingParser
+    from app.infrastructure.parsing.fallback_parser import FallbackDocumentParser
     from app.infrastructure.parsing.llamaparse_parser import LlamaParseParser
     from app.infrastructure.parsing.pymupdf_parser import PymupdfParser
 
@@ -67,7 +68,13 @@ def create_document_parser(
         if not key:
             _logger.warning("parser_gate_llamaparse_no_key_fallback_pymupdf")
             return PymupdfParser()
-        return LlamaParseParser(api_key=key)
+        # Wrap the cloud parser so a timeout/error degrades to local PyMuPDF
+        # instead of leaving the file stuck at "pending" (see FallbackDocumentParser).
+        timeout = float(getattr(settings, "LLAMA_PARSE_TIMEOUT_SECONDS", 120.0))
+        return FallbackDocumentParser(
+            primary=LlamaParseParser(api_key=key, timeout=timeout),
+            fallback=PymupdfParser(),
+        )
 
     if backend == "docling":
         return DoclingParser()

--- a/backend/app/infrastructure/parsing/fallback_parser.py
+++ b/backend/app/infrastructure/parsing/fallback_parser.py
@@ -1,0 +1,42 @@
+"""Fallback DocumentParser — degrade to a secondary parser on primary failure.
+
+The cloud LlamaParse path can time out, error, or (worst case) block for a
+long time before failing. When it does, we must not leave the ArticleFile
+stuck at ``pending`` forever (the original "won't stop loading" bug). This
+adapter wraps a *primary* parser (LlamaParse) and a *fallback* parser
+(PyMuPDF): on any primary exception it logs and retries with the fallback,
+so the document still gets parsed — just at the local parser's quality.
+
+Both parsers implement the DocumentParser port, so this composes cleanly and
+the DocumentParsingService stays unaware of the fallback.
+"""
+
+from __future__ import annotations
+
+from app.core.logging import get_logger
+from app.infrastructure.parsing.base import DocumentParser, ParsedBlock
+
+_logger = get_logger(__name__)
+
+
+class FallbackDocumentParser(DocumentParser):
+    """Try ``primary``; on any failure, parse with ``fallback`` instead."""
+
+    def __init__(self, *, primary: DocumentParser, fallback: DocumentParser) -> None:
+        self.primary = primary
+        self.fallback = fallback
+
+    def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:
+        try:
+            return self.primary.parse(pdf_bytes)
+        except Exception as exc:
+            # Degrade, do NOT swallow: log the primary failure, then let the
+            # fallback run. If the fallback ALSO raises, that error propagates
+            # so the service marks the file parse_failed (never silently lost).
+            _logger.warning(
+                "document_parser_fallback",
+                primary=type(self.primary).__name__,
+                fallback=type(self.fallback).__name__,
+                error=str(exc),
+            )
+            return self.fallback.parse(pdf_bytes)

--- a/backend/app/infrastructure/parsing/llamaparse_parser.py
+++ b/backend/app/infrastructure/parsing/llamaparse_parser.py
@@ -112,12 +112,26 @@ def _blocks_from_markdown(result: Any) -> list[ParsedBlock]:
     return blocks
 
 
+# Bounded fallback default — never inherit the SDK's 7200s (2h) parse timeout.
+# Keep in sync with Settings.LLAMA_PARSE_TIMEOUT_SECONDS (the runtime value the
+# factory injects); this constant only applies to a bare construction.
+_DEFAULT_TIMEOUT_SECONDS = 240.0
+
+
 class LlamaParseParser(DocumentParser):
     """High-quality cloud parser. Implements the DocumentParser port."""
 
-    def __init__(self, api_key: str, tier: str = "agentic") -> None:
+    def __init__(
+        self, api_key: str, tier: str = "agentic", timeout: float = _DEFAULT_TIMEOUT_SECONDS
+    ) -> None:
         self._api_key = api_key
         self._tier = tier
+        self._timeout = timeout
+
+    @property
+    def timeout(self) -> float:
+        """The cap (seconds) applied to the blocking parse()/upload calls."""
+        return self._timeout
 
     def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:
         from llama_cloud import LlamaCloud  # lazy: cloud SDK, not a unit dep
@@ -126,13 +140,17 @@ class LlamaParseParser(DocumentParser):
         with tempfile.NamedTemporaryFile(suffix=".pdf") as tmp:
             tmp.write(pdf_bytes)
             tmp.flush()
-            uploaded = client.files.create(file=tmp.name, purpose="parse")
+            # Bound BOTH the upload and the (otherwise 2h-default) parse poll so
+            # a slow/stuck cloud job fails fast — the caller falls back to the
+            # local parser instead of pinning a worker slot forever.
+            uploaded = client.files.create(file=tmp.name, purpose="parse", timeout=self._timeout)
             result = client.parsing.parse(
                 file_id=uploaded.id,
                 tier=self._tier,
                 version="latest",
                 output_options={"granular_bboxes": ["word", "line", "cell"]},
                 expand=["markdown", "items"],
+                timeout=self._timeout,
             )
 
         return self._map_result(result)

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -48,6 +48,14 @@ celery_app.conf.update(
     # Concurrency
     worker_concurrency=4,
     worker_prefetch_multiplier=2,
+    # Redis visibility timeout. With task_acks_late=True, an in-flight message
+    # stays "invisible" only this long before Redis redelivers it. The
+    # invariant: it MUST exceed every task's hard time_limit, or a still-running
+    # task gets redelivered and runs twice (the classic Celery+Redis duplicate-
+    # execution footgun). 3600s is the library default, made explicit here so it
+    # can't silently fall below a task limit; the bounded parse task (hard 360s)
+    # sits well under it.
+    broker_transport_options={"visibility_timeout": 3600},
     # Task routes (queues separated by type). Every module in
     # ``include=`` MUST appear here explicitly — the registry test in
     # ``tests/unit/test_celery_app_task_registry.py`` enforces this so

--- a/backend/app/worker/tasks/parsing_tasks.py
+++ b/backend/app/worker/tasks/parsing_tasks.py
@@ -11,10 +11,28 @@ from typing import Any
 from uuid import UUID
 
 from celery import Task
+from celery.exceptions import SoftTimeLimitExceeded
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.worker._runner import run_task
 from app.worker.celery_app import celery_app
+
+# Per-task time limits (NOT global — extraction/LLM tasks legitimately run far
+# longer and must not be capped). They bound the LlamaParse SDK timeout
+# (LLAMA_PARSE_TIMEOUT_SECONDS, default 240s, applied to BOTH upload and parse,
+# so worst-case primary work is ~480s) plus the PyMuPDF fallback + DB writes,
+# with headroom — hence soft > 2x the SDK timeout.
+#   SOFT (catchable): raises SoftTimeLimitExceeded → the task marks the file
+#     parse_failed terminally (see parse_article_file_task), so a slow parse
+#     never lingers at "pending".
+#   HARD (SIGKILL): last-resort backstop for a child wedged in native code that
+#     ignored the soft signal. Celery acks + fails that task on a hard timeout
+#     (task_acks_on_failure_or_timeout defaults True) — it is NOT redelivered —
+#     so at worst that one file needs a manual re-parse.
+# Both stay well under the broker visibility_timeout (3600s) so a still-running
+# task is never redelivered (see celery_app.broker_transport_options).
+_PARSE_SOFT_TIME_LIMIT_SECONDS = 600
+_PARSE_HARD_TIME_LIMIT_SECONDS = 660
 
 
 async def _run_parse(
@@ -64,6 +82,7 @@ async def _run_parse(
         call_settings = SimpleNamespace(
             PARSER_BACKEND=backend,
             LLAMA_CLOUD_API_KEY=app_settings.LLAMA_CLOUD_API_KEY,
+            LLAMA_PARSE_TIMEOUT_SECONDS=app_settings.LLAMA_PARSE_TIMEOUT_SECONDS,
         )
         parser = create_document_parser(
             call_settings,
@@ -130,6 +149,8 @@ async def _mark_parse_failed(article_file_id: str, error_message: str) -> None:
     max_retries=3,
     default_retry_delay=60,
     rate_limit="10/m",
+    soft_time_limit=_PARSE_SOFT_TIME_LIMIT_SECONDS,
+    time_limit=_PARSE_HARD_TIME_LIMIT_SECONDS,
 )
 def parse_article_file_task(
     self: Task[Any, Any],
@@ -144,6 +165,14 @@ def parse_article_file_task(
         return run_task(
             lambda: _run_parse(article_file_id, project_id, user_id, trace_id or self.request.id)
         )
+    except SoftTimeLimitExceeded:
+        # The soft time limit fired (the parse + fallback could not finish in
+        # time). A retry would hit the same wall, so fail terminally now — mark
+        # the file parse_failed in its own committed session (the main session
+        # already rolled back) so it never lingers at "pending". Must precede
+        # the generic Exception branch (SoftTimeLimitExceeded subclasses it).
+        run_task(lambda: _mark_parse_failed(article_file_id, "parse exceeded time limit"))
+        raise
     except Exception as exc:
         if self.request.retries >= self.max_retries:
             # Terminal: the main session already rolled back, so persist the

--- a/backend/tests/unit/test_celery_parse_task_limits.py
+++ b/backend/tests/unit/test_celery_parse_task_limits.py
@@ -1,0 +1,65 @@
+"""Guards for the parse task's time bounds + the Redis visibility window.
+
+Root cause of the "stuck pending forever" bug: the LlamaParse parse() call
+blocks (default 2h) with no Celery time limit, so a slow/stuck cloud job
+never reaches a terminal status. These guards keep the bounds in place:
+
+- The parse task carries PER-TASK soft/hard time limits (not global, so
+  long-running extraction/LLM tasks are unaffected).
+- The Redis visibility_timeout exceeds the parse hard limit, so an
+  acks_late task can never be redelivered while still running (the classic
+  Celery+Redis duplicate-execution footgun).
+"""
+
+from __future__ import annotations
+
+import pytest
+from celery.exceptions import SoftTimeLimitExceeded
+
+import app.worker.tasks.parsing_tasks as parsing_tasks
+from app.worker.celery_app import celery_app
+from app.worker.tasks.parsing_tasks import parse_article_file_task
+
+
+def test_parse_task_has_bounded_per_task_time_limits() -> None:
+    assert parse_article_file_task.soft_time_limit is not None
+    assert parse_article_file_task.time_limit is not None
+    assert parse_article_file_task.soft_time_limit < parse_article_file_task.time_limit
+
+
+def test_global_time_limits_stay_unset() -> None:
+    # Setting a GLOBAL limit would cap legitimately long extraction/LLM tasks.
+    assert celery_app.conf.task_soft_time_limit is None
+    assert celery_app.conf.task_time_limit is None
+
+
+def test_visibility_timeout_exceeds_parse_hard_limit() -> None:
+    opts = celery_app.conf.broker_transport_options or {}
+    visibility_timeout = opts.get("visibility_timeout")
+    assert visibility_timeout is not None
+    assert visibility_timeout > parse_article_file_task.time_limit
+
+
+def test_soft_time_limit_marks_failed_terminally(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When the soft limit fires, the file must be marked parse_failed (not
+    # retried), so a slow parse becomes terminal instead of lingering at pending.
+    state: dict[str, object] = {"run_task_calls": 0, "marked": []}
+
+    def fake_run_task(fn):  # type: ignore[no-untyped-def]
+        state["run_task_calls"] = int(state["run_task_calls"]) + 1
+        if state["run_task_calls"] == 1:
+            raise SoftTimeLimitExceeded  # the parse exceeded its soft budget
+        return fn()  # the _mark_parse_failed call
+
+    def fake_mark(article_file_id: str, error_message: str) -> None:
+        marked = state["marked"]
+        assert isinstance(marked, list)
+        marked.append((article_file_id, error_message))
+
+    monkeypatch.setattr(parsing_tasks, "run_task", fake_run_task)
+    monkeypatch.setattr(parsing_tasks, "_mark_parse_failed", fake_mark)
+
+    with pytest.raises(SoftTimeLimitExceeded):
+        parse_article_file_task.run("afid", "pid", "uid", "tid")
+
+    assert state["marked"] == [("afid", "parse exceeded time limit")]

--- a/backend/tests/unit/test_config_parser_fields.py
+++ b/backend/tests/unit/test_config_parser_fields.py
@@ -5,3 +5,6 @@ def test_parser_defaults():
     s = Settings()  # type: ignore[call-arg]
     assert s.PARSER_BACKEND == "pymupdf"  # free default; Docling is opt-in
     assert s.LLAMA_CLOUD_API_KEY is None  # cloud key optional (BYOK/global)
+    # The LlamaParse SDK's parse() blocks up to its own default (7200s = 2h);
+    # we cap it so a slow/stuck cloud job fails fast and the fallback engages.
+    assert s.LLAMA_PARSE_TIMEOUT_SECONDS == 240.0

--- a/backend/tests/unit/test_fallback_parser.py
+++ b/backend/tests/unit/test_fallback_parser.py
@@ -1,0 +1,85 @@
+"""Unit tests for FallbackDocumentParser.
+
+The cloud LlamaParse path can block, time out, or error (see
+parsing_tasks + the 2h-blocking SDK call). FallbackDocumentParser wraps a
+primary parser so that any primary failure degrades to a secondary parser
+(PyMuPDF) instead of leaving the ArticleFile stuck at ``pending`` forever.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.infrastructure.parsing.base import DocumentParser, ParsedBlock
+from app.infrastructure.parsing.fallback_parser import FallbackDocumentParser
+
+
+def _block(text: str) -> ParsedBlock:
+    return ParsedBlock(
+        page_number=1,
+        block_index=0,
+        text=text,
+        char_start=0,
+        char_end=len(text),
+        bbox={"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0},
+        block_type="paragraph",
+    )
+
+
+class _StubParser(DocumentParser):
+    def __init__(
+        self, *, blocks: list[ParsedBlock] | None = None, error: Exception | None = None
+    ) -> None:
+        self._blocks = blocks or []
+        self._error = error
+        self.calls = 0
+
+    def parse(self, pdf_bytes: bytes) -> list[ParsedBlock]:  # noqa: ARG002
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        return self._blocks
+
+
+def test_uses_primary_when_it_succeeds() -> None:
+    primary = _StubParser(blocks=[_block("primary")])
+    fallback = _StubParser(blocks=[_block("fallback")])
+    parser = FallbackDocumentParser(primary=primary, fallback=fallback)
+
+    out = parser.parse(b"%PDF-1.4")
+
+    assert [b.text for b in out] == ["primary"]
+    assert primary.calls == 1
+    assert fallback.calls == 0  # fallback must NOT run when primary works
+
+
+def test_falls_back_when_primary_raises() -> None:
+    primary = _StubParser(error=RuntimeError("llamaparse timed out"))
+    fallback = _StubParser(blocks=[_block("fallback")])
+    parser = FallbackDocumentParser(primary=primary, fallback=fallback)
+
+    out = parser.parse(b"%PDF-1.4")
+
+    assert [b.text for b in out] == ["fallback"]
+    assert primary.calls == 1
+    assert fallback.calls == 1
+
+
+def test_propagates_when_fallback_also_fails() -> None:
+    # If BOTH fail there is nothing to degrade to — the error must reach the
+    # service so the ArticleFile is marked parse_failed (not silently lost).
+    primary = _StubParser(error=RuntimeError("primary boom"))
+    fallback = _StubParser(error=ValueError("fallback boom too"))
+    parser = FallbackDocumentParser(primary=primary, fallback=fallback)
+
+    with pytest.raises(ValueError, match="fallback boom too"):
+        parser.parse(b"%PDF-1.4")
+
+
+def test_exposes_primary_and_fallback_for_inspection() -> None:
+    primary = _StubParser(blocks=[])
+    fallback = _StubParser(blocks=[])
+    parser = FallbackDocumentParser(primary=primary, fallback=fallback)
+
+    assert parser.primary is primary
+    assert parser.fallback is fallback

--- a/backend/tests/unit/test_llamaparse_parser.py
+++ b/backend/tests/unit/test_llamaparse_parser.py
@@ -105,3 +105,53 @@ def test_raises_only_when_truly_empty() -> None:
     result = _response(items=Items(pages=[]), markdown=Markdown(pages=[]))
     with pytest.raises(ValueError, match="no text blocks"):
         LlamaParseParser._map_result(result)
+
+
+def test_parse_passes_timeout_to_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """parse() MUST cap the blocking SDK call (default is 7200s = 2h)."""
+    from types import SimpleNamespace
+
+    parse_captured: dict[str, object] = {}
+    upload_captured: dict[str, object] = {}
+
+    class _FakeParsing:
+        def parse(self, **kwargs: object) -> ParsingGetResponse:
+            parse_captured.update(kwargs)
+            return _response(
+                markdown=Markdown(
+                    pages=[
+                        MarkdownPageMarkdownResultPage(
+                            markdown="Body.", page_number=1, success=True
+                        )
+                    ]
+                )
+            )
+
+    class _FakeFiles:
+        def create(self, **kwargs: object) -> SimpleNamespace:
+            upload_captured.update(kwargs)
+            return SimpleNamespace(id="file-123")
+
+    class _FakeLlamaCloud:
+        def __init__(self, *, api_key: str) -> None:  # noqa: ARG002
+            self.parsing = _FakeParsing()
+            self.files = _FakeFiles()
+
+    # parse() does `from llama_cloud import LlamaCloud` lazily, so patch the
+    # module attribute it re-reads on each call.
+    monkeypatch.setattr("llama_cloud.LlamaCloud", _FakeLlamaCloud)
+
+    parser = LlamaParseParser(api_key="k", timeout=99.0)
+    blocks = parser.parse(b"%PDF-1.4 fake")
+
+    # BOTH the upload and the parse poll must be bounded (each can block).
+    assert upload_captured["timeout"] == 99.0
+    assert upload_captured["purpose"] == "parse"
+    assert parse_captured["timeout"] == 99.0
+    assert parse_captured["file_id"] == "file-123"
+    assert [b.text for b in blocks] == ["Body."]
+
+
+def test_timeout_defaults_to_capped_value() -> None:
+    # A bare construction must still be bounded — never inherit the SDK's 2h.
+    assert LlamaParseParser(api_key="k").timeout == 240.0

--- a/backend/tests/unit/test_parser_factory.py
+++ b/backend/tests/unit/test_parser_factory.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from app.core.factories import create_document_parser
 from app.infrastructure.parsing.docling_parser import DoclingParser
+from app.infrastructure.parsing.fallback_parser import FallbackDocumentParser
 from app.infrastructure.parsing.llamaparse_parser import LlamaParseParser
 from app.infrastructure.parsing.pymupdf_parser import PymupdfParser
 
@@ -18,9 +19,25 @@ def test_llamaparse_without_key_falls_back_to_pymupdf():
     assert isinstance(p, PymupdfParser)
 
 
-def test_llamaparse_with_key():
-    p = create_document_parser(SimpleNamespace(PARSER_BACKEND="llamaparse"), llama_cloud_key="k")
-    assert isinstance(p, LlamaParseParser)
+def test_llamaparse_with_key_wraps_fallback_to_pymupdf():
+    # The cloud parser is wrapped so a timeout/error degrades to PyMuPDF
+    # instead of leaving the file stuck at "pending".
+    p = create_document_parser(
+        SimpleNamespace(PARSER_BACKEND="llamaparse", LLAMA_PARSE_TIMEOUT_SECONDS=120.0),
+        llama_cloud_key="k",
+    )
+    assert isinstance(p, FallbackDocumentParser)
+    assert isinstance(p.primary, LlamaParseParser)
+    assert isinstance(p.fallback, PymupdfParser)
+
+
+def test_llamaparse_primary_receives_configured_timeout():
+    p = create_document_parser(
+        SimpleNamespace(PARSER_BACKEND="llamaparse", LLAMA_PARSE_TIMEOUT_SECONDS=42.0),
+        llama_cloud_key="k",
+    )
+    assert isinstance(p, FallbackDocumentParser)
+    assert p.primary.timeout == 42.0
 
 
 def test_docling_is_opt_in_only():

--- a/frontend/pdf-viewer/PrumoPdfViewer.tsx
+++ b/frontend/pdf-viewer/PrumoPdfViewer.tsx
@@ -101,7 +101,7 @@ function ViewerContent({
   // loading yet (or fails).
   if (mode === 'reader') {
     return (
-      <div className="flex-1 overflow-auto bg-muted/30">
+      <div className="flex-1 overflow-auto bg-muted/30" data-reader-scroll="">
         <Reader blocks={readerBlocks ?? []} loading={readerLoading} />
       </div>
     );

--- a/frontend/pdf-viewer/__tests__/reader.test.tsx
+++ b/frontend/pdf-viewer/__tests__/reader.test.tsx
@@ -1,7 +1,8 @@
-import {render, screen} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import {describe, expect, it} from 'vitest';
 
 import {Reader, type ReaderTextBlock} from '../primitives/Reader';
+import {ViewerProvider} from '../core/context';
 import {createViewerStore} from '../core/store';
 
 describe('<Reader>', () => {
@@ -50,6 +51,53 @@ describe('<Reader>', () => {
     // Pages still appear in sorted order even when input is shuffled.
     expect(sections[0]).toHaveAttribute('data-reader-page', '1');
     expect(sections[1]).toHaveAttribute('data-reader-page', '2');
+  });
+});
+
+describe('reader find-in-document', () => {
+  const blocks: ReaderTextBlock[] = [
+    {id: 'b1', pageNumber: 1, blockIndex: 0, text: 'The tumor was large.', blockType: 'paragraph'},
+    {id: 'b2', pageNumber: 1, blockIndex: 1, text: 'Another **tumor** appeared.', blockType: 'paragraph'},
+  ];
+
+  function renderReader(store = createViewerStore({mode: 'reader'})) {
+    render(
+      <ViewerProvider store={store}>
+        <div data-reader-scroll>
+          <Reader blocks={blocks} />
+        </div>
+      </ViewerProvider>,
+    );
+    return store;
+  }
+
+  it('reports the count of matches in the rendered markdown to the store', async () => {
+    const store = renderReader();
+    act(() => store.getState().actions.setSearchQuery('tumor'));
+    await waitFor(() => expect(store.getState().search.matchCount).toBe(2));
+    expect(store.getState().search.activeIndex).toBe(0);
+  });
+
+  it('matches a phrase that spans inline markdown emphasis', async () => {
+    const store = renderReader();
+    act(() => store.getState().actions.setSearchQuery('Another tumor appeared'));
+    await waitFor(() => expect(store.getState().search.matchCount).toBe(1));
+  });
+
+  it('clears the count when the query is emptied', async () => {
+    const store = renderReader();
+    act(() => store.getState().actions.setSearchQuery('tumor'));
+    await waitFor(() => expect(store.getState().search.matchCount).toBe(2));
+    act(() => store.getState().actions.setSearchQuery(''));
+    await waitFor(() => expect(store.getState().search.matchCount).toBe(0));
+  });
+
+  it('does not search when the viewer is in canvas mode', async () => {
+    const store = renderReader(createViewerStore({mode: 'canvas'}));
+    act(() => store.getState().actions.setSearchQuery('tumor'));
+    // Give any effect a tick; reader must stay inert in canvas mode.
+    await Promise.resolve();
+    expect(store.getState().search.matchCount).toBe(0);
   });
 });
 

--- a/frontend/pdf-viewer/__tests__/store.test.ts
+++ b/frontend/pdf-viewer/__tests__/store.test.ts
@@ -161,6 +161,18 @@ describe('search actions', () => {
     expect(store.getState().search.activeIndex).toBe(-1);
   });
 
+  it('setSearchMatches mirrors the count into matchCount', () => {
+    const store = createViewerStore();
+    const {actions} = store.getState();
+    actions.setSearchMatches([
+      {pageNumber: 1, charStart: 0, charEnd: 4, context: 'a'},
+      {pageNumber: 2, charStart: 5, charEnd: 9, context: 'b'},
+    ]);
+    expect(store.getState().search.matchCount).toBe(2);
+    actions.setSearchMatches([]);
+    expect(store.getState().search.matchCount).toBe(0);
+  });
+
   it('goToNextMatch wraps around and calls goToPage', () => {
     const store = createViewerStore();
     const {actions} = store.getState();
@@ -231,5 +243,86 @@ describe('search actions', () => {
     expect(search.query).toBe('');
     expect(search.matches).toHaveLength(0);
     expect(search.activeIndex).toBe(-1);
+    expect(search.matchCount).toBe(0);
+  });
+});
+
+describe('mode switch clears stale search results', () => {
+  it('switching modes drops matches/count/activeIndex but keeps the query', () => {
+    const store = createViewerStore({mode: 'canvas'});
+    const {actions} = store.getState();
+    actions.setSearchQuery('tumor');
+    actions.setSearchMatches([
+      {pageNumber: 1, charStart: 0, charEnd: 5, context: 'a'},
+      {pageNumber: 2, charStart: 5, charEnd: 10, context: 'b'},
+    ]);
+    expect(store.getState().search.matchCount).toBe(2);
+
+    actions.setMode('reader');
+    const s = store.getState().search;
+    expect(s.matchCount).toBe(0);
+    expect(s.matches).toHaveLength(0);
+    expect(s.activeIndex).toBe(-1);
+    expect(s.query).toBe('tumor'); // preserved so the new mode re-searches
+  });
+
+  it('setMode to the same mode does not touch search', () => {
+    const store = createViewerStore({mode: 'reader'});
+    const {actions} = store.getState();
+    actions.setReaderMatchCount(3);
+    actions.setMode('reader');
+    expect(store.getState().search.matchCount).toBe(3);
+  });
+
+  it('locateInReader from canvas clears stale canvas matches', () => {
+    const store = createViewerStore({mode: 'canvas'});
+    const {actions} = store.getState();
+    actions.setSearchMatches([{pageNumber: 1, charStart: 0, charEnd: 5, context: 'a'}]);
+    actions.locateInReader('some quote', 1, [0]);
+    expect(store.getState().search.matchCount).toBe(0);
+    expect(store.getState().search.matches).toHaveLength(0);
+  });
+});
+
+describe('reader search navigation', () => {
+  it('setReaderMatchCount records the count, clears PDF matches, activates the first', () => {
+    const store = createViewerStore();
+    const {actions} = store.getState();
+    actions.setReaderMatchCount(3);
+    const {search} = store.getState();
+    expect(search.matchCount).toBe(3);
+    expect(search.matches).toHaveLength(0); // reader matches live in the DOM, not the store
+    expect(search.activeIndex).toBe(0);
+  });
+
+  it('setReaderMatchCount(0) deactivates', () => {
+    const store = createViewerStore();
+    const {actions} = store.getState();
+    actions.setReaderMatchCount(2);
+    actions.setReaderMatchCount(0);
+    expect(store.getState().search.activeIndex).toBe(-1);
+    expect(store.getState().search.matchCount).toBe(0);
+  });
+
+  it('goToNextMatch wraps on matchCount without moving the page (reader has no PDF pages)', () => {
+    const store = createViewerStore({mode: 'reader'});
+    const {actions} = store.getState();
+    actions.setReaderMatchCount(3);
+    expect(store.getState().currentPage).toBe(1);
+    actions.goToNextMatch();
+    expect(store.getState().search.activeIndex).toBe(1);
+    actions.goToNextMatch();
+    expect(store.getState().search.activeIndex).toBe(2);
+    actions.goToNextMatch();
+    expect(store.getState().search.activeIndex).toBe(0); // wraps
+    expect(store.getState().currentPage).toBe(1); // unchanged — no goToPage in reader mode
+  });
+
+  it('goToPrevMatch wraps on matchCount in reader mode', () => {
+    const store = createViewerStore({mode: 'reader'});
+    const {actions} = store.getState();
+    actions.setReaderMatchCount(3);
+    actions.goToPrevMatch();
+    expect(store.getState().search.activeIndex).toBe(2);
   });
 });

--- a/frontend/pdf-viewer/core/state.ts
+++ b/frontend/pdf-viewer/core/state.ts
@@ -25,8 +25,18 @@ export interface SearchOptions {
 export interface SearchState {
   query: string;
   options: SearchOptions;
+  /**
+   * Canvas-mode matches with PDF coordinates. Empty in reader mode — the
+   * reader's matches are DOM Ranges owned by the reader, not the store.
+   */
   matches: ReadonlyArray<SearchMatch>;
-  /** Index in `matches` of the currently-active match, or -1 if none. */
+  /**
+   * Total match count for the ACTIVE mode (canvas = `matches.length`,
+   * reader = the reader's DOM-match count). The mode-agnostic field the
+   * search bar reads for its "n / N" label and prev/next enabling.
+   */
+  matchCount: number;
+  /** Index of the currently-active match (into `matchCount`), or -1 if none. */
   activeIndex: number;
   /** True while a search is in progress. */
   searching: boolean;
@@ -120,6 +130,11 @@ export interface ViewerActions {
   setSearchQuery(query: string): void;
   setSearchOptions(opts: Partial<SearchOptions>): void;
   setSearchMatches(matches: ReadonlyArray<SearchMatch>): void;
+  /**
+   * Reader-mode search result: record the DOM-match count (the Ranges live in
+   * the reader). Clears any canvas matches and activates the first match.
+   */
+  setReaderMatchCount(count: number): void;
   setSearchSearching(searching: boolean): void;
   goToNextMatch(): void;
   goToPrevMatch(): void;

--- a/frontend/pdf-viewer/core/store.ts
+++ b/frontend/pdf-viewer/core/store.ts
@@ -9,9 +9,23 @@ const initialSearch: SearchState = {
   query: '',
   options: {caseSensitive: false, wholeWords: false},
   matches: [],
+  matchCount: 0,
   activeIndex: -1,
   searching: false,
 };
+
+/**
+ * Drop computed results (matches/count/active) but keep the query + options.
+ * Used on a mode switch: canvas matches (PDF coords + TextLayer) and reader
+ * matches (DOM Ranges) are disjoint, so carrying a count across modes leaves a
+ * stale "n / N" with live prev/next firing against the now-hidden surface.
+ */
+const clearedResults = (s: SearchState): SearchState => ({
+  ...s,
+  matches: [],
+  matchCount: 0,
+  activeIndex: -1,
+});
 
 const initialData: ViewerData = {
   source: null,
@@ -82,14 +96,17 @@ export function createViewerStore(
       },
 
       setMode(mode: ViewerMode) {
-        set({mode});
+        if (mode === get().mode) return;
+        set({mode, search: clearedResults(get().search)});
       },
 
       locateInReader(quote: string, page?: number | null, blockIds: number[] = []) {
         const prevNonce = get().readerLocate?.nonce ?? 0;
+        const switchingFromCanvas = get().mode !== 'reader';
         set({
           mode: 'reader',
           readerLocate: {quote, page: page ?? null, blockIds, nonce: prevNonce + 1},
+          ...(switchingFromCanvas ? {search: clearedResults(get().search)} : {}),
         });
       },
 
@@ -106,7 +123,25 @@ export function createViewerStore(
       },
 
       setSearchMatches(matches) {
-        set({search: {...get().search, matches, activeIndex: matches.length > 0 ? 0 : -1}});
+        set({
+          search: {
+            ...get().search,
+            matches,
+            matchCount: matches.length,
+            activeIndex: matches.length > 0 ? 0 : -1,
+          },
+        });
+      },
+
+      setReaderMatchCount(count: number) {
+        set({
+          search: {
+            ...get().search,
+            matches: [],
+            matchCount: count,
+            activeIndex: count > 0 ? 0 : -1,
+          },
+        });
       },
 
       setSearchSearching(searching: boolean) {
@@ -115,25 +150,30 @@ export function createViewerStore(
 
       goToNextMatch() {
         const s = get().search;
-        if (s.matches.length === 0) return;
-        const next = (s.activeIndex + 1) % s.matches.length;
+        if (s.matchCount === 0) return;
+        const next = (s.activeIndex + 1) % s.matchCount;
         set({search: {...s, activeIndex: next}});
-        get().actions.goToPage(s.matches[next].pageNumber);
+        // Canvas matches carry a page; bring it into view. Reader matches live
+        // in the DOM (no `matches` entry) and are scrolled by the reader itself.
+        const match = s.matches[next];
+        if (match) get().actions.goToPage(match.pageNumber);
       },
 
       goToPrevMatch() {
         const s = get().search;
-        if (s.matches.length === 0) return;
-        const next = (s.activeIndex - 1 + s.matches.length) % s.matches.length;
+        if (s.matchCount === 0) return;
+        const next = (s.activeIndex - 1 + s.matchCount) % s.matchCount;
         set({search: {...s, activeIndex: next}});
-        get().actions.goToPage(s.matches[next].pageNumber);
+        const match = s.matches[next];
+        if (match) get().actions.goToPage(match.pageNumber);
       },
 
       setActiveMatchIndex(index: number) {
         const s = get().search;
-        if (index < -1 || index >= s.matches.length) return;
+        if (index < -1 || index >= s.matchCount) return;
         set({search: {...s, activeIndex: index}});
-        if (index >= 0) get().actions.goToPage(s.matches[index].pageNumber);
+        const match = index >= 0 ? s.matches[index] : undefined;
+        if (match) get().actions.goToPage(match.pageNumber);
       },
 
       clearSearch() {

--- a/frontend/pdf-viewer/primitives/Reader.tsx
+++ b/frontend/pdf-viewer/primitives/Reader.tsx
@@ -13,10 +13,10 @@
  * flash. When rendered outside a ViewerProvider (e.g. unit tests) the optional
  * store hook returns null and locating is simply inert.
  */
-import {useEffect, useRef, useState, type ReactNode} from 'react';
+import {memo, useEffect, useRef, useState, type ReactNode, type RefObject} from 'react';
 
 import {cn} from '@/lib/utils';
-import {useViewerStoreApiOptional} from '../core/context';
+import {useViewerStore, useViewerStoreApi, useViewerStoreApiOptional} from '../core/context';
 import {subscribeReaderLocate} from '../core/subscribeReaderLocate';
 import {MarkdownContent} from '../markdown/MarkdownContent';
 import {findBlockByIndex, findBlockForQuote} from './readerLocate';
@@ -26,6 +26,12 @@ import {
   locateQuoteRange,
   setCitationHighlight,
 } from './spanHighlight';
+import {
+  clearReaderSearchHighlights,
+  computeRevealScroll,
+  findReaderMatches,
+  setReaderSearchHighlights,
+} from './readerSearch';
 
 export interface ReaderTextBlock {
   id: string;
@@ -81,8 +87,16 @@ function cssEscape(value: string): string {
   return typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(value) : value;
 }
 
-/** Render one block's body, choosing markdown vs. plain de-emphasised text by type. */
-function BlockBody({block}: {block: ReaderTextBlock}) {
+/**
+ * Render one block's body, choosing markdown vs. plain de-emphasised text by type.
+ *
+ * `memo` is load-bearing, not just perf: search highlights are DOM Ranges over
+ * this rendered text, and any re-render rebuilds the markdown subtree (new text
+ * nodes) which silently detaches those Ranges. Memoising on the stable `block`
+ * keeps the DOM (and thus the highlights) intact across unrelated Reader
+ * re-renders — e.g. a citation flash toggling a sibling block's background.
+ */
+const BlockBody = memo(function BlockBody({block}: {block: ReaderTextBlock}) {
   const text = block.text;
   switch (block.blockType) {
     case 'header':
@@ -97,6 +111,198 @@ function BlockBody({block}: {block: ReaderTextBlock}) {
     default:
       return <MarkdownContent>{text}</MarkdownContent>;
   }
+});
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+/**
+ * Suppress the page-sync IntersectionObserver for ~500ms so a programmatic
+ * scroll (page nav OR find reveal) isn't mistaken for a user scroll — otherwise
+ * the observer writes currentPage, which triggers a competing section-scroll
+ * that fights the reveal (snapping to the page header instead of the match).
+ */
+function armScrollGuard(
+  flagRef: {current: boolean},
+  timerRef: {current: ReturnType<typeof setTimeout> | null},
+) {
+  flagRef.current = true;
+  if (timerRef.current) clearTimeout(timerRef.current);
+  timerRef.current = setTimeout(() => {
+    flagRef.current = false;
+    timerRef.current = null;
+  }, 500);
+}
+
+/**
+ * Reveal a match Range inside the reader's scroll container, centering the exact
+ * match (not its enclosing block — a long paragraph centered would still hide
+ * the hit). No-op when the match is already comfortably visible, so stepping
+ * through nearby matches (or typing) doesn't jangle the view. `onBeforeScroll`
+ * fires only when a scroll will actually happen (used to arm the scroll guard).
+ */
+function revealRange(scroller: Element | null, range: Range, onBeforeScroll?: () => void) {
+  if (!scroller || typeof range.getBoundingClientRect !== 'function') return;
+  const rRect = range.getBoundingClientRect();
+  // jsdom returns all-zero rects — nothing meaningful to scroll there.
+  if (rRect.top === 0 && rRect.height === 0 && rRect.width === 0) return;
+  const el = scroller as HTMLElement;
+  const {needsScroll, top} = computeRevealScroll({
+    rangeTop: rRect.top,
+    rangeHeight: rRect.height,
+    scrollerTop: el.getBoundingClientRect().top,
+    scrollTop: el.scrollTop,
+    clientHeight: el.clientHeight,
+  });
+  if (!needsScroll) return;
+  onBeforeScroll?.();
+  const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
+  if (typeof el.scrollTo === 'function') el.scrollTo({top, behavior});
+  else el.scrollTop = top;
+}
+
+/**
+ * ReaderInteractions — wires the shared toolbar controls to the reader DOM.
+ *
+ * Rendered only inside a ViewerProvider (Reader guards on the optional store),
+ * so it may use the non-optional store hooks. It supplies the behaviours the PDF
+ * engine gives canvas mode but that have no equivalent for the markdown reader:
+ *   - find-in-document over the rendered markdown (highlight + count + scroll)
+ *   - page nav: scroll to a page's reader section, and report the visible page
+ *     back as the user scrolls (mirrors <Viewer.Body>'s two-way sync)
+ * Renders nothing.
+ */
+function ReaderInteractions({
+  rootRef,
+  blocks,
+}: {
+  rootRef: RefObject<HTMLElement | null>;
+  blocks: readonly ReaderTextBlock[];
+}) {
+  const storeApi = useViewerStoreApi();
+  const mode = useViewerStore((s) => s.mode);
+  const query = useViewerStore((s) => s.search.query);
+  const caseSensitive = useViewerStore((s) => s.search.options.caseSensitive);
+  const wholeWords = useViewerStore((s) => s.search.options.wholeWords);
+  const activeIndex = useViewerStore((s) => s.search.activeIndex);
+  const currentPage = useViewerStore((s) => s.currentPage);
+
+  const rangesRef = useRef<Range[]>([]);
+  const isProgrammaticScrollRef = useRef(false);
+  const programmaticTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Find-in-document: recompute matches when the query, options, mode, or the
+  // rendered blocks change. Highlights live in the CSS Custom Highlight registry
+  // (no-op where unsupported); the count flows to the store so the shared search
+  // bar shows "n / N".
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    if (mode !== 'reader' || !query.trim()) {
+      rangesRef.current = [];
+      clearReaderSearchHighlights();
+      storeApi.getState().actions.setReaderMatchCount(0);
+      return;
+    }
+    // Debounce the DOM scan (mirrors the canvas search) so typing doesn't run a
+    // full TreeWalker + aria-live announcement on every keystroke.
+    const timer = setTimeout(() => {
+      const ranges = findReaderMatches(root, query, {caseSensitive, wholeWords});
+      rangesRef.current = ranges;
+      setReaderSearchHighlights(ranges, 0);
+      const prevActive = storeApi.getState().search.activeIndex;
+      storeApi.getState().actions.setReaderMatchCount(ranges.length); // sets activeIndex 0
+      // Reveal the first hit. When prevActive was already 0 the active effect
+      // won't re-fire (0 → 0), so reveal here; otherwise the active effect
+      // (prev → 0) owns the reveal and we skip to avoid a double scroll.
+      if (ranges.length > 0 && prevActive === 0) {
+        revealRange(root.closest('[data-reader-scroll]'), ranges[0], () =>
+          armScrollGuard(isProgrammaticScrollRef, programmaticTimerRef),
+        );
+      }
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [rootRef, mode, query, caseSensitive, wholeWords, blocks, storeApi]);
+
+  // Move the active highlight + reveal it as the user steps through matches
+  // (next/prev). Re-anchors first if a re-render detached the stored Ranges
+  // (defense-in-depth; React.memo on BlockBody prevents the common flash case).
+  useEffect(() => {
+    const root = rootRef.current;
+    let ranges = rangesRef.current;
+    if (root && ranges.length > 0 && !ranges[0].startContainer.isConnected) {
+      const {query: q, options} = storeApi.getState().search;
+      ranges = findReaderMatches(root, q, options);
+      rangesRef.current = ranges;
+    }
+    if (activeIndex < 0 || activeIndex >= ranges.length) return;
+    setReaderSearchHighlights(ranges, activeIndex);
+    revealRange(root?.closest('[data-reader-scroll]') ?? null, ranges[activeIndex], () =>
+      armScrollGuard(isProgrammaticScrollRef, programmaticTimerRef),
+    );
+  }, [activeIndex, rootRef, storeApi]);
+
+  // Page nav (programmatic): currentPage → scroll the matching reader section.
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const section = root.querySelector<HTMLElement>(`[data-reader-page="${currentPage}"]`);
+    if (!section || typeof section.scrollIntoView !== 'function') return;
+    armScrollGuard(isProgrammaticScrollRef, programmaticTimerRef);
+    section.scrollIntoView({block: 'start', behavior: prefersReducedMotion() ? 'auto' : 'smooth'});
+  }, [currentPage, rootRef]);
+
+  // Page nav (inverse): report the section closest to the top as currentPage.
+  useEffect(() => {
+    const root = rootRef.current;
+    const scroller = root?.closest('[data-reader-scroll]') ?? null;
+    if (!root || !scroller) return;
+    if (typeof IntersectionObserver === 'undefined') return; // jsdom / SSR safety
+
+    const visible = new Map<number, IntersectionObserverEntry>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const page = parseInt((entry.target as HTMLElement).dataset.readerPage ?? '', 10);
+          if (Number.isNaN(page)) continue;
+          if (entry.isIntersecting) visible.set(page, entry);
+          else visible.delete(page);
+        }
+        if (isProgrammaticScrollRef.current || visible.size === 0) return;
+        let best = -1;
+        let bestDistance = Infinity;
+        for (const [page, entry] of visible) {
+          const distance = Math.abs(entry.boundingClientRect.top);
+          if (distance < bestDistance) {
+            bestDistance = distance;
+            best = page;
+          }
+        }
+        if (best > 0 && best !== storeApi.getState().currentPage) {
+          storeApi.getState().actions.goToPage(best);
+        }
+      },
+      {root: scroller, threshold: [0, 0.1, 0.5, 1], rootMargin: '0px 0px -50% 0px'},
+    );
+    root.querySelectorAll<HTMLElement>('[data-reader-page]').forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [blocks, rootRef, storeApi]);
+
+  // Clear search highlights + count on unmount (mode switch / document switch).
+  useEffect(
+    () => () => {
+      clearReaderSearchHighlights();
+      storeApi.getState().actions.setReaderMatchCount(0);
+    },
+    [storeApi],
+  );
+
+  return null;
 }
 
 function Reader({blocks, emptyState, loading, loadingState, className}: ReaderProps) {
@@ -184,6 +390,7 @@ function Reader({blocks, emptyState, loading, loadingState, className}: ReaderPr
       data-pdf-viewer-reader=""
       className={cn('mx-auto max-w-2xl space-y-6 px-6 py-8', className)}
     >
+      {storeApi && <ReaderInteractions rootRef={rootRef} blocks={blocks} />}
       {pages.map((page) => {
         const items = (byPage.get(page) ?? []).sort(
           (a, b) => a.blockIndex - b.blockIndex,

--- a/frontend/pdf-viewer/primitives/__tests__/readerSearch.test.ts
+++ b/frontend/pdf-viewer/primitives/__tests__/readerSearch.test.ts
@@ -1,0 +1,198 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {
+  READER_SEARCH_ACTIVE_HIGHLIGHT,
+  READER_SEARCH_HIGHLIGHT,
+  clearReaderSearchHighlights,
+  computeRevealScroll,
+  findReaderMatches,
+  setReaderSearchHighlights,
+} from '../readerSearch';
+
+/** Build a reader-like root: an <article> with `[data-block-id]` blocks. */
+function reader(...blocksHtml: string[]): HTMLElement {
+  const root = document.createElement('article');
+  root.innerHTML = blocksHtml
+    .map((html, i) => `<div data-block-id="b${i}">${html}</div>`)
+    .join('');
+  document.body.appendChild(root);
+  return root;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+});
+
+describe('findReaderMatches', () => {
+  it('finds every occurrence across blocks in document order', () => {
+    const root = reader(
+      '<p>The tumor was small.</p>',
+      '<p>A second tumor appeared, then a third tumor.</p>',
+    );
+    const ranges = findReaderMatches(root, 'tumor', {
+      caseSensitive: false,
+      wholeWords: false,
+    });
+    expect(ranges).toHaveLength(3);
+    for (const r of ranges) {
+      expect(r.toString().toLowerCase()).toBe('tumor');
+    }
+  });
+
+  it('is case-insensitive by default', () => {
+    const root = reader('<p>Tumor TUMOR tumor</p>');
+    const ranges = findReaderMatches(root, 'tumor', {
+      caseSensitive: false,
+      wholeWords: false,
+    });
+    expect(ranges).toHaveLength(3);
+  });
+
+  it('respects the case-sensitive option', () => {
+    const root = reader('<p>Tumor TUMOR tumor</p>');
+    const ranges = findReaderMatches(root, 'tumor', {
+      caseSensitive: true,
+      wholeWords: false,
+    });
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0].toString()).toBe('tumor');
+  });
+
+  it('respects the whole-words option', () => {
+    const root = reader('<p>a tumor and a peritumoral region</p>');
+    const all = findReaderMatches(root, 'tumor', {
+      caseSensitive: false,
+      wholeWords: false,
+    });
+    expect(all).toHaveLength(2); // "tumor" + the "tumor" inside "peritumoral"
+    const wholeOnly = findReaderMatches(root, 'tumor', {
+      caseSensitive: false,
+      wholeWords: true,
+    });
+    expect(wholeOnly).toHaveLength(1);
+    expect(wholeOnly[0].toString()).toBe('tumor');
+  });
+
+  it('matches a phrase split across inline markup', () => {
+    const root = reader(
+      '<p>elevated <strong>tumor mutational</strong> burden overall</p>',
+    );
+    const ranges = findReaderMatches(root, 'tumor mutational burden', {
+      caseSensitive: false,
+      wholeWords: false,
+    });
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0].toString().toLowerCase()).toContain('mutational');
+  });
+
+  it('matches phrases regardless of collapsed whitespace', () => {
+    const root = reader('<p>were   FOLLOWED\n   for six months</p>');
+    const ranges = findReaderMatches(root, 'were followed for', {
+      caseSensitive: false,
+      wholeWords: false,
+    });
+    expect(ranges).toHaveLength(1);
+  });
+
+  it('returns [] for an empty or whitespace query', () => {
+    const root = reader('<p>some content here</p>');
+    expect(findReaderMatches(root, '', {caseSensitive: false, wholeWords: false})).toEqual([]);
+    expect(findReaderMatches(root, '   ', {caseSensitive: false, wholeWords: false})).toEqual([]);
+  });
+
+  it('ignores text outside [data-block-id] blocks (page-header chrome)', () => {
+    const root = document.createElement('article');
+    root.innerHTML =
+      '<header>Page 1</header><div data-block-id="b0"><p>body text</p></div>';
+    document.body.appendChild(root);
+    // "Page" lives only in the chrome header → no match.
+    expect(
+      findReaderMatches(root, 'Page', {caseSensitive: false, wholeWords: false}),
+    ).toHaveLength(0);
+    expect(
+      findReaderMatches(root, 'body', {caseSensitive: false, wholeWords: false}),
+    ).toHaveLength(1);
+  });
+
+  it('does not match a phrase that spans two separate blocks', () => {
+    const root = reader('<p>ends here</p>', '<p>here begins</p>');
+    expect(
+      findReaderMatches(root, 'here here', {caseSensitive: false, wholeWords: false}),
+    ).toHaveLength(0);
+  });
+});
+
+describe('computeRevealScroll', () => {
+  // Scroller viewport occupies client-y [100, 700] (top=100, clientHeight=600);
+  // comfortable band with margin 24 is [124, 676].
+  const base = {scrollerTop: 100, clientHeight: 600, scrollTop: 0, margin: 24};
+
+  it('does not scroll when the match is comfortably in view', () => {
+    const r = computeRevealScroll({...base, rangeTop: 300, rangeHeight: 20});
+    expect(r.needsScroll).toBe(false);
+  });
+
+  it('centers a match that is below the viewport', () => {
+    const r = computeRevealScroll({...base, rangeTop: 2000, rangeHeight: 20});
+    expect(r.needsScroll).toBe(true);
+    // scrollTop + (rangeTop - scrollerTop) - (clientHeight - rangeHeight)/2
+    expect(r.top).toBe(0 + (2000 - 100) - (600 - 20) / 2);
+  });
+
+  it('scrolls up for a match above the viewport', () => {
+    const r = computeRevealScroll({...base, scrollTop: 500, rangeTop: 110, rangeHeight: 20});
+    expect(r.needsScroll).toBe(true);
+    expect(r.top).toBe(500 + (110 - 100) - (600 - 20) / 2);
+  });
+
+  it('aligns to the top (not center) for a match taller than the viewport', () => {
+    const r = computeRevealScroll({...base, rangeTop: 1000, rangeHeight: 800});
+    expect(r.needsScroll).toBe(true);
+    expect(r.top).toBe(0 + (1000 - 100) - 24); // scrollTop + offset - margin
+  });
+
+  it('never returns a negative scroll target', () => {
+    const r = computeRevealScroll({...base, scrollTop: 0, rangeTop: 110, rangeHeight: 20});
+    expect(r.needsScroll).toBe(true);
+    expect(r.top).toBe(0); // clamped from a negative center target
+  });
+});
+
+describe('reader search highlight registry', () => {
+  it('is a no-op (no throw) when the Highlight API is unsupported', () => {
+    vi.stubGlobal('Highlight', undefined);
+    const root = reader('<p>alpha beta gamma</p>');
+    const ranges = findReaderMatches(root, 'beta', {caseSensitive: false, wholeWords: false});
+    expect(() => setReaderSearchHighlights(ranges, 0)).not.toThrow();
+    expect(() => clearReaderSearchHighlights()).not.toThrow();
+  });
+
+  it('registers all matches plus the active one when supported', () => {
+    const store = new Map<string, unknown>();
+    class FakeHighlight {
+      ranges: Range[];
+      constructor(...ranges: Range[]) {
+        this.ranges = ranges;
+      }
+    }
+    vi.stubGlobal('Highlight', FakeHighlight);
+    vi.stubGlobal('CSS', {...(globalThis.CSS ?? {}), highlights: store});
+
+    const root = reader('<p>alpha beta alpha</p>');
+    const ranges = findReaderMatches(root, 'alpha', {caseSensitive: false, wholeWords: false});
+    expect(ranges).toHaveLength(2);
+
+    setReaderSearchHighlights(ranges, 1);
+    expect(store.has(READER_SEARCH_HIGHLIGHT)).toBe(true);
+    expect(store.has(READER_SEARCH_ACTIVE_HIGHLIGHT)).toBe(true);
+    // The active registry holds exactly the active range.
+    expect((store.get(READER_SEARCH_ACTIVE_HIGHLIGHT) as FakeHighlight).ranges).toEqual([
+      ranges[1],
+    ]);
+
+    clearReaderSearchHighlights();
+    expect(store.has(READER_SEARCH_HIGHLIGHT)).toBe(false);
+    expect(store.has(READER_SEARCH_ACTIVE_HIGHLIGHT)).toBe(false);
+  });
+});

--- a/frontend/pdf-viewer/primitives/reader.css
+++ b/frontend/pdf-viewer/primitives/reader.css
@@ -1,14 +1,36 @@
 /* Precise citation-span highlight (CSS Custom Highlight API), layered over the
    block-flash. Semantic + dark-mode aware; degrades to nothing where the API is
-   unsupported (the block-flash remains). */
+   unsupported (the block-flash remains). Dark variants are scoped to the app's
+   class-based theme (`.dark` on <html>, see tailwind.config darkMode:'class'),
+   NOT prefers-color-scheme, so they track the in-app theme toggle. */
 ::highlight(citation-quote) {
   background-color: hsl(var(--primary) / 0.25);
   color: inherit;
   border-radius: 2px;
 }
 
-@media (prefers-color-scheme: dark) {
-  ::highlight(citation-quote) {
-    background-color: hsl(var(--primary) / 0.35);
-  }
+.dark ::highlight(citation-quote) {
+  background-color: hsl(var(--primary) / 0.35);
+}
+
+/* Find-in-document highlights for the reader (CSS Custom Highlight API).
+   `reader-search` paints every match; `reader-search-active` paints the current
+   one more strongly (registered with a higher priority so it wins on overlap).
+   Yellow/orange mirrors the canvas TextLayer search styling for consistency. */
+::highlight(reader-search) {
+  background-color: rgba(255, 222, 0, 0.4);
+  border-radius: 2px;
+}
+
+::highlight(reader-search-active) {
+  background-color: rgba(255, 153, 0, 0.6);
+  border-radius: 2px;
+}
+
+.dark ::highlight(reader-search) {
+  background-color: rgba(255, 213, 0, 0.5);
+}
+
+.dark ::highlight(reader-search-active) {
+  background-color: rgba(255, 145, 0, 0.78);
 }

--- a/frontend/pdf-viewer/primitives/readerSearch.ts
+++ b/frontend/pdf-viewer/primitives/readerSearch.ts
@@ -1,0 +1,199 @@
+/**
+ * Find-in-document for the reader (markdown) view.
+ *
+ * Sibling of `spanHighlight.ts`: both locate text in the RENDERED reader DOM
+ * (never via source char offsets — markdown is rendered, so on-screen text is
+ * split across many text nodes). They stay separate because the rules differ:
+ * citation locating strips markdown syntax, always lowercases, tolerates a
+ * trailing ellipsis and finds ONE block; find-in-document searches the visible
+ * text as-is (case per option, optional whole-word) and returns EVERY match.
+ *
+ * Matching is scoped to `[data-block-id]` blocks, so page-header chrome
+ * ("Page 1") is excluded and a phrase never matches across two blocks.
+ *
+ * The CSS Custom Highlight API is feature-detected (shared with spanHighlight);
+ * on unsupported browsers the highlight wrappers are safe no-ops.
+ */
+import {isHighlightApiSupported} from './spanHighlight';
+
+export const READER_SEARCH_HIGHLIGHT = 'reader-search';
+export const READER_SEARCH_ACTIVE_HIGHLIGHT = 'reader-search-active';
+
+export interface ReaderSearchOptions {
+  caseSensitive: boolean;
+  wholeWords: boolean;
+}
+
+interface SourcePos {
+  node: Text;
+  offset: number; // offset into node.textContent (original, un-normalized)
+}
+
+interface BlockIndex {
+  /** Visible text with whitespace collapsed + trimmed (lowercased unless case-sensitive). */
+  text: string;
+  /** positions[i] = source position of text[i]. */
+  positions: SourcePos[];
+}
+
+/** Collapse whitespace runs to single spaces, trim; lowercase unless case-sensitive. */
+function buildBlockIndex(block: Element, caseSensitive: boolean): BlockIndex {
+  const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
+  const positions: SourcePos[] = [];
+  let text = '';
+  let lastWasSpace = false;
+
+  let node: Node | null = walker.nextNode();
+  while (node !== null) {
+    const textNode = node as Text;
+    const raw = textNode.textContent ?? '';
+    for (let i = 0; i < raw.length; i++) {
+      const ch = raw[i];
+      if (/\s/.test(ch)) {
+        // Collapse runs; never emit a leading space (mirrors .trim()).
+        if (!lastWasSpace && text.length > 0) {
+          positions.push({node: textNode, offset: i});
+          text += ' ';
+          lastWasSpace = true;
+        }
+      } else {
+        positions.push({node: textNode, offset: i});
+        text += caseSensitive ? ch : ch.toLowerCase();
+        lastWasSpace = false;
+      }
+    }
+    node = walker.nextNode();
+  }
+
+  // Trim trailing collapsed space; keep positions aligned with the string.
+  const trimmed = text.trimEnd();
+  return {text: trimmed, positions: positions.slice(0, trimmed.length)};
+}
+
+const isWordChar = (ch: string | undefined): boolean => ch !== undefined && /\w/.test(ch);
+
+function isWholeWordMatch(haystack: string, start: number, end: number): boolean {
+  return !isWordChar(haystack[start - 1]) && !isWordChar(haystack[end]);
+}
+
+/**
+ * Every match of `query` in the rendered reader DOM, as DOM Ranges in document
+ * order. Returns [] for an empty/whitespace query or when nothing matches.
+ * Never throws.
+ */
+export function findReaderMatches(
+  root: Element,
+  query: string,
+  options: ReaderSearchOptions,
+): Range[] {
+  try {
+    const collapsed = query.trim().replace(/\s+/g, ' ');
+    if (!collapsed) return [];
+    const needle = options.caseSensitive ? collapsed : collapsed.toLowerCase();
+
+    const ranges: Range[] = [];
+    const blocks = root.querySelectorAll('[data-block-id]');
+
+    for (const block of blocks) {
+      const {text, positions} = buildBlockIndex(block, options.caseSensitive);
+      let from = 0;
+      while (from <= text.length) {
+        const idx = text.indexOf(needle, from);
+        if (idx === -1) break;
+        const end = idx + needle.length; // exclusive
+        if (!options.wholeWords || isWholeWordMatch(text, idx, end)) {
+          const startPos = positions[idx];
+          const endPos = positions[end - 1];
+          if (startPos && endPos) {
+            const range = document.createRange();
+            range.setStart(startPos.node, startPos.offset);
+            range.setEnd(endPos.node, endPos.offset + 1); // Range end is exclusive
+            ranges.push(range);
+          }
+          from = end; // non-overlapping
+        } else {
+          from = idx + 1; // a rejected substring may still precede a real word match
+        }
+      }
+    }
+
+    return ranges;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Register the search highlights: all non-active matches under `reader-search`
+ * and the active match (if any) under `reader-search-active` (painted on top via
+ * priority). No-op when the API is unsupported.
+ */
+export function setReaderSearchHighlights(ranges: Range[], activeIndex: number): void {
+  if (!isHighlightApiSupported()) return;
+  const highlights = (CSS as unknown as {highlights: Map<string, unknown>}).highlights;
+
+  if (ranges.length === 0) {
+    highlights.delete(READER_SEARCH_HIGHLIGHT);
+    highlights.delete(READER_SEARCH_ACTIVE_HIGHLIGHT);
+    return;
+  }
+
+  const HighlightCtor = Highlight as unknown as new (...ranges: Range[]) => {priority?: number};
+  const base = ranges.filter((_, i) => i !== activeIndex);
+  highlights.set(READER_SEARCH_HIGHLIGHT, new HighlightCtor(...base));
+
+  const active = activeIndex >= 0 && activeIndex < ranges.length ? ranges[activeIndex] : null;
+  if (active) {
+    const hl = new HighlightCtor(active);
+    hl.priority = 1;
+    highlights.set(READER_SEARCH_ACTIVE_HIGHLIGHT, hl);
+  } else {
+    highlights.delete(READER_SEARCH_ACTIVE_HIGHLIGHT);
+  }
+}
+
+export interface RevealScrollInput {
+  /** Match top in client/viewport coords (range.getBoundingClientRect().top). */
+  rangeTop: number;
+  rangeHeight: number;
+  /** Scroller viewport top in the same coords (scroller.getBoundingClientRect().top). */
+  scrollerTop: number;
+  /** Current scroll offset of the scroller. */
+  scrollTop: number;
+  /** Visible height of the scroller (scroller.clientHeight). */
+  clientHeight: number;
+  /** Comfort padding kept above/below the match. */
+  margin?: number;
+}
+
+/**
+ * Pure reveal geometry for the find-in-document scroll. Returns whether the
+ * match needs scrolling and, if so, the target `scrollTop` that brings it into
+ * comfortable view — centered, or top-aligned when the match is taller than the
+ * viewport. Editor behaviour: leave the view alone when the match is already
+ * visible (no jarring re-center on every keystroke/step).
+ */
+export function computeRevealScroll(input: RevealScrollInput): {needsScroll: boolean; top: number} {
+  const {rangeTop, rangeHeight, scrollerTop, scrollTop, clientHeight} = input;
+  const margin = input.margin ?? 24;
+
+  const offsetInViewport = rangeTop - scrollerTop; // 0 = match at the scroller's top edge
+  const visibleTop = margin;
+  const visibleBottom = clientHeight - margin;
+  const inView = offsetInViewport >= visibleTop && offsetInViewport + rangeHeight <= visibleBottom;
+  if (inView) return {needsScroll: false, top: scrollTop};
+
+  const tallerThanViewport = rangeHeight > clientHeight - margin * 2;
+  const target = tallerThanViewport
+    ? scrollTop + offsetInViewport - margin // align top
+    : scrollTop + offsetInViewport - (clientHeight - rangeHeight) / 2; // center
+  return {needsScroll: true, top: Math.max(0, target)};
+}
+
+/** Remove both search highlights. No-op when unsupported or absent. */
+export function clearReaderSearchHighlights(): void {
+  if (!isHighlightApiSupported()) return;
+  const highlights = (CSS as unknown as {highlights: Map<string, unknown>}).highlights;
+  highlights.delete(READER_SEARCH_HIGHLIGHT);
+  highlights.delete(READER_SEARCH_ACTIVE_HIGHLIGHT);
+}

--- a/frontend/pdf-viewer/ui/SearchBar.tsx
+++ b/frontend/pdf-viewer/ui/SearchBar.tsx
@@ -13,17 +13,24 @@ export interface SearchBarProps {
 export function SearchBar({open, onClose}: SearchBarProps) {
   const storeApi = useViewerStoreApi();
   const document = useViewerStore((s) => s.document);
+  const mode = useViewerStore((s) => s.mode);
   const search = useViewerStore((s) => s.search);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Focus input when opened.
+  // Focus input when opened, and select any carried-over query so it can be
+  // replaced by typing immediately (standard find-bar behaviour).
   useEffect(() => {
-    if (open) inputRef.current?.focus();
+    if (open) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
   }, [open]);
 
-  // Debounced search: fires 250ms after query or options change.
+  // Debounced PDF search: fires 250ms after query or options change. Canvas
+  // only — in reader mode the reader searches its own rendered markdown and
+  // reports its match count via `setReaderMatchCount`.
   useEffect(() => {
-    if (!open || !document) return;
+    if (!open || mode !== 'canvas' || !document) return;
     const query = search.query;
     const options = search.options;
     if (!query) {
@@ -55,14 +62,20 @@ export function SearchBar({open, onClose}: SearchBarProps) {
       clearTimeout(timer);
       ctrl.abort();
     };
-  }, [open, document, search.query, search.options, storeApi]);
+  }, [open, mode, document, search.query, search.options, storeApi]);
 
   if (!open) return null;
 
   const {actions} = storeApi.getState();
 
+  // Editor-grade match navigation from the input: Enter / F3 / Cmd|Ctrl+G go to
+  // the next match, with Shift for the previous. Esc closes.
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    const isNavKey =
+      e.key === 'Enter' ||
+      e.key === 'F3' ||
+      (e.key.toLowerCase() === 'g' && (e.metaKey || e.ctrlKey));
+    if (isNavKey) {
       e.preventDefault();
       if (e.shiftKey) actions.goToPrevMatch();
       else actions.goToNextMatch();
@@ -72,7 +85,17 @@ export function SearchBar({open, onClose}: SearchBarProps) {
     }
   };
 
-  const matchCount = search.matches.length;
+  // Keep focus in the input after a chevron click so Enter/F3 keep working.
+  const goPrev = () => {
+    actions.goToPrevMatch();
+    inputRef.current?.focus();
+  };
+  const goNext = () => {
+    actions.goToNextMatch();
+    inputRef.current?.focus();
+  };
+
+  const matchCount = search.matchCount;
   const positionLabel =
     matchCount === 0
       ? search.searching
@@ -98,7 +121,12 @@ export function SearchBar({open, onClose}: SearchBarProps) {
         className="h-8 w-full min-w-0 max-w-64 text-sm"
         aria-label="Search query"
       />
-      <span className="text-xs text-muted-foreground min-w-[68px] text-center">
+      <span
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="text-xs text-muted-foreground min-w-[68px] text-center"
+      >
         {positionLabel}
       </span>
       <Button
@@ -106,7 +134,7 @@ export function SearchBar({open, onClose}: SearchBarProps) {
         size="icon"
         className="h-8 w-8"
         disabled={matchCount === 0}
-        onClick={() => actions.goToPrevMatch()}
+        onClick={goPrev}
         aria-label="Previous match"
       >
         <ChevronUp className="h-4 w-4" />
@@ -116,7 +144,7 @@ export function SearchBar({open, onClose}: SearchBarProps) {
         size="icon"
         className="h-8 w-8"
         disabled={matchCount === 0}
-        onClick={() => actions.goToNextMatch()}
+        onClick={goNext}
         aria-label="Next match"
       >
         <ChevronDown className="h-4 w-4" />

--- a/frontend/pdf-viewer/ui/Toolbar.tsx
+++ b/frontend/pdf-viewer/ui/Toolbar.tsx
@@ -55,7 +55,9 @@ export function Toolbar({
         <NavigationControls />
       </div>
       <div className="flex min-w-0 items-center gap-3">
-        <ZoomControls />
+        {/* Zoom scales the PDF canvas; the reader is typography, not a page
+            surface, so there's nothing to zoom there — hide it in reader mode. */}
+        {!isReader && <ZoomControls />}
         {onSearchToggle && (
           <Button
             variant="ghost"

--- a/frontend/pdf-viewer/ui/__tests__/SearchBar.test.tsx
+++ b/frontend/pdf-viewer/ui/__tests__/SearchBar.test.tsx
@@ -1,0 +1,91 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import {SearchBar} from '../SearchBar';
+import {ViewerProvider} from '../../core/context';
+import {createViewerStore} from '../../core/store';
+import type {StoreApi} from 'zustand';
+import type {ViewerMode, ViewerState} from '../../core/state';
+
+function setup(mode: ViewerMode, configure?: (store: StoreApi<ViewerState>) => void) {
+  const store = createViewerStore({mode});
+  configure?.(store);
+  render(
+    <ViewerProvider store={store}>
+      <SearchBar open onClose={() => {}} />
+    </ViewerProvider>,
+  );
+  return store;
+}
+
+/** Seed a reader search with `count` matches starting at index 0. */
+function withMatches(count: number) {
+  return (store: StoreApi<ViewerState>) => {
+    store.getState().actions.setSearchQuery('tumor');
+    store.getState().actions.setReaderMatchCount(count);
+  };
+}
+
+describe('<SearchBar> count wiring', () => {
+  it('reflects the reader match count in its position label', () => {
+    setup('reader', (store) => {
+      store.getState().actions.setSearchQuery('tumor');
+      store.getState().actions.setReaderMatchCount(2);
+    });
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Next match')).toBeEnabled();
+    expect(screen.getByLabelText('Previous match')).toBeEnabled();
+  });
+
+  it('disables match navigation when there are no reader matches', () => {
+    setup('reader', (store) => {
+      store.getState().actions.setSearchQuery('zzz');
+      store.getState().actions.setReaderMatchCount(0);
+    });
+    expect(screen.getByText('No results')).toBeInTheDocument();
+    expect(screen.getByLabelText('Next match')).toBeDisabled();
+  });
+
+  it('announces the match count in a live region for screen readers', () => {
+    setup('reader', withMatches(9));
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('1 / 9');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+});
+
+describe('<SearchBar> editor-grade keyboard + focus', () => {
+  it('F3 goes to the next match, Shift+F3 to the previous', () => {
+    const store = setup('reader', withMatches(3));
+    const input = screen.getByLabelText('Search query');
+    fireEvent.keyDown(input, {key: 'F3'});
+    expect(store.getState().search.activeIndex).toBe(1);
+    fireEvent.keyDown(input, {key: 'F3', shiftKey: true});
+    expect(store.getState().search.activeIndex).toBe(0);
+  });
+
+  it('Cmd/Ctrl+G goes to the next match, with Shift to the previous', () => {
+    const store = setup('reader', withMatches(3));
+    const input = screen.getByLabelText('Search query');
+    fireEvent.keyDown(input, {key: 'g', metaKey: true});
+    expect(store.getState().search.activeIndex).toBe(1);
+    fireEvent.keyDown(input, {key: 'g', metaKey: true, shiftKey: true});
+    expect(store.getState().search.activeIndex).toBe(0);
+  });
+
+  it('returns focus to the input after clicking a navigation chevron', () => {
+    setup('reader', withMatches(3));
+    const input = screen.getByLabelText('Search query');
+    input.blur();
+    expect(document.activeElement).not.toBe(input);
+    fireEvent.click(screen.getByLabelText('Next match'));
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('selects existing query text when opened so it can be replaced immediately', () => {
+    setup('reader', withMatches(3));
+    const input = screen.getByLabelText('Search query') as HTMLInputElement;
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe('tumor'.length);
+  });
+});

--- a/frontend/pdf-viewer/ui/__tests__/Toolbar.test.tsx
+++ b/frontend/pdf-viewer/ui/__tests__/Toolbar.test.tsx
@@ -1,0 +1,36 @@
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import {Toolbar} from '../Toolbar';
+import {ViewerProvider} from '../../core/context';
+import {createViewerStore} from '../../core/store';
+import type {ViewerMode} from '../../core/state';
+
+function renderToolbar(mode: ViewerMode) {
+  const store = createViewerStore({mode, numPages: 9});
+  return render(
+    <ViewerProvider store={store}>
+      <Toolbar onSearchToggle={() => {}} />
+    </ViewerProvider>,
+  );
+}
+
+describe('<Toolbar> zoom visibility', () => {
+  it('shows zoom controls in canvas mode', () => {
+    renderToolbar('canvas');
+    expect(screen.getByLabelText('Zoom in')).toBeInTheDocument();
+    expect(screen.getByLabelText('Zoom out')).toBeInTheDocument();
+  });
+
+  it('hides zoom controls in reader mode (no page surface to scale)', () => {
+    renderToolbar('reader');
+    expect(screen.queryByLabelText('Zoom in')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Zoom out')).not.toBeInTheDocument();
+  });
+
+  it('keeps page navigation in both modes', () => {
+    renderToolbar('reader');
+    expect(screen.getByLabelText('Next page')).toBeInTheDocument();
+    expect(screen.getByLabelText('Previous page')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Promotes accumulated dev work to prod (merge commit, not squash):

- #430 fix(parsing): bound LlamaParse cloud call + PyMuPDF fallback so parses never hang at "pending"
- #428 feat(pdf-viewer): editor-grade find-in-document for the markdown reader

Preflight GREEN (with pre-existing Supabase advisor baseline only): Railway web /health 200, worker+Redis ready, Vercel Ready, 0 prod errors. Backend changes in #430 are migration-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)