### PR TITLE
Promote dev to main

### DIFF
--- a/.claude/commands/ship-spec.md
+++ b/.claude/commands/ship-spec.md
@@ -196,9 +196,28 @@ Evidence, not assertion:
 - `curl -fsS -o /dev/null -w "%{http_code}" https://web-production-48b398.up.railway.app/health` → expect 200.
 - Confirm `post-deploy-smoke` is green (health + frontend + CORS
   preflight from the prod origin).
-- Run the Playwright E2E smoke against the deployed flow for the feature
-  you shipped (`web-testing`), and a `/design-review` pass on the
-  user-facing surface if one changed.
+- Run the Playwright E2E smoke for the shipped feature (`web-testing`),
+  but serve the frontend on a **local server** instead of loading the
+  Vercel deployment in a browser. Keep the prod-targeting `remote-smoke`
+  project (it exercises the prod backend with the designated test account
+  and is non-destructive); only override its frontend origin to local:
+  1. `npm run dev` — serve the frontend on `http://127.0.0.1:8080` (built
+     from the promoted `main` commit, with the `VITE_*` env aimed at the
+     prod backend + Supabase).
+  2. `E2E_FRONTEND_URL=http://127.0.0.1:8080
+     E2E_API_URL=https://web-production-48b398.up.railway.app
+     npm run test:e2e:remote` — the browser loads the **local** frontend
+     while the auth/extraction assertions run against the prod backend, so
+     the deployed backend, DB, and data path are still verified end-to-end.
+
+  Do **not** point `E2E_FRONTEND_URL` at `https://prumoai.vercel.app`:
+  driving a browser against `*.vercel.app` is blocked by the org browser
+  policy, and the deployed frontend bundle's reachability is already
+  covered by `post-deploy-smoke` (step 2). Do **not** substitute
+  `npm run test:e2e:local` — those projects self-provision and hard-reset
+  fixtures, so against the prod backend they would mutate prod data.
+- Finish with a `/design-review` pass on the user-facing surface if one
+  changed.
 
 ## Phase 8 — Verdict
 

--- a/.github/cspell-words.txt
+++ b/.github/cspell-words.txt
@@ -139,6 +139,7 @@ unblinded
 unblinding
 unblinds
 ungated
+ungroundable
 univariable
 upserted
 upserts

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -30,6 +30,7 @@ docs/superpowers/plans/2026-06-27-citation-p2-span-highlight.md
 docs/superpowers/plans/2026-06-28-qa-extraction-shared-shell.md
 docs/superpowers/plans/2026-06-28-citation-p3-table-cells.md
 docs/superpowers/plans/2026-06-28-citation-p4-figures.md
+docs/superpowers/plans/2026-06-29-ai-extraction-popup-ux.md
 
 # Design specs — likewise snapshots
 docs/superpowers/specs/2026-*-design.md

--- a/backend/app/infrastructure/parsing/docling_parser.py
+++ b/backend/app/infrastructure/parsing/docling_parser.py
@@ -109,6 +109,38 @@ def docling_cell_fields(cell: object) -> _DoclingCellFields:
     }
 
 
+def picture_figure_block(
+    item: object,
+    *,
+    bbox: dict[str, float],
+    page_number: int,
+    block_index: int,
+) -> ParsedBlock | None:
+    """Figure-region block for a docling picture/image item, else ``None``.
+
+    Mirrors ``docling_cell_fields``: duck-typed (no docling import) so it stays
+    unit-testable without the heavy dependency. ``_LABEL_MAP`` is the single
+    source of truth for which labels are figures, and a docling ``PictureItem``
+    always carries the ``picture`` label, so label-based detection covers both
+    ``PictureItem`` instances and any picture/image-labeled item. Figures have
+    no text layer, so ``text=""`` — the entailment judge is bypassed and the UI
+    shows the "Verify manually" badge (same contract as PymupdfParser figure
+    regions).
+    """
+    label = getattr(getattr(item, "label", None), "value", "")
+    if _LABEL_MAP.get(label) != "figure":
+        return None
+    return ParsedBlock(
+        page_number=page_number,
+        block_index=block_index,
+        text="",
+        char_start=0,
+        char_end=0,
+        bbox=bbox,
+        block_type=normalize_block_type("figure"),
+    )
+
+
 class DoclingParser(DocumentParser):
     """Self-hosted layout parser. Implements the DocumentParser port."""
 
@@ -180,6 +212,20 @@ class DoclingParser(DocumentParser):
                             is_header=grid["is_header"],
                         )
                     )
+                continue
+
+            # Figures carry no text, so they must be emitted before the text
+            # guard below — otherwise real (text-less) docling pictures are
+            # silently dropped and never become anchorable figure regions.
+            figure = picture_figure_block(
+                item,
+                bbox=bbox,
+                page_number=page_no,
+                block_index=per_page_index.get(page_no, 0),
+            )
+            if figure is not None:
+                per_page_index[page_no] = figure.block_index + 1
+                blocks.append(figure)
                 continue
 
             text = getattr(item, "text", "").strip()

--- a/backend/app/infrastructure/parsing/pymupdf_parser.py
+++ b/backend/app/infrastructure/parsing/pymupdf_parser.py
@@ -275,7 +275,9 @@ class PymupdfParser(DocumentParser):
                         idx += 1
 
             if not blocks:
-                raise ValueError("PymupdfParser produced no text blocks")
+                # ``blocks`` here can hold figures / table cells with no text,
+                # so this is "no blocks at all", not "no text blocks".
+                raise ValueError("PymupdfParser produced no blocks")
             return assign_char_offsets_to_blocks(blocks)
         finally:
             doc.close()

--- a/backend/tests/unit/test_docling_figure_block.py
+++ b/backend/tests/unit/test_docling_figure_block.py
@@ -1,0 +1,118 @@
+import sys
+import types
+from types import SimpleNamespace
+
+from app.infrastructure.parsing import docling_parser
+from app.infrastructure.parsing.docling_parser import DoclingParser, picture_figure_block
+
+
+def _bbox() -> dict[str, float]:
+    return {"x": 10.0, "y": 20.0, "width": 100.0, "height": 80.0}
+
+
+# --- picture_figure_block() helper (duck-typed, no docling) ----------------
+
+
+def test_picture_label_emits_text_less_figure_block():
+    item = SimpleNamespace(label=SimpleNamespace(value="picture"))
+    block = picture_figure_block(item, bbox=_bbox(), page_number=3, block_index=5)
+    assert block is not None
+    assert block.block_type == "figure"
+    assert block.text == ""
+    assert block.page_number == 3
+    assert block.block_index == 5
+    assert block.bbox == _bbox()
+    # figure regions carry no native cell-grid
+    assert block.row_index is None and block.col_index is None
+
+
+def test_image_label_emits_figure_block():
+    item = SimpleNamespace(label=SimpleNamespace(value="image"))
+    block = picture_figure_block(item, bbox=_bbox(), page_number=1, block_index=0)
+    assert block is not None
+    assert block.block_type == "figure"
+    assert block.text == ""
+
+
+def test_text_label_is_not_a_figure():
+    item = SimpleNamespace(label=SimpleNamespace(value="text"))
+    assert picture_figure_block(item, bbox=_bbox(), page_number=1, block_index=0) is None
+
+
+def test_missing_label_is_not_a_figure():
+    item = SimpleNamespace()  # no .label at all
+    assert picture_figure_block(item, bbox=_bbox(), page_number=1, block_index=0) is None
+
+
+# --- DoclingParser.parse() figure emission (docling import mocked) ----------
+#
+# Drives parse() end-to-end without the heavy docling dependency by injecting a
+# minimal fake import surface + a fake converter. This covers the figure branch
+# inside parse() (the helper tests above only cover the helper in isolation).
+
+
+class _FakeTableItem:
+    """Stand-in TableItem class; the fake items below are never instances."""
+
+
+def _install_fake_docling(monkeypatch, items):
+    base_models = types.ModuleType("docling.datamodel.base_models")
+    base_models.InputFormat = SimpleNamespace(PDF="pdf")
+
+    class _FakeConverter:
+        def __init__(self, **_kwargs):
+            pass
+
+        def convert(self, _path):
+            document = SimpleNamespace(iterate_items=lambda: [(it, 0) for it in items])
+            return SimpleNamespace(document=document)
+
+    converter_mod = types.ModuleType("docling.document_converter")
+    converter_mod.DocumentConverter = _FakeConverter
+    converter_mod.PdfFormatOption = lambda **_kwargs: None
+
+    core_doc = types.ModuleType("docling_core.types.doc")
+    core_doc.TableItem = _FakeTableItem
+
+    monkeypatch.setitem(sys.modules, "docling.datamodel.base_models", base_models)
+    monkeypatch.setitem(sys.modules, "docling.document_converter", converter_mod)
+    monkeypatch.setitem(sys.modules, "docling_core.types.doc", core_doc)
+    # Skip the heavy accelerator/pipeline-options import chain.
+    monkeypatch.setattr(docling_parser, "_pdf_pipeline_options", lambda: None)
+
+
+def _item(label: str, *, page_no: int, bbox: tuple[float, float, float, float], text: str = ""):
+    left, top, right, bottom = bbox
+    bb = SimpleNamespace(l=left, t=top, r=right, b=bottom)
+    return SimpleNamespace(
+        prov=[SimpleNamespace(page_no=page_no, bbox=bb)],
+        label=SimpleNamespace(value=label),
+        text=text,
+    )
+
+
+def test_parse_emits_figure_region_for_picture_item(monkeypatch):
+    picture = _item("picture", page_no=1, bbox=(10.0, 200.0, 110.0, 120.0))
+    _install_fake_docling(monkeypatch, [picture])
+
+    blocks = DoclingParser().parse(b"%PDF-fake")
+
+    assert len(blocks) == 1
+    fig = blocks[0]
+    assert fig.block_type == "figure"
+    assert fig.text == ""
+    assert fig.page_number == 1
+    assert fig.block_index == 0
+    # bbox normalised to lower-left origin + positive extent
+    assert fig.bbox == {"x": 10.0, "y": 120.0, "width": 100.0, "height": 80.0}
+
+
+def test_parse_interleaves_figure_after_text_with_monotonic_index(monkeypatch):
+    text = _item("text", page_no=1, bbox=(0.0, 300.0, 50.0, 290.0), text="Intro paragraph.")
+    picture = _item("picture", page_no=1, bbox=(10.0, 200.0, 110.0, 120.0))
+    _install_fake_docling(monkeypatch, [text, picture])
+
+    blocks = DoclingParser().parse(b"%PDF-fake")
+
+    assert [b.block_type for b in blocks] == ["paragraph", "figure"]
+    assert [b.block_index for b in blocks] == [0, 1]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,12 @@
 ---
 status: stable
-last_reviewed: 2026-06-20
+last_reviewed: 2026-06-29
 owner: '@raphaelfh'
 ---
 
 # Roadmap
 
-> **Status:** Stable · Last reviewed: 2026-06-20 · Owner: @raphaelfh
+> **Status:** Stable · Last reviewed: 2026-06-29 · Owner: @raphaelfh
 
 The day-to-day roadmap with status, priority, owner, and target dates lives
 on the GitHub Project:
@@ -25,6 +25,7 @@ This file records only the **top-level milestones** (one bullet each) — the
 
 ## Recently shipped (2026-Q2)
 
+- ✅ Table-cell + figure citations — native fitz table-cell grid with cell-scoped entailment (migration `0036`); `figure` region blocks + a "Verify manually" badge for ungroundable values (migration `0037`); P3/P4 of the grounded-extraction citation work (2026-06-29).
 - ✅ Stored-markdown ingestion + deterministic citation highlight — `content_markdown` written atomically with blocks (migration `0033`); PyMuPDF free default; highlight anchored by `(page, block_index)`; `pypdf` path removed (2026-06-24).
 - ✅ Extraction data-path consolidation — single API read path (ADR 0007); shipped via #228/#324 (2026-06).
 - ✅ Extraction-centric HITL unification (2026-04-27).

--- a/docs/superpowers/plans/2026-06-29-ai-extraction-popup-ux.md
+++ b/docs/superpowers/plans/2026-06-29-ai-extraction-popup-ux.md
@@ -1,0 +1,497 @@
+---
+status: draft
+last_reviewed: 2026-06-29
+owner: '@raphaelfh'
+---
+
+# AI-extraction popup UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the two AI-suggestion popups (details + history, shared by Extraction and QA) opaque/readable, responsive, with an easy "click-the-passage" locate, and fix the broken history popover.
+
+**Architecture:** Frontend-only. (1) Make all floating Radix surfaces (popover, dropdown) solid instead of frosted. (2) Add a thin shared `AIPopoverShell` for consistent header + sizing. (3) Details popover: solid evidence block + the cited passage becomes the locate target (keeps the popup open, marks the citation active). (4) History popover: real run identity, no truncation, no debug logs, content-aware height.
+
+**Tech Stack:** React 19 + TS strict, Radix popover/dropdown, Tailwind v3 + shadcn, Vitest + Testing Library. Copy via `frontend/lib/copy/`.
+
+## Global Constraints
+
+- English only for code, comments, copy keys (CLAUDE.md hard rule).
+- All user-facing text through `frontend/lib/copy/` — never hardcode strings.
+- Data path unchanged (no service/hook/network changes). No backend, schema, migration.
+- React Compiler `panicThreshold: all_errors`: no `try/finally` / `throw` in component/hook bodies.
+- Tests run from repo root: `npm run test:run` (never `npm test` — watch mode hangs).
+- **Unit-test copy convention:** the existing tests `vi.mock('@/lib/copy', () => ({ t: (_ns, key) => key }))` — so `t('extraction','X')` renders the **key** `X`, not the English string. New/updated tests MUST follow this and assert on the **key**, not English copy.
+- **Locate hook mock:** mock `@/hooks/extraction/useReaderLocate` (its real path) as the existing details test does — NOT `@/pdf-viewer/core`. (`@/pdf-viewer/core` exports `ViewerProvider`, not the hook; its import chain is jsdom-safe if a test ever needs the real store, but mocking the hook is simpler and is the established pattern.)
+- `cn()` merge order matters; every interactive element keeps a visible focus state.
+
+---
+
+### Task 1: Solid floating surfaces (popover + dropdown)
+
+**Files:**
+- Modify: `frontend/components/ui/popover.tsx:21`
+- Modify: `frontend/components/ui/dropdown-menu.tsx:65`
+- Modify: `frontend/index.css:220-240` (remove `.frosted-overlay` def + its two fallback rules; keep `.frosted-header`)
+- Modify (test): `frontend/components/ui/overlay-frosted.test.tsx`
+
+**Interfaces:**
+- Produces: `PopoverContent` / `DropdownMenuContent` render an opaque `bg-popover` surface (no `frosted-overlay`, no `backdrop-filter`).
+
+- [ ] **Step 1: Rewrite the surface test to assert solid, not frosted**
+
+Replace `frontend/components/ui/overlay-frosted.test.tsx` body:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './dropdown-menu';
+
+describe('floating overlays', () => {
+  it('renders dropdown content with a solid surface and viewport clamp', () => {
+    render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    const content = screen.getByText('item').closest('[role="menu"]')!;
+    expect(content.className).toContain('bg-popover');
+    expect(content.className).not.toContain('frosted-overlay');
+    expect(content.className).toContain('shadow-elev-header');
+    expect(content.className).toContain('max-w-[calc(100vw-1rem)]');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it FAILS**
+
+Run: `npm run test:run -- overlay-frosted`
+Expected: FAIL — content still contains `frosted-overlay`.
+
+- [ ] **Step 3: Make popover + dropdown solid**
+
+In `popover.tsx:21` replace the token `frosted-overlay` with `bg-popover` (leave every other class). In `dropdown-menu.tsx:65` replace `frosted-overlay` with `bg-popover`.
+
+- [ ] **Step 4: Remove the now-unused frosted-overlay CSS (precise)**
+
+In `frontend/index.css`:
+- Delete the comment + block at lines ~220-225 (`/* Frosted floating overlay ... */` and `.frosted-overlay { ... }`).
+- In the `@supports not (...)` block, delete only the line `.frosted-overlay { background-color: hsl(var(--popover)); }` (keep `.frosted-header { ... }`).
+- In the `@media (prefers-reduced-transparency: reduce)` block, **split the grouped selector**: change `.frosted-header, .frosted-overlay {` to just `.frosted-header {` (keep its body), and delete the trailing `.frosted-overlay { background-color: hsl(var(--popover)); }` line.
+
+Then verify nothing references it:
+
+Run: `grep -rn "frosted-overlay" frontend/`
+Expected: no matches. Also confirm `.frosted-header` survived: `grep -rn "frosted-header" frontend/index.css` → expect 3 matches.
+
+- [ ] **Step 5: Run the test, verify it PASSES**
+
+Run: `npm run test:run -- overlay-frosted`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/ui/popover.tsx frontend/components/ui/dropdown-menu.tsx frontend/index.css frontend/components/ui/overlay-frosted.test.tsx
+git commit -m "fix(ui): make floating popover/dropdown surfaces solid (no frosted transparency)"
+```
+
+---
+
+### Task 2: Shared AIPopoverShell
+
+**Files:**
+- Create: `frontend/components/extraction/ai/shared/AIPopoverShell.tsx`
+- Test: `frontend/components/extraction/ai/shared/AIPopoverShell.test.tsx`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  interface AIPopoverShellProps {
+    icon: React.ReactNode;        // leading header icon (Sparkles / Clock)
+    title: string;
+    count?: string;               // optional subtitle/count line under title
+    align?: 'start' | 'center' | 'end';  // default 'start'
+    className?: string;           // extra classes for PopoverContent
+    children: React.ReactNode;    // body (caller owns inner padding)
+  }
+  ```
+  Renders a `PopoverContent` with `w-[min(380px,calc(100vw-1.5rem))] overflow-hidden p-0`, a `border-b` header (icon + title + optional count), and a scrollable body region `max-h-[min(70vh,32rem)] overflow-y-auto`. Caller wraps it in `<Popover>` + `<PopoverTrigger>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Popover, PopoverTrigger } from '@/components/ui/popover';
+import { AIPopoverShell } from './AIPopoverShell';
+
+describe('AIPopoverShell', () => {
+  it('renders a solid, responsive shell with header + body', () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>open</PopoverTrigger>
+        <AIPopoverShell icon={<span>i</span>} title="Suggestion details" count="3 found">
+          <p>body content</p>
+        </AIPopoverShell>
+      </Popover>,
+    );
+    const popover = document.querySelector('.bg-popover') as HTMLElement;
+    expect(popover).not.toBeNull();
+    expect(popover.className).toContain('w-[min(380px,calc(100vw-1.5rem))]');
+    expect(popover.textContent).toContain('Suggestion details');
+    expect(popover.textContent).toContain('3 found');
+    expect(popover.textContent).toContain('body content');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it FAILS**
+
+Run: `npm run test:run -- AIPopoverShell`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement AIPopoverShell**
+
+```tsx
+/**
+ * Shared shell for the AI-suggestion popovers (details + history).
+ * Owns the solid surface, consistent header, responsive width, and a single
+ * scrollable body region so the two popovers don't drift on chrome.
+ */
+import {PopoverContent} from '@/components/ui/popover';
+
+interface AIPopoverShellProps {
+  icon: React.ReactNode;
+  title: string;
+  count?: string;
+  align?: 'start' | 'center' | 'end';
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function AIPopoverShell({
+  icon,
+  title,
+  count,
+  align = 'start',
+  className,
+  children,
+}: AIPopoverShellProps) {
+  return (
+    <PopoverContent
+      align={align}
+      side="bottom"
+      className={`w-[min(380px,calc(100vw-1.5rem))] overflow-hidden p-0 ${className ?? ''}`}
+    >
+      <div className="flex items-center gap-2 border-b px-4 py-3">
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-ai">
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold">{title}</div>
+          {count != null && (
+            <div className="text-xs text-muted-foreground">{count}</div>
+          )}
+        </div>
+      </div>
+      <div className="max-h-[min(70vh,32rem)] overflow-y-auto">{children}</div>
+    </PopoverContent>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test, verify it PASSES**
+
+Run: `npm run test:run -- AIPopoverShell`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/extraction/ai/shared/AIPopoverShell.tsx frontend/components/extraction/ai/shared/AIPopoverShell.test.tsx
+git commit -m "feat(extraction): shared AIPopoverShell (solid, responsive, consistent header)"
+```
+
+---
+
+### Task 3: Details popover — solid evidence + click-the-passage locate (option A)
+
+**Files:**
+- Modify: `frontend/components/extraction/ai/AISuggestionEvidence.tsx`
+- Modify: `frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx`
+- Modify: `frontend/lib/copy/extraction.ts`
+- Modify (existing): `frontend/components/extraction/ai/AISuggestionEvidence.test.tsx`
+- Modify (existing): `frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx`
+
+**Interfaces:**
+- Consumes: `AIPopoverShell` (Task 2).
+- Produces: `AISuggestionEvidence` accepts `activeRank?: number | null`; when `onLocate` is provided the cited passage is a `button` (aria-label `evidenceLocate`, or `evidenceLocatedInReader` when active) carrying `data-active-citation` + a ring when active. `AISuggestionDetailsPopover` no longer closes on locate; it tracks `activeRank`.
+
+**Key reuse decision:** the new clickable passage keeps the existing `evidenceLocate` aria-label, so the existing `AISuggestionEvidence` scenario-(a) tests and the details-popover locate query (`getByRole('button',{name:'evidenceLocate'})`) keep working. The standalone map-pin Button in the row header is removed.
+
+- [ ] **Step 1: Add copy key**
+
+In `frontend/lib/copy/extraction.ts` add (English only): `evidenceLocatedInReader: 'Highlighted in the reader'`. Keep `evidenceLocate: 'Locate in document'` (reused). Do NOT add `evidenceShowInDocument`.
+
+- [ ] **Step 2: Add the new failing tests (extend the existing file)**
+
+Append to `frontend/components/extraction/ai/AISuggestionEvidence.test.tsx` a new scenario (keep all existing scenarios a–g intact):
+
+```tsx
+  describe('(h) active citation ring', () => {
+    it('marks the cited passage active when activeRank matches its rank', () => {
+      const { container } = render(
+        <AISuggestionEvidence evidence={singleCitation} onLocate={vi.fn()} activeRank={0} />,
+        { wrapper: Wrapper },
+      );
+      expect(container.querySelector('[data-active-citation="true"]')).not.toBeNull();
+    });
+
+    it('does not mark active when activeRank differs', () => {
+      const { container } = render(
+        <AISuggestionEvidence evidence={singleCitation} onLocate={vi.fn()} activeRank={5} />,
+        { wrapper: Wrapper },
+      );
+      expect(container.querySelector('[data-active-citation="true"]')).toBeNull();
+    });
+  });
+```
+
+- [ ] **Step 3: Run, verify FAIL**
+
+Run: `npm run test:run -- AISuggestionEvidence`
+Expected: FAIL on scenario (h) — no `data-active-citation` yet. (a)–(g) still pass.
+
+- [ ] **Step 4: Implement evidence changes**
+
+In `AISuggestionEvidence.tsx`:
+- Container `bg-muted/50` → `bg-muted` (line ~193).
+- Add `activeRank?: number | null` to `AISuggestionEvidenceProps`; thread `isActive={citation.rank === activeRank}` into each `CitationRow`.
+- Remove the map-pin locate `Button` from the row-header action cluster (keep the Copy button, page badge, attribution badge, FileText icon).
+- Replace the `blockquote` with: when `onLocate` is provided, a full-width `button`; else the existing `blockquote`:
+
+```tsx
+{onLocate ? (
+  <button
+    type="button"
+    data-active-citation={isActive ? 'true' : undefined}
+    aria-label={isActive ? t('extraction', 'evidenceLocatedInReader') : t('extraction', 'evidenceLocate')}
+    onClick={(e) => { e.stopPropagation(); onLocate(citation.rank); }}
+    className={cn(
+      'group block w-full rounded-md border-l-2 pl-3 sm:pl-5 py-1 text-left transition-colors',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+      borderClass,
+      isActive ? 'bg-primary/5 ring-2 ring-primary/40' : 'hover:bg-muted-foreground/5',
+    )}
+  >
+    <span className="block text-sm italic text-foreground/90 whitespace-pre-wrap break-words leading-relaxed">
+      "{citation.text}"
+    </span>
+    <span className="mt-1.5 inline-flex items-center gap-1 text-xs text-primary opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+      <MapPin className="h-3.5 w-3.5" aria-hidden />
+      {isActive ? t('extraction', 'evidenceLocatedInReader') : t('extraction', 'evidenceLocate')}
+    </span>
+  </button>
+) : (
+  <blockquote className={cn('text-sm text-foreground/90 italic pl-3 sm:pl-5 border-l-2 whitespace-pre-wrap break-words leading-relaxed', borderClass)}>
+    "{citation.text}"
+  </blockquote>
+)}
+```
+
+`CitationRow` gains an `isActive?: boolean` prop; remove the now-unused `onLocate` handling in the row header (the passage owns the click).
+
+- [ ] **Step 5: Run, verify PASS (all scenarios)**
+
+Run: `npm run test:run -- AISuggestionEvidence`
+Expected: PASS — (a)–(h). Note (a) still finds the passage by `evidenceLocate` aria-label and gets `onLocate(0)`.
+
+- [ ] **Step 6: Wire keep-open + activeRank in the details popover**
+
+In `AISuggestionDetailsPopover.tsx`:
+- Replace the hand-rolled `PopoverContent` + header with `AIPopoverShell` (icon `<Sparkles className="h-4 w-4" />`, title `t('extraction','aiSuggestionDetailsTitle')`); move rationale + evidence into the body (keep the `space-y-4 p-4` wrapper as the body child).
+- Add `const [activeRank, setActiveRank] = useState<number | null>(null);`.
+- In `EvidenceSection`, the locate handler becomes `(rank) => { const c = evidence.find(e => e.rank === rank) ?? evidence[0]; onActivate(rank); locate(c.text, c.pageNumber ?? null, c.blockIds ?? []); }` — **no `onClose()`**. Pass `activeRank` + `onActivate={setActiveRank}` from the parent; pass `activeRank` into `AISuggestionEvidence`.
+- Remove the now-unused `onClose` prop from `EvidenceSection`.
+
+- [ ] **Step 7: Update the existing details test (keep-open, not close)**
+
+In `frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx`, rewrite the second test (was "…then closes the popover"):
+
+```tsx
+  it('locate calls reader-locate with text + page and keeps the popover open + marks active', async () => {
+    const user = userEvent.setup();
+    render(
+      <AISuggestionDetailsPopover suggestion={suggestion} trigger={<button>Open</button>} />,
+      {wrapper: Wrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    const passage = await screen.findByRole('button', {name: 'evidenceLocate'});
+
+    await user.click(passage);
+    expect(locateSpy).toHaveBeenCalledOnce();
+    expect(locateSpy).toHaveBeenCalledWith('test evidence', 2, [5]);
+
+    // Popover stays open; the citation is now marked active.
+    expect(screen.getByText(/test evidence/)).toBeInTheDocument();
+    expect(document.querySelector('[data-active-citation="true"]')).not.toBeNull();
+  });
+```
+
+Keep tests 1 ("opens and shows rationale + evidence") and 3 ("no viewer → no locate button") unchanged — test 3 still passes because with `isAvailable=false` the passage is a plain `blockquote` (no button named `evidenceLocate`).
+
+- [ ] **Step 8: Run, verify PASS**
+
+Run: `npm run test:run -- AISuggestionEvidence AISuggestionDetailsPopover`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/components/extraction/ai/AISuggestionEvidence.tsx frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx frontend/lib/copy/extraction.ts frontend/components/extraction/ai/AISuggestionEvidence.test.tsx frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
+git commit -m "feat(extraction): solid evidence + click-the-passage locate that keeps the details popup open"
+```
+
+---
+
+### Task 4: History popover — real run identity, no truncation, no debug logs
+
+**Files:**
+- Modify: `frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx`
+- Modify: `frontend/lib/copy/extraction.ts`
+- Create: `frontend/components/extraction/ai/AISuggestionHistoryPopover.test.tsx`
+
+**Interfaces:**
+- Consumes: `AIPopoverShell` (Task 2), `AISuggestionHistoryItem` (existing).
+- Produces: history popover inside the shared shell; run-group header = existing `formatTimestamp(...)` (NOT a new relative-time helper) with a `Current` pill on the run holding `currentSuggestionId`; non-truncated `line-clamp-2` values with full value in `title`; typed `formatValue(value: unknown)`; no `console.warn`; content-aware height.
+
+**Simplicity note:** do NOT add a `formatRunAge`/relative-time helper. The reported defect is the misleading positional `Extraction #N`. Dropping `#N` and reusing the existing `formatTimestamp` (already invalid-date-guarded, already used in this file) fixes it with no new code.
+
+- [ ] **Step 1: Copy keys**
+
+In `frontend/lib/copy/extraction.ts`: add `historyCurrentRun: 'Current'`; **remove** the now-unused `historyExtractionRun` key (its only consumer is deleted in Step 4 — clean-in-touched-code).
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `frontend/components/extraction/ai/AISuggestionHistoryPopover.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/copy', () => ({ t: (_ns: string, key: string) => key }));
+
+import { AISuggestionHistoryPopover } from './AISuggestionHistoryPopover';
+import type { AISuggestionHistoryItem } from '@/hooks/extraction/ai/useAISuggestions';
+
+const longValue =
+  'Randomized controlled trial with a very long extracted value that clearly exceeds fifty characters of text';
+const items: AISuggestionHistoryItem[] = [
+  { id: 'cur', runId: 'r2', value: longValue, confidence: 0.9, reasoning: 'r', status: 'pending', timestamp: new Date('2026-06-27T10:00:00'), evidence: [] },
+  { id: 'old', runId: 'r1', value: 'Cohort', confidence: 0.4, reasoning: 'r', status: 'rejected', timestamp: new Date('2026-06-20T09:00:00'), evidence: [] },
+];
+
+async function open() {
+  const user = userEvent.setup();
+  render(
+    <AISuggestionHistoryPopover
+      instanceId="i" fieldId="f" currentSuggestionId="cur"
+      getHistory={async () => items}
+      trigger={<button>open</button>}
+    />,
+  );
+  await user.click(screen.getByText('open'));
+}
+
+describe('AISuggestionHistoryPopover', () => {
+  it('shows the full (untruncated) value', async () => {
+    await open();
+    await waitFor(() => expect(screen.getByText(longValue)).toBeInTheDocument());
+  });
+
+  it('marks the run holding the current suggestion with the Current key', async () => {
+    await open();
+    await waitFor(() => expect(screen.getByText('historyCurrentRun')).toBeInTheDocument());
+  });
+
+  it('does not label runs by positional index', async () => {
+    await open();
+    await waitFor(() => expect(screen.getByText(longValue)).toBeInTheDocument());
+    expect(screen.queryByText(/#\s*\d/)).toBeNull();
+  });
+
+  it('does not emit console.warn debug logs', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await open();
+    await waitFor(() => expect(screen.getByText(longValue)).toBeInTheDocument());
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 3: Run, verify FAIL**
+
+Run: `npm run test:run -- AISuggestionHistoryPopover`
+Expected: FAIL — value truncated / no `historyCurrentRun` / `#N` present / `console.warn` called.
+
+- [ ] **Step 4: Implement the history changes**
+
+In `AISuggestionHistoryPopover.tsx`:
+- Render inside `AIPopoverShell` (icon `<Clock className="h-4 w-4" />`, title `t('extraction','historySuggestionsTitle')`, `count={`${history.length} ${t('extraction','historySuggestionsCount')}`}`); drop the hand-rolled `PopoverContent` + header and the `ScrollArea h-[400px]` (the shell provides the scroll region). Keep the loading / empty / list branches as the shell body.
+- Remove the three `console.warn` calls (lines 68, 73, 80); keep the `console.error` in the `.catch`.
+- Translate `// Agrupar por runId` → `// Group by run id`; `// Header do Run` → `// Run header`.
+- `formatValue(value: unknown)`: object → `JSON.stringify(value)`; null/undefined → `t('extraction','emptyValue')`; else `String(value)`. **Remove** the 50-char truncation.
+- Value cell: `<p className="text-sm font-medium line-clamp-2 break-words" title={formatValue(suggestion.value)}>{formatValue(suggestion.value)}</p>`.
+- Run-group header: delete `{t('extraction','historyExtractionRun')} #{runIndex + 1}`. Render `formatTimestamp(suggestions[0].timestamp, invalidDateLabel)` as the label. If any suggestion in the group has `id === currentSuggestionId`, render a `Current` pill: `<span className="rounded bg-ai/10 border border-ai/30 px-1.5 py-0.5 text-xs text-ai">{t('extraction','historyCurrentRun')}</span>`.
+
+- [ ] **Step 5: Run, verify PASS**
+
+Run: `npm run test:run -- AISuggestionHistoryPopover`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx frontend/lib/copy/extraction.ts frontend/components/extraction/ai/AISuggestionHistoryPopover.test.tsx
+git commit -m "fix(extraction): history popover — real run identity, no truncation, no debug logs, content-aware height"
+```
+
+---
+
+### Task 5: Remove the throwaway design-review harness
+
+**Files:**
+- Delete: `frontend/pages/_DevAiPopupReview.tsx`
+- Modify: `frontend/App.tsx` (remove the DEV-only lazy import + route)
+
+- [ ] **Step 1: Delete the harness page + route**
+
+Remove `frontend/pages/_DevAiPopupReview.tsx`; in `frontend/App.tsx` remove the `DevAiPopupReview` lazy import (~line 50) and the `import.meta.env.DEV && <Route path="/dev/ai-popup-review" .../>` block.
+
+- [ ] **Step 2: Verify no references remain + build is clean**
+
+Run: `grep -rn "DevAiPopupReview\|_DevAiPopupReview\|ai-popup-review" frontend/` → expect no matches.
+Run: `npm run build` → expect success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A frontend/App.tsx frontend/pages
+git commit -m "chore(extraction): remove throwaway AI-popup design-review harness"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** D1 shell → Task 2; D2 solid surfaces → Task 1; D3 locate option A (keep-open + active ring) → Task 3; D4 history fixes → Task 4; solid evidence block → Task 3; copy keys → Tasks 3-4; harness removal → Task 5. No gaps.
+- **Panel blockers resolved:** (1) import constraint fixed (mock `@/hooks/extraction/useReaderLocate`); (2) existing details "closes" test rewritten to keep-open in Task 3 Step 7; (3) existing evidence tests preserved by reusing the `evidenceLocate` aria-label (only scenario (h) added); (4) spec/plan contradictions reconciled — `line-clamp-2` (kept), reuse `evidenceLocate` (no `evidenceShowInDocument`), tests assert copy **keys** not English; `formatRunAge` cut (reuse `formatTimestamp`); orphan `historyExtractionRun` removed; CSS grouped-selector split made precise.
+- **Placeholder scan:** none — all steps carry real code/commands.
+- **Type consistency:** `activeRank?: number | null` consistent (evidence + details); `formatValue(value: unknown)`; `AIPopoverShellProps` (`count?: string`) matches consumers.

--- a/docs/superpowers/specs/2026-06-29-ai-extraction-popup-ux-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-extraction-popup-ux-design.md
@@ -1,0 +1,182 @@
+---
+status: draft
+last_reviewed: 2026-06-29
+owner: '@raphaelfh'
+---
+
+# AI-extraction popups: opacity, responsiveness, locate UX, and history fixes — design
+
+> **Status:** Draft · Date: 2026-06-29 · Deciders: @raphaelfh
+> **Scope:** Frontend only. No backend, schema, or migration changes.
+> **Origin:** User-reported UX defects on the two AI-suggestion popups that
+> appear on both the Extraction and QA session screens — they are too
+> transparent to read over the document, the history popup "has broken
+> things", and finding the cited evidence in the text is hard.
+
+## 1. Problem
+
+Two Radix popovers surface AI-extraction detail on a field. Both are shared by
+the Extraction and QA screens because both screens compose the same
+`FieldInput` (QA reuses it through `QASectionAccordion`):
+
+1. **Details popover** —
+   [`AISuggestionDetailsPopover.tsx`](../../../frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx).
+   Opens on clicking the extracted value or the `%` badge. Shows rationale +
+   cited evidence ([`AISuggestionEvidence.tsx`](../../../frontend/components/extraction/ai/AISuggestionEvidence.tsx)).
+2. **History popover** —
+   [`AISuggestionHistoryPopover.tsx`](../../../frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx).
+   Past suggestions grouped by run, with accept/reject.
+
+Findings from a design-review pass (rendered the real components over a busy
+document via a throwaway harness; measured computed styles):
+
+- **Transparency hurts readability (confirmed with computed values).** The
+  popover surface is `frosted-overlay` = `rgba(255,255,255,0.82)` + `blur(12px)`
+  ([`popover.tsx:21`](../../../frontend/components/ui/popover.tsx) →
+  [`index.css` `.frosted-overlay`](../../../frontend/index.css)). The evidence
+  block is `bg-muted/50` = `rgba(244,244,245,0.5)` with **no blur**
+  ([`AISuggestionEvidence.tsx:193`](../../../frontend/components/extraction/ai/AISuggestionEvidence.tsx)) —
+  the worst offender; sharp document text reads straight through the cited
+  quote.
+- **History "broken things"**: ships three `console.warn` debug logs to prod;
+  Portuguese comments (`// Agrupar por runId`, `// Header do Run`) violating the
+  English-only rule; group headers labelled `Extraction Run #N` from **array
+  order**, not run identity; values hard-truncated at 50 chars
+  (`...very long extra...`) with no way to see the full value;
+  `formatValue(value: any)`; a rigid `h-[400px]` scroll box (dead space for a
+  single item).
+- **Locate is hard to find.** Jumping to the evidence in the document is a tiny,
+  ambiguous map-pin icon buried in the action cluster next to Copy, and it
+  closes the popup on jump.
+- **Responsiveness.** The two popups don't share consistent width / height /
+  scroll rules; the history popup's fixed height ignores both content and
+  viewport.
+
+## 2. Decisions (locked with the user)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Structure | **Keep two popovers, unify the shell.** No merge into a tabbed popover. |
+| D2 | Opacity scope | **All floating menus solid.** Frosted stays on headers only. |
+| D3 | Locate UX | **Option A:** clicking the cited passage jumps to it in the reader; the popup **stays open**; the jumped citation gets an **active ring**. |
+| D4 | History | Fix the broken bits (see §5). |
+
+## 3. Non-goals
+
+- No merge of the two popovers into one tabbed surface (D1).
+- No change to the locate *mechanism* (`useReaderLocate` → viewer store →
+  reader highlight/flash). Only the trigger surface and open/close behavior
+  change.
+- No backend, schema, migration, or API changes.
+- No auto-jump-on-open, no per-citation prev/next stepper (explicitly out).
+
+## 4. Design
+
+### 4.1 Shared shell
+
+Introduce one internal building block, `AIPopoverShell`, that both popovers
+render inside. It owns the consistent surface, header, sizing, and scroll. This
+is the unification from D1 — the two popovers keep their distinct bodies but
+stop drifting on chrome.
+
+- **Solid surface (D2).** Change the shared `PopoverContent` default in
+  [`popover.tsx`](../../../frontend/components/ui/popover.tsx) and
+  [`dropdown-menu.tsx`](../../../frontend/components/ui/dropdown-menu.tsx) from
+  `frosted-overlay` to a solid `bg-popover`. Every floating menu app-wide
+  becomes opaque; `frosted-header` (Topbar, RunHeader) is untouched. If
+  `.frosted-overlay` ends up with no remaining consumers, remove its definition
+  in `index.css`; otherwise leave it. (Verify with a grep before deleting.)
+- **Header.** Leading icon (`Sparkles` for details, `Clock` for history) +
+  title + optional count, `border-b`, consistent padding.
+- **Responsive sizing.** Width `min(380px, calc(100vw - 1.5rem))`;
+  content-aware height via `max-h-[min(70vh,32rem)]` with natural growth (no
+  fixed `h-[400px]`); a single internal scroll region.
+
+`AIPopoverShell` is a presentational wrapper (header slot + body slot +
+sizing). It does not own open state — each popover keeps its own `Popover`
+root and trigger.
+
+### 4.2 Details popover + evidence + locate (D3)
+
+- **Evidence surface.** `AISuggestionEvidence` container `bg-muted/50` →
+  solid `bg-muted`. The per-citation page chip currently `bg-background` stays;
+  re-check contrast on the now-solid surface during design-review.
+- **Locate = click the passage (D3, option A).**
+  - The cited passage (`blockquote`) becomes the jump target: a full-width
+    `button` (keeping the existing `evidenceLocate` aria-label so existing tests
+    + queries still resolve), with a hover affordance (subtle `hover:bg` and an
+    inline "Locate in document" hint). The standalone map-pin icon button in the
+    row header is removed; Copy stays.
+  - On click it calls the existing per-citation `onLocate(rank)` →
+    `useReaderLocate().locate(...)`.
+  - **The popup no longer closes on locate.** Remove the `onClose()` call from
+    the locate path in `AISuggestionDetailsPopover`'s `EvidenceSection`.
+  - The clicked citation gets a persistent **active ring** + a small
+    "Highlighted in the reader" confirmation; clicking another passage moves the
+    ring and re-locates. The active citation rank is local popover state.
+  - When `useReaderLocate().isAvailable` is false (outside a `ViewerProvider`),
+    the passage is not a jump target (plain blockquote, today's behavior).
+- Reasoning/rationale section unchanged except for inheriting the shared shell.
+
+### 4.3 History popover (D4)
+
+- Render inside `AIPopoverShell` (solid surface, `Clock` header + count).
+- **Remove** the three `console.warn` calls; keep the `console.error` on the
+  `getHistory` rejection path.
+- **Translate** the Portuguese comments to English.
+- **Run identity, not array order.** Drop `Extraction Run #N` (the reported
+  defect). Each group header shows the run's timestamp via the **existing**
+  `formatTimestamp` helper (already invalid-date-guarded, already used here — no
+  new relative-time helper); the group containing `currentSuggestionId` gets a
+  `Current` pill. (Relative time — "9 days ago" — deferred to a future shared
+  helper rather than a third bespoke one.)
+- **No hard truncation.** Values wrap with `line-clamp-2` and expose the full
+  value on hover (`title`). Remove the 50-char substring cut.
+- **Type** `formatValue(value: unknown)` (object → JSON, null/undefined → empty
+  label, else `String`).
+- **Content-aware height** from the shell; no `h-[400px]`.
+
+### 4.4 Copy
+
+In [`frontend/lib/copy/extraction.ts`](../../../frontend/lib/copy/extraction.ts),
+English only. New: `evidenceLocatedInReader` ("Highlighted in the reader"),
+`historyCurrentRun` ("Current"). Reuse `evidenceLocate` ("Locate in document")
+for the passage hint + aria-label (no new `evidenceShowInDocument`). Remove the
+now-dead `historyExtractionRun` key.
+
+## 5. Components touched
+
+| File | Change |
+|------|--------|
+| `frontend/components/ui/popover.tsx` | `frosted-overlay` → solid `bg-popover` (D2). |
+| `frontend/components/ui/dropdown-menu.tsx` | same (D2). |
+| `frontend/index.css` | remove `.frosted-overlay` if unused after the above. |
+| `frontend/components/extraction/ai/shared/AIPopoverShell.tsx` | **new** shared shell. |
+| `frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx` | use shell; keep-open on locate; active-ring state. |
+| `frontend/components/extraction/ai/AISuggestionEvidence.tsx` | solid evidence bg; clickable passage (reuses `evidenceLocate` aria-label); drop map-pin icon; `activeRank` prop. |
+| `frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx` | use shell; remove debug logs; English comments; run timestamp + `Current`; no truncation (`line-clamp-2` + title); typed `formatValue`; content-aware height. |
+| `frontend/lib/copy/extraction.ts` | add `evidenceLocatedInReader`, `historyCurrentRun`; remove dead `historyExtractionRun`. |
+
+## 6. Testing & verification
+
+- **Vitest unit** (mock `@/hooks/extraction/useReaderLocate` as existing tests
+  do; mock `@/lib/copy` → returns the key, so assert on keys not English):
+  - Details: clicking the passage calls `locate(text, page, blockIds)`, does
+    **not** close the popover, and marks the citation active
+    (`data-active-citation="true"`).
+  - Evidence: existing scenarios stay green (passage reuses `evidenceLocate`);
+    new scenario asserts the active ring on `activeRank` match.
+  - History: full (untruncated) value present; `Current` (`historyCurrentRun`)
+    pill on the live run; no positional `#N`; `console.warn` not called.
+- **design-review loop** after implementation: solid surface over the real
+  reader, narrow (~390) and dark mode; confirm no text bleed-through and no
+  overflow/clipping.
+- **Lint/typecheck**: `npm run lint`, `tsc` clean (React Compiler:
+  `panicThreshold: all_errors` — no `try/finally` in component bodies).
+
+## 7. Rollout
+
+- Frontend-only PR → `dev`, squash-merge. Both screens inherit the fixes via the
+  shared `FieldInput`.
+- **Delete the throwaway harness before merge**: `frontend/pages/_DevAiPopupReview.tsx`
+  and its DEV-only route + lazy import in `frontend/App.tsx`.

--- a/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
@@ -194,4 +194,22 @@ describe('AISuggestionEvidence', () => {
       expect(container.firstChild).toBeNull();
     });
   });
+
+  describe('(h) active citation ring', () => {
+    it('marks the cited passage active when activeRank matches its rank', () => {
+      const {container} = render(
+        <AISuggestionEvidence evidence={singleCitation} onLocate={vi.fn()} activeRank={0} />,
+        {wrapper: Wrapper},
+      );
+      expect(container.querySelector('[data-active-citation="true"]')).not.toBeNull();
+    });
+
+    it('does not mark active when activeRank differs', () => {
+      const {container} = render(
+        <AISuggestionEvidence evidence={singleCitation} onLocate={vi.fn()} activeRank={5} />,
+        {wrapper: Wrapper},
+      );
+      expect(container.querySelector('[data-active-citation="true"]')).toBeNull();
+    });
+  });
 });

--- a/frontend/components/extraction/ai/AISuggestionEvidence.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.tsx
@@ -35,10 +35,15 @@ interface AISuggestionEvidenceProps {
   className?: string;
   showCopyButton?: boolean;
   /**
-   * Called with the rank of the citation the user clicked "Locate" on.
-   * When absent the locate button is not rendered (backward compatible).
+   * Called with the rank of the citation the user clicked to locate. When
+   * absent the cited passage is a plain blockquote (backward compatible).
    */
   onLocate?: (rank: number) => void;
+  /**
+   * Rank of the citation currently located in the reader, if any. The matching
+   * passage gets a persistent active ring. The popover keeps it across clicks.
+   */
+  activeRank?: number | null;
 }
 
 // =================== CITATION ROW ===================
@@ -48,9 +53,10 @@ interface CitationRowProps {
   showCopyButton: boolean;
   onLocate?: (rank: number) => void;
   isPrimary?: boolean;
+  isActive?: boolean;
 }
 
-function CitationRow({citation, showCopyButton, onLocate, isPrimary}: CitationRowProps) {
+function CitationRow({citation, showCopyButton, onLocate, isPrimary, isActive}: CitationRowProps) {
   const [copied, setCopied] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
 
@@ -112,28 +118,6 @@ function CitationRow({citation, showCopyButton, onLocate, isPrimary}: CitationRo
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
-          {onLocate && (
-            <Tooltip delayDuration={300}>
-              <TooltipTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-8 w-8 p-0 hover:bg-muted"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onLocate(citation.rank);
-                  }}
-                  aria-label={t('extraction', 'evidenceLocate')}
-                >
-                  <MapPin className="h-4 w-4 text-primary" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                <p>{t('extraction', 'evidenceLocate')}</p>
-              </TooltipContent>
-            </Tooltip>
-          )}
-
           {showCopyButton && (
             <Tooltip open={showTooltip && !copied} delayDuration={300}>
               <TooltipTrigger asChild>
@@ -165,15 +149,43 @@ function CitationRow({citation, showCopyButton, onLocate, isPrimary}: CitationRo
         </div>
       </div>
 
-      {/* Cited passage */}
-      <blockquote
-        className={cn(
-          'text-sm text-foreground/90 italic pl-3 sm:pl-5 border-l-2 whitespace-pre-wrap break-words leading-relaxed',
-          borderClass,
-        )}
-      >
-        "{citation.text}"
-      </blockquote>
+      {/* Cited passage — the jump target when locate is available. Clicking it
+          locates the passage in the reader; the popover stays open and the
+          located citation keeps an active ring. */}
+      {onLocate ? (
+        <button
+          type="button"
+          data-active-citation={isActive ? 'true' : undefined}
+          aria-label={isActive ? t('extraction', 'evidenceLocatedInReader') : t('extraction', 'evidenceLocate')}
+          onClick={(e) => {
+            e.stopPropagation();
+            onLocate(citation.rank);
+          }}
+          className={cn(
+            'group block w-full rounded-md border-l-2 py-1 pl-3 sm:pl-5 text-left transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+            borderClass,
+            isActive ? 'bg-primary/5 ring-2 ring-primary/40' : 'hover:bg-foreground/5',
+          )}
+        >
+          <span className="block text-sm italic leading-relaxed text-foreground/90 whitespace-pre-wrap break-words">
+            "{citation.text}"
+          </span>
+          <span className="mt-1.5 inline-flex items-center gap-1 text-xs text-primary opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+            <MapPin className="h-3.5 w-3.5" aria-hidden />
+            {isActive ? t('extraction', 'evidenceLocatedInReader') : t('extraction', 'evidenceLocate')}
+          </span>
+        </button>
+      ) : (
+        <blockquote
+          className={cn(
+            'text-sm text-foreground/90 italic pl-3 sm:pl-5 border-l-2 whitespace-pre-wrap break-words leading-relaxed',
+            borderClass,
+          )}
+        >
+          "{citation.text}"
+        </blockquote>
+      )}
     </div>
   );
 }
@@ -181,7 +193,7 @@ function CitationRow({citation, showCopyButton, onLocate, isPrimary}: CitationRo
 // =================== COMPONENT ===================
 
 export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
-  const {evidence, className, showCopyButton = true, onLocate} = props;
+  const {evidence, className, showCopyButton = true, onLocate, activeRank} = props;
   const [expanded, setExpanded] = useState(false);
 
   if (evidence.length === 0) return null;
@@ -190,11 +202,12 @@ export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
   const hasExtra = rest.length > 0;
 
   return (
-    <div className={cn('flex flex-col gap-4 p-4 bg-muted/50 rounded-lg border', className)}>
+    <div className={cn('flex flex-col gap-4 p-4 bg-muted rounded-lg border', className)}>
       <CitationRow
         citation={primary}
         showCopyButton={showCopyButton}
         onLocate={onLocate}
+        isActive={activeRank != null && primary.rank === activeRank}
         isPrimary
       />
 
@@ -225,6 +238,7 @@ export function AISuggestionEvidence(props: AISuggestionEvidenceProps) {
                   citation={citation}
                   showCopyButton={showCopyButton}
                   onLocate={onLocate}
+                  isActive={activeRank != null && citation.rank === activeRank}
                 />
               ))}
             </div>

--- a/frontend/components/extraction/ai/AISuggestionHistoryPopover.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionHistoryPopover.test.tsx
@@ -1,0 +1,62 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/lib/copy', () => ({t: (_ns: string, key: string) => key}));
+
+import {AISuggestionHistoryPopover} from './AISuggestionHistoryPopover';
+import type {AISuggestionHistoryItem} from '@/hooks/extraction/ai/useAISuggestions';
+
+const longValue =
+  'Randomized controlled trial with a very long extracted value that clearly exceeds fifty characters of text';
+
+const items: AISuggestionHistoryItem[] = [
+  {
+    id: 'cur', runId: 'r2', value: longValue, confidence: 0.9, reasoning: 'r',
+    status: 'pending', timestamp: new Date('2026-06-27T10:00:00'), evidence: [],
+  },
+  {
+    id: 'old', runId: 'r1', value: 'Cohort', confidence: 0.4, reasoning: 'r',
+    status: 'rejected', timestamp: new Date('2026-06-20T09:00:00'), evidence: [],
+  },
+];
+
+async function open() {
+  const user = userEvent.setup();
+  render(
+    <AISuggestionHistoryPopover
+      instanceId="i"
+      fieldId="f"
+      currentSuggestionId="cur"
+      getHistory={async () => items}
+      trigger={<button>open</button>}
+    />,
+  );
+  await user.click(screen.getByText('open'));
+}
+
+describe('AISuggestionHistoryPopover', () => {
+  it('shows the full (untruncated) value', async () => {
+    await open();
+    await waitFor(() => expect(screen.getByText(longValue)).toBeInTheDocument());
+  });
+
+  it('marks the run holding the current suggestion with the Current key', async () => {
+    await open();
+    await waitFor(() => expect(screen.getByText('historyCurrentRun')).toBeInTheDocument());
+  });
+
+  it('does not label runs by positional index', async () => {
+    await open();
+    await waitFor(() => expect(screen.getByText(longValue)).toBeInTheDocument());
+    expect(screen.queryByText(/#\s*\d/)).toBeNull();
+  });
+
+  it('does not emit console.warn debug logs', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await open();
+    await waitFor(() => expect(screen.getByText(longValue)).toBeInTheDocument());
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx
+++ b/frontend/components/extraction/ai/AISuggestionHistoryPopover.tsx
@@ -1,15 +1,16 @@
 /**
  * AI suggestion history popover
  *
- * Shows full history of suggestions grouped by run_id
- * Allows accepting/rejecting past suggestions
- * 
+ * Shows the full history of suggestions grouped by run id, inside the shared
+ * AIPopoverShell (solid surface, content-aware height). Allows accepting /
+ * rejecting past suggestions.
+ *
  * @component
  */
 
 import {useEffect, useState} from 'react';
-import {Popover, PopoverContent, PopoverTrigger,} from '@/components/ui/popover';
-import {ScrollArea} from '@/components/ui/scroll-area';
+import {Popover, PopoverTrigger} from '@/components/ui/popover';
+import {AIPopoverShell} from './shared/AIPopoverShell';
 import {Badge} from '@/components/ui/badge';
 import {Button} from '@/components/ui/button';
 import {Separator} from '@/components/ui/separator';
@@ -21,8 +22,8 @@ import type {AISuggestionHistoryItem} from '@/hooks/extraction/ai/useAISuggestio
 const formatTimestamp = (date: Date | string, invalidLabel: string = 'Invalid date'): string => {
   try {
     const dateObj = date instanceof Date ? date : new Date(date);
-      if (isNaN(dateObj.getTime())) return invalidLabel;
-      return new Intl.DateTimeFormat('en-US', {
+    if (isNaN(dateObj.getTime())) return invalidLabel;
+    return new Intl.DateTimeFormat('en-US', {
       day: '2-digit',
       month: '2-digit',
       year: 'numeric',
@@ -30,7 +31,7 @@ const formatTimestamp = (date: Date | string, invalidLabel: string = 'Invalid da
       minute: '2-digit',
     }).format(dateObj);
   } catch {
-      return invalidLabel;
+    return invalidLabel;
   }
 };
 
@@ -65,19 +66,15 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
 
   const loadHistory = async () => {
     if (!instanceId || !fieldId) {
-        console.warn('[AISuggestionHistoryPopover] instanceId or fieldId not provided');
       return;
     }
 
     setLoading(true);
-    console.warn('[AISuggestionHistoryPopover] Loading history...', {instanceId, fieldId});
-
     const data = await getHistory(instanceId, fieldId).catch((err: unknown) => {
-        console.error('[AISuggestionHistoryPopover] Error loading history:', err);
+      console.error('[AISuggestionHistoryPopover] Error loading history:', err);
       return [] as typeof history;
     });
 
-    console.warn('[AISuggestionHistoryPopover] History loaded:', {count: data.length, data});
     setHistory(data);
     setLoading(false);
   };
@@ -99,7 +96,7 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
     }
   }, [open, loadHistory]);
 
-  // Agrupar por runId (tratar casos onde runId pode ser undefined/null)
+  // Group by run id (handle cases where runId may be undefined/null).
   const groupedByRun = history.reduce((acc, suggestion) => {
     const runId = suggestion.runId || 'unknown';
     if (!acc[runId]) {
@@ -109,60 +106,58 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
     return acc;
   }, {} as Record<string, AISuggestionHistoryItem[]>);
 
-    const invalidDateLabel = t('extraction', 'historyInvalidDate');
-  const formatValue = (value: any): string => {
-      if (value === null || value === undefined) return t('extraction', 'emptyValue');
+  const invalidDateLabel = t('extraction', 'historyInvalidDate');
+  const formatValue = (value: unknown): string => {
+    if (value === null || value === undefined) return t('extraction', 'emptyValue');
     if (typeof value === 'object') return JSON.stringify(value);
-    if (typeof value === 'string' && value.length > 50) {
-      return `${value.substring(0, 50)}...`;
-    }
     return String(value);
   };
 
+  const countLabel = `${history.length} ${t('extraction', 'historySuggestionsCount')}`;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        {trigger}
-      </PopoverTrigger>
-      <PopoverContent className="w-96 max-w-[90vw] sm:max-w-md p-0 z-50" align="start" side="bottom">
-        <div className="p-4 border-b">
-            <h4 className="font-semibold text-sm">{t('extraction', 'historySuggestionsTitle')}</h4>
-          <p className="text-xs text-muted-foreground mt-1">
-              {history.length} {t('extraction', 'historySuggestionsCount')}
-          </p>
-        </div>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <AIPopoverShell
+        icon={<Clock className="h-4 w-4" />}
+        title={t('extraction', 'historySuggestionsTitle')}
+        count={loading ? undefined : countLabel}
+      >
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : history.length === 0 ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            {t('extraction', 'historyNoSuggestions')}
+          </div>
+        ) : (
+          <div className="p-2 sm:p-3">
+            {Object.entries(groupedByRun).map(([runId, suggestions], runIndex) => {
+              const isCurrentRun = suggestions.some((s) => s.id === currentSuggestionId);
 
-        <ScrollArea className="h-[400px] max-h-[70vh]">
-          {loading ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-            </div>
-          ) : history.length === 0 ? (
-            <div className="p-8 text-center text-sm text-muted-foreground">
-                {t('extraction', 'historyNoSuggestions')}
-            </div>
-          ) : (
-            <div className="p-2 sm:p-3">
-              {Object.entries(groupedByRun).map(([runId, suggestions], runIndex) => (
+              return (
                 <div key={runId} className="mb-4">
-                  {/* Header do Run */}
+                  {/* Run header */}
                   <div className="px-2 py-1.5 mb-2 bg-muted/50 rounded">
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="text-xs font-medium truncate">
-                        {t('extraction', 'historyExtractionRun')} #{runIndex + 1}
-                      </span>
-                      <span className="text-xs text-muted-foreground shrink-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-medium text-muted-foreground truncate">
                         {formatTimestamp(suggestions[0].timestamp, invalidDateLabel)}
                       </span>
+                      {isCurrentRun && (
+                        <span className="shrink-0 rounded border border-ai/30 bg-ai/10 px-1.5 py-0.5 text-[11px] font-medium text-ai">
+                          {t('extraction', 'historyCurrentRun')}
+                        </span>
+                      )}
                     </div>
                   </div>
 
-                    {/* Run suggestions */}
+                  {/* Run suggestions */}
                   <div className="space-y-2">
                     {suggestions.map((suggestion) => {
                       const isCurrent = suggestion.id === currentSuggestionId;
                       const confidencePercent = Math.round(suggestion.confidence * 100);
+                      const fullValue = formatValue(suggestion.value);
 
                       return (
                         <div
@@ -174,11 +169,11 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
                               : "bg-background border-border/60 hover:bg-muted/40"
                           )}
                         >
-                          {/* Valor e Status */}
+                          {/* Value and status */}
                           <div className="flex items-start justify-between gap-2 mb-2">
                             <div className="flex-1 min-w-0 overflow-hidden">
-                              <p className="text-sm font-medium break-words">
-                                {formatValue(suggestion.value)}
+                              <p className="text-sm font-medium line-clamp-2 break-words" title={fullValue}>
+                                {fullValue}
                               </p>
                               {suggestion.reasoning && (
                                 <p className="text-xs text-muted-foreground mt-1 line-clamp-3 break-words">
@@ -199,20 +194,21 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
                                 )}
                               >
                                 {suggestion.status === 'accepted'
-                                    ? t('extraction', 'suggestionAccepted')
+                                  ? t('extraction', 'suggestionAccepted')
                                   : suggestion.status === 'rejected'
-                                        ? t('extraction', 'suggestionRejected')
-                                  : `${confidencePercent}%`}
+                                    ? t('extraction', 'suggestionRejected')
+                                    : `${confidencePercent}%`}
                               </Badge>
                             </div>
                           </div>
 
-                            {/* Metadata and actions */}
+                          {/* Metadata and actions */}
                           <div className="flex items-center justify-between gap-2 flex-wrap">
                             <div className="flex items-center gap-2 text-xs text-muted-foreground shrink-0">
                               <Clock className="h-3 w-3" />
-                                <span
-                                    className="truncate">{formatTimestamp(suggestion.timestamp, invalidDateLabel)}</span>
+                              <span className="truncate">
+                                {formatTimestamp(suggestion.timestamp, invalidDateLabel)}
+                              </span>
                             </div>
 
                             {suggestion.status === 'pending' && (
@@ -251,12 +247,11 @@ export function AISuggestionHistoryPopover(props: AISuggestionHistoryPopoverProp
                     <Separator className="my-4" />
                   )}
                 </div>
-              ))}
-            </div>
-          )}
-        </ScrollArea>
-      </PopoverContent>
+              );
+            })}
+          </div>
+        )}
+      </AIPopoverShell>
     </Popover>
   );
 }
-

--- a/frontend/components/extraction/ai/__tests__/AISuggestionEvidence.ungroundable.test.tsx
+++ b/frontend/components/extraction/ai/__tests__/AISuggestionEvidence.ungroundable.test.tsx
@@ -19,4 +19,12 @@ describe('AISuggestionEvidence ungroundable', () => {
     render(<AISuggestionEvidence evidence={ev} />, {wrapper: Wrapper});
     expect(screen.getByText(/verify manually/i)).toBeInTheDocument();
   });
+
+  it('applies the cautionary amber treatment to the ungroundable badge', () => {
+    render(<AISuggestionEvidence evidence={ev} />, {wrapper: Wrapper});
+    // The badge must keep its amber (caution) styling — a regression that
+    // drops it to a neutral/entailed look should fail here, not just slip
+    // past the copy assertion above.
+    expect(screen.getByText(/verify manually/i).className).toMatch(/amber/);
+  });
 });

--- a/frontend/components/extraction/ai/shared/AIPopoverShell.test.tsx
+++ b/frontend/components/extraction/ai/shared/AIPopoverShell.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Popover, PopoverTrigger } from '@/components/ui/popover';
+import { AIPopoverShell } from './AIPopoverShell';
+
+describe('AIPopoverShell', () => {
+  it('renders a solid, responsive shell with header + body', () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>open</PopoverTrigger>
+        <AIPopoverShell icon={<span>i</span>} title="Suggestion details" count="3 found">
+          <p>body content</p>
+        </AIPopoverShell>
+      </Popover>,
+    );
+    const popover = document.querySelector('.bg-popover') as HTMLElement;
+    expect(popover).not.toBeNull();
+    expect(popover.className).toContain('w-[min(380px,calc(100vw-1.5rem))]');
+    expect(popover.textContent).toContain('Suggestion details');
+    expect(popover.textContent).toContain('3 found');
+    expect(popover.textContent).toContain('body content');
+  });
+});

--- a/frontend/components/extraction/ai/shared/AIPopoverShell.tsx
+++ b/frontend/components/extraction/ai/shared/AIPopoverShell.tsx
@@ -1,0 +1,48 @@
+/**
+ * Shared shell for the AI-suggestion popovers (details + history).
+ *
+ * Owns the solid surface, consistent header, responsive width, and a single
+ * scrollable body region so the two popovers don't drift on chrome. The caller
+ * wraps it in <Popover> + <PopoverTrigger> and supplies the body.
+ */
+import {PopoverContent} from '@/components/ui/popover';
+import {cn} from '@/lib/utils';
+
+interface AIPopoverShellProps {
+  icon: React.ReactNode;
+  title: string;
+  count?: string;
+  align?: 'start' | 'center' | 'end';
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function AIPopoverShell({
+  icon,
+  title,
+  count,
+  align = 'start',
+  className,
+  children,
+}: AIPopoverShellProps) {
+  return (
+    <PopoverContent
+      align={align}
+      side="bottom"
+      className={cn('w-[min(380px,calc(100vw-1.5rem))] overflow-hidden p-0', className)}
+    >
+      <div className="flex items-center gap-2 border-b px-4 py-3">
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-ai">
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold">{title}</div>
+          {count != null && (
+            <div className="text-xs text-muted-foreground">{count}</div>
+          )}
+        </div>
+      </div>
+      <div className="max-h-[min(70vh,32rem)] overflow-y-auto">{children}</div>
+    </PopoverContent>
+  );
+}

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.test.tsx
@@ -12,7 +12,7 @@
  * Mocks: useReaderLocate (the markdown-first locate hook).
  */
 
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {describe, expect, it, vi, beforeEach} from 'vitest';
 import type {ReactNode} from 'react';
@@ -64,7 +64,7 @@ describe('AISuggestionDetailsPopover — reader-locate wiring', () => {
     expect(screen.getByText(/test evidence/)).toBeInTheDocument();
   });
 
-  it('locate button calls reader-locate with text + page, then closes the popover', async () => {
+  it('locate calls reader-locate with text + page and keeps the popover open + marks active', async () => {
     const user = userEvent.setup();
     render(
       <AISuggestionDetailsPopover suggestion={suggestion} trigger={<button>Open</button>} />,
@@ -72,16 +72,15 @@ describe('AISuggestionDetailsPopover — reader-locate wiring', () => {
     );
 
     await user.click(screen.getByRole('button', {name: 'Open'}));
-    const locateBtn = await screen.findByRole('button', {name: 'evidenceLocate'});
+    const passage = await screen.findByRole('button', {name: 'evidenceLocate'});
 
-    await user.click(locateBtn);
+    await user.click(passage);
     expect(locateSpy).toHaveBeenCalledOnce();
     expect(locateSpy).toHaveBeenCalledWith('test evidence', 2, [5]);
 
-    // Popover closed → content unmounts.
-    await waitFor(() => {
-      expect(screen.queryByText(/test evidence/)).not.toBeInTheDocument();
-    });
+    // Popover stays open; the located citation is marked active.
+    expect(screen.getByText(/test evidence/)).toBeInTheDocument();
+    expect(document.querySelector('[data-active-citation="true"]')).not.toBeNull();
   });
 
   it('no viewer (isAvailable=false) → no locate button, evidence still shown', async () => {

--- a/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionDetailsPopover.tsx
@@ -3,20 +3,18 @@
  *
  * Rendered as a non-modal, anchored Popover (not a full-screen modal): it
  * floats beside its trigger in the form panel and never covers the document
- * viewer. That is what makes "Locate in document" usable — clicking it closes
- * the popover and the reader, still visible on the right, scrolls to and
- * flashes the cited passage (markdown-first locate, via the shared viewer
+ * viewer. That is what makes locating usable — clicking a cited passage scrolls
+ * the reader (still visible on the right) to the quote and flashes it, while the
+ * popover stays open so the user can step through other citations; the located
+ * citation keeps an active ring (markdown-first locate, via the shared viewer
  * store). Outside a ViewerProvider the locate affordance is simply absent.
  */
 
 import {useState} from 'react';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+import {Popover, PopoverTrigger} from '@/components/ui/popover';
 import {Sparkles} from 'lucide-react';
 import {AISuggestionEvidence} from '../AISuggestionEvidence';
+import {AIPopoverShell} from './AIPopoverShell';
 import {t} from '@/lib/copy';
 import type {AISuggestion, EvidenceCitation} from '@/types/ai-extraction';
 import {useReaderLocate} from '@/hooks/extraction/useReaderLocate';
@@ -46,19 +44,21 @@ interface AISuggestionDetailsPopoverProps {
 
 interface EvidenceSectionProps {
   evidence: EvidenceCitation[];
-  onClose: () => void;
+  activeRank: number | null;
+  onActivate: (rank: number) => void;
 }
 
-function EvidenceSection({evidence, onClose}: EvidenceSectionProps) {
+function EvidenceSection({evidence, activeRank, onActivate}: EvidenceSectionProps) {
   const {locate, isAvailable} = useReaderLocate();
 
-  // Per-citation locate: finds the matching citation by rank, then locates it
-  // in the reader. Closes the popover so the flash is unobstructed.
+  // Per-citation locate: finds the matching citation by rank, marks it active,
+  // then locates it in the reader. The popover stays open so the user can step
+  // through other citations; the active citation keeps a ring.
   const onLocate = isAvailable
     ? (rank: number) => {
         const citation = evidence.find((e) => e.rank === rank) ?? evidence[0];
+        onActivate(rank);
         locate(citation.text, citation.pageNumber ?? null, citation.blockIds ?? []);
-        onClose();
       }
     : undefined;
 
@@ -67,6 +67,7 @@ function EvidenceSection({evidence, onClose}: EvidenceSectionProps) {
       <AISuggestionEvidence
         evidence={evidence}
         onLocate={onLocate}
+        activeRank={activeRank}
       />
     </section>
   );
@@ -81,6 +82,7 @@ export function AISuggestionDetailsPopover({
   trigger,
 }: AISuggestionDetailsPopoverProps) {
   const [open, setOpen] = useState(false);
+  const [activeRank, setActiveRank] = useState<number | null>(null);
 
   if (!hasSuggestionDetails(suggestion)) {
     return <>{trigger}</>;
@@ -90,21 +92,19 @@ export function AISuggestionDetailsPopover({
   const evidence = suggestion.evidence;
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setActiveRank(null);
+      }}
+    >
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent
-        align="start"
-        side="bottom"
-        className="w-[380px] max-w-[calc(100vw-1.5rem)] overflow-hidden p-0"
+      <AIPopoverShell
+        icon={<Sparkles className="h-4 w-4" />}
+        title={t('extraction', 'aiSuggestionDetailsTitle')}
       >
-        <div className="flex items-center gap-2 border-b px-4 py-3">
-          <Sparkles className="h-4 w-4 shrink-0 text-ai" />
-          <span className="text-sm font-semibold">
-            {t('extraction', 'aiSuggestionDetailsTitle')}
-          </span>
-        </div>
-
-        <div className="max-h-[min(60vh,28rem)] space-y-4 overflow-y-auto p-4">
+        <div className="space-y-4 p-4">
           {hasReasoning && (
             <section className="space-y-1.5" aria-label={t('extraction', 'aiRationaleLabel')}>
               <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -119,11 +119,12 @@ export function AISuggestionDetailsPopover({
           {evidence && evidence.length > 0 && evidence[0]?.text?.trim() && (
             <EvidenceSection
               evidence={evidence}
-              onClose={() => setOpen(false)}
+              activeRank={activeRank}
+              onActivate={setActiveRank}
             />
           )}
         </div>
-      </PopoverContent>
+      </AIPopoverShell>
     </Popover>
   );
 }

--- a/frontend/components/ui/dropdown-menu.tsx
+++ b/frontend/components/ui/dropdown-menu.tsx
@@ -62,7 +62,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       collisionPadding={8}
       className={cn(
-          "z-50 min-w-[8rem] max-w-[calc(100vw-1rem)] overflow-hidden rounded-md border border-border/50 frosted-overlay p-1 text-popover-foreground shadow-elev-header data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[8rem] max-w-[calc(100vw-1rem)] overflow-hidden rounded-md border border-border/50 bg-popover p-1 text-popover-foreground shadow-elev-header data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/frontend/components/ui/overlay-frosted.test.tsx
+++ b/frontend/components/ui/overlay-frosted.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './dropdown-menu';
 
-describe('frosted overlays', () => {
-  it('renders dropdown content with a frosted surface and viewport clamp', () => {
+describe('floating overlays', () => {
+  it('renders dropdown content with a solid surface and viewport clamp', () => {
     render(
       <DropdownMenu defaultOpen>
         <DropdownMenuTrigger>open</DropdownMenuTrigger>
@@ -13,7 +13,8 @@ describe('frosted overlays', () => {
       </DropdownMenu>,
     );
     const content = screen.getByText('item').closest('[role="menu"]')!;
-    expect(content.className).toContain('frosted-overlay');
+    expect(content.className).toContain('bg-popover');
+    expect(content.className).not.toContain('frosted-overlay');
     expect(content.className).toContain('shadow-elev-header');
     expect(content.className).toContain('max-w-[calc(100vw-1rem)]');
   });

--- a/frontend/components/ui/popover.tsx
+++ b/frontend/components/ui/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = React.forwardRef<
       sideOffset={sideOffset}
       collisionPadding={8}
       className={cn(
-        "z-50 w-72 max-w-[calc(100vw-1rem)] rounded-md border frosted-overlay p-4 text-popover-foreground shadow-elev-header outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 max-w-[calc(100vw-1rem)] rounded-md border bg-popover p-4 text-popover-foreground shadow-elev-header outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -217,26 +217,17 @@
         backdrop-filter: blur(var(--header-blur));
         -webkit-backdrop-filter: blur(var(--header-blur));
     }
-    /* Frosted floating overlay — same surface for menus/popovers. */
-    .frosted-overlay {
-        background-color: hsl(var(--popover) / var(--header-surface-alpha));
-        backdrop-filter: blur(var(--header-blur));
-        -webkit-backdrop-filter: blur(var(--header-blur));
-    }
-    /* Legibility fallbacks: no backdrop-filter support, or user opts out of
-       transparency. Solid surface in both cases. */
+    /* Legibility fallback: no backdrop-filter support → solid header surface.
+       (Floating menus/popovers are solid `bg-popover` and need no fallback.) */
     @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
         .frosted-header { background-color: hsl(var(--background)); }
-        .frosted-overlay { background-color: hsl(var(--popover)); }
     }
     @media (prefers-reduced-transparency: reduce) {
-        .frosted-header,
-        .frosted-overlay {
+        .frosted-header {
             backdrop-filter: none;
             -webkit-backdrop-filter: none;
             background-color: hsl(var(--background));
         }
-        .frosted-overlay { background-color: hsl(var(--popover)); }
     }
 
     /* Subtle button style */

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -446,8 +446,7 @@ export const extraction = {
     tableInDevelopment: 'In development',
     tableClearSelection: 'Clear selection',
     // AI suggestion history popover
-    historyExtractionRun: 'Extraction',
-    historyProcessing: 'Processing…',
+    historyCurrentRun: 'Current',
     // AISuggestionHistoryPopover
     historyInvalidDate: 'Invalid date',
     historySuggestionsTitle: 'Suggestion history',
@@ -846,6 +845,7 @@ export const extraction = {
     aiRationaleLabel: 'Rationale',
     // AISuggestionEvidence – markdown-first citation locate
     evidenceLocate: 'Locate in document',
+    evidenceLocatedInReader: 'Highlighted in the reader',
     // AISuggestionEvidence – multi-citation list + attribution badges
     evidenceAlsoCited: 'Also cited ({{n}})',
     attributionEntailed: 'Verified',


### PR DESCRIPTION
Promote `dev` → `main`.

Carries:
- **#436** fix(extraction): AI-suggestion popups — solid surfaces, easier locate, history fixes (this run)
- **#435** chore(extraction): citation P3/P4 follow-ups + local-server ship-spec verify (already on dev)

Both validated on dev (CI + CodeQL green on `fc7f9322`). Merge-commit promotion (not squash/ff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
