### PR TITLE
promote: dev → main (AI-suggestion follow-ups #445)

### DIFF
--- a/backend/app/services/extraction_suggestion_read_service.py
+++ b/backend/app/services/extraction_suggestion_read_service.py
@@ -35,6 +35,7 @@ from app.models.extraction_workflow import (
     ExtractionReviewerDecisionType,
     ExtractionReviewerState,
 )
+from app.models.user import Profile
 from app.schemas.extraction import parse_position
 from app.schemas.extraction_suggestion import (
     AISuggestionHistoryItem,
@@ -81,11 +82,19 @@ def _resolve_status(decision: str | None) -> str:
 
 
 async def _load_run_provenance(
-    db: AsyncSession, run_ids: set[UUID]
+    db: AsyncSession, run_ids: set[UUID], *, resolve_names: bool = False
 ) -> dict[UUID, dict[str, Any] | None]:
     """Fetch each run's provenance snapshot (extraction_runs.results['provenance'])
     in one query, so suggestions can show how they were generated without an
-    N+1. Legacy runs without provenance map to None."""
+    N+1. Legacy runs without provenance map to None.
+
+    When ``resolve_names`` is set, each snapshot carrying a ``ran_by_user_id``
+    also gets a resolved ``ran_by_name`` (the runner's profile display name)
+    injected, so the review popover can show *who* ran the extraction without
+    the frontend joining on profiles. Off by default: only the on-demand history
+    path pays the extra profile lookup; the hot ``load_suggestions`` path stays a
+    single query.
+    """
     if not run_ids:
         return {}
     rows = (
@@ -93,7 +102,46 @@ async def _load_run_provenance(
             select(ExtractionRun.id, ExtractionRun.results).where(ExtractionRun.id.in_(run_ids))
         )
     ).all()
-    return {run_id: (results or {}).get("provenance") for run_id, results in rows}
+    prov_by_run: dict[UUID, dict[str, Any] | None] = {
+        run_id: (results or {}).get("provenance") for run_id, results in rows
+    }
+    if resolve_names:
+        await _inject_ran_by_names(db, prov_by_run)
+    return prov_by_run
+
+
+async def _inject_ran_by_names(
+    db: AsyncSession, prov_by_run: dict[UUID, dict[str, Any] | None]
+) -> None:
+    """Resolve each snapshot's ``ran_by_user_id`` to a ``ran_by_name`` in place.
+
+    One batched ``profiles`` lookup for the distinct runner ids. A snapshot
+    whose runner has no profile (or a malformed id) is left untouched — the
+    "Ran by" row stays absent rather than showing a bare uuid.
+    """
+    uuid_by_raw: dict[str, UUID] = {}
+    for prov in prov_by_run.values():
+        raw = prov.get("ran_by_user_id") if prov else None
+        if raw is None or str(raw) in uuid_by_raw:
+            continue
+        try:
+            uuid_by_raw[str(raw)] = UUID(str(raw))
+        except (ValueError, TypeError):
+            continue
+    if not uuid_by_raw:
+        return
+    rows = (
+        await db.execute(
+            select(Profile.id, Profile.full_name).where(Profile.id.in_(list(uuid_by_raw.values())))
+        )
+    ).all()
+    name_by_id = {str(pid): full_name for pid, full_name in rows if full_name}
+    for prov in prov_by_run.values():
+        if not prov:
+            continue
+        name = name_by_id.get(str(prov.get("ran_by_user_id")))
+        if name:
+            prov["ran_by_name"] = name
 
 
 async def load_suggestions(
@@ -309,7 +357,10 @@ async def get_suggestion_history(
         rows.sort(key=lambda e: (e.rank, str(e.id)))
 
     items: list[AISuggestionHistoryItem] = []
-    prov_by_run = await _load_run_provenance(db, {p.run_id for p in proposals})
+    # History feeds the review popover (RunProvenanceDisclosure), the only
+    # surface that shows the "Ran by" row — resolve the runner's display name
+    # here so the frontend needs no profiles join.
+    prov_by_run = await _load_run_provenance(db, {p.run_id for p in proposals}, resolve_names=True)
     for p in proposals:
         evidence_list = [
             EvidenceResponse(

--- a/backend/tests/integration/test_suggestion_read.py
+++ b/backend/tests/integration/test_suggestion_read.py
@@ -339,12 +339,70 @@ async def test_load_suggestions_includes_run_provenance(
         caller_id=reviewer_a,
         run_id=run_id,
     )
+    # The hot load path returns the raw snapshot verbatim (no profiles join).
     assert result.suggestions[0].provenance == prov
 
     history = await get_suggestion_history(
         db_session, instance_id, field_id, article_id=SEED.primary_article
     )
-    assert history[0].provenance == prov
+    # The history (popover) path resolves the runner's display name on top of
+    # the raw snapshot — assert every raw key survives unchanged.
+    hist_prov = history[0].provenance
+    assert hist_prov is not None
+    for key, value in prov.items():
+        assert hist_prov[key] == value
+
+
+@pytest.mark.asyncio
+async def test_get_suggestion_history_resolves_ran_by_name(
+    db_session: AsyncSession,
+) -> None:
+    """The history path resolves ran_by_user_id → ran_by_name from the runner's
+    profile; the hot load path leaves the raw snapshot untouched."""
+    import json
+
+    built = await _build_suggestion_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, instance_id, field_id, reviewer_a, reviewer_b = built
+
+    # Pin the runner's profile name deterministically (the shared dev DB may
+    # carry a pre-existing reviewer_b row whose full_name the builder's
+    # ON CONFLICT DO UPDATE leaves untouched).
+    await db_session.execute(
+        text("UPDATE public.profiles SET full_name = :n WHERE id = :id"),
+        {"n": "Integration Reviewer B (Suggest)", "id": str(reviewer_b)},
+    )
+    prov = {
+        "model": "gpt-4o-mini",
+        "ran_by_user_id": str(reviewer_b),
+    }
+    await db_session.execute(
+        text(
+            "UPDATE extraction_runs "
+            "SET results = jsonb_set(coalesce(results, '{}'::jsonb), "
+            "'{provenance}', cast(:p as jsonb)) WHERE id = :id"
+        ),
+        {"p": json.dumps(prov), "id": str(run_id)},
+    )
+    await db_session.flush()
+
+    history = await get_suggestion_history(
+        db_session, instance_id, field_id, article_id=SEED.primary_article
+    )
+    assert history[0].provenance is not None
+    assert history[0].provenance["ran_by_name"] == "Integration Reviewer B (Suggest)"
+
+    # Hot load path must NOT inject the name (stays a single query).
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=reviewer_a,
+        run_id=run_id,
+    )
+    assert result.suggestions[0].provenance is not None
+    assert "ran_by_name" not in result.suggestions[0].provenance
 
 
 @pytest.mark.asyncio

--- a/frontend/components/extraction/ai/AISuggestionEvidence.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.tsx
@@ -26,6 +26,7 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {useState} from 'react';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
+import {useCopyToClipboard} from '@/hooks/useCopyToClipboard';
 import type {EvidenceCitation} from '@/types/ai-extraction';
 
 // =================== INTERFACES ===================
@@ -57,17 +58,8 @@ interface CitationRowProps {
 }
 
 function CitationRow({citation, showCopyButton, onLocate, isPrimary, isActive}: CitationRowProps) {
-  const [copied, setCopied] = useState(false);
+  const {copied, copy} = useCopyToClipboard();
   const [showTooltip, setShowTooltip] = useState(false);
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(citation.text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }).catch((err: unknown) => {
-      console.error('Failed to copy evidence text:', err);
-    });
-  };
 
   const label = citation.attributionLabel;
   const isEntailed = label === 'entailed';
@@ -127,7 +119,7 @@ function CitationRow({citation, showCopyButton, onLocate, isPrimary, isActive}: 
                   className="h-8 w-8 p-0 shrink-0 hover:bg-muted"
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleCopy();
+                    copy(citation.text);
                     setShowTooltip(false);
                   }}
                   onMouseEnter={() => setShowTooltip(true)}

--- a/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.test.tsx
+++ b/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.test.tsx
@@ -27,6 +27,22 @@ describe("RunProvenanceDisclosure", () => {
     expect(screen.getByText("Temperature")).toBeInTheDocument();
   });
 
+  it("renders the resolved 'Ran by' name row", () => {
+    render(<RunProvenanceDisclosure provenance={prov} defaultOpen />);
+    expect(screen.getByText("Ran by")).toBeInTheDocument();
+    expect(screen.getByText("Raphael F.")).toBeInTheDocument();
+  });
+
+  it("omits the 'Ran by' row when no ranByName resolved (only a raw id)", () => {
+    render(
+      <RunProvenanceDisclosure
+        provenance={{ ranByUserId: "uuid-secret", model: "m" }}
+        defaultOpen
+      />,
+    );
+    expect(screen.queryByText("Ran by")).not.toBeInTheDocument();
+  });
+
   it("does not leak the raw ranByUserId as a generic row", () => {
     render(
       <RunProvenanceDisclosure

--- a/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.tsx
+++ b/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.tsx
@@ -16,6 +16,7 @@ import {Check, ChevronDown, ChevronRight, Copy} from 'lucide-react';
 import {Button} from '@/components/ui/button';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
+import {useCopyToClipboard} from '@/hooks/useCopyToClipboard';
 import type {ExtractionCopy} from '@/lib/copy/extraction';
 import type {RunProvenance} from '@/types/ai-extraction';
 
@@ -46,10 +47,11 @@ const PROVENANCE_REGISTRY: ProvenanceFieldDef[] = [
 ];
 
 const REGISTRY_KEYS = new Set<string>(PROVENANCE_REGISTRY.map((f) => f.key as string));
-// The raw `ranByUserId` is captured as audit provenance but suppressed from the
-// generic fallback (a bare uuid is not reviewer-facing). The "Ran by" row renders
-// only when a human-readable `ranByName` is present — backend/caller name
-// resolution is a follow-up; until then the row is simply absent.
+// The raw `ranByUserId` is captured as audit provenance but never shown (a bare
+// uuid is not reviewer-facing). The human-readable "Ran by" row uses `ranByName`,
+// which the backend resolves from the runner's profile on the history path
+// (see extraction_suggestion_read_service._inject_ran_by_names) and the service
+// flattens to camelCase. Absent name → the row is simply omitted.
 const SUPPRESSED_KEYS = new Set<string>(['ranByUserId']);
 
 function isPresent(value: unknown): boolean {
@@ -73,18 +75,7 @@ function ScalarRow({label, value}: RowProps) {
 }
 
 function CodeRow({label, value}: RowProps) {
-  const [copied, setCopied] = useState(false);
-  const onCopy = () => {
-    navigator.clipboard
-      .writeText(value)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      })
-      .catch((err: unknown) => {
-        console.error('Failed to copy prompt text:', err);
-      });
-  };
+  const {copied, copy} = useCopyToClipboard();
 
   return (
     <div className="space-y-1">
@@ -94,7 +85,7 @@ function CodeRow({label, value}: RowProps) {
           size="sm"
           variant="ghost"
           className="h-6 w-6 p-0"
-          onClick={onCopy}
+          onClick={() => copy(value)}
           aria-label={copied ? t('extraction', 'provenanceCopied') : t('extraction', 'provenanceCopyPrompt')}
         >
           {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}

--- a/frontend/hooks/useCopyToClipboard.test.ts
+++ b/frontend/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,70 @@
+import {act, renderHook, waitFor} from '@testing-library/react';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {useCopyToClipboard} from './useCopyToClipboard';
+
+// jsdom does not provide navigator.clipboard (only @testing-library/user-event
+// installs a stub). renderHook tests don't use user-event, so define it here.
+function mockWriteText(impl: () => Promise<void>): ReturnType<typeof vi.fn> {
+  const writeText = vi.fn(impl);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {writeText},
+    configurable: true,
+    writable: true,
+  });
+  return writeText;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('useCopyToClipboard', () => {
+  it('starts not copied', () => {
+    const {result} = renderHook(() => useCopyToClipboard());
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('writes the text and flips copied=true on success', async () => {
+    const writeText = mockWriteText(() => Promise.resolve());
+    const {result} = renderHook(() => useCopyToClipboard());
+
+    act(() => result.current.copy('hello'));
+
+    expect(writeText).toHaveBeenCalledWith('hello');
+    await waitFor(() => expect(result.current.copied).toBe(true));
+  });
+
+  it('does NOT flip copied when the clipboard write rejects', async () => {
+    const writeText = mockWriteText(() => Promise.reject(new Error('denied')));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const {result} = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      result.current.copy('hello');
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(result.current.copied).toBe(false);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('reverts copied to false after resetMs', async () => {
+    vi.useFakeTimers();
+    mockWriteText(() => Promise.resolve());
+    const {result} = renderHook(() => useCopyToClipboard(1000));
+
+    await act(async () => {
+      result.current.copy('hello');
+      await Promise.resolve();
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+});

--- a/frontend/hooks/useCopyToClipboard.ts
+++ b/frontend/hooks/useCopyToClipboard.ts
@@ -1,0 +1,37 @@
+/**
+ * useCopyToClipboard — copy text and flash a "copied" state for `resetMs`.
+ *
+ * The clipboard-with-checkmark idiom (copy → show a check → revert after ~2s)
+ * was duplicated across the AI-suggestion surfaces (provenance prompt, cited
+ * evidence). This is the single home for it.
+ *
+ * `copy` swallows clipboard rejections (logs them) so callers never need a
+ * try/finally — which the React Compiler bans in component/hook bodies.
+ */
+
+import {useState} from 'react';
+
+export interface UseCopyToClipboardResult {
+  /** True for `resetMs` after a successful copy; never flips on failure. */
+  copied: boolean;
+  /** Write `text` to the clipboard; flips `copied` only on success. */
+  copy: (text: string) => void;
+}
+
+export function useCopyToClipboard(resetMs = 2000): UseCopyToClipboardResult {
+  const [copied, setCopied] = useState(false);
+
+  const copy = (text: string) => {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), resetMs);
+      })
+      .catch((err: unknown) => {
+        console.error('Failed to copy to clipboard:', err);
+      });
+  };
+
+  return {copied, copy};
+}

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -396,7 +396,6 @@ export const extraction = {
     createValidationFramework: 'Select a framework',
     examplePlaceholder: 'e.g. Extract the total number of participants at baseline, before exclusions…',
     noDescription: 'No description',
-    historySuggestionsAria: 'Suggestion history',
     // ArticleExtractionTable (columns, filters, actions)
     tableFilterAllStatus: 'All statuses',
     tableColumnTitle: 'Title',
@@ -445,18 +444,11 @@ export const extraction = {
     tableExport: 'Export',
     tableInDevelopment: 'In development',
     tableClearSelection: 'Clear selection',
-    // AI suggestion history popover
-    historyCurrentRun: 'Current',
-    // AISuggestionHistoryPopover
+    // AISuggestionReviewPopover – invalid-timestamp fallback
     historyInvalidDate: 'Invalid date',
-    historySuggestionsTitle: 'Suggestion history',
-    historySuggestionsCount: 'suggestion(s) found',
-    historyNoSuggestions: 'No previous suggestions found',
     suggestionAccepted: 'Accepted',
     suggestionRejected: 'Rejected',
     aiAccepted: 'AI accepted',
-    acceptButton: 'Accept',
-    rejectButton: 'Reject',
     toastSuggestionAcceptedSuccess: 'Suggestion accepted successfully',
     toastSuggestionRejectedSuccess: 'Suggestion rejected',
     emptyValue: '(empty)',
@@ -836,12 +828,8 @@ export const extraction = {
     modelNameEmpty: 'Model name cannot be empty',
     modelNameMinLength: 'Model name must be at least 2 characters',
     modelNameDuplicate: 'A model with this name already exists',
-    // AISuggestionDisplay / AISuggestionDetailsPopover – evidence accessibility
-    aiEvidenceClickTitle: 'Click to view evidence',
-    aiEvidenceClickAria: 'View evidence for this suggestion',
     evidenceCitedAria: 'Cited evidence',
-    // AISuggestionDetailsPopover – header + sections
-    aiSuggestionDetailsTitle: 'Suggestion details',
+    // AISuggestionReviewPopover – rationale section label
     aiRationaleLabel: 'Rationale',
     // AISuggestionConfidence
     aiConfidenceTooltip: 'AI suggestion confidence level',

--- a/frontend/services/aiSuggestionService.ts
+++ b/frontend/services/aiSuggestionService.ts
@@ -63,6 +63,7 @@ function mapProvenance(
     params,
     tokens,
     ran_by_user_id,
+    ran_by_name,
     prompt_version,
     prompt_text,
     ...rest
@@ -74,6 +75,10 @@ function mapProvenance(
     if (value !== undefined) out[key] = value;
   };
   assign('ranByUserId', ran_by_user_id);
+  // The backend resolves `ran_by_name` from the runner's profile on the history
+  // path; map it to camelCase so the disclosure's "Ran by" row picks it up
+  // (instead of falling through `...rest` as a raw `ran_by_name` generic row).
+  assign('ranByName', ran_by_name);
   assign('promptVersion', prompt_version);
   assign('promptText', prompt_text);
   assign('temperature', p['temperature']);

--- a/frontend/test/services/aiSuggestionService.test.ts
+++ b/frontend/test/services/aiSuggestionService.test.ts
@@ -452,6 +452,30 @@ describe('provenance mapping', () => {
     });
   });
 
+  it('maps the backend-resolved ran_by_name to camelCase ranByName', async () => {
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: 'p-1',
+        run_id: 'run-A',
+        instance_id: 'inst-1',
+        field_id: 'f-1',
+        proposed_value: { value: 'V' },
+        confidence_score: 0.8,
+        rationale: null,
+        created_at: '2026-04-28T10:00:00Z',
+        evidence: [],
+        provenance: { ...serverProvenance, ran_by_name: 'Raphael F.' },
+      },
+    ]);
+    const result = await AISuggestionService.getHistory('art-1', 'inst-1', 'f-1');
+    expect(result[0].provenance).toMatchObject({
+      ranByUserId: 'user-9',
+      ranByName: 'Raphael F.',
+    });
+    // never leaks the raw snake_case key into the flattened shape
+    expect(result[0].provenance).not.toHaveProperty('ran_by_name');
+  });
+
   it('flattens provenance on getHistory items too', async () => {
     (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       {


### PR DESCRIPTION
Promotion of `dev` → `main`. Ships exactly one squash-merged PR:

- [#445](https://github.com/raphaelfh/prumo/pull/445) — feat(extraction): wire provenance "Ran by" name + share `useCopyToClipboard` hook + prune dead AI copy.

All CI green on dev (Backend Tests, Frontend Tests, Frontend + Backend E2E, CodeQL, Architectural Fitness, Docker Build). Merge-commit promotion (not squash/ff). Railway (web + worker) and Vercel redeploy from `main`; Post-deploy Smoke is the prod-health gate. Supabase Preview is expected to fail on promotion (ignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)