### PR TITLE
refactor(extraction): unify the value-emptiness predicate

### DIFF
--- a/backend/app/services/extraction_suggestion_read_service.py
+++ b/backend/app/services/extraction_suggestion_read_service.py
@@ -43,6 +43,7 @@ from app.schemas.extraction_suggestion import (
     AISuggestionsResponse,
     EvidenceResponse,
 )
+from app.services.value_semantics import is_value_empty
 
 
 def _extract_block_ids(ev: ExtractionEvidence) -> list[int]:
@@ -79,19 +80,6 @@ def _resolve_status(decision: str | None) -> str:
     if decision == ExtractionReviewerDecisionType.REJECT.value:
         return "rejected"
     return "accepted"
-
-
-def _is_no_info(proposed_value: Any) -> bool:
-    """True when a proposal carries no actionable value (the model abstained).
-
-    Mirrors the frontend ``isNoInfoValue``: a bare ``None``, the JSONB envelope
-    ``{"value": None}`` (the shape recorded for a "no information" outcome since
-    #443), or an empty string all mean "no information".
-    """
-    if proposed_value is None:
-        return True
-    value = proposed_value.get("value") if isinstance(proposed_value, dict) else proposed_value
-    return value is None or value == ""
 
 
 async def _load_run_provenance(
@@ -222,7 +210,7 @@ async def load_suggestions(
         existing = chosen.get(key)
         if existing is None:
             chosen[key] = p
-        elif _is_no_info(existing.proposed_value) and not _is_no_info(p.proposed_value):
+        elif is_value_empty(existing.proposed_value) and not is_value_empty(p.proposed_value):
             # The more recent pick abstained; this older one found a value → use it.
             chosen[key] = p
     deduped = list(chosen.values())

--- a/backend/app/services/run_lifecycle_service.py
+++ b/backend/app/services/run_lifecycle_service.py
@@ -33,6 +33,7 @@ from app.services._extraction_run_lock import load_run_for_update
 from app.services.extraction_consensus_service import ExtractionConsensusService
 from app.services.extraction_snapshot import build_template_version_snapshot
 from app.services.hitl_config_service import HitlConfigService
+from app.services.value_semantics import is_value_filled
 
 
 class InvalidStageTransitionError(Exception):
@@ -97,30 +98,6 @@ _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     ExtractionRunStage.FINALIZED.value: set(),  # terminal
     ExtractionRunStage.CANCELLED.value: set(),  # terminal
 }
-
-
-def _unwrap_value(raw: Any) -> Any:
-    """Peel a single ``{"value": X}`` envelope, matching the frontend's
-    one-level unwrap in ``progress.ts`` / ``useReviewerSummary``. A bare
-    scalar (or any dict without a ``value`` key) is returned untouched.
-    """
-    if isinstance(raw, dict) and "value" in raw:
-        return raw["value"]
-    return raw
-
-
-def _is_value_filled(raw: Any) -> bool:
-    """True when a stored value counts as "filled" for completeness.
-
-    Mirrors the frontend predicate (``value === null | undefined | ''``):
-    only ``None`` and the empty string are empty. Whitespace, ``0``,
-    ``False``, ``[]`` and non-``value`` dicts all count as filled so the
-    backend gate is never stricter than the form the user just saw.
-    """
-    value = _unwrap_value(raw)
-    if value is None:
-        return False
-    return not (isinstance(value, str) and value == "")
 
 
 class RunLifecycleService:
@@ -413,7 +390,7 @@ class RunLifecycleService:
             )
         ).all()
         for instance_id, field_id, value in published_rows:
-            if _is_value_filled(value):
+            if is_value_filled(value):
                 filled.add((instance_id, field_id))
 
         for instance_id, field_id, _resolved in await self._resolved_reviewer_values(run_id):
@@ -471,7 +448,7 @@ class RunLifecycleService:
             resolved = value
             if resolved is None and proposal_record_id is not None:
                 resolved = proposal_values.get(proposal_record_id)
-            if _is_value_filled(resolved):
+            if is_value_filled(resolved):
                 resolved_values.append((instance_id, field_id, resolved))
         return resolved_values
 

--- a/backend/app/services/value_semantics.py
+++ b/backend/app/services/value_semantics.py
@@ -1,0 +1,48 @@
+"""Pure predicates for extraction value emptiness (no DB, no IO).
+
+ONE rule, two polarities, shared by the two callers that previously each kept
+their own copy:
+
+- ``is_value_filled`` — the finalize completeness gate
+  (``run_lifecycle_service``): a run may not publish while a required field is
+  empty. The authoritative server-side mirror of the frontend ``progress.ts``
+  metric, so it must never be STRICTER than the form the user just saw.
+- ``is_value_empty`` — the AI-suggestion "no information" rule
+  (``extraction_suggestion_read_service``): a later abstention must not bury an
+  earlier real value in the dedup.
+
+Both mirror the frontend ``isNoInfoValue`` (``value === null | undefined | ''``):
+only ``None`` and the empty string are empty. Whitespace, ``0``, ``False``,
+``[]`` and non-envelope dicts all count as filled. Layer-legal (services, no IO)
+under ``scripts/fitness/check_layered_arch.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def unwrap_value_envelope(raw: Any) -> Any:
+    """Peel a single ``{"value": X}`` envelope, matching the frontend's one-level
+    unwrap in ``progress.ts`` / ``useReviewerSummary``. A bare scalar (or any dict
+    without a ``value`` key) is returned untouched.
+    """
+    if isinstance(raw, dict) and "value" in raw:
+        return raw["value"]
+    return raw
+
+
+def is_value_empty(raw: Any) -> bool:
+    """True when *raw* carries no information — ``None`` or the empty string,
+    after peeling one ``{"value": X}`` envelope. The inverse of
+    ``is_value_filled``.
+    """
+    value = unwrap_value_envelope(raw)
+    return value is None or (isinstance(value, str) and value == "")
+
+
+def is_value_filled(raw: Any) -> bool:
+    """True when a stored value counts as "filled" for completeness — the
+    negation of ``is_value_empty``.
+    """
+    return not is_value_empty(raw)

--- a/backend/tests/unit/test_value_semantics.py
+++ b/backend/tests/unit/test_value_semantics.py
@@ -1,0 +1,71 @@
+"""Unit tests for the shared value-emptiness predicate.
+
+``is_value_filled`` powers the finalize completeness gate (run_lifecycle_service)
+and ``is_value_empty`` powers the AI-suggestion dedup "no information" rule
+(extraction_suggestion_read_service). They are exact inverses of ONE rule,
+mirroring the frontend ``isNoInfoValue`` (value === null | undefined | '').
+The gate must never become stricter than the form the user just saw, so only
+``None`` and the empty string count as empty — whitespace, 0, False and []
+are filled.
+"""
+
+import pytest
+
+from app.services.value_semantics import (
+    is_value_empty,
+    is_value_filled,
+    unwrap_value_envelope,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "empty"),
+    [
+        (None, True),
+        ("", True),
+        ({"value": None}, True),
+        ({"value": ""}, True),
+        ("x", False),
+        (0, False),
+        (False, False),
+        ([], False),
+        ("  ", False),  # whitespace is filled — gate must not be stricter than the form
+        ({"value": "x"}, False),
+        ({"value": 0}, False),
+        ({"value": {"value": "x", "unit": "mg"}}, False),  # double-wrapped unit value
+    ],
+    ids=[
+        "none",
+        "empty-string",
+        "envelope-none",
+        "envelope-empty-string",
+        "scalar-string",
+        "zero",
+        "false",
+        "empty-list",
+        "whitespace",
+        "envelope-value",
+        "envelope-zero",
+        "double-wrapped-unit",
+    ],
+)
+def test_is_value_empty_and_filled_are_inverses(raw, empty):
+    assert is_value_empty(raw) is empty
+    assert is_value_filled(raw) is (not empty)
+
+
+def test_unwrap_peels_one_value_level_only():
+    assert unwrap_value_envelope({"value": "x"}) == "x"
+    # A bare scalar or a dict WITHOUT a "value" key is returned untouched.
+    assert unwrap_value_envelope("x") == "x"
+    assert unwrap_value_envelope({"unit": "mg"}) == {"unit": "mg"}
+    # Only one level is peeled.
+    assert unwrap_value_envelope({"value": {"value": "x"}}) == {"value": "x"}
+
+
+def test_dict_without_value_key_counts_as_filled():
+    # A dict that is NOT a value envelope (no "value" key) is content, not empty —
+    # this keeps the gate from blocking on structured data. (Proposals never carry
+    # this shape, so the suggestion-dedup caller is unaffected in practice.)
+    assert is_value_empty({"unit": "mg"}) is False
+    assert is_value_filled({"unit": "mg"}) is True


### PR DESCRIPTION
## Why

`extraction_suggestion_read_service._is_no_info` and `run_lifecycle_service._is_value_filled` were two copies of one rule — the frontend `isNoInfoValue` (`value === null | undefined | ''`). Deferred from #448's `/simplify`.

## What changed

- New pure module `app/services/value_semantics.py`: `unwrap_value_envelope` + `is_value_empty` + `is_value_filled` (exact inverses). No DB, no IO — layer-legal.
- `run_lifecycle_service` (completeness gate) imports `is_value_filled`; `extraction_suggestion_read_service` (suggestion dedup) imports `is_value_empty`. Both private copies removed.
- `value_envelope.py` (export/openpyxl-coupled) was deliberately **not** chosen as the home — the predicate is pure semantics, not an export concern.

## Risk

`is_value_filled` powers the finalize completeness gate (the historical "40%/can't-submit" area). Semantics are preserved **exactly**: the shared predicate keeps the one-level `{"value": X}` unwrap, so only `None` and `""` are empty; whitespace/0/False/[] stay filled and the gate is never stricter than the form. The two predicates were already equivalent inverses on every input proposals/resolved-values actually carry (they diverged only on a non-envelope dict, which neither caller receives — pinned in the truth-table test).

## Test plan

- [x] `make lint-backend` clean (ruff)
- [x] `uv run pytest tests/unit/test_value_semantics.py` — 14 passed (truth table incl. the gate-critical `None`/`""`/`{"value":null}`/`0`/`False`/`[]`/double-wrapped-unit cases)
- [x] `uv run pytest tests/integration/test_run_lifecycle_service.py tests/integration/test_suggestion_read.py` — 60 passed (completeness gate + suggestion dedup unchanged)
- [x] Architectural Fitness (layered-arch OK; file-size unchanged)

## Out of scope

P4 (token-shape) and P5 (docstring sweep) ship as separate PRs.