### PR TITLE
Promote dev → main: extraction AI-suggestion review fixes (#448, #447)

### DIFF
--- a/backend/app/llm/claim_value.py
+++ b/backend/app/llm/claim_value.py
@@ -1,0 +1,78 @@
+"""Human-readable value rendering for the entailment CLAIM.
+
+A select/multiselect field stores the option CODE (e.g. "Y"), because the
+extraction output schema constrains the LLM to ``opt["value"]`` (see
+``app.llm.schema._enum_values`` / ``_value_type``). Handing that bare code to
+the entailment judge as ``CLAIM: "<field> = Y"`` is near-uninterpretable
+against prose, biasing coded select/boolean fields toward ``weak`` /
+``unsupported`` regardless of the citation quality. Resolve the code to its
+human label ("Yes") before building the claim so the judge can actually assess
+entailment.
+
+Numeric / date / text values pass through unchanged so the deterministic
+numeric check (``app.llm.value_support.numeric_value_supported``) still sees the
+raw number. Pure, no IO.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_options(allowed_values: Any) -> list[Any]:
+    """Return the raw option list from an ``allowed_values`` payload.
+
+    Tolerates both shapes the template builder emits: ``{"options": [...]}`` or a
+    bare ``[...]``; anything else yields ``[]``. Single source of the shape
+    tolerance, shared by ``option_label_map`` here and
+    ``app.llm.schema._enum_values`` so a new option encoding is handled once.
+    """
+    if isinstance(allowed_values, dict) and "options" in allowed_values:
+        options = allowed_values["options"]
+    elif isinstance(allowed_values, list):
+        options = allowed_values
+    else:
+        return []
+    return list(options or [])
+
+
+def option_label_map(allowed_values: Any) -> dict[str, str]:
+    """Map each select option's stored value (code) to its human label.
+
+    Options are ``{"value","label"}`` dicts or plain strings. Plain strings (and
+    options without a distinct label) map to themselves, so resolution is a safe
+    no-op for label-less templates.
+    """
+    out: dict[str, str] = {}
+    for opt in normalize_options(allowed_values):
+        if isinstance(opt, dict) and "value" in opt:
+            label = opt.get("label")
+            out[str(opt["value"])] = str(label) if label else str(opt["value"])
+        elif isinstance(opt, str):
+            out[opt] = opt
+    return out
+
+
+def value_str_for_claim(*, field_type: str | None, allowed_values: Any, value: Any) -> str:
+    """Render *value* as a human-readable string for the entailment CLAIM.
+
+    - ``bool``            -> "Yes" / "No"
+    - ``select``          -> the option's label for the code (fallback: the code)
+    - ``multiselect``     -> comma-joined option labels (fallback: each code)
+    - everything else     -> ``str(value)`` unchanged (numeric / date / text keep
+                             their raw form so the deterministic numeric check
+                             still works; ``allow_other`` free text falls through
+                             the option map to its raw string).
+
+    Never raises: an unknown shape or a code missing from the option map falls
+    back to the raw ``str(value)`` — today's behaviour.
+    """
+    # bool is a subclass of int, so check it before any numeric handling.
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if field_type in ("select", "multiselect"):
+        label_map = option_label_map(allowed_values)
+        if isinstance(value, list):
+            return ", ".join(label_map.get(str(v), str(v)) for v in value)
+        return label_map.get(str(value), str(value))
+    return str(value)

--- a/backend/app/llm/entailment.py
+++ b/backend/app/llm/entailment.py
@@ -93,40 +93,48 @@ class GateSpec:
 def _build_premise(spec: GateSpec) -> str:
     """Return the premise string for the entailment gate.
 
-    For a table-cell citation, returns just the cited cell's text (so the value
+    Locates the cited block(s) by the anchor's ``block_ids`` — the per-page
+    ``block_index`` values the quote matched (see
+    ``evidence_anchor_service.match``). This correctly handles a quote that
+    spans MORE THAN ONE block; a single-containment char-range scan finds no
+    block for such a quote and silently degrades to the bare quote, robbing the
+    judge of neighbouring context.
+
+    For a table-cell citation, returns just the cited cell(s) text (so the value
     check is cell-scoped — an adjacent cell's number must not satisfy it). For
-    prose, returns the cited block + one neighbour on each side. Falls back to
-    the raw evidence quote when the cited block cannot be located by page/char
-    range in ``anchor_blocks``.
+    prose, returns the cited block span plus one neighbour block on each side
+    (``anchor_blocks`` is in reading order). Falls back to the raw evidence
+    quote when ``block_ids`` is empty or none resolve to a block on the anchor's
+    page in ``anchor_blocks``.
     """
-    if spec.pos is not None and spec.anchor_blocks:
-        blocks_by_idx: dict[int, Any] = dict(enumerate(spec.anchor_blocks))
-        anchor_range = spec.pos.anchor.range  # PDFTextRange
-        cited_idx = next(
-            (
-                i
-                for i, b in enumerate(spec.anchor_blocks)
-                if b.page_number == anchor_range.page
-                and b.char_start <= anchor_range.char_start
-                and b.char_end >= anchor_range.char_end
-            ),
-            None,
-        )
-        if cited_idx is not None:
-            cited = blocks_by_idx[cited_idx]
-            # Table cells verify against the cell itself: "the cited cell
-            # contains the value." Including neighbour cells would let an
-            # adjacent cell's number satisfy the deterministic check.
-            if getattr(cited, "block_type", None) == "table_cell":
-                cell_text: str = cited.text
-                return cell_text
-            parts = [
-                blocks_by_idx[j].text
-                for j in (cited_idx - 1, cited_idx, cited_idx + 1)
-                if j in blocks_by_idx
-            ]
-            return "\n".join(parts)
-    return spec.quote
+    if spec.pos is None or not spec.anchor_blocks:
+        return spec.quote
+
+    anchor = spec.pos.anchor
+    block_ids = anchor.block_ids
+    if not block_ids:
+        return spec.quote
+
+    page = anchor.range.page
+    cited_positions = [
+        i
+        for i, b in enumerate(spec.anchor_blocks)
+        if b.page_number == page and b.block_index in block_ids
+    ]
+    if not cited_positions:
+        return spec.quote
+
+    # Table cells verify against the cited cell(s) only: including neighbour
+    # cells would let an adjacent cell's number satisfy the deterministic value
+    # check.
+    if all(spec.anchor_blocks[i].block_type == "table_cell" for i in cited_positions):
+        return "\n".join(spec.anchor_blocks[i].text for i in cited_positions)
+
+    # Prose: the cited block span + one neighbour block on each side
+    # (``anchor_blocks`` is in reading order).
+    lo = max(0, cited_positions[0] - 1)
+    hi = min(len(spec.anchor_blocks) - 1, cited_positions[-1] + 1)
+    return "\n".join(spec.anchor_blocks[j].text for j in range(lo, hi + 1))
 
 
 async def run_entailment_gate(

--- a/backend/app/llm/schema.py
+++ b/backend/app/llm/schema.py
@@ -12,6 +12,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
+from app.llm.claim_value import normalize_options
+
 OPENAI_STRICT_PROPERTY_BUDGET = 100
 _PROPERTIES_PER_FIELD = 8  # value, confidence, reasoning, evidence{text,page}, status
 
@@ -44,18 +46,13 @@ _LIST_TYPES = ("array", "list", "multiselect")
 
 
 def _enum_values(field: Any) -> list[Any]:
-    """allowed_values can be {"options": [...]} or [...]; options are
-    dicts with a "value" key or plain strings (same tolerance as the
-    legacy schema builder)."""
-    allowed = getattr(field, "allowed_values", None)
-    if isinstance(allowed, dict) and "options" in allowed:
-        options = allowed["options"]
-    elif isinstance(allowed, list):
-        options = allowed
-    else:
-        return []
+    """allowed_values options → list of option codes (each option's "value").
+
+    Options are dicts with a "value" key or plain strings. Shape tolerance
+    ({"options": [...]} vs [...]) lives in ``claim_value.normalize_options``.
+    """
     values: list[Any] = []
-    for opt in options or []:
+    for opt in normalize_options(getattr(field, "allowed_values", None)):
         if isinstance(opt, dict) and "value" in opt:
             values.append(opt["value"])
         elif isinstance(opt, str):

--- a/backend/app/repositories/extraction_run_repository.py
+++ b/backend/app/repositories/extraction_run_repository.py
@@ -131,6 +131,35 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
         )
         return await self.get_by_id(run_id)
 
+    async def merge_results(
+        self,
+        run_id: UUID,
+        patch: dict[str, Any],
+    ) -> ExtractionRun | None:
+        """Shallow-merge *patch* into the run's ``results`` JSONB; keep status.
+
+        The session-run extraction path (``extract_section`` / ``extract_for_run``
+        on a run the HITL session owns) must keep the run alive in EXTRACT, so it
+        cannot call ``complete_run`` (which marks the run COMPLETED). This lets it
+        still persist run-level data — notably ``provenance`` (how the suggestions
+        were generated) — so the review UI's "How this was generated" disclosure
+        has data to show.
+
+        Args:
+            run_id: the run to update.
+            patch: top-level keys to merge into ``results``.
+
+        Returns:
+            The updated ExtractionRun, or None if the run does not exist.
+        """
+        run = await self.get_by_id(run_id)
+        if run is None:
+            return None
+        # Reassign (not in-place mutate) so SQLAlchemy tracks the JSONB change.
+        run.results = {**(run.results or {}), **patch}
+        await self.db.flush()
+        return run
+
     async def fail_run(
         self,
         run_id: UUID,

--- a/backend/app/services/extraction_suggestion_read_service.py
+++ b/backend/app/services/extraction_suggestion_read_service.py
@@ -81,6 +81,19 @@ def _resolve_status(decision: str | None) -> str:
     return "accepted"
 
 
+def _is_no_info(proposed_value: Any) -> bool:
+    """True when a proposal carries no actionable value (the model abstained).
+
+    Mirrors the frontend ``isNoInfoValue``: a bare ``None``, the JSONB envelope
+    ``{"value": None}`` (the shape recorded for a "no information" outcome since
+    #443), or an empty string all mean "no information".
+    """
+    if proposed_value is None:
+        return True
+    value = proposed_value.get("value") if isinstance(proposed_value, dict) else proposed_value
+    return value is None or value == ""
+
+
 async def _load_run_provenance(
     db: AsyncSession, run_ids: set[UUID], *, resolve_names: bool = False
 ) -> dict[UUID, dict[str, Any] | None]:
@@ -159,7 +172,10 @@ async def load_suggestions(
        optional run_id, ORDER BY created_at DESC.
        Scoped to article_id via JOIN on ExtractionInstance — instances that do not
        belong to the path article are silently dropped (cross-project IDOR guard).
-    2. Dedup: first-per-(instance_id, field_id) wins (desc order → latest wins).
+    2. Dedup per (instance_id, field_id): the latest proposal wins, EXCEPT a
+       later "no information" (null) proposal never buries an earlier real
+       value — the most recent value-bearing proposal is preferred, falling
+       back to the latest no-info only when no run found a value.
     3. Load evidence for the deduplicated proposal_ids.
     4. Load ExtractionReviewerState WHERE reviewer_id == caller_id (blind boundary)
        joined to ExtractionReviewerDecision via the composite FK for `.decision`.
@@ -193,14 +209,23 @@ async def load_suggestions(
     proposals = (await db.execute(proposal_stmt)).scalars().all()
 
     # --- Step 2: dedup to latest-per-(instance_id, field_id) ---
-    seen: set[tuple[UUID, UUID]] = set()
-    deduped: list[ExtractionProposalRecord] = []
+    # A later run that abstained ("no information" → proposed_value
+    # {"value": null}, recorded as a first-class proposal since #443) must NOT
+    # bury an earlier run's real value in the inline strip. Prefer the most
+    # recent proposal that carries a value; fall back to the most recent no-info
+    # proposal only when no run ever found one. The full trail (including the
+    # abstention) stays available via get_suggestion_history. ``proposals`` is
+    # ordered newest-first, so dict insertion order keeps the latest per coord.
+    chosen: dict[tuple[UUID, UUID], ExtractionProposalRecord] = {}
     for p in proposals:
         key = (p.instance_id, p.field_id)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(p)
+        existing = chosen.get(key)
+        if existing is None:
+            chosen[key] = p
+        elif _is_no_info(existing.proposed_value) and not _is_no_info(p.proposed_value):
+            # The more recent pick abstained; this older one found a value → use it.
+            chosen[key] = p
+    deduped = list(chosen.values())
 
     if not deduped:
         return AISuggestionsResponse(suggestions=[], count=0)

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.logging import LoggerMixin
 from app.infrastructure.storage import StorageAdapter
+from app.llm.claim_value import value_str_for_claim
 from app.llm.entailment import GateSpec, run_entailment_gate
 from app.llm.extractor import (
     LLM_TEMPERATURE,
@@ -341,6 +342,16 @@ class SectionExtractionService(LoggerMixin):
                     },
                 )
                 phase_durations_ms["complete_run"] = (perf_counter() - phase_start) * 1000
+            else:
+                # Session-run path: the HITL session owns the run lifecycle, so we
+                # must NOT complete it (that would close the run after one section
+                # and break further section-by-section AI clicks). Still persist
+                # the provenance snapshot so the review popover's "How this was
+                # generated" metadata renders for these suggestions — without this
+                # merge, session-run suggestions carried no provenance at all.
+                provenance = self._provenance_with_tokens(llm_usage)
+                if provenance is not None:
+                    await self._runs.merge_results(run.id, {"provenance": provenance})
 
             self.logger.info(
                 "section_extraction_complete",
@@ -505,6 +516,16 @@ class SectionExtractionService(LoggerMixin):
 
             duration_ms = (perf_counter() - start_time) * 1000
 
+            # Persist how the suggestions were generated so the review popover's
+            # "How this was generated" metadata renders. ``_run_provenance`` holds
+            # the run config (model/provider/params/prompt) set by the last
+            # ``_extract_with_llm`` call; pair it with the run-aggregate token total.
+            run_provenance = (
+                {**self._run_provenance, "tokens": {"total": total_tokens}}
+                if self._run_provenance is not None
+                else None
+            )
+
             await self._runs.complete_run(
                 run_id=run.id,
                 results={
@@ -517,6 +538,7 @@ class SectionExtractionService(LoggerMixin):
                     "kind": kind,
                     "skip_fields_with_human_proposals": skip_fields_with_human_proposals,
                     "auto_advance_to_review": auto_advance_to_review,
+                    "provenance": run_provenance,
                 },
             )
 
@@ -1316,14 +1338,18 @@ class SectionExtractionService(LoggerMixin):
             )
             return 0
 
-        # Build field_name -> field_id map
+        # Build field_name -> field_id / label / field maps. The field object is
+        # kept so the entailment gate can resolve a select/boolean CODE to its
+        # human label before building the judge claim (see value_str_for_claim).
         field_map: dict[str, UUID] = {}
         field_label_map: dict[str, str] = {}
+        field_by_name: dict[str, Any] = {}
         for field in entity_type.fields or []:
             field_map[field.name] = field.id
             field_label_map[field.name] = (
                 field.label if hasattr(field, "label") and field.label else field.name
             )
+            field_by_name[field.name] = field
 
         # Fetch existing instance
         instances = await self._instances.get_by_article(article_id, entity_type_id)
@@ -1490,10 +1516,18 @@ class SectionExtractionService(LoggerMixin):
                 # Queue for entailment gate: found fields with ANCHORED evidence only.
                 if isinstance(value, dict) and value.get("status") == "found" and quote:
                     if pos is not None:
+                        _gate_field = field_by_name.get(field_name)
                         _gate_specs.append(
                             GateSpec(
                                 field_label=field_label_map.get(field_name, field_name),
-                                value_str=str(inner_value),
+                                # Resolve a select/boolean CODE ("Y") to its human
+                                # label ("Yes") so the judge claim is interpretable;
+                                # numeric/date/text pass through unchanged.
+                                value_str=value_str_for_claim(
+                                    field_type=getattr(_gate_field, "field_type", None),
+                                    allowed_values=getattr(_gate_field, "allowed_values", None),
+                                    value=inner_value,
+                                ),
                                 quote=quote,
                                 pos=pos,
                                 anchor_blocks=_anchor_blocks,

--- a/backend/tests/integration/test_section_extraction_gate.py
+++ b/backend/tests/integration/test_section_extraction_gate.py
@@ -30,8 +30,10 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.llm.entailment as entailment_mod
+from app.core.config import settings
 from app.infrastructure.parsing.base import ParsedBlock
-from app.models.extraction import ExtractionEvidence, ExtractionRunStage
+from app.llm.extractor import LlmUsage
+from app.models.extraction import ExtractionEvidence, ExtractionRun, ExtractionRunStage
 from app.services import section_extraction_service as ses
 from app.services.run_lifecycle_service import RunLifecycleService
 from tests.integration.conftest import SEED
@@ -218,6 +220,101 @@ async def test_evidence_gets_attribution_label_and_not_found_recorded(
     # Cascade order: evidence → proposal_records → runs (FK CASCADE handles
     # child tables under runs; explicit DELETE for evidence which references
     # proposal_records via proposal_record_id).
+    await db_session_real.execute(
+        text("DELETE FROM public.extraction_evidence WHERE run_id = ANY(:ids)"),
+        {"ids": run_ids},
+    )
+    await db_session_real.execute(
+        text("DELETE FROM public.extraction_proposal_records WHERE run_id = ANY(:ids)"),
+        {"ids": run_ids},
+    )
+    await db_session_real.execute(
+        text("DELETE FROM public.extraction_runs WHERE id = ANY(:ids)"),
+        {"ids": run_ids},
+    )
+    await db_session_real.commit()
+
+
+@pytest.mark.asyncio
+async def test_session_run_extraction_persists_provenance(
+    db_session_real: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session-run extraction (run_id passed) persists results['provenance'].
+
+    Regression: ``extract_section`` only wrote provenance in the
+    ``manage_lifecycle`` (standalone) branch, so SESSION runs — the extraction
+    and QA screens always pass an existing ``run_id`` — had no provenance and the
+    review popover's "How this was generated" metadata never rendered. The run
+    must stay alive (EXTRACT) — the HITL session owns its lifecycle — so the
+    provenance is merged into ``results`` without completing the run.
+    """
+
+    async def _stub_gate(**_kwargs: Any) -> str:
+        return "entailed"
+
+    monkeypatch.setattr(entailment_mod, "gate_evidence", _stub_gate)
+    fake_model = MagicMock()
+    monkeypatch.setattr(ses, "build_model", lambda *_a, **_kw: fake_model)
+
+    run = await _build_run_in_extract(db_session_real)
+    service = _make_service(db_session_real)
+
+    # Stub the two IO methods extract_section calls before _create_suggestions:
+    # _assemble_prompt_text (needs a real PDF) and _extract_with_llm (real LLM).
+    async def _fake_assemble(_article_id: Any, _model: str) -> str:
+        service._run_anchor_blocks = [_make_anchor_block()]
+        service._run_anchor_file_id = None
+        return "fake prompt"
+
+    monkeypatch.setattr(service, "_assemble_prompt_text", _fake_assemble)
+
+    async def _fake_extract(**_kwargs: Any) -> tuple[dict[str, Any], LlmUsage]:
+        # Mirror the real _extract_with_llm, which builds the run provenance snapshot.
+        service._run_provenance = service._build_run_provenance(
+            model="gpt-4o-mini",
+            prompt_name="section_extraction",
+            prompt_version="1",
+            prompt_text="PROMPT TEXT",
+        )
+        data = {
+            "sample_size": {
+                "value": 142,
+                "confidence": 0.95,
+                "reasoning": "Stated in the abstract.",
+                "evidence": {"text": _EVIDENCE_QUOTE, "page_number": 1},
+                "status": "found",
+            }
+        }
+        return data, LlmUsage(prompt_tokens=100, completion_tokens=20)
+
+    monkeypatch.setattr(service, "_extract_with_llm", _fake_extract)
+
+    await service.extract_section(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        template_id=SEED.primary_template,
+        entity_type_id=SEED.primary_entity_type,
+        run_id=run.id,  # SESSION PATH — manage_lifecycle is False
+    )
+    await db_session_real.flush()
+
+    refreshed = await db_session_real.get(ExtractionRun, run.id)
+    assert refreshed is not None and refreshed.results is not None
+    assert "provenance" in refreshed.results, (
+        "session-run extraction did not persist results['provenance'] — the "
+        "review popover's 'How this was generated' metadata would be empty."
+    )
+    prov = refreshed.results["provenance"]
+    assert prov["model"] == "gpt-4o-mini"
+    assert prov["provider"] == settings.LLM_PROVIDER
+    assert prov["tokens"]["total"] == 120
+    # The session run must stay editable (NOT completed by this call).
+    assert refreshed.stage == ExtractionRunStage.EXTRACT.value
+
+    # --- cleanup ---
+    await db_session_real.commit()
+    run_ids = [str(run.id)]
     await db_session_real.execute(
         text("DELETE FROM public.extraction_evidence WHERE run_id = ANY(:ids)"),
         {"ids": run_ids},

--- a/backend/tests/integration/test_suggestion_read.py
+++ b/backend/tests/integration/test_suggestion_read.py
@@ -583,6 +583,132 @@ async def test_load_suggestions_dedup_latest_per_coord(
 
 
 @pytest.mark.asyncio
+async def test_load_suggestions_latest_no_info_keeps_earlier_real_value(
+    db_session: AsyncSession,
+) -> None:
+    """A later 'no information' run must not bury an earlier run's real value.
+
+    Since #443 an AI run that abstains records a real proposal with
+    proposed_value={"value": None}. The inline strip dedups to latest-per-coord;
+    without the no-info guard, re-running extraction (which often abstains on a
+    field the first run found) would surface the null proposal and blank the
+    suggestion. The dedup must fall back to the most recent proposal that
+    actually carries a value — the abstention stays in get_suggestion_history.
+    Regression test for the "suggestion disappears after a 2nd AI extraction" bug.
+    """
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+    manager_id = SEED.primary_profile
+
+    lifecycle = RunLifecycleService(db_session)
+    run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.EXTRACT, user_id=manager_id
+    )
+
+    proposal_svc = ExtractionProposalService(db_session)
+    # Older run found a value; the latest run abstained (no information).
+    older = await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": "REAL-VALUE"},
+    )
+    await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": None},  # no information
+    )
+    await db_session.flush()
+    # Back-date the OLDER (real-value) row so created_at ordering is unambiguous.
+    await db_session.execute(
+        text(
+            "UPDATE public.extraction_proposal_records "
+            "SET created_at = created_at - interval '1 second' "
+            "WHERE id = :id"
+        ),
+        {"id": str(older.id)},
+    )
+    await db_session.flush()
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=manager_id,
+        run_id=run.id,
+    )
+
+    assert result.count == 1
+    assert result.suggestions[0].proposed_value == {"value": "REAL-VALUE"}, (
+        "A later no-information proposal buried the earlier real value in the "
+        "inline strip — the dedup should prefer the latest proposal WITH a value."
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_all_no_info_returns_no_info(
+    db_session: AsyncSession,
+) -> None:
+    """When every run abstained, the coord still surfaces a (no-info) proposal.
+
+    The latest-with-value preference only kicks in when a real value exists;
+    if all proposals are no-info, the coord still appears (so the quiet
+    "no information" indicator and its provenance remain reachable).
+    """
+    project_id = SEED.primary_project
+    article_id = SEED.primary_article
+    template_id = SEED.primary_template
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+    manager_id = SEED.primary_profile
+
+    lifecycle = RunLifecycleService(db_session)
+    run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_id,
+        project_template_id=template_id,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.EXTRACT, user_id=manager_id
+    )
+
+    proposal_svc = ExtractionProposalService(db_session)
+    for _ in range(2):
+        await proposal_svc.record_proposal(
+            run_id=run.id,
+            instance_id=instance_id,
+            field_id=field_id,
+            source=ExtractionProposalSource.AI,
+            proposed_value={"value": None},
+        )
+    await db_session.flush()
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=manager_id,
+        run_id=run.id,
+    )
+
+    assert result.count == 1
+    assert result.suggestions[0].proposed_value == {"value": None}
+
+
+@pytest.mark.asyncio
 async def test_load_suggestions_empty_instance_ids(
     db_session: AsyncSession,
 ) -> None:

--- a/backend/tests/unit/llm/test_claim_value.py
+++ b/backend/tests/unit/llm/test_claim_value.py
@@ -1,0 +1,78 @@
+"""value_str_for_claim / option_label_map — unit tests (pure, no IO).
+
+Guards the fix for the "Not supported" attribution bug: a select/boolean field
+stores the option CODE ("Y"), and the entailment judge must receive the human
+LABEL ("Yes") so the claim is interpretable. Numeric/date/text must pass
+through unchanged so the deterministic numeric check still works.
+"""
+
+from app.llm.claim_value import option_label_map, value_str_for_claim
+
+
+class TestOptionLabelMap:
+    def test_options_dict_shape_with_labels(self) -> None:
+        allowed = {"options": [{"value": "Y", "label": "Yes"}, {"value": "N", "label": "No"}]}
+        assert option_label_map(allowed) == {"Y": "Yes", "N": "No"}
+
+    def test_plain_string_options_map_to_themselves(self) -> None:
+        assert option_label_map(["Case series", "Registry"]) == {
+            "Case series": "Case series",
+            "Registry": "Registry",
+        }
+
+    def test_dict_without_label_falls_back_to_value(self) -> None:
+        assert option_label_map([{"value": "Y"}]) == {"Y": "Y"}
+
+    def test_none_or_unknown_shape_is_empty(self) -> None:
+        assert option_label_map(None) == {}
+        assert option_label_map("nonsense") == {}
+        assert option_label_map({}) == {}
+
+
+class TestValueStrForClaim:
+    def test_select_code_resolves_to_label(self) -> None:
+        """The core bug: a select CODE 'Y' must become 'Yes' for the judge."""
+        allowed = {"options": [{"value": "Y", "label": "Yes"}]}
+        assert value_str_for_claim(field_type="select", allowed_values=allowed, value="Y") == "Yes"
+
+    def test_select_unknown_code_falls_back_to_raw(self) -> None:
+        """allow_other free text (not in the option map) keeps its raw value."""
+        allowed = {"options": [{"value": "Y", "label": "Yes"}]}
+        assert (
+            value_str_for_claim(field_type="select", allowed_values=allowed, value="other text")
+            == "other text"
+        )
+
+    def test_multiselect_joins_labels(self) -> None:
+        allowed = {"options": [{"value": "A", "label": "Alpha"}, {"value": "B", "label": "Beta"}]}
+        assert (
+            value_str_for_claim(field_type="multiselect", allowed_values=allowed, value=["A", "B"])
+            == "Alpha, Beta"
+        )
+
+    def test_boolean_renders_yes_no(self) -> None:
+        assert value_str_for_claim(field_type="boolean", allowed_values=None, value=True) == "Yes"
+        assert value_str_for_claim(field_type="boolean", allowed_values=None, value=False) == "No"
+
+    def test_numeric_passes_through_unchanged(self) -> None:
+        """Numbers must NOT be remapped — the deterministic numeric check needs the raw form."""
+        assert value_str_for_claim(field_type="number", allowed_values=None, value=287) == "287"
+        assert value_str_for_claim(field_type="number", allowed_values=None, value=11.8) == "11.8"
+
+    def test_text_passes_through_unchanged(self) -> None:
+        assert (
+            value_str_for_claim(field_type="text", allowed_values=None, value="Case series")
+            == "Case series"
+        )
+
+    def test_string_options_select_is_identity(self) -> None:
+        """A select whose options are plain label strings resolves to itself."""
+        assert (
+            value_str_for_claim(
+                field_type="select", allowed_values=["Case series"], value="Case series"
+            )
+            == "Case series"
+        )
+
+    def test_missing_field_type_falls_back_to_str(self) -> None:
+        assert value_str_for_claim(field_type=None, allowed_values=None, value="Y") == "Y"

--- a/backend/tests/unit/test_entailment_cell_premise.py
+++ b/backend/tests/unit/test_entailment_cell_premise.py
@@ -3,46 +3,85 @@ from types import SimpleNamespace
 from app.llm.entailment import GateSpec, _build_premise
 
 
-def _block(page, idx, text, bt, cs, ce):
-    return SimpleNamespace(
-        page_number=page,
-        block_index=idx,
-        text=text,
-        block_type=bt,
-        char_start=cs,
-        char_end=ce,
-    )
+def _block(page, idx, text, bt):
+    return SimpleNamespace(page_number=page, block_index=idx, text=text, block_type=bt)
 
 
-def _pos(page, cs, ce):
-    rng = SimpleNamespace(page=page, char_start=cs, char_end=ce)
-    return SimpleNamespace(anchor=SimpleNamespace(range=rng))
+def _pos(page, block_ids):
+    """A PositionV1-shaped anchor carrying the per-page block_index ids it matched."""
+    rng = SimpleNamespace(page=page)
+    return SimpleNamespace(anchor=SimpleNamespace(range=rng, block_ids=block_ids))
 
 
 def test_table_cell_premise_is_cell_only():
     # neighbouring cells must NOT leak into the premise for a table_cell citation
     blocks = [
-        _block(1, 0, "11.8", "table_cell", 0, 4),
-        _block(1, 1, "999", "table_cell", 5, 8),
+        _block(1, 0, "11.8", "table_cell"),
+        _block(1, 1, "999", "table_cell"),
     ]
     spec = GateSpec(
-        field_label="EPV", value_str="11.8", quote="11.8", pos=_pos(1, 0, 4), anchor_blocks=blocks
+        field_label="EPV",
+        value_str="11.8",
+        quote="11.8",
+        pos=_pos(1, [0]),
+        anchor_blocks=blocks,
     )
     assert _build_premise(spec) == "11.8"
 
 
 def test_prose_premise_keeps_neighbours():
     blocks = [
-        _block(1, 0, "Intro.", "paragraph", 0, 6),
-        _block(1, 1, "The EPV was 4.6.", "paragraph", 7, 23),
-        _block(1, 2, "Outro.", "paragraph", 24, 30),
+        _block(1, 0, "Intro.", "paragraph"),
+        _block(1, 1, "The EPV was 4.6.", "paragraph"),
+        _block(1, 2, "Outro.", "paragraph"),
     ]
     spec = GateSpec(
         field_label="EPV",
         value_str="4.6",
         quote="The EPV was 4.6.",
-        pos=_pos(1, 7, 23),
+        pos=_pos(1, [1]),
         anchor_blocks=blocks,
     )
     premise = _build_premise(spec)
     assert "Intro." in premise and "Outro." in premise  # prose keeps the window
+
+
+def test_prose_premise_spans_two_blocks():
+    # A quote whose char range spans TWO blocks: no single block fully contains
+    # it, so the old single-containment scan found nothing and silently degraded
+    # to the bare quote (dropping all neighbouring context, biasing the judge
+    # toward weak/unsupported). Building the window from the anchor's block_ids
+    # surfaces the cited blocks PLUS one neighbour on each side.
+    blocks = [
+        _block(1, 0, "Methods.", "paragraph"),
+        _block(1, 1, "Patients received drug A", "paragraph"),
+        _block(1, 2, "at 10 mg once daily.", "paragraph"),
+        _block(1, 3, "Results follow.", "paragraph"),
+    ]
+    spec = GateSpec(
+        field_label="Dose",
+        value_str="10 mg once daily",
+        quote="Patients received drug A at 10 mg once daily.",
+        pos=_pos(1, [1, 2]),  # spans block_index 1 AND 2
+        anchor_blocks=blocks,
+    )
+    premise = _build_premise(spec)
+    # Both cited blocks present (the old scan returned only the bare quote)...
+    assert "Patients received drug A" in premise
+    assert "at 10 mg once daily." in premise
+    # ...plus one neighbour block on each side — the context the judge needs.
+    assert "Methods." in premise
+    assert "Results follow." in premise
+
+
+def test_premise_falls_back_to_quote_when_block_ids_empty():
+    # No resolvable block_ids → degrade to the raw evidence quote.
+    blocks = [_block(1, 0, "Some prose.", "paragraph")]
+    spec = GateSpec(
+        field_label="X",
+        value_str="v",
+        quote="verbatim quote",
+        pos=_pos(1, []),
+        anchor_blocks=blocks,
+    )
+    assert _build_premise(spec) == "verbatim quote"

--- a/frontend/components/extraction/FieldInput.tsx
+++ b/frontend/components/extraction/FieldInput.tsx
@@ -29,7 +29,7 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {cn} from '@/lib/utils';
 import type {ExtractionField} from '@/types/extraction';
 import type {AISuggestion, AISuggestionHistoryItem} from '@/hooks/extraction/ai/useAISuggestions';
-import {AISuggestionDisplay} from './ai/AISuggestionDisplay';
+import {AISuggestionDisplay, type AISuggestionReviewBinding} from './ai/AISuggestionDisplay';
 import {AISuggestionBadge} from './ai/AISuggestionBadge';
 import {AISuggestionReviewPopover} from './ai/AISuggestionReviewPopover';
 import {getRelatedUnits} from '@/lib/unitConversions';
@@ -386,6 +386,24 @@ export function FieldInput(props: FieldInputProps) {
     aiSuggestion.status === 'rejected'
   );
 
+  // One binding for the AI review popover (its props minus `trigger`), shared by
+  // the History-icon trigger and the inline suggestion strip so the two entry
+  // points to the same coord can't drift. align='end' opens it left of the
+  // right-edge trigger, clear of the PDF/markdown viewer.
+  const reviewBinding: AISuggestionReviewBinding | undefined =
+    getSuggestionsHistory && aiSuggestion
+      ? {
+          instanceId,
+          fieldId: field.id,
+          getHistory: getSuggestionsHistory,
+          selectedProposalId: aiSuggestion.id,
+          onSelect: (proposalRecordId, selectedValue, selectedConfidence) =>
+            selectSuggestion?.(instanceId, field.id, proposalRecordId, selectedValue, selectedConfidence),
+          onClear: onRejectAI,
+          align: 'end',
+        }
+      : undefined;
+
   return (
       <div
           data-just-updated={justUpdated || undefined}
@@ -434,19 +452,12 @@ export function FieldInput(props: FieldInputProps) {
               {/* Single AI trigger: review + select past versions, see how each
                   was generated, locate evidence, or clear. Replaces the old
                   split history + details popovers. */}
-            {getSuggestionsHistory && aiSuggestion && (
+            {reviewBinding && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div>
                     <AISuggestionReviewPopover
-                      instanceId={instanceId}
-                      fieldId={field.id}
-                      getHistory={getSuggestionsHistory}
-                      selectedProposalId={aiSuggestion.id}
-                      onSelect={(proposalRecordId, selectedValue, selectedConfidence) =>
-                        selectSuggestion?.(instanceId, field.id, proposalRecordId, selectedValue, selectedConfidence)
-                      }
-                      onClear={onRejectAI}
+                      {...reviewBinding}
                       trigger={
                         <Button
                           size="icon"
@@ -478,6 +489,9 @@ export function FieldInput(props: FieldInputProps) {
             onAccept={onAcceptAI}
             onReject={onRejectAI}
             loading={isActionLoading ? isActionLoading(instanceId, field.id) === 'accept' || isActionLoading(instanceId, field.id) === 'reject' : false}
+            // Same review surface as the History icon (shared binding): clicking
+            // the inline value/confidence opens the version history + provenance.
+            review={reviewBinding}
           />
         )}
 

--- a/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
@@ -9,13 +9,14 @@
  */
 
 import { render as rtlRender, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 vi.mock('@/lib/copy', () => ({ t: (_ns: string, key: string) => key }));
 
 import { AISuggestionDisplay } from './AISuggestionDisplay';
-import type { AISuggestion } from '@/types/ai-extraction';
+import type { AISuggestion, AISuggestionHistoryItem } from '@/types/ai-extraction';
 
 // AISuggestionConfidence renders a Tooltip; the real app has a root provider.
 const render = (ui: React.ReactElement) => rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
@@ -53,5 +54,51 @@ describe('AISuggestionDisplay — no-information handling', () => {
     expect(screen.getByText('Retrospective cohort')).toBeInTheDocument();
     expect(screen.getByText('90%')).toBeInTheDocument();
     expect(screen.queryByText('reviewNoInformation')).not.toBeInTheDocument();
+  });
+});
+
+describe('AISuggestionDisplay — review popover entry point', () => {
+  const historyItem = (over: Partial<AISuggestionHistoryItem>): AISuggestionHistoryItem => ({
+    id: 'p1',
+    runId: 'run-A',
+    value: 'Retrospective cohort',
+    confidence: 0.9,
+    reasoning: '',
+    status: 'pending',
+    timestamp: new Date('2026-04-28T10:00:00Z'),
+    evidence: [],
+    ...over,
+  });
+
+  it('opens the review popover from the inline value when a review binding is supplied', async () => {
+    const getHistory = vi.fn(async () => [historyItem({})]);
+    const user = userEvent.setup();
+    render(
+      <AISuggestionDisplay
+        suggestion={makeSuggestion({ value: 'Retrospective cohort', confidence: 0.9 })}
+        review={{ instanceId: 'i', fieldId: 'f', getHistory, selectedProposalId: 'p1', onSelect: vi.fn() }}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'reviewOpenFromValue' }));
+    expect(getHistory).toHaveBeenCalledWith('i', 'f');
+  });
+
+  it('opens the review popover from the no-information indicator too', async () => {
+    const getHistory = vi.fn(async () => [] as AISuggestionHistoryItem[]);
+    const user = userEvent.setup();
+    render(
+      <AISuggestionDisplay
+        suggestion={makeSuggestion({ value: null, confidence: 0 })}
+        review={{ instanceId: 'i', fieldId: 'f', getHistory, onSelect: vi.fn() }}
+      />,
+    );
+    expect(screen.getByText('reviewNoInformation')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'reviewOpenFromValue' }));
+    expect(getHistory).toHaveBeenCalledWith('i', 'f');
+  });
+
+  it('renders no review trigger when no binding is supplied (backward compat)', () => {
+    render(<AISuggestionDisplay suggestion={makeSuggestion({ value: 'X', confidence: 0.5 })} />);
+    expect(screen.queryByRole('button', { name: 'reviewOpenFromValue' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -3,24 +3,86 @@
  *
  * Shows the suggested value + confidence + quick accept/reject below the input.
  * The rich review surface (version history, provenance, cited evidence + locate)
- * now lives behind the single review trigger in `FieldInput`
- * (`AISuggestionReviewPopover`), so this strip stays a lightweight inline glance.
+ * lives behind `AISuggestionReviewPopover`. When a `review` binding is supplied,
+ * the value/confidence (and the "no information" indicator) become a trigger
+ * that opens that SAME popover — so the user can reach version history straight
+ * from the inline strip, not only from the History icon in `FieldInput`.
  *
  * @component
  */
 
-import type {AISuggestion} from '@/hooks/extraction/ai/useAISuggestions';
+import type {AISuggestion, AISuggestionHistoryItem} from '@/hooks/extraction/ai/useAISuggestions';
 import {AISuggestionActions} from '@/components/shared/ai-suggestions';
 import {AISuggestionConfidence} from './shared/AISuggestionConfidence';
 import {AISuggestionValue} from './shared/AISuggestionValue';
+import {AISuggestionReviewPopover} from './AISuggestionReviewPopover';
 import {isNoInfoValue, isSuggestionAccepted} from '@/lib/ai-extraction/suggestionUtils';
+import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
+
+/**
+ * Wiring for the review popover the inline strip opens. Mirrors the props the
+ * History-icon popover in `FieldInput` already binds, so both entry points
+ * resolve to one surface for the same (instance, field) coord.
+ */
+export interface AISuggestionReviewBinding {
+  instanceId: string;
+  fieldId: string;
+  getHistory: (instanceId: string, fieldId: string) => Promise<AISuggestionHistoryItem[]>;
+  selectedProposalId?: string;
+  onSelect: (proposalRecordId: string, value: unknown, confidence: number) => void;
+  onClear?: () => void;
+  /** Defaults to 'end' so the popover opens left, clear of the PDF panel. */
+  align?: 'start' | 'center' | 'end';
+}
 
 interface AISuggestionDisplayProps {
   suggestion: AISuggestion;
   onAccept?: () => void;
   onReject?: () => void;
   loading?: boolean;
+  /** When present, the value area becomes a trigger for the review popover. */
+  review?: AISuggestionReviewBinding;
+}
+
+/**
+ * Wraps `children` in the review popover's trigger button when a binding is
+ * supplied; otherwise renders a plain container with the same layout classes.
+ */
+function ReviewTrigger({
+  review,
+  className,
+  children,
+}: {
+  review?: AISuggestionReviewBinding;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  if (!review) {
+    return <div className={className}>{children}</div>;
+  }
+  return (
+    // The binding is exactly the popover's props minus `trigger`, so spread it;
+    // default align to 'end' so the popover opens left, clear of the PDF panel.
+    <AISuggestionReviewPopover
+      {...review}
+      align={review.align ?? 'end'}
+      trigger={
+        <button
+          type="button"
+          aria-label={t('extraction', 'reviewOpenFromValue')}
+          title={t('extraction', 'reviewOpenFromValue')}
+          className={cn(
+            'rounded-md text-left transition-colors cursor-pointer hover:bg-ai/5',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ai/40 focus-visible:ring-offset-1',
+            className,
+          )}
+        >
+          {children}
+        </button>
+      }
+    />
+  );
 }
 
 export function AISuggestionDisplay({
@@ -28,19 +90,23 @@ export function AISuggestionDisplay({
   onAccept,
   onReject,
   loading = false,
+  review,
 }: AISuggestionDisplayProps) {
   const isAccepted = isSuggestionAccepted(suggestion);
   const isRejected = suggestion.status === 'rejected';
 
   // A "no information found" outcome is now a first-class proposal. Render it as
   // a quiet, de-emphasized indicator — never a loud "(empty) · 0%" strip with
-  // Accept/Reject (the full record + acknowledge live behind the review trigger).
+  // Accept/Reject. It still opens the review popover (history + provenance) when
+  // a binding is supplied, so the abstention stays traceable.
   if (isNoInfoValue(suggestion.value)) {
     return (
       <div className="mt-2 animate-in fade-in duration-200">
-        <span className="text-xs italic text-muted-foreground">
-          {t('extraction', 'reviewNoInformation')}
-        </span>
+        <ReviewTrigger review={review} className="inline-flex px-1.5 py-0.5 -mx-1.5">
+          <span className="text-xs italic text-muted-foreground">
+            {t('extraction', 'reviewNoInformation')}
+          </span>
+        </ReviewTrigger>
       </div>
     );
   }
@@ -48,11 +114,14 @@ export function AISuggestionDisplay({
   return (
     <div className="mt-2 animate-in fade-in slide-in-from-top-2 duration-200 w-full">
       <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-2 w-full">
-          {/* Suggested value + confidence */}
-        <div className="flex-1 min-w-0 w-full sm:w-auto flex items-center gap-2">
+          {/* Suggested value + confidence — opens the review popover on click */}
+        <ReviewTrigger
+          review={review}
+          className="flex-1 min-w-0 w-full sm:w-auto flex items-center gap-2 px-1.5 py-1 -mx-1.5"
+        >
           <AISuggestionValue suggestion={suggestion} maxLength={150} className="flex-1 min-w-0" />
           <AISuggestionConfidence suggestion={suggestion} />
-        </div>
+        </ReviewTrigger>
 
           {/* Action buttons - always show */}
         <div className="flex items-center gap-2 shrink-0 w-full sm:w-auto justify-end sm:justify-start pr-1">

--- a/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.test.tsx
@@ -177,6 +177,29 @@ describe('AISuggestionEvidence', () => {
     });
   });
 
+  describe('(e2) attribution badge carries the clarifying explanation', () => {
+    it('annotates "Not supported" so it reads as grading the quote, not the value', () => {
+      const unsupportedCitation: EvidenceCitation[] = [
+        {text: 'x', pageNumber: 1, blockIds: [], attributionLabel: 'unsupported', rank: 0},
+      ];
+      render(<AISuggestionEvidence evidence={unsupportedCitation} />, {wrapper: Wrapper});
+      // The badge exposes the explanation (tooltip body) as its accessible name so
+      // reviewers don't read "Not supported" next to a confident rationale as a contradiction.
+      expect(screen.getByText('attributionUnsupported')).toHaveAttribute(
+        'aria-label',
+        'attributionTooltipUnsupported',
+      );
+    });
+
+    it('annotates the "Verified" badge with its own explanation', () => {
+      render(<AISuggestionEvidence evidence={twoCitations} />, {wrapper: Wrapper});
+      expect(screen.getByText('attributionEntailed')).toHaveAttribute(
+        'aria-label',
+        'attributionTooltipEntailed',
+      );
+    });
+  });
+
   describe('(f) legacy — length-1 list with null attributionLabel', () => {
     it('renders the single citation without any "also cited" toggle', () => {
       render(<AISuggestionEvidence evidence={singleCitation} />, {wrapper: Wrapper});

--- a/frontend/components/extraction/ai/AISuggestionEvidence.tsx
+++ b/frontend/components/extraction/ai/AISuggestionEvidence.tsx
@@ -26,8 +26,22 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {useState} from 'react';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
+import type {ExtractionCopy} from '@/lib/copy/extraction';
 import {useCopyToClipboard} from '@/hooks/useCopyToClipboard';
 import type {EvidenceCitation} from '@/types/ai-extraction';
+
+// One source of truth mapping each attribution label to its badge copy + the
+// tooltip that explains it grades the QUOTE (not the value/confidence). A new
+// attribution state is added here once; copy and tooltip stay in lockstep.
+const ATTRIBUTION_COPY: Record<
+  'entailed' | 'weak' | 'unsupported' | 'ungroundable',
+  {copy: keyof ExtractionCopy; tooltip: keyof ExtractionCopy}
+> = {
+  entailed: {copy: 'attributionEntailed', tooltip: 'attributionTooltipEntailed'},
+  weak: {copy: 'attributionWeak', tooltip: 'attributionTooltipWeak'},
+  unsupported: {copy: 'attributionUnsupported', tooltip: 'attributionTooltipUnsupported'},
+  ungroundable: {copy: 'attributionUngroundable', tooltip: 'attributionTooltipUngroundable'},
+};
 
 // =================== INTERFACES ===================
 
@@ -66,16 +80,13 @@ function CitationRow({citation, showCopyButton, onLocate, isPrimary, isActive}: 
   const isUngroundable = label === 'ungroundable';
   const isAmber = label === 'weak' || label === 'unsupported' || isUngroundable;
 
-  const badgeCopy =
-    isEntailed
-      ? t('extraction', 'attributionEntailed')
-      : label === 'weak'
-        ? t('extraction', 'attributionWeak')
-        : label === 'unsupported'
-          ? t('extraction', 'attributionUnsupported')
-          : isUngroundable
-            ? t('extraction', 'attributionUngroundable')
-            : null;
+  // Badge text + its tooltip resolve from one table (see ATTRIBUTION_COPY). The
+  // tooltip spells out that the badge grades the cited QUOTE, not the AI's
+  // confidence/rationale — so "Not supported" next to a confident rationale
+  // doesn't read as a contradiction.
+  const attribution = label ? ATTRIBUTION_COPY[label] : undefined;
+  const badgeCopy = attribution ? t('extraction', attribution.copy) : null;
+  const badgeTooltip = attribution ? t('extraction', attribution.tooltip) : null;
 
   const borderClass = isEntailed
     ? 'border-l-green-500'
@@ -96,16 +107,29 @@ function CitationRow({citation, showCopyButton, onLocate, isPrimary, isActive}: 
             </span>
           )}
           {badgeCopy !== null && (
-            <span
-              className={cn(
-                'px-2 py-0.5 rounded text-xs font-medium shrink-0',
-                isEntailed
-                  ? 'bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300'
-                  : 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300',
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  tabIndex={0}
+                  role="note"
+                  aria-label={badgeTooltip ?? badgeCopy}
+                  className={cn(
+                    'px-2 py-0.5 rounded text-xs font-medium shrink-0 cursor-help',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    isEntailed
+                      ? 'bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300'
+                      : 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300',
+                  )}
+                >
+                  {badgeCopy}
+                </span>
+              </TooltipTrigger>
+              {badgeTooltip !== null && (
+                <TooltipContent side="top" className="max-w-xs">
+                  <p>{badgeTooltip}</p>
+                </TooltipContent>
               )}
-            >
-              {badgeCopy}
-            </span>
+            </Tooltip>
           )}
         </div>
 

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -845,6 +845,7 @@ export const extraction = {
     reviewClear: 'Clear',
     reviewClearHint: 'Each selection is recorded with who chose it and when.',
     reviewDetails: 'Details',
+    reviewOpenFromValue: 'Open review · see other versions, evidence and provenance',
     // RunProvenanceDisclosure – "how this was generated" (transparency)
     provenanceToggle: 'How this was generated',
     provenanceRanBy: 'Ran by',
@@ -870,6 +871,16 @@ export const extraction = {
     attributionWeak: 'Weak match',
     attributionUnsupported: 'Not supported',
     attributionUngroundable: 'Verify manually',
+    // Attribution badge tooltips — this grades whether the CITED QUOTE supports
+    // the value, independent of the AI's confidence or its rationale.
+    attributionTooltipEntailed:
+      'The cited quote supports this value. This grades the quote — not the AI confidence or rationale.',
+    attributionTooltipWeak:
+      'The cited quote is related but does not clearly establish this value. This grades the quote, not whether the value is right — verify in the document.',
+    attributionTooltipUnsupported:
+      'The cited quote does not establish this value. This grades the quote, not the AI confidence or rationale — the value may still be correct, but verify it against the document.',
+    attributionTooltipUngroundable:
+      'The value could not be located in the document text (e.g. it appears only in a figure). Verify manually.',
     // useExtractionJob async polling toasts
     extractionJobFailedTitle: 'AI extraction failed',
     extractionJobCancelledTitle: 'AI extraction cancelled',

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -2,10 +2,10 @@
 # May shrink (re-run --update-baseline to tighten), never grow. Cleanup is a separate effort.
 backend/app/seed.py:1941
 backend/app/services/extraction_export_service.py:2252
-backend/app/services/section_extraction_service.py:1581
+backend/app/services/section_extraction_service.py:1615
 frontend/components/articles/ArticleForm.tsx:1272
 frontend/components/articles/ArticlesList.tsx:1360
 frontend/components/extraction/ArticleExtractionTable.tsx:1130
-frontend/lib/copy/extraction.ts:890
+frontend/lib/copy/extraction.ts:901
 frontend/pages/ExtractionFullScreen.tsx:1284
 frontend/pages/QualityAssessmentFullScreen.tsx:802


### PR DESCRIPTION
## Promote dev → main (production)

Ships two extraction AI-suggestion fixes to production:

- **#448** — AI-suggestion review: keep the inline suggestion visible after a re-run (dedup prefers latest-with-value), resolve coded select values to their human label before the entailment judge (+ clarifying badge tooltip), and persist run provenance for session runs so "How this was generated" renders.
- **#447** — entailment premise spans multi-block citations via anchor block_ids.

## Verification

Both already merged green to `dev` (full CI). Merged-tree local gates re-run before the dev PR landed: backend 2311 passed, frontend 936 passed, lint/typecheck clean.

## Notes

- Merge-commit promotion (not squash/ff). Railway deploys from `main`; Post-deploy Smoke gates prod health. Supabase Preview is expected to fail on promotions (ignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
