### PR TITLE
chore(extraction): citation P3/P4 follow-ups + local-server ship-spec verify

### DIFF
--- a/.claude/commands/ship-spec.md
+++ b/.claude/commands/ship-spec.md
@@ -196,9 +196,28 @@ Evidence, not assertion:
 - `curl -fsS -o /dev/null -w "%{http_code}" https://web-production-48b398.up.railway.app/health` → expect 200.
 - Confirm `post-deploy-smoke` is green (health + frontend + CORS
   preflight from the prod origin).
-- Run the Playwright E2E smoke against the deployed flow for the feature
-  you shipped (`web-testing`), and a `/design-review` pass on the
-  user-facing surface if one changed.
+- Run the Playwright E2E smoke for the shipped feature (`web-testing`),
+  but serve the frontend on a **local server** instead of loading the
+  Vercel deployment in a browser. Keep the prod-targeting `remote-smoke`
+  project (it exercises the prod backend with the designated test account
+  and is non-destructive); only override its frontend origin to local:
+  1. `npm run dev` — serve the frontend on `http://127.0.0.1:8080` (built
+     from the promoted `main` commit, with the `VITE_*` env aimed at the
+     prod backend + Supabase).
+  2. `E2E_FRONTEND_URL=http://127.0.0.1:8080
+     E2E_API_URL=https://web-production-48b398.up.railway.app
+     npm run test:e2e:remote` — the browser loads the **local** frontend
+     while the auth/extraction assertions run against the prod backend, so
+     the deployed backend, DB, and data path are still verified end-to-end.
+
+  Do **not** point `E2E_FRONTEND_URL` at `https://prumoai.vercel.app`:
+  driving a browser against `*.vercel.app` is blocked by the org browser
+  policy, and the deployed frontend bundle's reachability is already
+  covered by `post-deploy-smoke` (step 2). Do **not** substitute
+  `npm run test:e2e:local` — those projects self-provision and hard-reset
+  fixtures, so against the prod backend they would mutate prod data.
+- Finish with a `/design-review` pass on the user-facing surface if one
+  changed.
 
 ## Phase 8 — Verdict
 

--- a/.github/cspell-words.txt
+++ b/.github/cspell-words.txt
@@ -139,6 +139,7 @@ unblinded
 unblinding
 unblinds
 ungated
+ungroundable
 univariable
 upserted
 upserts

--- a/backend/app/infrastructure/parsing/docling_parser.py
+++ b/backend/app/infrastructure/parsing/docling_parser.py
@@ -109,6 +109,38 @@ def docling_cell_fields(cell: object) -> _DoclingCellFields:
     }
 
 
+def picture_figure_block(
+    item: object,
+    *,
+    bbox: dict[str, float],
+    page_number: int,
+    block_index: int,
+) -> ParsedBlock | None:
+    """Figure-region block for a docling picture/image item, else ``None``.
+
+    Mirrors ``docling_cell_fields``: duck-typed (no docling import) so it stays
+    unit-testable without the heavy dependency. ``_LABEL_MAP`` is the single
+    source of truth for which labels are figures, and a docling ``PictureItem``
+    always carries the ``picture`` label, so label-based detection covers both
+    ``PictureItem`` instances and any picture/image-labeled item. Figures have
+    no text layer, so ``text=""`` — the entailment judge is bypassed and the UI
+    shows the "Verify manually" badge (same contract as PymupdfParser figure
+    regions).
+    """
+    label = getattr(getattr(item, "label", None), "value", "")
+    if _LABEL_MAP.get(label) != "figure":
+        return None
+    return ParsedBlock(
+        page_number=page_number,
+        block_index=block_index,
+        text="",
+        char_start=0,
+        char_end=0,
+        bbox=bbox,
+        block_type=normalize_block_type("figure"),
+    )
+
+
 class DoclingParser(DocumentParser):
     """Self-hosted layout parser. Implements the DocumentParser port."""
 
@@ -180,6 +212,20 @@ class DoclingParser(DocumentParser):
                             is_header=grid["is_header"],
                         )
                     )
+                continue
+
+            # Figures carry no text, so they must be emitted before the text
+            # guard below — otherwise real (text-less) docling pictures are
+            # silently dropped and never become anchorable figure regions.
+            figure = picture_figure_block(
+                item,
+                bbox=bbox,
+                page_number=page_no,
+                block_index=per_page_index.get(page_no, 0),
+            )
+            if figure is not None:
+                per_page_index[page_no] = figure.block_index + 1
+                blocks.append(figure)
                 continue
 
             text = getattr(item, "text", "").strip()

--- a/backend/app/infrastructure/parsing/pymupdf_parser.py
+++ b/backend/app/infrastructure/parsing/pymupdf_parser.py
@@ -275,7 +275,9 @@ class PymupdfParser(DocumentParser):
                         idx += 1
 
             if not blocks:
-                raise ValueError("PymupdfParser produced no text blocks")
+                # ``blocks`` here can hold figures / table cells with no text,
+                # so this is "no blocks at all", not "no text blocks".
+                raise ValueError("PymupdfParser produced no blocks")
             return assign_char_offsets_to_blocks(blocks)
         finally:
             doc.close()

--- a/backend/tests/unit/test_docling_figure_block.py
+++ b/backend/tests/unit/test_docling_figure_block.py
@@ -1,10 +1,16 @@
+import sys
+import types
 from types import SimpleNamespace
 
-from app.infrastructure.parsing.docling_parser import picture_figure_block
+from app.infrastructure.parsing import docling_parser
+from app.infrastructure.parsing.docling_parser import DoclingParser, picture_figure_block
 
 
 def _bbox() -> dict[str, float]:
     return {"x": 10.0, "y": 20.0, "width": 100.0, "height": 80.0}
+
+
+# --- picture_figure_block() helper (duck-typed, no docling) ----------------
 
 
 def test_picture_label_emits_text_less_figure_block():
@@ -36,3 +42,77 @@ def test_text_label_is_not_a_figure():
 def test_missing_label_is_not_a_figure():
     item = SimpleNamespace()  # no .label at all
     assert picture_figure_block(item, bbox=_bbox(), page_number=1, block_index=0) is None
+
+
+# --- DoclingParser.parse() figure emission (docling import mocked) ----------
+#
+# Drives parse() end-to-end without the heavy docling dependency by injecting a
+# minimal fake import surface + a fake converter. This covers the figure branch
+# inside parse() (the helper tests above only cover the helper in isolation).
+
+
+class _FakeTableItem:
+    """Stand-in TableItem class; the fake items below are never instances."""
+
+
+def _install_fake_docling(monkeypatch, items):
+    base_models = types.ModuleType("docling.datamodel.base_models")
+    base_models.InputFormat = SimpleNamespace(PDF="pdf")
+
+    class _FakeConverter:
+        def __init__(self, **_kwargs):
+            pass
+
+        def convert(self, _path):
+            document = SimpleNamespace(iterate_items=lambda: [(it, 0) for it in items])
+            return SimpleNamespace(document=document)
+
+    converter_mod = types.ModuleType("docling.document_converter")
+    converter_mod.DocumentConverter = _FakeConverter
+    converter_mod.PdfFormatOption = lambda **_kwargs: None
+
+    core_doc = types.ModuleType("docling_core.types.doc")
+    core_doc.TableItem = _FakeTableItem
+
+    monkeypatch.setitem(sys.modules, "docling.datamodel.base_models", base_models)
+    monkeypatch.setitem(sys.modules, "docling.document_converter", converter_mod)
+    monkeypatch.setitem(sys.modules, "docling_core.types.doc", core_doc)
+    # Skip the heavy accelerator/pipeline-options import chain.
+    monkeypatch.setattr(docling_parser, "_pdf_pipeline_options", lambda: None)
+
+
+def _item(label: str, *, page_no: int, bbox: tuple[float, float, float, float], text: str = ""):
+    left, top, right, bottom = bbox
+    bb = SimpleNamespace(l=left, t=top, r=right, b=bottom)
+    return SimpleNamespace(
+        prov=[SimpleNamespace(page_no=page_no, bbox=bb)],
+        label=SimpleNamespace(value=label),
+        text=text,
+    )
+
+
+def test_parse_emits_figure_region_for_picture_item(monkeypatch):
+    picture = _item("picture", page_no=1, bbox=(10.0, 200.0, 110.0, 120.0))
+    _install_fake_docling(monkeypatch, [picture])
+
+    blocks = DoclingParser().parse(b"%PDF-fake")
+
+    assert len(blocks) == 1
+    fig = blocks[0]
+    assert fig.block_type == "figure"
+    assert fig.text == ""
+    assert fig.page_number == 1
+    assert fig.block_index == 0
+    # bbox normalised to lower-left origin + positive extent
+    assert fig.bbox == {"x": 10.0, "y": 120.0, "width": 100.0, "height": 80.0}
+
+
+def test_parse_interleaves_figure_after_text_with_monotonic_index(monkeypatch):
+    text = _item("text", page_no=1, bbox=(0.0, 300.0, 50.0, 290.0), text="Intro paragraph.")
+    picture = _item("picture", page_no=1, bbox=(10.0, 200.0, 110.0, 120.0))
+    _install_fake_docling(monkeypatch, [text, picture])
+
+    blocks = DoclingParser().parse(b"%PDF-fake")
+
+    assert [b.block_type for b in blocks] == ["paragraph", "figure"]
+    assert [b.block_index for b in blocks] == [0, 1]

--- a/backend/tests/unit/test_docling_figure_block.py
+++ b/backend/tests/unit/test_docling_figure_block.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from app.infrastructure.parsing.docling_parser import picture_figure_block
+
+
+def _bbox() -> dict[str, float]:
+    return {"x": 10.0, "y": 20.0, "width": 100.0, "height": 80.0}
+
+
+def test_picture_label_emits_text_less_figure_block():
+    item = SimpleNamespace(label=SimpleNamespace(value="picture"))
+    block = picture_figure_block(item, bbox=_bbox(), page_number=3, block_index=5)
+    assert block is not None
+    assert block.block_type == "figure"
+    assert block.text == ""
+    assert block.page_number == 3
+    assert block.block_index == 5
+    assert block.bbox == _bbox()
+    # figure regions carry no native cell-grid
+    assert block.row_index is None and block.col_index is None
+
+
+def test_image_label_emits_figure_block():
+    item = SimpleNamespace(label=SimpleNamespace(value="image"))
+    block = picture_figure_block(item, bbox=_bbox(), page_number=1, block_index=0)
+    assert block is not None
+    assert block.block_type == "figure"
+    assert block.text == ""
+
+
+def test_text_label_is_not_a_figure():
+    item = SimpleNamespace(label=SimpleNamespace(value="text"))
+    assert picture_figure_block(item, bbox=_bbox(), page_number=1, block_index=0) is None
+
+
+def test_missing_label_is_not_a_figure():
+    item = SimpleNamespace()  # no .label at all
+    assert picture_figure_block(item, bbox=_bbox(), page_number=1, block_index=0) is None

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,12 @@
 ---
 status: stable
-last_reviewed: 2026-06-20
+last_reviewed: 2026-06-29
 owner: '@raphaelfh'
 ---
 
 # Roadmap
 
-> **Status:** Stable · Last reviewed: 2026-06-20 · Owner: @raphaelfh
+> **Status:** Stable · Last reviewed: 2026-06-29 · Owner: @raphaelfh
 
 The day-to-day roadmap with status, priority, owner, and target dates lives
 on the GitHub Project:
@@ -25,6 +25,7 @@ This file records only the **top-level milestones** (one bullet each) — the
 
 ## Recently shipped (2026-Q2)
 
+- ✅ Table-cell + figure citations — native fitz table-cell grid with cell-scoped entailment (migration `0036`); `figure` region blocks + a "Verify manually" badge for ungroundable values (migration `0037`); P3/P4 of the grounded-extraction citation work (2026-06-29).
 - ✅ Stored-markdown ingestion + deterministic citation highlight — `content_markdown` written atomically with blocks (migration `0033`); PyMuPDF free default; highlight anchored by `(page, block_index)`; `pypdf` path removed (2026-06-24).
 - ✅ Extraction data-path consolidation — single API read path (ADR 0007); shipped via #228/#324 (2026-06).
 - ✅ Extraction-centric HITL unification (2026-04-27).

--- a/frontend/components/extraction/ai/__tests__/AISuggestionEvidence.ungroundable.test.tsx
+++ b/frontend/components/extraction/ai/__tests__/AISuggestionEvidence.ungroundable.test.tsx
@@ -19,4 +19,12 @@ describe('AISuggestionEvidence ungroundable', () => {
     render(<AISuggestionEvidence evidence={ev} />, {wrapper: Wrapper});
     expect(screen.getByText(/verify manually/i)).toBeInTheDocument();
   });
+
+  it('applies the cautionary amber treatment to the ungroundable badge', () => {
+    render(<AISuggestionEvidence evidence={ev} />, {wrapper: Wrapper});
+    // The badge must keep its amber (caution) styling — a regression that
+    // drops it to a neutral/entailed look should fail here, not just slip
+    // past the copy assertion above.
+    expect(screen.getByText(/verify manually/i).className).toMatch(/amber/);
+  });
 });


### PR DESCRIPTION
## What

Wrap-up follow-ups after shipping citation provenance **P3 (table cells)** and **P4 (figures)** to prod (#434). Three small, low-risk groups in one PR.

### Part B — code follow-ups
- **`parsing(docling)`** — emit `figure` region blocks for picture/image items **before** the text guard. The old `if not text: continue` silently dropped real (text-less) docling figures, so the `picture`/`image` → `figure` map only ever fired for the rare text-bearing picture. New duck-typed helper `picture_figure_block()` driven by `_LABEL_MAP` (single source of truth, no docling import — mirrors `docling_cell_fields`), plus unit tests with `SimpleNamespace` fakes. Default parser is PyMuPDF (already covers figures); Docling is an opt-in tier, so impact is low.
- **`parsing(pymupdf)`** — reword the **second** empty-doc guard to `"PymupdfParser produced no blocks"`. At that point `blocks` can hold figures / table cells with no text, so "no text blocks" was misleading. Condition unchanged (cosmetic); the first guard is intentionally left as-is.
- **`test(ai)`** — strengthen the ungroundable test to assert the badge keeps its **amber** caution styling, so dropping it is caught (not just the "Verify manually" copy).

### Part C — housekeeping
- **`docs(roadmap)`** — mark table-cell + figure citations (migrations `0036`/`0037`) shipped to prod 2026-06-29; bump `last_reviewed`. The grounded-extraction milestone stays open (vision figure-content extraction is still deferred by design).
- Add `ungroundable` to the cspell dictionary (real domain term — the literal `attributionLabel` value).

### Tooling (carried from the prior approved change)
- **`ship-spec`** — Phase 7 now verifies prod via a **local** frontend server (pointed at the prod backend) instead of loading `*.vercel.app` in a browser, which the org browser policy blocks. Keeps the non-destructive `remote-smoke` project; explicitly rejects `test:e2e:local` (it would mutate prod data).

## Why
No schema/migration change — the `figure` block_type already exists from migration `0037`. These are correctness + clarity follow-ups, not new behavior on the hot path.

## Verification (local, all green)
- Backend: `ruff check` + `format --check` clean; parser unit tests `18 passed` (4 new figure-block + 14 baseline pymupdf/docling). Docling **integration** test is invariant-based and stays green (figures satisfy `block_type ∈ BLOCK_TYPES`, monotonic index, and the empty-text offset invariant `char_start == char_end`).
- Frontend: `vitest` `20 passed`, `typecheck` exit 0, `eslint` clean.
- Docs-ci gates: `markdownlint`, `cspell`, frontmatter check all pass.

## Out of scope (deferred by design — gated behind the §4.11 eval harness)
The eval harness (TEDS + LLM-judge + bbox IoU + ALCE), pymupdf4llm-as-default, HTML/cell-KV prompt serialization, vision figure-content extraction, and LlamaParse live-billing validation are intentionally **not** here.
