### PR TITLE
fix(extraction): persist run provenance at the proposal choke-point

### DIFF
--- a/backend/app/repositories/extraction_run_repository.py
+++ b/backend/app/repositories/extraction_run_repository.py
@@ -102,26 +102,29 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
         run_id: UUID,
         results: dict[str, Any],
     ) -> ExtractionRun | None:
-        """
-        Marca uma execucao como concluida.
+        """Mark a run COMPLETED, shallow-merging *results* into its ``results`` JSONB.
+
+        MERGE (not REPLACE) so run-level data already recorded — notably the
+        ``provenance`` snapshot the proposal choke-point (``_create_suggestions``
+        → ``merge_results``) writes — survives completion. A REPLACE would clobber
+        it. Callers whose run still has empty ``results`` (model extraction, the
+        batch primary run) are unaffected: merging into ``{}`` equals a replace.
 
         Args:
-            run_id: execucao.
-            results: Resultados da execucao.
+            run_id: the run to complete.
+            results: top-level keys to merge into ``results``.
 
         Returns:
-            ExtractionRun atualizado or None.
+            The updated ExtractionRun, or None if the run does not exist.
         """
         query_start = perf_counter()
-        await self.db.execute(
-            update(ExtractionRun)
-            .where(ExtractionRun.id == run_id)
-            .values(
-                status=ExtractionRunStatus.COMPLETED.value,
-                completed_at=datetime.now(UTC),
-                results=results,
-            )
-        )
+        run = await self.get_by_id(run_id)
+        if run is None:
+            return None
+        run.status = ExtractionRunStatus.COMPLETED.value
+        run.completed_at = datetime.now(UTC)
+        # Reassign (not in-place mutate) so SQLAlchemy tracks the JSONB change.
+        run.results = {**(run.results or {}), **results}
         await self.db.flush()
         query_duration_ms = (perf_counter() - query_start) * 1000
         logger.info(
@@ -129,7 +132,7 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
             run_id=str(run_id),
             db_duration_ms=query_duration_ms,
         )
-        return await self.get_by_id(run_id)
+        return run
 
     async def merge_results(
         self,

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -309,6 +309,7 @@ class SectionExtractionService(LoggerMixin):
                 extracted_data=extracted_data,
                 run=run,
                 model=model,
+                usage=llm_usage,
             )
             phase_durations_ms["create_suggestions"] = (perf_counter() - phase_start) * 1000
 
@@ -338,20 +339,14 @@ class SectionExtractionService(LoggerMixin):
                         "duration_ms": duration,
                         "fields_extracted": len(extracted_data) if extracted_data else 0,
                         "phase_durations_ms": phase_durations_ms,
-                        "provenance": self._provenance_with_tokens(llm_usage),
                     },
                 )
                 phase_durations_ms["complete_run"] = (perf_counter() - phase_start) * 1000
-            else:
-                # Session-run path: the HITL session owns the run lifecycle, so we
-                # must NOT complete it (that would close the run after one section
-                # and break further section-by-section AI clicks). Still persist
-                # the provenance snapshot so the review popover's "How this was
-                # generated" metadata renders for these suggestions — without this
-                # merge, session-run suggestions carried no provenance at all.
-                provenance = self._provenance_with_tokens(llm_usage)
-                if provenance is not None:
-                    await self._runs.merge_results(run.id, {"provenance": provenance})
+            # Session-run path: the HITL session owns the run lifecycle, so we
+            # must NOT complete it (that would close the run after one section
+            # and break further section-by-section AI clicks). The run's
+            # provenance was already persisted by ``_create_suggestions`` (the
+            # proposal choke-point), so nothing else to do here.
 
             self.logger.info(
                 "section_extraction_complete",
@@ -635,6 +630,7 @@ class SectionExtractionService(LoggerMixin):
                 extracted_data=extracted_data,
                 run=run,
                 model=model,
+                usage=llm_usage,
             )
             return {
                 "suggestions_created": suggestions_created,
@@ -1040,6 +1036,7 @@ class SectionExtractionService(LoggerMixin):
                 extracted_data=extracted_data,
                 run=run,
                 model=model,
+                usage=llm_usage,
             )
             section_phase_durations_ms["create_suggestions"] = (perf_counter() - phase_start) * 1000
 
@@ -1062,7 +1059,6 @@ class SectionExtractionService(LoggerMixin):
                     "summary": summary,
                     "duration_ms": (perf_counter() - section_start) * 1000,
                     "phase_durations_ms": section_phase_durations_ms,
-                    "provenance": self._provenance_with_tokens(llm_usage),
                 },
             )
             section_phase_durations_ms["complete_run"] = (perf_counter() - phase_start) * 1000
@@ -1299,12 +1295,15 @@ class SectionExtractionService(LoggerMixin):
         extracted_data: dict[str, Any],
         run: ExtractionRun,
         model: str = settings.LLM_DEFAULT_MODEL,
+        usage: LlmUsage | None = None,
     ) -> int:
         """
         Create extraction suggestions in database via repository.
 
         Automatically create an instance when missing.
-        Link suggestions to extraction_run_id for traceability.
+        Link suggestions to extraction_run_id for traceability. As the single
+        choke-point for AI proposals, this also persists the run ``provenance``
+        snapshot so every suggestion-owning run carries it (see below).
 
         Args:
             project_id: Project ID.
@@ -1314,6 +1313,8 @@ class SectionExtractionService(LoggerMixin):
             extracted_data: Extracted data.
             run: ExtractionRun used to link suggestions.
             model: LLM model name (used to build the entailment judge model).
+            usage: token usage for this extraction call, paired with the run
+                provenance snapshot. None (or no LLM run) skips provenance.
 
         Returns:
             Number of created suggestions.
@@ -1559,6 +1560,14 @@ class SectionExtractionService(LoggerMixin):
             instance_id=str(instance.id),
             run_id=str(run.id),
         )
+
+        # Single choke-point for run provenance: persist HOW the suggestions
+        # were generated wherever proposals are recorded, so no extraction path
+        # can silently omit it. ``complete_run`` later shallow-merges its summary
+        # on top (it MERGEs, so this key survives). Skipped when no LLM ran.
+        provenance = self._provenance_with_tokens(usage or LlmUsage())
+        if count and provenance is not None:
+            await self._runs.merge_results(run.id, {"provenance": provenance})
 
         return count
 

--- a/backend/tests/unit/test_extraction_run_repository.py
+++ b/backend/tests/unit/test_extraction_run_repository.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.extraction import ExtractionRunStatus
 from app.repositories.extraction_run_repository import ExtractionRunRepository
 
 
@@ -83,3 +84,59 @@ class TestRollbackAndFail:
         assert logger.warning.call_args.args[0] == "section_extraction_rollback_failed"
         # fail_run is still attempted after a failed rollback.
         repo.fail_run.assert_awaited_once()
+
+
+class TestCompleteRunMerge:
+    """``complete_run`` MERGES results into the run's existing ``results`` JSONB
+    (not REPLACE), so the provenance written at the proposal choke-point
+    (``_create_suggestions`` → ``merge_results``) survives completion. A REPLACE
+    would clobber it — the bug class this guards against.
+    """
+
+    @pytest.mark.asyncio
+    async def test_merges_into_existing_results_preserving_prior_keys(self, repo) -> None:
+        run_id = uuid4()
+        existing = MagicMock()
+        existing.results = {"provenance": {"model": "gpt"}}
+        repo.get_by_id = AsyncMock(return_value=existing)
+
+        out = await repo.complete_run(run_id, {"suggestions_created": 2})
+
+        assert out is existing
+        # Prior provenance preserved; the completion summary merged on top.
+        assert existing.results == {"provenance": {"model": "gpt"}, "suggestions_created": 2}
+        assert existing.status == ExtractionRunStatus.COMPLETED.value
+        assert existing.completed_at is not None
+        repo.db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_treats_empty_results_like_replace(self, repo) -> None:
+        # A fresh run (results == {}) merging is equivalent to a replace, so the
+        # non-proposal callers (model_extraction, batch primary run) are unaffected.
+        existing = MagicMock()
+        existing.results = {}
+        repo.get_by_id = AsyncMock(return_value=existing)
+
+        await repo.complete_run(uuid4(), {"models_count": 3})
+
+        assert existing.results == {"models_count": 3}
+
+    @pytest.mark.asyncio
+    async def test_patch_key_overwrites_on_conflict(self, repo) -> None:
+        # Shallow top-level merge: a patch key replaces the same key.
+        existing = MagicMock()
+        existing.results = {"tokens_total": 1, "provenance": {"a": 1}}
+        repo.get_by_id = AsyncMock(return_value=existing)
+
+        await repo.complete_run(uuid4(), {"tokens_total": 5})
+
+        assert existing.results == {"tokens_total": 5, "provenance": {"a": 1}}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_run_missing(self, repo) -> None:
+        repo.get_by_id = AsyncMock(return_value=None)
+
+        out = await repo.complete_run(uuid4(), {"x": 1})
+
+        assert out is None
+        repo.db.flush.assert_not_awaited()

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -1067,6 +1067,69 @@ class TestCreateSuggestions:
         )
         assert result == 0
 
+    def _wire_one_field(self, service):
+        field1 = MagicMock()
+        field1.id, field1.name = uuid4(), "f1"
+        field1.field_type = "text"
+        field1.allowed_values = None
+        et = MagicMock()
+        et.fields = [field1]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        instance = MagicMock()
+        instance.id = uuid4()
+        instance.parent_instance_id = None
+        service._instances.get_by_article = AsyncMock(return_value=[instance])
+        service._proposals.record_proposal = AsyncMock(return_value=MagicMock(id=uuid4()))
+        service.db.flush = AsyncMock()
+        service._runs.merge_results = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_persists_provenance_at_chokepoint_when_llm_ran(self, service):
+        # Provenance is written ONCE at the proposal choke-point so EVERY
+        # suggestion-owning run records how it was generated — even a future
+        # extraction path that forgets to write it at completion.
+        self._wire_one_field(service)
+        service._run_provenance = service._build_run_provenance(
+            model="gpt-x", prompt_name="extract", prompt_version="1", prompt_text="P"
+        )
+
+        run = self._make_run()
+        await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"f1": "value"},
+            run=run,
+            usage=LlmUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+        service._runs.merge_results.assert_awaited_once()
+        merged_run_id, patch = service._runs.merge_results.await_args.args
+        assert merged_run_id == run.id
+        prov = patch["provenance"]
+        assert prov["model"] == "gpt-x"
+        assert prov["tokens"] == {"prompt": 10, "completion": 5, "total": 15}
+
+    @pytest.mark.asyncio
+    async def test_skips_provenance_when_no_llm_ran(self, service):
+        # No provenance snapshot → nothing to record; never write a null provenance.
+        self._wire_one_field(service)
+        service._run_provenance = None
+
+        run = self._make_run()
+        await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"f1": "value"},
+            run=run,
+            usage=LlmUsage(prompt_tokens=1, completion_tokens=1),
+        )
+
+        service._runs.merge_results.assert_not_awaited()
+
     @pytest.mark.asyncio
     async def test_creates_no_info_proposal_for_none_and_abstention(self, service):
         # "No information found" outcomes (bare None + structured abstention) must

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -2,7 +2,7 @@
 # May shrink (re-run --update-baseline to tighten), never grow. Cleanup is a separate effort.
 backend/app/seed.py:1941
 backend/app/services/extraction_export_service.py:2252
-backend/app/services/section_extraction_service.py:1615
+backend/app/services/section_extraction_service.py:1624
 frontend/components/articles/ArticleForm.tsx:1272
 frontend/components/articles/ArticlesList.tsx:1360
 frontend/components/extraction/ArticleExtractionTable.tsx:1130


### PR DESCRIPTION
## Why

Run provenance (how an AI run's suggestions were generated) was written at four separate sites in `section_extraction_service`. A new suggestion-owning path would silently omit it — a bug that already shipped twice (#443, #448). Deferred from #448's `/code-review`.

## What changed

- **Choke-point**: `_create_suggestions` (the single place AI proposals are recorded) now persists the run `provenance` snapshot via `ExtractionRunRepository.merge_results`, so every proposal-owning run carries it — including any future path. Skipped when no LLM ran.
- **`complete_run` now MERGES `results`** instead of REPLACE, so the provenance the choke-point wrote survives completion. Verified safe for all callers: `model_extraction_service` and the batch primary run start from empty `results` (merge == replace); the section paths want their provenance preserved. Its docstring is translated to English while here.
- Removed the now-redundant explicit provenance writes from the single-section paths (`extract_section` both branches, `_extract_section_with_memory`). `extract_for_run` keeps its run-aggregate token write (its token-shape fix is a separate PR).

## Risk

`complete_run` semantics change (REPLACE → MERGE) on a core repository method. Audited every caller (`grep complete_run app/`): all five either start from `{}` (model extraction, batch primary run) or want the merged key preserved (section paths). The choke-point write adds one `merge_results` per proposal batch (a cached `get_by_id` + flush within the same transaction).

## Test plan

- [x] `make lint-backend` clean (ruff check + format)
- [x] `uv run pytest tests/unit/test_extraction_run_repository.py tests/unit/test_section_extraction_service.py tests/unit/test_model_extraction_service.py …` — 90 passed, incl. new `complete_run` merge-semantics (preserve prior keys, empty==replace, overwrite-on-conflict, missing-run) and choke-point provenance (persists when LLM ran, skips otherwise)
- [x] `uv run pytest tests/integration/test_section_extraction_gate.py tests/integration/test_section_extraction_evidence.py` — 8 passed (incl. the session-run provenance regression test, still green via the choke-point)
- [x] Architectural Fitness (layered-arch OK; file-size baseline bumped +9 for the choke-point, surgical 1-line change)

## Out of scope

P4 (provenance token-shape consistency for `extract_for_run`) and P5 (docstring sweep of the remaining repository methods) ship as separate PRs.