### PR TITLE
fix(extraction): render select option labels (not codes) in AI suggestions

### DIFF
--- a/frontend/components/extraction/FieldInput.tsx
+++ b/frontend/components/extraction/FieldInput.tsx
@@ -401,6 +401,10 @@ export function FieldInput(props: FieldInputProps) {
             selectSuggestion?.(instanceId, field.id, proposalRecordId, selectedValue, selectedConfidence),
           onClear: onRejectAI,
           align: 'end',
+          // So the version-history popover resolves a select/multiselect CODE
+          // to its human label, same as the inline card.
+          fieldType: field.field_type,
+          allowedValues: field.allowed_values,
         }
       : undefined;
 
@@ -492,6 +496,9 @@ export function FieldInput(props: FieldInputProps) {
             // Same review surface as the History icon (shared binding): clicking
             // the inline value/confidence opens the version history + provenance.
             review={reviewBinding}
+            // Render a select/multiselect CODE as its human label on the card.
+            fieldType={field.field_type}
+            allowedValues={field.allowed_values}
           />
         )}
 

--- a/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
@@ -102,3 +102,27 @@ describe('AISuggestionDisplay — review popover entry point', () => {
     expect(screen.queryByRole('button', { name: 'reviewOpenFromValue' })).not.toBeInTheDocument();
   });
 });
+
+describe('AISuggestionDisplay — select option code → label', () => {
+  const YES_NO = [
+    { value: 'Y', label: 'Yes' },
+    { value: 'N', label: 'No' },
+  ];
+
+  it('renders the human label for a coded select value', () => {
+    render(
+      <AISuggestionDisplay
+        suggestion={makeSuggestion({ value: 'Y', confidence: 0.9 })}
+        fieldType="select"
+        allowedValues={YES_NO}
+      />,
+    );
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.queryByText('Y')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the raw code when no field context is supplied', () => {
+    render(<AISuggestionDisplay suggestion={makeSuggestion({ value: 'Y', confidence: 0.9 })} />);
+    expect(screen.getByText('Y')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -34,6 +34,10 @@ export interface AISuggestionReviewBinding {
   onClear?: () => void;
   /** Defaults to 'end' so the popover opens left, clear of the PDF panel. */
   align?: 'start' | 'center' | 'end';
+  /** Field type + allowed_values so the version-history popover resolves a
+   *  select/multiselect CODE to its human label, same as the inline card. */
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
 interface AISuggestionDisplayProps {
@@ -43,6 +47,10 @@ interface AISuggestionDisplayProps {
   loading?: boolean;
   /** When present, the value area becomes a trigger for the review popover. */
   review?: AISuggestionReviewBinding;
+  /** Field type + allowed_values so a select/multiselect CODE renders as its
+   *  human label on the inline card. Omit for non-select fields. */
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
 /**
@@ -91,6 +99,8 @@ export function AISuggestionDisplay({
   onReject,
   loading = false,
   review,
+  fieldType,
+  allowedValues,
 }: AISuggestionDisplayProps) {
   const isAccepted = isSuggestionAccepted(suggestion);
   const isRejected = suggestion.status === 'rejected';
@@ -119,7 +129,13 @@ export function AISuggestionDisplay({
           review={review}
           className="flex-1 min-w-0 w-full sm:w-auto flex items-center gap-2 px-1.5 py-1 -mx-1.5"
         >
-          <AISuggestionValue suggestion={suggestion} maxLength={150} className="flex-1 min-w-0" />
+          <AISuggestionValue
+            suggestion={suggestion}
+            maxLength={150}
+            className="flex-1 min-w-0"
+            fieldType={fieldType}
+            allowedValues={allowedValues}
+          />
           <AISuggestionConfidence suggestion={suggestion} />
         </ReviewTrigger>
 

--- a/frontend/components/extraction/ai/AISuggestionReviewPopover.tsx
+++ b/frontend/components/extraction/ai/AISuggestionReviewPopover.tsx
@@ -79,9 +79,12 @@ interface VersionRowProps {
   version: AISuggestionHistoryItem;
   isSelected: boolean;
   onUse: () => void;
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
-function VersionRow({version, isSelected, onUse}: VersionRowProps) {
+function VersionRow({version, isSelected, onUse, fieldType, allowedValues}: VersionRowProps) {
+  const fieldContext = {fieldType, allowedValues};
   const [expanded, setExpanded] = useState(false);
   const showDetails = isSelected || expanded;
 
@@ -114,9 +117,9 @@ function VersionRow({version, isSelected, onUse}: VersionRowProps) {
           ) : (
             <p
               className="line-clamp-3 break-words text-sm font-medium"
-              title={formatFullSuggestionValue(version.value)}
+              title={formatFullSuggestionValue(version.value, fieldContext)}
             >
-              {formatFullSuggestionValue(version.value)}
+              {formatFullSuggestionValue(version.value, fieldContext)}
             </p>
           )}
         </div>
@@ -190,10 +193,14 @@ interface AISuggestionReviewPopoverProps {
   onClear?: () => void;
   trigger: React.ReactNode;
   align?: 'start' | 'center' | 'end';
+  /** Field type + allowed_values so each version resolves a select/multiselect
+   *  CODE to its human label, same as the inline card. */
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
 export function AISuggestionReviewPopover(props: AISuggestionReviewPopoverProps) {
-  const {instanceId, fieldId, getHistory, selectedProposalId, onSelect, onClear, trigger, align} = props;
+  const {instanceId, fieldId, getHistory, selectedProposalId, onSelect, onClear, trigger, align, fieldType, allowedValues} = props;
 
   const [open, setOpen] = useState(false);
   const [history, setHistory] = useState<AISuggestionHistoryItem[]>([]);
@@ -296,6 +303,8 @@ export function AISuggestionReviewPopover(props: AISuggestionReviewPopoverProps)
                     version={version}
                     isSelected={version.id === effectiveSelected}
                     onUse={() => handleUse(version)}
+                    fieldType={fieldType}
+                    allowedValues={allowedValues}
                   />
                 ))}
                 {runIndex < runOrder.length - 1 && <Separator />}

--- a/frontend/components/extraction/ai/shared/AISuggestionValue.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionValue.tsx
@@ -11,15 +11,22 @@ interface AISuggestionValueProps {
   suggestion: AISuggestion;
   maxLength?: number;
   className?: string;
+  /** Field type + allowed_values so a select/multiselect CODE renders as its
+   *  human label ("Y" → "Yes"). Omit for non-select fields. */
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
 export function AISuggestionValue({
   suggestion,
   maxLength = 150,
   className = "",
+  fieldType,
+  allowedValues,
 }: AISuggestionValueProps) {
-  const displayValue = formatSuggestionValue(suggestion.value, maxLength);
-  const fullValue = formatFullSuggestionValue(suggestion.value);
+  const fieldContext = {fieldType, allowedValues};
+  const displayValue = formatSuggestionValue(suggestion.value, maxLength, fieldContext);
+  const fullValue = formatFullSuggestionValue(suggestion.value, fieldContext);
   const isTruncated = displayValue !== fullValue || fullValue.length > maxLength;
 
   const valueElement = (

--- a/frontend/lib/ai-extraction/suggestionUtils.ts
+++ b/frontend/lib/ai-extraction/suggestionUtils.ts
@@ -7,6 +7,72 @@
 import type {AISuggestion} from '@/types/ai-extraction';
 
 /**
+ * Field context needed to resolve a select/multiselect option CODE to its human
+ * label. Optional everywhere — callers without a select field omit it and the
+ * formatters fall back to the raw value (today's behaviour).
+ */
+export interface SuggestionFieldContext {
+  fieldType?: string | null;
+  allowedValues?: unknown;
+}
+
+/**
+ * Return the raw option list from an `allowed_values` payload. Tolerates both
+ * shapes the template builder emits: `{options: [...]}` or a bare `[...]`;
+ * anything else yields `[]`. Mirrors backend `normalize_options`
+ * (backend/app/llm/claim_value.py) so a new option encoding is handled once.
+ */
+function normalizeOptions(allowedValues: unknown): unknown[] {
+  if (
+    allowedValues &&
+    typeof allowedValues === 'object' &&
+    !Array.isArray(allowedValues) &&
+    'options' in allowedValues
+  ) {
+    const options = (allowedValues as {options?: unknown}).options;
+    return Array.isArray(options) ? options : [];
+  }
+  return Array.isArray(allowedValues) ? allowedValues : [];
+}
+
+/**
+ * Map each select option's stored value (code) to its human label. Options are
+ * `{value, label}` objects or plain strings; plain strings (and options without
+ * a distinct label) map to themselves. Mirrors backend `option_label_map`.
+ */
+function optionLabelMap(allowedValues: unknown): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const opt of normalizeOptions(allowedValues)) {
+    if (opt && typeof opt === 'object' && 'value' in opt) {
+      const code = String((opt as {value: unknown}).value);
+      const label = (opt as {label?: unknown}).label;
+      map.set(code, label ? String(label) : code);
+    } else if (typeof opt === 'string') {
+      map.set(opt, opt);
+    }
+  }
+  return map;
+}
+
+/**
+ * Resolve a select/multiselect coded value to human labels. Returns `undefined`
+ * for non-select fields so the caller keeps its default formatting; for a
+ * select/multiselect it always resolves (comma-joining arrays), falling back to
+ * the raw code per item — matching backend `value_str_for_claim`.
+ */
+function resolveOptionLabels(value: unknown, field?: SuggestionFieldContext): string | undefined {
+  if (!field || (field.fieldType !== 'select' && field.fieldType !== 'multiselect')) {
+    return undefined;
+  }
+  const labelMap = optionLabelMap(field.allowedValues);
+  const resolveOne = (v: unknown): string => labelMap.get(String(v)) ?? String(v);
+  if (Array.isArray(value)) {
+    return value.map(resolveOne).join(', ');
+  }
+  return resolveOne(value);
+}
+
+/**
  * Calculates formatted confidence percentage
  *
  * @param confidence - Confidence value (0-1)
@@ -25,7 +91,11 @@ export function calculateConfidencePercent(confidence: number): number {
  * @param maxLength - Max length (default: 40)
  * @returns Formatted string
  */
-export function formatSuggestionValue(value: any, maxLength: number = 40): string {
+export function formatSuggestionValue(
+  value: any,
+  maxLength: number = 40,
+  field?: SuggestionFieldContext,
+): string {
     // Empty string is also a valid value; show "(empty)" only for null/undefined
   if (value === null || value === undefined) {
       return '(empty)';
@@ -37,6 +107,13 @@ export function formatSuggestionValue(value: any, maxLength: number = 40): strin
 
   if (typeof value === 'boolean') {
       return value ? 'Yes' : 'No';
+  }
+
+  // Resolve a select/multiselect option CODE ("Y") to its human label ("Yes")
+  // so the card matches what the user picked. No-op for non-select fields.
+  const resolved = resolveOptionLabels(value, field);
+  if (resolved !== undefined) {
+    return resolved.length > maxLength ? `${resolved.substring(0, maxLength)}...` : resolved;
   }
 
   if (typeof value === 'number') {
@@ -62,9 +139,16 @@ export function formatSuggestionValue(value: any, maxLength: number = 40): strin
  * @param value - Value to format
  * @returns Full string of value
  */
-export function formatFullSuggestionValue(value: any): string {
+export function formatFullSuggestionValue(value: any, field?: SuggestionFieldContext): string {
   if (value === null || value === undefined) {
       return '(empty)';
+  }
+
+  // Resolve a select/multiselect option CODE to its human label (no-op for
+  // non-select fields), matching the inline card.
+  const resolved = resolveOptionLabels(value, field);
+  if (resolved !== undefined) {
+    return resolved;
   }
 
   if (typeof value === 'string') {

--- a/frontend/test/suggestionUtils.test.ts
+++ b/frontend/test/suggestionUtils.test.ts
@@ -1,0 +1,111 @@
+/**
+ * suggestionUtils — select/multiselect option CODE → human LABEL resolution.
+ *
+ * The extraction output stores the option CODE ("Y"), so the AI-suggestion card
+ * and history must resolve it to the human label ("Yes") to match what the user
+ * picked — mirroring the backend `value_str_for_claim` / `option_label_map`
+ * (backend/app/llm/claim_value.py). Resolution is a safe no-op when there is no
+ * field context, no distinct label, or the value is free text (`allow_other`).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  formatFullSuggestionValue,
+  formatSuggestionValue,
+} from '@/lib/ai-extraction/suggestionUtils';
+
+const YES_NO = [
+  { value: 'Y', label: 'Yes' },
+  { value: 'N', label: 'No' },
+];
+
+describe('formatSuggestionValue — select/multiselect label resolution', () => {
+  it('resolves a select option code to its human label', () => {
+    expect(
+      formatSuggestionValue('Y', 40, { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('Yes');
+  });
+
+  it('joins a multiselect array of codes into resolved labels', () => {
+    expect(
+      formatSuggestionValue(['Y', 'N'], 40, { fieldType: 'multiselect', allowedValues: YES_NO }),
+    ).toBe('Yes, No');
+  });
+
+  it('tolerates the {options: [...]} allowed_values shape', () => {
+    expect(
+      formatSuggestionValue('Y', 40, {
+        fieldType: 'select',
+        allowedValues: { options: YES_NO, allow_other: true },
+      }),
+    ).toBe('Yes');
+  });
+
+  it('falls back to the raw code when the code is absent from the option map', () => {
+    expect(
+      formatSuggestionValue('Z', 40, { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('Z');
+  });
+
+  it('passes through allow_other free text unchanged (no matching code)', () => {
+    expect(
+      formatSuggestionValue('Custom answer', 40, {
+        fieldType: 'select',
+        allowedValues: { options: YES_NO, allow_other: true },
+      }),
+    ).toBe('Custom answer');
+  });
+
+  it('renders plain-string options as themselves (no distinct label)', () => {
+    expect(
+      formatSuggestionValue('RCT', 40, {
+        fieldType: 'select',
+        allowedValues: ['RCT', 'Cohort'],
+      }),
+    ).toBe('RCT');
+  });
+
+  it('does not resolve for non-select field types', () => {
+    expect(
+      formatSuggestionValue('Y', 40, { fieldType: 'text', allowedValues: YES_NO }),
+    ).toBe('Y');
+  });
+
+  it('does not resolve without field context (backward compatible)', () => {
+    expect(formatSuggestionValue('Y')).toBe('Y');
+  });
+
+  it('still shows (empty) for null/empty even with field context', () => {
+    expect(
+      formatSuggestionValue(null, 40, { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('(empty)');
+    expect(
+      formatSuggestionValue('', 40, { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('(empty)');
+  });
+
+  it('comma-joins multiselect codes even when no option labels are available', () => {
+    expect(
+      formatSuggestionValue(['Y', 'N'], 40, { fieldType: 'multiselect', allowedValues: null }),
+    ).toBe('Y, N');
+  });
+});
+
+describe('formatFullSuggestionValue — select/multiselect label resolution', () => {
+  it('resolves a select code to its label (untruncated)', () => {
+    expect(
+      formatFullSuggestionValue('Y', { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('Yes');
+  });
+
+  it('joins a multiselect array into resolved labels', () => {
+    expect(
+      formatFullSuggestionValue(['Y', 'N'], { fieldType: 'multiselect', allowedValues: YES_NO }),
+    ).toBe('Yes, No');
+  });
+
+  it('falls back to raw JSON / string without field context (backward compatible)', () => {
+    expect(formatFullSuggestionValue('Y')).toBe('Y');
+    expect(formatFullSuggestionValue(['Y', 'N'])).toBe('["Y","N"]');
+  });
+});


### PR DESCRIPTION
## Why

The entailment judge resolves a select/multiselect option CODE ("Y") to its human label ("Yes") in `backend/app/llm/claim_value.py` (`value_str_for_claim`), but the human-facing AI-suggestion **card** and **version-history popover** still showed the raw code. This is the highest-user-value cleanup deferred from #448.

## What changed

- `frontend/lib/ai-extraction/suggestionUtils.ts`: `formatSuggestionValue` / `formatFullSuggestionValue` accept an optional `{fieldType, allowedValues}` context and resolve a select/multiselect code → label, mirroring the backend `normalize_options` / `option_label_map` shape tolerance (`{options:[...]}`, `[{value,label}]`, plain strings). Comma-joins multiselect arrays. Falls back to the raw value when there is no field context, no distinct label, or the value is `allow_other` free text.
- Threaded `fieldType` / `allowedValues` through `AISuggestionValue` + `AISuggestionDisplay` (inline card) and through `AISuggestionReviewBinding` → `AISuggestionReviewPopover` → `VersionRow` (history). `FieldInput` supplies `field.field_type` / `field.allowed_values` to both the shared review binding and the inline card.

## Risk

Display-only — no schema, API, or cache change. Every new prop and the formatter context param are optional, so non-select fields and legacy callers are unaffected (951 existing frontend tests still pass).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test:run` passes (951 tests) — incl. new `frontend/test/suggestionUtils.test.ts` (TDD red→green: select scalar, multiselect array, `{options}` shape, plain-string options, allow_other passthrough, no-context fallback, empty handling) and new `AISuggestionDisplay` label-vs-fallback cases.

## Out of scope

P2–P5 of the follow-up (provenance choke-point, predicate unification, token-shape consistency, docstring sweep) ship as separate PRs.