### PR TITLE
Promote dev to main: run-header responsive rework + header follow-ups

### DIFF
--- a/frontend/components/extraction/ExtractionHeader.tsx
+++ b/frontend/components/extraction/ExtractionHeader.tsx
@@ -13,6 +13,10 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { type UserRole } from '@/lib/comparison/permissions';
 import { RunHeader, type RunHeaderValue, type StageTransition } from '@/components/runs/header';
+// Utility is imported directly (not via the RunHeader compound): it pulls in the
+// app-wide NotificationCenter/feedback, which reach the supabase client, and the
+// shared compound must stay free of that so its pure part tests don't need it.
+import { Utility } from '@/components/runs/header/Utility';
 import type { ExtractionRunStage } from '@/types/ai-extraction';
 import type { SaveState } from '@/hooks/runs';
 import { t } from '@/lib/copy';
@@ -273,13 +277,6 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
             <RunHeader.MobileNav onOpen={onOpenMobileNav} />
             <RunHeader.SidebarToggle pressed={!sidebarCollapsed} onToggle={onToggleSidebar} />
             <RunHeader.Breadcrumb onBack={onBack} crumbs={[{ label: projectName, onClick: () => navigate(`/projects/${props.projectId}`) }, { label: articleTitle }]} />
-            {articles.length > 1 && (
-              <RunHeader.Worklist
-                articles={articles}
-                currentId={currentArticleId}
-                onNavigate={onNavigateToArticle}
-              />
-            )}
             <RunHeader.Save
               state={saveState ?? 'idle'}
               lastSavedAt={lastSavedAt}
@@ -288,12 +285,31 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
             {stage != null && <RunHeader.StageRail />}
           </RunHeader.Left>
 
+          {/* The ‹N/M› pager is the highest-priority navigation, so it lives in
+              its OWN protected slot between the (overflow-hidden) identity and
+              context tracks — never clipped by either, shrink-0, always visible
+              whenever there is more than one article. */}
+          {articles.length > 1 && (
+            <RunHeader.Worklist
+              articles={articles}
+              currentId={currentArticleId}
+              onNavigate={onNavigateToArticle}
+            />
+          )}
+
           <RunHeader.Center>
             <RunHeader.Reviewers />
             <RunHeader.RoleChip />
           </RunHeader.Center>
 
           <RunHeader.Right>
+            {hasComparison && (
+              <RunHeader.CompareToggle
+                active={viewMode === 'compare'}
+                onToggle={() => onViewModeChange(viewMode === 'compare' ? 'extract' : 'compare')}
+                label={t('runs', 'compareToggleLabel')}
+              />
+            )}
             <RunHeader.AIActions
               pendingCount={aiPendingCount}
               canExtract={!!(canRunAI && onExtractWithAI)}
@@ -302,16 +318,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
               onOpenSuggestions={props.onAISuggestionsClick}
             />
             <RunHeader.PrimaryAction />
-            <span className="mx-1 hidden h-5 w-px bg-border/60 @[40rem]/headerbar:block" aria-hidden="true" />
-            <span className="hidden @[40rem]/headerbar:inline-flex">
-              <RunHeader.Help />
-            </span>
-            <RunHeader.Menu>
-              {hasComparison && (
-                <RunHeader.MenuItem onSelect={() => onViewModeChange(viewMode === 'compare' ? 'extract' : 'compare')}>
-                  {t('extraction', 'runHeaderCompareToggle')}
-                </RunHeader.MenuItem>
-              )}
+            <Utility>
               {canReopen && (
                 <RunHeader.MenuItem onSelect={() => onReopen?.()}>
                   {reopening
@@ -319,7 +326,7 @@ export function ExtractionHeader(props: ExtractionHeaderProps) {
                     : t('extraction', 'runHeaderReopenForRevision')}
                 </RunHeader.MenuItem>
               )}
-            </RunHeader.Menu>
+            </Utility>
             <RunHeader.PanelToggle pressed={showPDF} onToggle={onTogglePDF} />
           </RunHeader.Right>
         </RunHeader>

--- a/frontend/components/extraction/__tests__/ExtractionHeader.exports.test.tsx
+++ b/frontend/components/extraction/__tests__/ExtractionHeader.exports.test.tsx
@@ -14,6 +14,13 @@ vi.mock('@/hooks/extraction/ai/useRunAIExtraction', () => ({
 vi.mock('@/hooks/hitl/useHITLProjectTemplates', () => ({
   useHITLProjectTemplates: () => ({ globalTemplates: [], loading: false }),
 }));
+// The header now mounts NotificationCenter (via Utility), whose service import
+// graph reaches the supabase client — which throws at module load in the
+// env-less Frontend Tests CI job. Stub the client (the convention for tests
+// that pull it in); rendering makes no supabase calls here.
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { auth: { getSession: () => Promise.resolve({ data: { session: null }, error: null }) } },
+}));
 
 const base = {
   projectId: 'p', projectName: 'P', articleTitle: 'A', onBack: vi.fn(),
@@ -25,18 +32,27 @@ const base = {
 };
 
 describe('ExtractionHeader (post legacy-cascade)', () => {
-  it('hides the More menu entirely when it would have no items', () => {
-    // base has hasComparison:false and no canReopen, so the only two menu
-    // items are both gated off. An empty kebab is a dead affordance — it must
-    // not render at all (regression: it used to open to an empty dropdown).
+  it('folds feedback + help into the kebab at narrow header widths', async () => {
+    // The full-screen run page has no global Topbar, so notifications/feedback/
+    // help moved into the run header. Feedback + help are inline when the header
+    // is wide and fold into the kebab when narrow (Utility/useHeaderCompact). In
+    // jsdom getBoundingClientRect is zero-width, so the header reads as narrow
+    // here and the menu always renders with the folded items.
     render(<MemoryRouter><ExtractionHeader {...base} /></MemoryRouter>);
-    expect(screen.queryByRole('button', { name: /more/i })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /more/i }));
+    expect(screen.getByRole('menuitem', { name: /send feedback/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /help and shortcuts/i })).toBeInTheDocument();
   });
 
   it('renders the More menu (without an Export Data item) when it has items', async () => {
     render(<MemoryRouter><ExtractionHeader {...base} hasComparison /></MemoryRouter>);
     await userEvent.click(screen.getByRole('button', { name: /more/i }));
     expect(screen.queryByText(/Export Data/i)).not.toBeInTheDocument();
+  });
+
+  it('surfaces notifications inline (no global Topbar on the run page)', () => {
+    render(<MemoryRouter><ExtractionHeader {...base} /></MemoryRouter>);
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
   });
 
   // TDD: Task 9 — re-skin onto RunHeader compound

--- a/frontend/components/feedback/FeedbackButton.tsx
+++ b/frontend/components/feedback/FeedbackButton.tsx
@@ -4,7 +4,7 @@
 
 import {useState} from 'react';
 import {MessageCircle} from 'lucide-react';
-import {Button} from '@/components/ui/button';
+import {HeaderIconButton} from '@/components/layout/HeaderIconButton';
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip';
 import {FeedbackDialog} from './FeedbackDialog';
 import {t} from '@/lib/copy';
@@ -17,15 +17,12 @@ export function FeedbackButton() {
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
+            <HeaderIconButton
               onClick={() => setDialogOpen(true)}
               aria-label={t('navigation', 'sendFeedback')}
-              className="shrink-0 h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors duration-75"
             >
-                <MessageCircle className="h-4 w-4" strokeWidth={1.5}/>
-            </Button>
+                <MessageCircle strokeWidth={1.5}/>
+            </HeaderIconButton>
           </TooltipTrigger>
           <TooltipContent>
               <p>{t('navigation', 'sendFeedback')}</p>

--- a/frontend/components/layout/HeaderIconButton.tsx
+++ b/frontend/components/layout/HeaderIconButton.tsx
@@ -1,0 +1,30 @@
+import { forwardRef } from 'react';
+import { Button, type ButtonProps } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+/**
+ * The one header action button: a 32px ghost icon button with a 44px touch
+ * target (the `header-icon` size), muted-foreground default, and the shared
+ * header hover/focus treatment. Every header affordance — notifications,
+ * feedback, help, the kebab, the panel toggles — composes this so they stay
+ * identical in size, hover, and focus across the run header and the Topbar.
+ *
+ * Icons auto-size to 16px (Button base `[&_svg]:size-4`); pass lucide icons with
+ * `strokeWidth={1.5}` for the frontend-ux icon weight. Usable as a Radix trigger
+ * via `asChild` since it forwards both ref and props down to Button.
+ */
+export const HeaderIconButton = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => (
+    <Button
+      ref={ref}
+      size="header-icon"
+      variant="ghost"
+      className={cn(
+        'shrink-0 text-muted-foreground transition-colors duration-75 hover:bg-muted/50 hover:text-foreground',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+HeaderIconButton.displayName = 'HeaderIconButton';

--- a/frontend/components/layout/PanelToggleButton.tsx
+++ b/frontend/components/layout/PanelToggleButton.tsx
@@ -1,5 +1,5 @@
 import { PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { HeaderIconButton } from '@/components/layout/HeaderIconButton';
 import { cn } from '@/lib/utils';
 
 interface PanelToggleButtonProps {
@@ -19,25 +19,25 @@ export function PanelToggleButton({ side, pressed, onToggle, ariaLabel, classNam
   const Close = side === 'left' ? PanelLeftClose : PanelRightClose;
   const Open = side === 'left' ? PanelLeftOpen : PanelRightOpen;
   return (
-    <Button
-      size="header-icon"
-      variant="ghost"
+    <HeaderIconButton
       onClick={onToggle}
       aria-pressed={pressed}
       aria-keyshortcuts={side === 'left' ? 'Meta+B' : '\\'}
       aria-label={ariaLabel}
-      className={cn('relative shrink-0 p-0 text-muted-foreground transition-colors duration-75 hover:bg-muted/50', className)}
+      className={cn('relative', className)}
     >
       <span className="relative block h-4 w-4">
         <Close
+          strokeWidth={1.5}
           className={cn('absolute inset-0 h-4 w-4 transition-opacity duration-150 ease-out motion-reduce:duration-0', pressed ? 'opacity-100' : 'opacity-0')}
           aria-hidden="true"
         />
         <Open
+          strokeWidth={1.5}
           className={cn('absolute inset-0 h-4 w-4 transition-opacity duration-150 ease-out motion-reduce:duration-0', pressed ? 'opacity-0' : 'opacity-100')}
           aria-hidden="true"
         />
       </span>
-    </Button>
+    </HeaderIconButton>
   );
 }

--- a/frontend/components/navigation/NotificationCenter.tsx
+++ b/frontend/components/navigation/NotificationCenter.tsx
@@ -10,6 +10,7 @@
 import {useEffect, useMemo, useState} from 'react';
 import {Bell, CheckCircle2, Clock, Loader2, X, XCircle} from 'lucide-react';
 import {Button} from '@/components/ui/button';
+import {HeaderIconButton} from '@/components/layout/HeaderIconButton';
 import {Badge} from '@/components/ui/badge';
 import {
     DropdownMenu,
@@ -20,7 +21,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import {ScrollArea} from '@/components/ui/scroll-area';
 import {Progress} from '@/components/ui/progress';
-import {selectRecentJobs, useBackgroundJobs} from '@/stores/useBackgroundJobs';
+import {countUnreadJobs, selectRecentJobs, useBackgroundJobs} from '@/stores/useBackgroundJobs';
 import {useBackgroundJobPolling} from '@/hooks/useBackgroundJobPolling';
 import {cn} from '@/lib/utils';
 import {toast} from 'sonner';
@@ -35,26 +36,10 @@ import {t} from '@/lib/copy';
 import {getExportStatus as getArticlesExportStatus, type ExportStatusResponse} from '@/services/articlesExportService';
 import {getExportStatus as getExtractionExportStatus} from '@/services/extractionExportService';
 
-// Jobs that finished within the last five minutes count as "unread".
-// Module-scope because the clock read is impure and must stay out of
-// render-scoped functions (same memoization semantics as before: the
-// count refreshes when the job list changes).
-function countRecentlyFinished(jobs: BackgroundJob[]): number {
-    const now = Date.now();
-    const FIVE_MINUTES = 5 * 60 * 1000;
-    return jobs.filter((job) => {
-        if (job.status !== 'completed' && job.status !== 'failed') {
-            return false;
-        }
-        const completedTime = job.completedAt || 0;
-        return now - completedTime < FIVE_MINUTES;
-    }).length;
-}
-
 export function NotificationCenter() {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
-    const {jobs, removeJob, clearCompletedJobs, updateJob} = useBackgroundJobs();
+    const {jobs, removeJob, clearCompletedJobs, updateJob, lastReadAt, markAllRead} = useBackgroundJobs();
 
   // Derive from the reactive `jobs` (not the store getter): the React
   // Compiler tracks deps from the callback body, so the callback MUST
@@ -181,12 +166,25 @@ export function NotificationCenter() {
     },
   });
 
-    // Count unread notifications (jobs that finished recently)
-  const unreadCount = countRecentlyFinished(recentJobs);
+    // Count unread notifications (finished after the bell was last opened)
+  const unreadCount = countUnreadJobs(recentJobs, lastReadAt);
 
   const hasActiveBackgroundJobs = jobs.some(
     (job) => job.status === 'pending' || job.status === 'running'
   );
+
+  // Opening the bell marks everything read (clears the badge). Not in render —
+  // fires from the Radix open-change event.
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) markAllRead();
+  };
+
+  const bellLabel = hasActiveBackgroundJobs
+    ? t('navigation', 'notificationsAriaBackgroundActive')
+    : unreadCount > 0
+      ? t('navigation', 'notificationsAriaUnread').replace('{{count}}', String(unreadCount))
+      : t('navigation', 'notifications');
 
   const handleRemoveJob = (jobId: string, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -218,24 +216,17 @@ export function NotificationCenter() {
   };
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
+        <HeaderIconButton
           className={cn(
-              'relative h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors duration-75',
-              hasActiveBackgroundJobs &&
-              'text-foreground/90 [&_svg]:opacity-90'
+              'relative',
+              hasActiveBackgroundJobs && 'text-foreground/90 [&_svg]:opacity-90'
           )}
           aria-busy={hasActiveBackgroundJobs}
-          aria-label={
-              hasActiveBackgroundJobs
-                  ? t('navigation', 'notificationsAriaBackgroundActive')
-                  : t('navigation', 'notifications')
-          }
+          aria-label={bellLabel}
         >
-            <Bell className="h-4 w-4" strokeWidth={1.5}/>
+            <Bell strokeWidth={1.5}/>
             {hasActiveBackgroundJobs && (
                 <span
                     className="pointer-events-none absolute bottom-1 right-1 h-1.5 w-1.5 rounded-full bg-info shadow-[0_0_0_1px_hsl(var(--background))] motion-safe:animate-pulse"
@@ -243,14 +234,19 @@ export function NotificationCenter() {
                 />
             )}
           {unreadCount > 0 && (
-            <Badge 
-              variant="destructive" 
+            // Non-destructive: a finished background job is informational, not an
+            // error — a primary-accent count, not the alarming red destructive
+            // badge. The count is announced via the button's aria-label, so the
+            // badge itself is aria-hidden to avoid a double read.
+            <Badge
+              variant="default"
+              aria-hidden="true"
               className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 text-[10px]"
             >
               {unreadCount > 9 ? '9+' : unreadCount}
             </Badge>
           )}
-        </Button>
+        </HeaderIconButton>
       </DropdownMenuTrigger>
       
       <DropdownMenuContent align="end" className="w-[min(400px,calc(100vw-1rem))]">

--- a/frontend/components/navigation/Topbar.tsx
+++ b/frontend/components/navigation/Topbar.tsx
@@ -5,7 +5,7 @@
 
 import React, {useContext, useState} from 'react';
 import {Info, Menu} from 'lucide-react';
-import {Button} from '@/components/ui/button';
+import {HeaderIconButton} from '@/components/layout/HeaderIconButton';
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip';
 import {useUserProfile} from '@/hooks/useNavigation';
 import {SidebarContext} from '@/contexts/SidebarContext';
@@ -73,15 +73,13 @@ export const Topbar: React.FC<TopbarProps> = ({
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {/* Hamburger Menu — Mobile/Tablet only */}
         {sidebarContext && isProjectPage && (
-          <Button
-            variant="ghost"
-            size="icon"
+          <HeaderIconButton
             onClick={sidebarContext.toggleMobile}
             aria-label={t('navigation', 'ariaOpenMenu')}
-            className="flex h-8 w-8 shrink-0 transition-colors duration-75 hover:bg-muted/50 lg:hidden"
+            className="lg:hidden"
           >
-            <Menu className="h-4 w-4 text-muted-foreground" />
-          </Button>
+            <Menu strokeWidth={1.5} aria-hidden="true" />
+          </HeaderIconButton>
         )}
         {/* Sidebar Toggle — Desktop only. */}
         {sidebarContext && isProjectPage && (
@@ -117,10 +115,10 @@ export const Topbar: React.FC<TopbarProps> = ({
                   <TooltipTrigger asChild>
                     <button
                       type="button"
-                      className="hidden text-muted-foreground/60 transition-colors hover:text-foreground @[34rem]/headerbar:inline-flex"
+                      className="hidden rounded text-muted-foreground/60 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 @[34rem]/headerbar:inline-flex"
                       aria-label={t('navigation', sectionDescriptionKey[projectContext?.activeTab ?? ''])}
                     >
-                      <Info className="h-3.5 w-3.5" />
+                      <Info className="h-3.5 w-3.5" strokeWidth={1.5} />
                     </button>
                   </TooltipTrigger>
                   <TooltipContent>

--- a/frontend/components/navigation/__tests__/NotificationCenter.test.tsx
+++ b/frontend/components/navigation/__tests__/NotificationCenter.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import {beforeEach, describe, expect, it, vi} from "vitest";
-import {render, screen, act} from "@testing-library/react";
+import {render, screen, act, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {MemoryRouter} from "react-router-dom";
 
@@ -48,7 +48,9 @@ function completedExportJob(id: string) {
 
 beforeEach(() => {
     act(() => {
-        useBackgroundJobs.setState({jobs: []});
+        // Fresh slate: no jobs, and lastReadAt=now so nothing reads as unread
+        // until a test arranges it.
+        useBackgroundJobs.setState({jobs: [], lastReadAt: Date.now()});
     });
 });
 
@@ -72,5 +74,38 @@ describe("NotificationCenter", () => {
         // The bell must reflect it immediately (not only after a reload).
         expect(await screen.findByText("Export extraction data")).toBeInTheDocument();
         expect(screen.queryByText(/No notifications/i)).not.toBeInTheDocument();
+    });
+
+    it("announces the unread count, badges it non-destructively, and clears it on open", async () => {
+        const user = userEvent.setup();
+        // lastReadAt=0 → both finished jobs are unread.
+        act(() => {
+            useBackgroundJobs.setState({
+                lastReadAt: 0,
+                jobs: [completedExportJob("job-1"), completedExportJob("job-2")],
+            });
+        });
+        render(
+            <MemoryRouter>
+                <NotificationCenter />
+            </MemoryRouter>,
+        );
+
+        // The count is announced via the trigger's accessible name…
+        const bell = screen.getByRole("button", {name: /2 unread/i});
+        // …and shown as a NON-destructive (primary) badge that is aria-hidden so
+        // it isn't read twice.
+        const badge = screen.getByText("2");
+        expect(badge).toHaveClass("bg-primary");
+        expect(badge).not.toHaveClass("bg-destructive");
+        expect(badge).toHaveAttribute("aria-hidden", "true");
+
+        // Opening the bell marks everything read → badge clears.
+        await user.click(bell);
+        await waitFor(() =>
+            expect(useBackgroundJobs.getState().lastReadAt).toBeGreaterThan(0),
+        );
+        expect(screen.queryByText("2")).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", {name: /unread/i})).toBeNull();
     });
 });

--- a/frontend/components/runs/header/AIActions.tsx
+++ b/frontend/components/runs/header/AIActions.tsx
@@ -14,18 +14,18 @@ export function AIActions({ pendingCount, canExtract, extracting, onExtract, onO
   if (canExtract) {
     const label = extracting ? t('runs', 'extractingWithAI') : t('runs', 'extractWithAI');
     return (
-      // Label collapses to the icon below 40rem; aria-label keeps the
+      // Label collapses to the icon below 48rem; aria-label keeps the
       // accessible name since the Sparkles icon is aria-hidden.
-      <Button size="sm" variant="secondary" onClick={onExtract} disabled={extracting} aria-label={label} className="shrink-0 gap-1.5 whitespace-nowrap">
-        <Sparkles className="h-4 w-4 text-ai" aria-hidden="true" />
-        <span className="hidden @[40rem]/headerbar:inline">{label}</span>
+      <Button size="sm" variant="ghost" onClick={onExtract} disabled={extracting} aria-label={label} className="shrink-0 gap-1.5 whitespace-nowrap">
+        <Sparkles className="h-4 w-4 text-ai" strokeWidth={1.5} aria-hidden="true" />
+        <span className="hidden @[48rem]/headerbar:inline">{label}</span>
       </Button>
     );
   }
   if (pendingCount <= 0) return null;
   return (
-    <button type="button" onClick={() => onOpenSuggestions?.()} className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-ai/40 bg-ai/10 px-2.5 py-0.5 text-[11px] text-ai focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-      <Sparkles className="h-3.5 w-3.5" aria-hidden="true" /><span className="hidden @[48rem]/headerbar:inline">AI · </span>{pendingCount}
+    <button type="button" onClick={() => onOpenSuggestions?.()} aria-label={t('runs', 'aiPendingSuggestions').replace('{{n}}', String(pendingCount))} className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md bg-ai/10 px-1.5 py-0.5 text-[11px] text-ai focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+      <Sparkles className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden="true" /><span className="hidden @[48rem]/headerbar:inline" aria-hidden="true">AI · </span><span aria-hidden="true">{pendingCount}</span>
     </button>
   );
 }

--- a/frontend/components/runs/header/Breadcrumb.tsx
+++ b/frontend/components/runs/header/Breadcrumb.tsx
@@ -1,5 +1,6 @@
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { ArrowLeft, ChevronRight } from 'lucide-react';
+import { HeaderIconButton } from '@/components/layout/HeaderIconButton';
+import { cn } from '@/lib/utils';
 import { t } from '@/lib/copy';
 import { TruncatedText } from './TruncatedText';
 
@@ -15,28 +16,46 @@ interface BreadcrumbProps {
 
 export function Breadcrumb({ onBack, crumbs }: BreadcrumbProps) {
   return (
-    <nav className="flex min-w-0 items-center gap-1" aria-label="breadcrumb">
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-8 w-8 shrink-0 p-0"
+    // min-w-0 so the title truncates under pressure instead of overflowing. The
+    // priority-drop order lives here: the back button and the non-final
+    // (project) crumbs disappear via @container queries before the final
+    // (article-title) crumb is ever forced to truncate — back drops first, then
+    // project, then the title is the last casualty (it only truncates, never
+    // hides). A dropped leaf is display:none (zero space); RunHeader.Left's
+    // overflow-hidden backstop only guards whitespace-nowrap paint-over.
+    <nav className="flex min-w-0 shrink items-center gap-1" aria-label="breadcrumb">
+      <HeaderIconButton
         aria-label={t('common', 'back')}
         onClick={onBack}
+        // Lowest-priority breadcrumb affordance, so the back arrow folds first.
+        // App-nav escape stays available via the always-present SidebarToggle
+        // (and the MobileNav drawer below lg, plus the browser back button); the
+        // back arrow is a convenience, not the only way out.
+        className="hidden @[42rem]/headerbar:inline-flex"
       >
-        <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-      </Button>
+        <ArrowLeft strokeWidth={1.5} aria-hidden="true" />
+      </HeaderIconButton>
       <ol className="flex min-w-0 items-center gap-1">
         {crumbs.map((crumb, index) => {
           const isLast = index === crumbs.length - 1;
           return (
-            <li key={index} className="flex min-w-0 items-center gap-1">
+            // The article title (last crumb) is the correctness anchor ("which
+            // paper am I on"). Non-final crumbs + their separator chevron HIDE
+            // below 36rem (and shrink 8x faster above it) so the project name is
+            // gone before the article title even truncates.
+            <li
+              key={index}
+              className={cn(
+                'min-w-0 items-center gap-1',
+                isLast ? 'flex shrink' : 'hidden shrink-[8] @[36rem]/headerbar:flex',
+              )}
+            >
               {index > 0 && (
-                <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+                <ChevronRight className="hidden h-3 w-3 shrink-0 text-muted-foreground @[36rem]/headerbar:block" aria-hidden="true" />
               )}
               {crumb.onClick ? (
-                // min-w-0 + truncate so the non-final crumb shrinks WITH its
-                // li under flex pressure instead of overflowing it and painting
-                // over the next crumb (the narrow-width overlap).
+                // min-w-0 + truncate so the non-final crumb shrinks WITH its li
+                // under flex pressure (above its 36rem hide threshold).
                 <button
                   type="button"
                   className="min-w-0 max-w-[180px] truncate rounded text-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -45,7 +64,7 @@ export function Breadcrumb({ onBack, crumbs }: BreadcrumbProps) {
                   {crumb.label}
                 </button>
               ) : isLast ? (
-                <TruncatedText text={crumb.label} className="max-w-[220px] text-sm font-medium text-foreground" />
+                <TruncatedText text={crumb.label} className="min-w-0 max-w-[20rem] text-sm font-medium text-foreground" />
               ) : (
                 <span className="block min-w-0 max-w-[180px] truncate text-sm text-muted-foreground">{crumb.label}</span>
               )}

--- a/frontend/components/runs/header/CompareToggle.tsx
+++ b/frontend/components/runs/header/CompareToggle.tsx
@@ -1,0 +1,34 @@
+import { Columns2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface CompareToggleProps {
+  /** True when the comparison view is currently active. */
+  active: boolean;
+  onToggle: () => void;
+  label: string;
+}
+
+/**
+ * Visible top-level toggle for the run's core review action — switching into the
+ * side-by-side reviewer comparison. Promoted out of the kebab because, for a HITL
+ * tool, reconciling reviewers is the reason the screen exists; it should never be
+ * a hidden menu item. Mirrors AIActions' responsive treatment: a labelled ghost
+ * button that collapses to its icon below 48rem (the name survives via
+ * `aria-label`). `aria-pressed` carries the on/off state.
+ */
+export function CompareToggle({ active, onToggle, label }: CompareToggleProps) {
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      onClick={onToggle}
+      aria-pressed={active}
+      aria-label={label}
+      className={cn('shrink-0 gap-1.5 whitespace-nowrap', active && 'bg-muted text-foreground')}
+    >
+      <Columns2 className="h-4 w-4" strokeWidth={1.5} aria-hidden="true" />
+      <span className="hidden @[48rem]/headerbar:inline">{label}</span>
+    </Button>
+  );
+}

--- a/frontend/components/runs/header/Help.tsx
+++ b/frontend/components/runs/header/Help.tsx
@@ -1,7 +1,8 @@
 import { HelpCircle } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { HeaderIconButton } from '@/components/layout/HeaderIconButton';
 import { KbdBadge } from '@/components/ui/kbd-badge';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { t } from '@/lib/copy';
 
 const SHORTCUTS: { combo: string; key: 'shortcutPalette' | 'shortcutNextPrev' | 'shortcutTogglePdf' | 'shortcutSidebar' | 'shortcutEsc' }[] = [
@@ -21,6 +22,33 @@ const GLOSSARY: ('glossaryExtract' | 'glossaryConsensus' | 'glossaryFinalize' | 
 ];
 
 /**
+ * The help body = keyboard shortcuts + workflow glossary. Extracted so the same
+ * content renders inside the inline Popover (wide header) AND the kebab-triggered
+ * Dialog (narrow header, where Help has folded into the "three dots").
+ */
+export function HelpContent() {
+  return (
+    <>
+      <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('runs', 'shortcutsHeading')}</p>
+      <ul className="mb-3 space-y-1">
+        {SHORTCUTS.map((s) => (
+          <li key={s.key} className="flex items-center justify-between gap-3">
+            <span className="text-muted-foreground">{t('runs', s.key)}</span>
+            <KbdBadge keys={[s.combo]} />
+          </li>
+        ))}
+      </ul>
+      <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('runs', 'glossaryHeading')}</p>
+      <ul className="space-y-1 text-muted-foreground">
+        {GLOSSARY.map((g) => (
+          <li key={g}>{t('runs', g)}</li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+/**
  * One "?" help panel = keyboard shortcuts + workflow glossary. Replaces the
  * ⌘K discoverability chip (the palette stays reachable by keyboard).
  */
@@ -28,28 +56,32 @@ export function Help() {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="ghost" size="sm" className="h-8 w-8 shrink-0 p-0 text-muted-foreground" aria-label={t('runs', 'helpButton')}>
-          <HelpCircle className="h-4 w-4" aria-hidden="true" />
-        </Button>
+        <HeaderIconButton aria-label={t('runs', 'helpButton')}>
+          <HelpCircle strokeWidth={1.5} aria-hidden="true" />
+        </HeaderIconButton>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-72 text-[13px]">
         <p className="mb-2 font-medium">{t('runs', 'helpTitle')}</p>
-        <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('runs', 'shortcutsHeading')}</p>
-        <ul className="mb-3 space-y-1">
-          {SHORTCUTS.map((s) => (
-            <li key={s.key} className="flex items-center justify-between gap-3">
-              <span className="text-muted-foreground">{t('runs', s.key)}</span>
-              <KbdBadge keys={[s.combo]} />
-            </li>
-          ))}
-        </ul>
-        <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('runs', 'glossaryHeading')}</p>
-        <ul className="space-y-1 text-muted-foreground">
-          {GLOSSARY.map((g) => (
-            <li key={g}>{t('runs', g)}</li>
-          ))}
-        </ul>
+        <HelpContent />
       </PopoverContent>
     </Popover>
+  );
+}
+
+/**
+ * The same help body in a Dialog. Used when the header narrows and Help folds
+ * into the kebab: a Popover anchored to a portaled DropdownMenuItem is not
+ * viable, so the menu item opens this controlled Dialog instead.
+ */
+export function HelpDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm text-[13px]">
+        <DialogHeader>
+          <DialogTitle>{t('runs', 'helpTitle')}</DialogTitle>
+        </DialogHeader>
+        <HelpContent />
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/components/runs/header/Menu.tsx
+++ b/frontend/components/runs/header/Menu.tsx
@@ -1,6 +1,6 @@
 import { Children, type ReactNode } from 'react';
 import { MoreHorizontal } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { HeaderIconButton } from '@/components/layout/HeaderIconButton';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,14 +25,9 @@ export function Menu({ children }: MenuProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 w-8 p-0 text-muted-foreground"
-          aria-label={t('runs', 'more')}
-        >
-          <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
-        </Button>
+        <HeaderIconButton aria-label={t('runs', 'more')}>
+          <MoreHorizontal strokeWidth={1.5} aria-hidden="true" />
+        </HeaderIconButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {children}

--- a/frontend/components/runs/header/MobileNav.tsx
+++ b/frontend/components/runs/header/MobileNav.tsx
@@ -1,5 +1,5 @@
 import { Menu } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { HeaderIconButton } from '@/components/layout/HeaderIconButton';
 import { t } from '@/lib/copy';
 
 /**
@@ -13,14 +13,12 @@ import { t } from '@/lib/copy';
 export function MobileNav({ onOpen }: { onOpen?: () => void }) {
   if (!onOpen) return null;
   return (
-    <Button
-      size="icon"
-      variant="ghost"
+    <HeaderIconButton
       onClick={onOpen}
       aria-label={t('navigation', 'ariaOpenMenu')}
-      className="flex h-8 w-8 shrink-0 p-0 text-muted-foreground transition-colors duration-75 hover:bg-muted/50 lg:hidden"
+      className="lg:hidden"
     >
-      <Menu className="h-4 w-4" aria-hidden="true" />
-    </Button>
+      <Menu strokeWidth={1.5} aria-hidden="true" />
+    </HeaderIconButton>
   );
 }

--- a/frontend/components/runs/header/Reviewers.tsx
+++ b/frontend/components/runs/header/Reviewers.tsx
@@ -16,8 +16,23 @@ export function Reviewers() {
           .replace('{{total}}', String(reviewers.readyTotal))
       : null;
   return (
-    <div className="flex items-center gap-2" data-testid="run-reviewers">
-      <div className="flex shrink-0 -space-x-2" title={`${reviewers.count}/${reviewers.required}`}>
+    // Whole cluster shows only on wide headers (≥64rem). Reviewers rank BELOW
+    // the article title, so wherever the title is crushed for room, the reviewer
+    // cluster must already be gone (otherwise "title < reviewer" — the inversion
+    // the priority forbids). The title is pure flex-shrink and reclaims the
+    // freed room. Avatars-only 64–72rem; full labels at 72rem+.
+    <div className="hidden items-center gap-2 @[64rem]/headerbar:flex" data-testid="run-reviewers">
+      {/* role=img + aria-label carries the count to assistive tech at EVERY
+          width, so the visual label can use display:none below 72rem without
+          losing it (and without the sr-only white-space:normal reset that
+          re-wraps the label). */}
+      <div
+        className="flex shrink-0 -space-x-2"
+        role="img"
+        aria-label={t('runs', 'reviewersOfExpected')
+          .replace('{{count}}', String(reviewers.count))
+          .replace('{{required}}', String(reviewers.required))}
+      >
         {Array.from({ length: shown }).map((_, i) => (
           <span key={i} className={cn('h-[18px] w-[18px] rounded-full border-2 border-background', AVATAR[i % AVATAR.length])} aria-hidden="true" />
         ))}
@@ -26,7 +41,8 @@ export function Reviewers() {
         )}
       </div>
       <span
-        className="text-[11px] text-muted-foreground"
+        aria-hidden="true"
+        className="hidden whitespace-nowrap text-[11px] text-muted-foreground @[72rem]/headerbar:inline"
         data-testid="run-reviewers-count"
       >
         {t('runs', 'reviewersOfExpected')
@@ -35,7 +51,7 @@ export function Reviewers() {
       </span>
       {readyLabel && (
         <span
-          className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
+          className="hidden whitespace-nowrap rounded-md bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground @[72rem]/headerbar:inline"
           data-testid="run-reviewers-ready"
           title={readyLabel}
         >
@@ -46,15 +62,17 @@ export function Reviewers() {
         <button
           type="button"
           onClick={() => onJumpToDivergence?.()}
-          className="flex items-center gap-1 rounded bg-warning/15 px-1.5 py-0.5 text-[11px] text-warning focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label={t('runs', 'reviewersDiffer').replace('{{count}}', String(reviewers.divergent))}
+          className="flex cursor-pointer items-center gap-1 rounded-md bg-warning/15 px-1.5 py-0.5 text-[11px] text-foreground transition-colors hover:bg-warning/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
-          <GitFork className="h-3 w-3" aria-hidden="true" />
-          {/* Compact tier: icon + count only; the "differ" word folds to
-              sr-only so the chip survives phone widths without clipping. */}
-          <span className="sr-only @[34rem]/headerbar:not-sr-only">
+          <GitFork className="h-3 w-3 shrink-0 text-warning" strokeWidth={1.5} aria-hidden="true" />
+          {/* Compact tier: icon + count only below 72rem; the full "N differ"
+              shows above it. Both are aria-hidden — the button's aria-label is
+              the canonical announced name (avoids the sr-only white-space reset). */}
+          <span aria-hidden="true" className="hidden whitespace-nowrap @[72rem]/headerbar:inline">
             {t('runs', 'reviewersDiffer').replace('{{count}}', String(reviewers.divergent))}
           </span>
-          <span className="@[34rem]/headerbar:hidden" aria-hidden="true">{reviewers.divergent}</span>
+          <span aria-hidden="true" className="@[72rem]/headerbar:hidden">{reviewers.divergent}</span>
         </button>
       )}
     </div>

--- a/frontend/components/runs/header/RoleChip.tsx
+++ b/frontend/components/runs/header/RoleChip.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from 'lucide-react';
+import { Eye } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Button } from '@/components/ui/button';
 import { t } from '@/lib/copy';
@@ -24,28 +24,36 @@ export function RoleChip() {
     <>
       {t('common', roleKeys[role])}
       {suffixKey && (
-        // Collapse the role qualifier on narrow headers (mirrors the StageRail
-        // label reveal at the same breakpoint) so the chip shrinks to just the
-        // role word before Center starts clipping.
-        <span className="hidden @[48rem]/headerbar:inline">
+        // Collapse the role qualifier on narrow headers so the chip shrinks to
+        // just the role word before it folds entirely.
+        <span className="hidden @[62rem]/headerbar:inline">
           <span className="text-muted-foreground" aria-hidden="true">{' · '}</span>
           <span className="text-muted-foreground">{t('runs', suffixKey)}</span>
         </span>
       )}
     </>
   );
-  // Compact tier (phone): the role qualifier is the lowest-priority Center
-  // affordance — hide the whole chip (still in the DOM, just `hidden`) so the
-  // row keeps the StageRail + PrimaryAction. Above 34rem it shows as before.
+  // The role qualifier is the lowest-priority Center affordance — fold the whole
+  // chip (still in the DOM, just `hidden`) below 40rem so the row keeps the
+  // StageRail + PrimaryAction. Above 40rem it shows as before.
   if (!canReveal) {
-    return <span className="hidden @[34rem]/headerbar:inline-flex whitespace-nowrap rounded-md bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">{text}</span>;
+    return <span className="hidden @[40rem]/headerbar:inline-flex whitespace-nowrap rounded-md bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">{text}</span>;
   }
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="ghost" size="sm" className="hidden h-7 gap-1 whitespace-nowrap px-2 text-[11px] text-muted-foreground hover:text-foreground @[34rem]/headerbar:inline-flex">
-          {text}
-          <ChevronDown className="h-3 w-3" aria-hidden="true" />
+        {/* Always a visible, shrink-0 touch target so the blind-reveal action
+            stays reachable on touch when the chip text folds at narrow widths:
+            the Eye icon persists; the role text collapses below 40rem. The
+            aria-label carries the role + reveal intent as the announced name. */}
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label={`${t('common', roleKeys[role])} — ${t('runs', 'reveal')}`}
+          className="inline-flex h-7 shrink-0 items-center gap-1 whitespace-nowrap px-1.5 text-[11px] text-muted-foreground hover:text-foreground [@media(pointer:coarse)]:h-9"
+        >
+          <Eye className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} aria-hidden="true" />
+          <span className="hidden items-center @[40rem]/headerbar:inline-flex">{text}</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-64 text-[13px]">

--- a/frontend/components/runs/header/RunHeader.tsx
+++ b/frontend/components/runs/header/RunHeader.tsx
@@ -14,26 +14,63 @@ import { Reviewers } from './Reviewers';
 import { SaveSlot } from './SaveSlot';
 import { AIActions } from './AIActions';
 import { Breadcrumb } from './Breadcrumb';
+import { CompareToggle } from './CompareToggle';
 import { Menu, MenuItem } from './Menu';
 import { Worklist } from './Worklist';
 import { CommandPalette } from './CommandPalette';
 
+/**
+ * RESPONSIVE DROP CASCADE (single source of truth for the scattered @container
+ * thresholds across the leaf components). The header keys off its OWN width via
+ * `@container/headerbar`. Target priority (highest survives longest):
+ *
+ *   pager  >  article title  >  stages  >  reviewers  >  project crumb  >  back
+ *
+ * Mechanism — only the title flex-shrinks (truncates); the pager + actions are
+ * shrink-0; everything else DROPS at a container-query threshold. As the header
+ * narrows, leaves disappear in this BY-WIDTH order (see each component):
+ *
+ *   reviewers cluster  <64rem  (Reviewers.tsx)   ← drops first
+ *   back arrow         <42rem  (Breadcrumb.tsx)
+ *   stages rail        <40rem  (StageRail.tsx) + role chip <40rem (RoleChip.tsx)
+ *   project crumb      <36rem  (Breadcrumb.tsx)
+ *   article title       never  (pure flex-shrink; truncates, can reach ~0 in the
+ *                               packed consensus config at oddball mid widths)
+ *   pager               never  (own shrink-0 slot, below)
+ *   verbose labels: reviewer/role/stage text fold at 62–72rem; save word <34rem.
+ *
+ * NOTE the by-width order is NOT the literal priority rank: reviewers drop BEFORE
+ * back/project even though they outrank them. This is deliberate — reviewers can
+ * only HIDE (fixed-size avatars), not shrink, and they appear only in the crowded
+ * consensus config; folding them early frees the room the (higher-priority) title
+ * needs, honouring "title > reviewer". Container queries are width-based and
+ * config-blind, so a strict rank-ordered fold isn't expressible in pure CSS; a
+ * JS measured priority-overflow would be (deferred).
+ */
 function Left({ children }: { children: ReactNode }) {
-  // overflow-hidden is the backstop: even after the shrinkable children
-  // (Breadcrumb truncates, StageRail clips) compress, content can never paint
-  // out of this track onto the Center slot — the narrow-width overlap bug.
-  return <div className={cn('flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden @[48rem]/headerbar:gap-3')}>{children}</div>;
+  // Identity + run-status track. It SHRINKS (the breadcrumb title truncates) and
+  // keeps `overflow-hidden` ONLY as an anti-overlap backstop: its leaves are
+  // `whitespace-nowrap`, so without it a shrunk track would paint its text on
+  // top of the next slot. It is no longer `flex-1` (that starved it to ~0 and
+  // clipped everything) and — crucially — the ‹N/M› pager has moved OUT into its
+  // own protected slot (see RunHeader.Worklist placement), so this clip can only
+  // ever bite the lowest-priority Left leaves (StageRail), never the pager. The
+  // article title is the flex cushion; back/project/stages drop via @container
+  // queries in priority order.
+  return <div className={cn('flex min-w-0 shrink items-center gap-1.5 overflow-hidden @[48rem]/headerbar:gap-3')}>{children}</div>;
 }
 function Center({ children }: { children: ReactNode }) {
-  // Mid-priority (reviewers + role chip). Allowed to shrink/clip so it yields
-  // room to Left instead of forcing overflow; its leaves collapse their labels
-  // via @container queries before any clipping engages.
+  // Lower priority than the Left identity + pager: reviewers + role chip drop via
+  // @container queries (Reviewers/RoleChip own their thresholds) before the
+  // article title is forced to truncate away — so "article > reviewer" holds.
+  // overflow-hidden is the same anti-overlap backstop as Left.
   return <div className={cn('flex min-w-0 shrink items-center gap-2 overflow-hidden')}>{children}</div>;
 }
 function Right({ children }: { children: ReactNode }) {
-  // Stays shrink-0 so the PrimaryAction is never clipped; only the inter-item
-  // gap tightens at narrow widths.
-  return <div className={cn('flex shrink-0 items-center gap-1 @[48rem]/headerbar:gap-2')}>{children}</div>;
+  // `ml-auto` makes this cluster absorb all free space and pin right (the job
+  // Left's `flex-1` used to do, minus the starvation). `shrink-0` so the
+  // PrimaryAction is never clipped; only the inter-item gap tightens.
+  return <div className={cn('ml-auto flex shrink-0 items-center gap-1 @[48rem]/headerbar:gap-2')}>{children}</div>;
 }
 
 function RunHeaderRoot({
@@ -58,4 +95,4 @@ function RunHeaderRoot({
   );
 }
 
-export const RunHeader = Object.assign(RunHeaderRoot, { Left, Center, Right, StageRail, PrimaryAction, PanelToggle, SidebarToggle, MobileNav, Help, RoleChip, Reviewers, Save: SaveSlot, AIActions, Breadcrumb, Menu, MenuItem, Worklist, CommandPalette });
+export const RunHeader = Object.assign(RunHeaderRoot, { Left, Center, Right, StageRail, PrimaryAction, PanelToggle, SidebarToggle, MobileNav, Help, RoleChip, Reviewers, Save: SaveSlot, AIActions, Breadcrumb, CompareToggle, Menu, MenuItem, Worklist, CommandPalette });

--- a/frontend/components/runs/header/SaveSlot.tsx
+++ b/frontend/components/runs/header/SaveSlot.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Check } from 'lucide-react';
+import { AlertCircle, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { t } from '@/lib/copy';
 import type { SaveState } from '@/hooks/runs';
@@ -51,6 +51,8 @@ export function SaveSlot({ state, lastSavedAt, hidden }: { state: SaveState; las
   const label = saving ? t('runs', 'saving') : failed ? t('runs', 'saveFailed') : t('runs', 'saved');
   return (
     <span
+      role="status"
+      aria-live={failed ? 'assertive' : 'polite'}
       className={cn(
         'flex items-center gap-1 whitespace-nowrap text-[11px] transition-opacity duration-300',
         failed ? 'text-destructive' : 'text-muted-foreground',
@@ -58,16 +60,21 @@ export function SaveSlot({ state, lastSavedAt, hidden }: { state: SaveState; las
       )}
       title={lastSavedAt ? lastSavedAt.toLocaleTimeString() : undefined}
     >
+      {/* Distinct glyph per state so the non-color cue survives the label fold:
+          alert (failed) vs. neutral pulsing dot (saving) vs. check (saved). */}
       {failed ? (
-        <span className="h-1.5 w-1.5 rounded-full bg-destructive" aria-hidden="true" />
+        <AlertCircle className="h-3 w-3 text-destructive" strokeWidth={1.5} aria-hidden="true" />
       ) : saving ? (
-        <span className="h-1.5 w-1.5 rounded-full bg-success" aria-hidden="true" />
+        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground motion-safe:animate-pulse" aria-hidden="true" />
       ) : (
-        <Check className="h-3 w-3 text-success" aria-hidden="true" />
+        <Check className="h-3 w-3 text-success" strokeWidth={1.5} aria-hidden="true" />
       )}
-      {/* Compact tier (phone): keep only the status dot/icon; the word collapses
-          to sr-only so it stays in the a11y tree without eating row width. */}
-      <span className="sr-only @[34rem]/headerbar:not-sr-only">{label}</span>
+      {/* Compact tier (phone): keep only the status glyph; the word collapses to
+          sr-only below 34rem. Kept at 34rem (not pushed wider) so the "Save
+          failed" WORD stays visible on tablet/mid widths — the aria-live region
+          is the only other failure signal and (being conditionally mounted) is an
+          unreliable SR announcement, so the visible word must not fold early. */}
+      <span className="whitespace-nowrap sr-only @[34rem]/headerbar:not-sr-only">{label}</span>
     </span>
   );
 }

--- a/frontend/components/runs/header/StageRail.tsx
+++ b/frontend/components/runs/header/StageRail.tsx
@@ -17,6 +17,13 @@ const STAGE_TOOLTIP_KEY: Record<StageKey, 'stageExtractTooltip' | 'stageConsensu
   finalized: 'stageFinalizedTooltip',
 };
 
+const STATE_COPY: Record<StageNode['state'], 'stageStateDone' | 'stageStateCurrent' | 'stageStateUpcoming' | 'stageStateCancelled'> = {
+  done: 'stageStateDone',
+  current: 'stageStateCurrent',
+  future: 'stageStateUpcoming',
+  cancelled: 'stageStateCancelled',
+};
+
 const DOT: Record<StageNode['state'], string> = {
   done: 'text-success',
   current: 'text-info',
@@ -28,9 +35,14 @@ export function StageRail() {
   const { stage, isRevision } = useRunHeader();
   const nodes = stageNodeStates(stage);
   return (
-    <nav className="flex min-w-0 shrink items-center gap-1.5 overflow-hidden" aria-label="Run stage">
+    // Folds as ONE unit below 40rem. Above it the rail competes proportionally
+    // with the article title for the Left track; the title (larger basis) shrinks
+    // first, and the rail clips at the track's overflow-hidden edge under heavy
+    // pressure. Stage labels collapse to dots at narrower widths (see the node
+    // label below) so any clip is of dots, not mid-word text.
+    <nav className="hidden min-w-0 shrink items-center gap-1.5 @[40rem]/headerbar:flex" aria-label="Run stage">
       {isRevision && (
-        <span className="mr-1 hidden @[48rem]/headerbar:inline-flex whitespace-nowrap rounded-md bg-ai/10 px-2 py-0.5 text-[11px] font-medium text-ai">
+        <span className="mr-1 hidden @[58rem]/headerbar:inline-flex whitespace-nowrap rounded-md bg-ai/10 px-1.5 py-0.5 text-[11px] font-medium text-ai">
           {t('runs', 'revision')}
         </span>
       )}
@@ -51,9 +63,10 @@ export function StageRail() {
             <TooltipTrigger asChild>
               <span
                 tabIndex={0}
+                aria-current={node.state === 'current' ? 'step' : undefined}
                 className={cn(
-                  'flex items-center gap-1.5 whitespace-nowrap rounded-full px-2 py-0.5 text-[13px] outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                  node.state === 'current' && 'bg-info/10 font-medium text-foreground',
+                  'flex items-center gap-1.5 whitespace-nowrap rounded-full px-1.5 py-0.5 text-[13px] outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  node.state === 'current' && 'font-medium text-foreground',
                   node.state !== 'current' && 'text-muted-foreground',
                 )}
               >
@@ -66,7 +79,14 @@ export function StageRail() {
                 ) : (
                   <Circle className={cn('h-3.5 w-3.5', DOT[node.state])} aria-hidden="true" />
                 )}
-                <span className="hidden @[48rem]/headerbar:inline">{t('runs', STAGE_COPY_KEY[node.key])}</span>
+                <span className="sr-only @[58rem]/headerbar:not-sr-only">{t('runs', STAGE_COPY_KEY[node.key])}</span>
+                {/* State (done/current/upcoming/locked/cancelled) is shown to
+                    sighted users by the icon; this sr-only suffix gives the same
+                    cue to assistive tech, completing each node's announced name. */}
+                <span className="sr-only">
+                  {', '}
+                  {t('runs', node.key === 'finalized' && node.state === 'future' ? 'stageStateLocked' : STATE_COPY[node.state])}
+                </span>
               </span>
             </TooltipTrigger>
             <TooltipContent>{t('runs', STAGE_TOOLTIP_KEY[node.key])}</TooltipContent>

--- a/frontend/components/runs/header/Utility.tsx
+++ b/frontend/components/runs/header/Utility.tsx
@@ -1,0 +1,84 @@
+import { Children, useState, type ReactNode } from 'react';
+import { MessageCircle } from 'lucide-react';
+import { HeaderIconButton } from '@/components/layout/HeaderIconButton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
+import { NotificationCenter } from '@/components/navigation/NotificationCenter';
+import { FeedbackDialog } from '@/components/feedback/FeedbackDialog';
+import { t } from '@/lib/copy';
+import { Menu, MenuItem } from './Menu';
+import { Help, HelpDialog } from './Help';
+import { useHeaderCompact } from './useHeaderCompact';
+
+interface UtilityProps {
+  /**
+   * Business-gated overflow items (compare toggle, reopen, …), rendered at the
+   * TOP of the kebab, above any folded feedback/help items.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Shared right-side utility cluster for the run header.
+ *
+ * The full-screen run pages have no global Topbar, so notifications + feedback +
+ * help must live here. The cluster degrades by width to keep the bar from
+ * crowding:
+ *
+ * - **Bell** is inline at every width — its badge/active-job dot must stay
+ *   glanceable, and nesting its dropdown inside the kebab is awkward.
+ * - **Feedback + Help** are inline when the header is wide and **fold into the
+ *   kebab** ("three dots") when it is narrow. The fold is driven by a measured
+ *   header width (`useHeaderCompact`) rather than a container query, because the
+ *   kebab content is portaled out of the `@container/headerbar`.
+ * - **Business items** (passed as children) always live in the kebab.
+ *
+ * `Menu` self-hides when it has no items, so a wide header with no business
+ * items shows no kebab at all.
+ *
+ * Feedback opens a single, lazily-mounted dialog shared by the inline trigger
+ * and the folded menu item — it is NOT the self-contained `FeedbackButton`,
+ * because that mounts its dialog (and thus its auth/mutation hooks) eagerly,
+ * which would couple the whole run header to `AuthProvider` on first render.
+ */
+export function Utility({ children }: UtilityProps) {
+  const { ref, compact } = useHeaderCompact();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const hasBusinessItems = Children.toArray(children).length > 0;
+
+  return (
+    <>
+      {/* Zero-footprint sentinel — anchors the width measurement to the header. */}
+      <span ref={ref} aria-hidden="true" className="hidden" />
+      {/* Separator before the cluster — only when items sit inline. */}
+      {!compact && <span className="mx-1 h-5 w-px bg-border/60" aria-hidden="true" />}
+      <NotificationCenter />
+      {!compact && (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <HeaderIconButton onClick={() => setFeedbackOpen(true)} aria-label={t('navigation', 'sendFeedback')}>
+                <MessageCircle strokeWidth={1.5} aria-hidden="true" />
+              </HeaderIconButton>
+            </TooltipTrigger>
+            <TooltipContent>{t('navigation', 'sendFeedback')}</TooltipContent>
+          </Tooltip>
+          <Help />
+        </>
+      )}
+      <Menu>
+        {children}
+        {compact && hasBusinessItems && <DropdownMenuSeparator />}
+        {compact && (
+          <MenuItem onSelect={() => setFeedbackOpen(true)}>{t('navigation', 'sendFeedback')}</MenuItem>
+        )}
+        {compact && (
+          <MenuItem onSelect={() => setHelpOpen(true)}>{t('runs', 'helpButton')}</MenuItem>
+        )}
+      </Menu>
+      {feedbackOpen && <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />}
+      {helpOpen && <HelpDialog open={helpOpen} onOpenChange={setHelpOpen} />}
+    </>
+  );
+}

--- a/frontend/components/runs/header/Worklist.tsx
+++ b/frontend/components/runs/header/Worklist.tsx
@@ -47,15 +47,19 @@ export function Worklist({ articles, currentId, onNavigate }: WorklistProps) {
 
   return (
     <div className="flex shrink-0 items-center gap-1">
+      {/* Leading divider groups the article pager apart from the breadcrumb/back
+          so the two never read as one crowded chevron cluster when the
+          breadcrumb text collapses at narrow widths. */}
+      <span className="mr-1 h-4 w-px shrink-0 bg-border/60" aria-hidden="true" />
       <Button
         variant="ghost"
         size="sm"
-        className="h-7 w-7 p-0"
+        className="h-7 w-7 p-0 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
         aria-label={t('runs', 'articlePrevious')}
         disabled={!hasPrev}
         onClick={() => hasPrev && onNavigate(articles[idx - 1].id)}
       >
-        <ChevronLeft className="h-4 w-4" />
+        <ChevronLeft className="h-4 w-4" strokeWidth={1.5} />
       </Button>
 
       <Popover open={open} onOpenChange={setOpen}>
@@ -63,8 +67,10 @@ export function Worklist({ articles, currentId, onNavigate }: WorklistProps) {
           <Button
             variant="ghost"
             size="sm"
-            className="h-7 px-2 text-[11px] tabular-nums text-muted-foreground"
-            aria-label={`${idx + 1} / ${articles.length}`}
+            className="h-7 px-2 text-[11px] tabular-nums text-muted-foreground [@media(pointer:coarse)]:h-11"
+            aria-label={t('runs', 'worklistPositionLabel')
+              .replace('{{n}}', String(idx + 1))
+              .replace('{{m}}', String(articles.length))}
           >
             {idx + 1} / {articles.length}
           </Button>
@@ -102,12 +108,12 @@ export function Worklist({ articles, currentId, onNavigate }: WorklistProps) {
       <Button
         variant="ghost"
         size="sm"
-        className="h-7 w-7 p-0"
+        className="h-7 w-7 p-0 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
         aria-label={t('runs', 'articleNext')}
         disabled={!hasNext}
         onClick={() => hasNext && onNavigate(articles[idx + 1].id)}
       >
-        <ChevronRight className="h-4 w-4" />
+        <ChevronRight className="h-4 w-4" strokeWidth={1.5} />
       </Button>
     </div>
   );

--- a/frontend/components/runs/header/__tests__/RoleChip.test.tsx
+++ b/frontend/components/runs/header/__tests__/RoleChip.test.tsx
@@ -21,6 +21,19 @@ describe('RunHeader.RoleChip', () => {
     await userEvent.click(screen.getByRole('button', { name: 'reveal' }));
     expect(onReveal).toHaveBeenCalledOnce();
   });
+  it('keeps a single always-present reveal trigger whose name carries role + reveal (touch-reachable)', async () => {
+    const onReveal = vi.fn();
+    render(<RunHeader value={{ ...base, role: 'reviewer', isBlind: true, canReveal: true, onReveal }}>
+      <RunHeader.Center><RunHeader.RoleChip /></RunHeader.Center>
+    </RunHeader>);
+    // The trigger's accessible name carries BOTH the role and the reveal intent,
+    // so it works when the visual role text folds away at narrow widths.
+    const trigger = screen.getByRole('button', { name: /reviewer.*reveal/i });
+    await userEvent.click(trigger);
+    await userEvent.click(screen.getByRole('button', { name: 'reveal' }));
+    expect(onReveal).toHaveBeenCalledOnce();
+  });
+
   it('renders a plain non-interactive chip for a reviewer', () => {
     render(<RunHeader value={{ ...base, role: 'reviewer', isBlind: true, canReveal: false }}>
       <RunHeader.Center><RunHeader.RoleChip /></RunHeader.Center>

--- a/frontend/components/runs/header/__tests__/StageRail.test.tsx
+++ b/frontend/components/runs/header/__tests__/StageRail.test.tsx
@@ -28,6 +28,18 @@ describe('RunHeader.StageRail (3-node)', () => {
     expect(screen.getByText('revision')).toBeInTheDocument();
   });
 
+  it('announces each node\'s state to assistive tech (not just the stage word)', () => {
+    render(
+      <RunHeader value={value}>
+        <RunHeader.Left><RunHeader.StageRail /></RunHeader.Left>
+      </RunHeader>,
+    );
+    // stage='extract' → extract is current, consensus upcoming, finalized locked.
+    expect(screen.getByText(/stageStateCurrent/)).toBeInTheDocument();
+    expect(screen.getByText(/stageStateUpcoming/)).toBeInTheDocument();
+    expect(screen.getByText(/stageStateLocked/)).toBeInTheDocument();
+  });
+
   it('does not render a gate-remaining chip in the rail', () => {
     render(
       <RunHeader value={{ ...value, transition: { to: 'consensus', label: 'x', gate: { ok: false, reason: 'r', remaining: 27 }, onAdvance: () => {} } }}>

--- a/frontend/components/runs/header/__tests__/Utility.test.tsx
+++ b/frontend/components/runs/header/__tests__/Utility.test.tsx
@@ -1,0 +1,123 @@
+import { type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RunHeader } from '@/components/runs/header';
+import { Utility } from '../Utility';
+import { makeRunHeaderValue } from './_headerTestUtils';
+
+// Copy stub: t(namespace, key) -> key (same convention as the other header tests).
+vi.mock('@/lib/copy', () => ({ t: (_n: string, k: string) => k }));
+
+// NotificationCenter reaches the supabase client through its export services; in
+// the env-less CI test run that client throws at module load. Stub the boundary
+// (it has its own test) so Utility's fold logic is what's under test here.
+vi.mock('@/components/navigation/NotificationCenter', () => ({
+  NotificationCenter: () => <button type="button" aria-label="notif-stub" />,
+}));
+
+// FeedbackDialog imports the supabase storage client (same env-less-CI reason).
+// Stub it to a presence marker; the REAL FeedbackButton/Help still render so the
+// inline-vs-folded behaviour is exercised for real.
+vi.mock('@/components/feedback/FeedbackDialog', () => ({
+  FeedbackDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="feedback-dialog" /> : null,
+}));
+
+// useHeaderCompact measures the nearest <header>'s width via getBoundingClientRect.
+// Drive that width to exercise the wide (inline) and narrow (folded) tiers.
+function setHeaderWidth(width: number) {
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    width, height: 48, top: 0, bottom: 48, left: 0, right: width, x: 0, y: 0, toJSON: () => {},
+  } as DOMRect);
+}
+
+function renderUtility(children?: ReactNode) {
+  // RunHeader supplies the <header> ancestor that useHeaderCompact measures.
+  return render(
+    <RunHeader value={makeRunHeaderValue()}>
+      <RunHeader.Right>
+        <Utility>{children}</Utility>
+      </RunHeader.Right>
+    </RunHeader>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('run header Utility', () => {
+  it('keeps the notification bell inline on a wide header', () => {
+    setHeaderWidth(1200);
+    renderUtility();
+    expect(screen.getByLabelText('notif-stub')).toBeInTheDocument();
+  });
+
+  it('keeps the notification bell inline on a narrow header', () => {
+    setHeaderWidth(400);
+    renderUtility();
+    expect(screen.getByLabelText('notif-stub')).toBeInTheDocument();
+  });
+
+  describe('wide header (room for inline icons)', () => {
+    it('shows feedback + help inline, not in a kebab', () => {
+      setHeaderWidth(1200);
+      renderUtility();
+      expect(screen.getByRole('button', { name: 'sendFeedback' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'helpButton' })).toBeInTheDocument();
+      // No business items + everything inline => no kebab at all.
+      expect(screen.queryByRole('button', { name: 'more' })).not.toBeInTheDocument();
+    });
+
+    it('still shows business items in the kebab, without folding feedback/help into it', async () => {
+      setHeaderWidth(1200);
+      renderUtility(<RunHeader.MenuItem onSelect={() => {}}>compareToggle</RunHeader.MenuItem>);
+      // Feedback + help stay inline.
+      expect(screen.getByRole('button', { name: 'sendFeedback' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'helpButton' })).toBeInTheDocument();
+      // Kebab holds only the business item.
+      await userEvent.click(screen.getByRole('button', { name: 'more' }));
+      const items = screen.getAllByRole('menuitem').map((el) => el.textContent);
+      expect(items).toEqual(['compareToggle']);
+    });
+  });
+
+  describe('narrow header (folds into the kebab)', () => {
+    it('hides the inline feedback + help icons and folds them into the kebab', async () => {
+      setHeaderWidth(400);
+      renderUtility();
+      expect(screen.queryByRole('button', { name: 'sendFeedback' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'helpButton' })).not.toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: 'more' }));
+      expect(screen.getByRole('menuitem', { name: 'sendFeedback' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'helpButton' })).toBeInTheDocument();
+    });
+
+    it('orders business items above the folded feedback/help items', async () => {
+      setHeaderWidth(400);
+      renderUtility(<RunHeader.MenuItem onSelect={() => {}}>compareToggle</RunHeader.MenuItem>);
+      await userEvent.click(screen.getByRole('button', { name: 'more' }));
+      const items = screen.getAllByRole('menuitem').map((el) => el.textContent);
+      expect(items).toEqual(['compareToggle', 'sendFeedback', 'helpButton']);
+    });
+
+    it('opens the feedback dialog from the folded item', async () => {
+      setHeaderWidth(400);
+      renderUtility();
+      await userEvent.click(screen.getByRole('button', { name: 'more' }));
+      expect(screen.queryByTestId('feedback-dialog')).not.toBeInTheDocument();
+      await userEvent.click(screen.getByRole('menuitem', { name: 'sendFeedback' }));
+      expect(screen.getByTestId('feedback-dialog')).toBeInTheDocument();
+    });
+
+    it('opens the help dialog (shortcuts + glossary) from the folded item', async () => {
+      setHeaderWidth(400);
+      renderUtility();
+      await userEvent.click(screen.getByRole('button', { name: 'more' }));
+      await userEvent.click(screen.getByRole('menuitem', { name: 'helpButton' }));
+      expect(screen.getByText('shortcutsHeading')).toBeInTheDocument();
+      expect(screen.getByText('glossaryHeading')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/components/runs/header/__tests__/Worklist.test.tsx
+++ b/frontend/components/runs/header/__tests__/Worklist.test.tsx
@@ -20,7 +20,7 @@ const articles = [
 describe('RunHeader.Worklist', () => {
   it('renders "2 / 3" trigger when current is middle article', () => {
     render(<Worklist articles={articles} currentId="a2" onNavigate={vi.fn()} />);
-    expect(screen.getByRole('button', { name: '2 / 3' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'worklistPositionLabel' })).toHaveTextContent('2 / 3');
   });
 
   it('calls onNavigate with first article id when prev is clicked', async () => {
@@ -51,7 +51,7 @@ describe('RunHeader.Worklist', () => {
 
   it('opens popover and lists all article titles on trigger click', async () => {
     render(<Worklist articles={articles} currentId="a2" onNavigate={vi.fn()} />);
-    await userEvent.click(screen.getByRole('button', { name: '2 / 3' }));
+    await userEvent.click(screen.getByRole('button', { name: 'worklistPositionLabel' }));
     expect(screen.getByText('Article One')).toBeInTheDocument();
     expect(screen.getByText('Article Two')).toBeInTheDocument();
     expect(screen.getByText('Article Three')).toBeInTheDocument();
@@ -60,7 +60,7 @@ describe('RunHeader.Worklist', () => {
   it('calls onNavigate with article id when a row in the popover is clicked', async () => {
     const onNavigate = vi.fn();
     render(<Worklist articles={articles} currentId="a2" onNavigate={onNavigate} />);
-    await userEvent.click(screen.getByRole('button', { name: '2 / 3' }));
+    await userEvent.click(screen.getByRole('button', { name: 'worklistPositionLabel' }));
     await userEvent.click(screen.getByText('Article One'));
     expect(onNavigate).toHaveBeenCalledWith('a1');
   });

--- a/frontend/components/runs/header/useHeaderCompact.ts
+++ b/frontend/components/runs/header/useHeaderCompact.ts
@@ -1,0 +1,35 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+/**
+ * Reports whether the run header is narrower than `breakpointPx`, by measuring
+ * its nearest `<header>` ancestor with a ResizeObserver.
+ *
+ * Why JS measurement and not a container query: the affordances that fold at
+ * narrow widths live inside the kebab's `DropdownMenuContent`, which Radix
+ * portals OUT of the `@container/headerbar` element — so `@[..]/headerbar:`
+ * utilities cannot gate them. A measured width can. The default breakpoint
+ * mirrors the `@[40rem]` (640px) container query used for the StageRail/RoleChip
+ * fold, so inline collapse and kebab fold cross over at the same width.
+ *
+ * Guarded for non-DOM/test envs: `ResizeObserver` is mocked to a no-op there,
+ * but the synchronous first `measure()` still sets the initial state from
+ * `getBoundingClientRect`, which keeps the hook deterministic under test.
+ */
+export function useHeaderCompact(breakpointPx = 640) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [compact, setCompact] = useState(false);
+
+  useLayoutEffect(() => {
+    const anchor = ref.current;
+    const target = anchor?.closest('header') ?? anchor?.parentElement ?? null;
+    if (!target) return;
+    const measure = () => setCompact(target.getBoundingClientRect().width < breakpointPx);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(target);
+    return () => ro.disconnect();
+  }, [breakpointPx]);
+
+  return { ref, compact };
+}

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -69,13 +69,14 @@
     --ai-foreground: 0 0% 100%;
 
     /* Reviewer palette — used by ReviewerAvatarStack to colour avatar
-       bubbles deterministically by user_id hash. Same hue intent as the
-       legacy sky/emerald/amber/violet/rose 200/800 pair. */
-    --reviewer-1: 199 89% 48%;   /* sky    */
+       bubbles deterministically by user_id hash. Hues are kept OFF the semantic
+       colours (info 199 / warning 38 / ai 262) so an avatar never reads as a
+       status next to the amber divergence or violet AI chips. */
+    --reviewer-1: 230 72% 52%;   /* indigo  */
     --reviewer-2: 158 64% 40%;   /* emerald */
-    --reviewer-3: 38 92% 50%;    /* amber  */
-    --reviewer-4: 262 83% 58%;   /* violet */
-    --reviewer-5: 350 89% 60%;   /* rose   */
+    --reviewer-3: 305 68% 50%;   /* magenta */
+    --reviewer-4: 90 55% 38%;    /* olive   */
+    --reviewer-5: 350 89% 60%;   /* rose    */
 
     /* Shadows — soft elevation tokens. `card` for static surfaces,
        `popover` for floating menus / dropdowns. Defined as full
@@ -150,11 +151,11 @@
     --ai-foreground: 0 0% 100%;
 
     /* Reviewer palette — lifted for dark-mode legibility. */
-    --reviewer-1: 199 89% 60%;
-    --reviewer-2: 158 64% 52%;
-    --reviewer-3: 38 92% 60%;
-    --reviewer-4: 262 83% 68%;
-    --reviewer-5: 350 89% 70%;
+    --reviewer-1: 230 78% 70%;   /* indigo  */
+    --reviewer-2: 158 64% 52%;   /* emerald */
+    --reviewer-3: 305 72% 68%;   /* magenta */
+    --reviewer-4: 90 52% 58%;    /* olive   */
+    --reviewer-5: 350 89% 70%;   /* rose    */
 
     /* Shadows — higher alpha because dark backgrounds swallow low-alpha
        shadows. */

--- a/frontend/lib/copy/navigation.ts
+++ b/frontend/lib/copy/navigation.ts
@@ -5,6 +5,7 @@ export const navigation = {
     notifications: 'Notifications',
     notificationsAriaBackgroundActive:
         'Notifications — background activity in progress',
+    notificationsAriaUnread: 'Notifications, {{count}} unread',
     notificationsCleared: 'Notifications cleared',
     viewProject: 'View project',
     errorPrefix: 'Error',

--- a/frontend/lib/copy/qa.ts
+++ b/frontend/lib/copy/qa.ts
@@ -44,10 +44,6 @@ export const qa = {
   managerVisibilitySectionDesc:
     'Control whether managers see other reviewers’ assessments for this project.',
 
-  // Assess vs. compare view toggle (assessment screen header)
-  compareToggle: 'Comparison',
-  assessToggle: 'Assessment',
-
   // QualityAssessmentFullScreen — header, status, toasts
   badge: 'Quality Assessment',
   badgeShort: 'QA',

--- a/frontend/lib/copy/runs.ts
+++ b/frontend/lib/copy/runs.ts
@@ -13,6 +13,13 @@ export const runs = {
   stageExtractTooltip: 'Fill the form and review AI suggestions for this article.',
   stageConsensusTooltip: 'Reconcile reviewer values into one agreed answer.',
   stageFinalizedTooltip: 'Locked and published — reopen to make changes.',
+  // StageRail per-node STATE, appended to each node's accessible name so the
+  // state a sighted user reads from the icon is also announced to assistive tech.
+  stageStateDone: 'completed',
+  stageStateCurrent: 'current step',
+  stageStateUpcoming: 'upcoming',
+  stageStateLocked: 'locked',
+  stageStateCancelled: 'cancelled',
   // PrimaryAction
   requiredOfTotal: '{{done}} of {{total}} required',
   // Transition label (QA's buildQaTransition uses this shared key)
@@ -44,6 +51,9 @@ export const runs = {
   // Worklist popover
   worklistSearch: 'Go to article…',
   worklistPosition: '{{n}} of {{m}}',
+  worklistPositionLabel: 'Article {{n}} of {{m}}, open list',
+  aiPendingSuggestions: '{{n}} AI suggestions pending',
+  compareToggleLabel: 'Compare',
   // CommandPalette
   commandPlaceholder: 'Type a command or search…',
   commandEmpty: 'No results',

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -48,6 +48,9 @@ import {
 } from "@/hooks/runs";
 import { ConsensusPanel } from "@/components/runs/ConsensusPanel";
 import { RunHeader } from "@/components/runs/header";
+// Imported directly (not via the RunHeader compound) so the shared compound
+// stays free of the supabase-reaching NotificationCenter/feedback deps.
+import { Utility } from "@/components/runs/header/Utility";
 import { buildQaTransition } from "@/lib/qa/qaTransition";
 import { usePdfPanel } from "@/hooks/usePdfPanel";
 import { setManagerReviewVisibility } from "@/services/hitlConfigService";
@@ -620,6 +623,13 @@ export default function QualityAssessmentFullScreen() {
         </RunHeader.Center>
 
         <RunHeader.Right>
+          {canCompare && (
+            <RunHeader.CompareToggle
+              active={effectiveViewMode === "compare"}
+              onToggle={() => setViewMode((m) => (m === "assess" ? "compare" : "assess"))}
+              label={t("runs", "compareToggleLabel")}
+            />
+          )}
           <RunHeader.AIActions
             pendingCount={Object.keys(aiSuggestions).length}
             canExtract={!!(session && !finalized)}
@@ -627,22 +637,7 @@ export default function QualityAssessmentFullScreen() {
             onExtract={onExtractWithAI}
           />
           <RunHeader.PrimaryAction />
-          <span className="mx-1 hidden h-5 w-px bg-border/60 @[40rem]/headerbar:block" aria-hidden="true" />
-          <span className="hidden @[40rem]/headerbar:inline-flex">
-            <RunHeader.Help />
-          </span>
-          <RunHeader.Menu>
-            {canCompare && (
-              <RunHeader.MenuItem
-                onSelect={() =>
-                  setViewMode((m) => (m === "assess" ? "compare" : "assess"))
-                }
-              >
-                {effectiveViewMode === "assess"
-                  ? t("qa", "compareToggle")
-                  : t("qa", "assessToggle")}
-              </RunHeader.MenuItem>
-            )}
+          <Utility>
             {finalized && (
               <RunHeader.MenuItem
                 onSelect={() => void handleReopen()}
@@ -652,7 +647,7 @@ export default function QualityAssessmentFullScreen() {
                   : t("qa", "reopenButton")}
               </RunHeader.MenuItem>
             )}
-          </RunHeader.Menu>
+          </Utility>
           <RunHeader.PanelToggle
             pressed={pdfPanelState.isOpen}
             onToggle={pdfPanelState.toggle}

--- a/frontend/stores/useBackgroundJobs.ts
+++ b/frontend/stores/useBackgroundJobs.ts
@@ -11,13 +11,22 @@ import type {BackgroundJob} from '@/types/background-jobs';
 
 interface BackgroundJobsState {
   jobs: BackgroundJob[];
-  
+  /**
+   * Timestamp the user last opened the notification bell. A finished job is
+   * "unread" until then (see countUnreadJobs). Initialised to now so jobs that
+   * finished in a previous session (rehydrated from storage) don't show as
+   * unread on load. Persisted, so unread survives across reloads.
+   */
+  lastReadAt: number;
+
   // Actions
   addJob: (job: BackgroundJob) => void;
   updateJob: (jobId: string, updates: Partial<BackgroundJob>) => void;
   removeJob: (jobId: string) => void;
   clearCompletedJobs: () => void;
-  
+  /** Mark every finished job as read (clears the bell's unread badge). */
+  markAllRead: () => void;
+
   // Queries
   getJob: (jobId: string) => BackgroundJob | undefined;
   getActiveJobs: () => BackgroundJob[];
@@ -25,6 +34,19 @@ interface BackgroundJobsState {
 }
 
 const MAX_COMPLETED_JOBS = 10; // Keep only last 10 completed jobs
+
+/**
+ * Count finished (completed/failed/cancelled) jobs that finished AFTER the user
+ * last opened the bell — i.e. genuinely unread. Pure selector so the React
+ * Compiler tracks deps from the callback body (mirrors selectRecentJobs).
+ */
+export function countUnreadJobs(jobs: BackgroundJob[], lastReadAt: number): number {
+  return jobs.filter(
+    (job) =>
+      (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') &&
+      (job.completedAt ?? 0) > lastReadAt,
+  ).length;
+}
 
 /**
  * Pure selector for the notification list: active jobs first, then the most
@@ -58,6 +80,11 @@ export const useBackgroundJobs = create<BackgroundJobsState>()(
   persist(
     (set, get) => ({
       jobs: [],
+      // Date.now() at store creation: anything finished before "now" counts as
+      // already-read (so a fresh load with old persisted jobs shows no badge).
+      // On rehydrate, the persisted lastReadAt shallow-merges over this default;
+      // pre-update persisted state (no lastReadAt key) keeps this default.
+      lastReadAt: Date.now(),
 
       addJob: (job) => {
         set((state) => ({
@@ -93,6 +120,10 @@ export const useBackgroundJobs = create<BackgroundJobsState>()(
             (job) => job.status === 'running' || job.status === 'pending'
           ),
         }));
+      },
+
+      markAllRead: () => {
+        set({ lastReadAt: Date.now() });
       },
 
       getJob: (jobId) => {

--- a/frontend/test/QualityAssessmentFullScreen.test.tsx
+++ b/frontend/test/QualityAssessmentFullScreen.test.tsx
@@ -405,20 +405,20 @@ describe("QualityAssessmentFullScreen", () => {
     expect(sideEffects).toHaveLength(0);
   });
 
-  it("blind reviewer sees no comparison menu item and stays on the assess view", async () => {
+  it("blind reviewer sees no compare control and stays on the assess view", async () => {
     // Default permissions (BLIND_PERMISSIONS) → canSeeOthers=false →
-    // no compare MenuItem even when the menu is open.
+    // canCompare is false, so the CompareToggle never renders.
     renderPage();
     await waitFor(() =>
       expect(screen.getByTestId("qa-domains")).toBeInTheDocument(),
     );
     // Compare view must not appear passively.
     expect(screen.queryByTestId("qa-compare-view")).not.toBeInTheDocument();
-    // The compare text must not appear anywhere in the rendered output.
-    expect(screen.queryByText(/comparison/i)).not.toBeInTheDocument();
+    // No visible compare affordance for a blind reviewer.
+    expect(screen.queryByRole("button", { name: /^compare$/i })).not.toBeInTheDocument();
   });
 
-  it("manager who may see peers gets the compare menu item, clicking it renders the comparison", async () => {
+  it("manager who may see peers gets a visible Compare toggle, clicking it renders the comparison", async () => {
     mockedPermissions.mockReturnValue({
       ...BLIND_PERMISSIONS,
       userRole: "manager",
@@ -434,22 +434,14 @@ describe("QualityAssessmentFullScreen", () => {
       expect(screen.getByTestId("qa-domains")).toBeInTheDocument(),
     );
 
-    // Open the RunHeader.Menu (aria-label "More options").
-    const menuTrigger = await screen.findByRole("button", {
-      name: /more options/i,
-    });
-    await userEvent.click(menuTrigger);
-
-    // The "Comparison" menu item should appear in the open dropdown.
-    const compareItem = await screen.findByRole("menuitem", {
-      name: /comparison/i,
-    });
-    expect(compareItem).toBeInTheDocument();
+    // The Compare toggle is now a visible top-level control (not a kebab item).
+    const compareToggle = await screen.findByRole("button", { name: /^compare$/i });
+    expect(compareToggle).toBeInTheDocument();
 
     // Still on the assess view before clicking.
     expect(screen.queryByTestId("qa-compare-view")).not.toBeInTheDocument();
 
-    await userEvent.click(compareItem);
+    await userEvent.click(compareToggle);
 
     // Compare view replaces the domain accordions and renders the shared
     // server-blinded comparison table (peer column sourced from decisionsByCoord).

--- a/frontend/test/extractionReveal.test.tsx
+++ b/frontend/test/extractionReveal.test.tsx
@@ -13,6 +13,14 @@ import { MemoryRouter } from 'react-router-dom';
 // Mock copy so t() returns the key (avoids needing the full copy registry).
 vi.mock('@/lib/copy', () => ({ t: (_n: string, k: string) => k }));
 
+// The header now mounts NotificationCenter (via Utility), whose service import
+// graph reaches the supabase client — which throws at module load in the
+// env-less Frontend Tests CI job. Stub the client; rendering makes no supabase
+// calls here.
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { auth: { getSession: () => Promise.resolve({ data: { session: null }, error: null }) } },
+}));
+
 // ---- Test 1: ExtractionHeader passes canReveal/onReveal through to RoleChip ----
 
 import { ExtractionHeader } from '@/components/extraction/ExtractionHeader';


### PR DESCRIPTION
Promote `dev` → `main` (production). Delta is one squash commit:

- **#450** — responsive run-header re-architecture (pager/title/StageRail no longer clipped; priority cascade) + 5 header follow-ups (non-destructive announced bell badge + mark-as-read shared with Topbar, StageRail a11y state labels, RoleChip reveal-on-touch).

Frontend-only. Green on dev (all required checks). Preflight GREEN (1 pre-existing Supabase-advisor warn; migrations in sync; Railway web/worker/Redis healthy; Vercel Ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)