### PR TITLE
fix(extraction): consistent {prompt,completion,total} provenance token shape

### DIFF
--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -451,6 +451,9 @@ class SectionExtractionService(LoggerMixin):
         section_results: list[dict[str, Any]] = []
         total_suggestions = 0
         total_tokens = 0
+        # Aggregate prompt+completion so provenance uses the same {prompt,
+        # completion, total} shape as the single-section paths.
+        accumulated_usage = LlmUsage()
         successful = 0
         failed = 0
 
@@ -473,6 +476,8 @@ class SectionExtractionService(LoggerMixin):
                     successful += 1
                     total_suggestions += result["suggestions_created"]
                     total_tokens += result["tokens_total"]
+                    # Skipped sections omit "usage" (0 tokens) — default to empty.
+                    accumulated_usage = accumulated_usage + result.get("usage", LlmUsage())
                     section_results.append(
                         {
                             "entity_type_id": str(entity_type.id),
@@ -511,15 +516,9 @@ class SectionExtractionService(LoggerMixin):
 
             duration_ms = (perf_counter() - start_time) * 1000
 
-            # Persist how the suggestions were generated so the review popover's
-            # "How this was generated" metadata renders. ``_run_provenance`` holds
-            # the run config (model/provider/params/prompt) set by the last
-            # ``_extract_with_llm`` call; pair it with the run-aggregate token total.
-            run_provenance = (
-                {**self._run_provenance, "tokens": {"total": total_tokens}}
-                if self._run_provenance is not None
-                else None
-            )
+            # Persist run provenance with the run-aggregate token usage in the
+            # {prompt, completion, total} shape. None when no LLM ran.
+            run_provenance = self._provenance_with_tokens(accumulated_usage)
 
             await self._runs.complete_run(
                 run_id=run.id,
@@ -635,6 +634,7 @@ class SectionExtractionService(LoggerMixin):
             return {
                 "suggestions_created": suggestions_created,
                 "tokens_total": llm_usage.total_tokens,
+                "usage": llm_usage,
             }
         finally:
             # Restore the unfiltered field list so callers that rely on

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -538,6 +538,37 @@ class TestExtractForRun:
         service._lifecycle.advance_stage.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_extract_for_run_provenance_has_full_token_shape(
+        self, service, qa_run, qa_template
+    ):
+        # Provenance tokens must be the consistent {prompt, completion, total}
+        # shape (via _provenance_with_tokens), aggregated across sections — not
+        # the {total}-only shape that rendered as raw-key generic rows.
+        ets = []
+        for i in range(2):
+            et = MagicMock()
+            et.id = uuid4()
+            et.name = f"Section{i}"
+            et.fields = []
+            et.parent_entity_type_id = None
+            ets.append(et)
+        self._wire_minimal_qa_pipeline(service, qa_run, qa_template, ets)
+        # An LLM ran → provenance snapshot set (normally by _extract_with_llm).
+        service._run_provenance = service._build_run_provenance(
+            model="m", prompt_name="qa", prompt_version="1", prompt_text="P"
+        )
+
+        await service.extract_for_run(run_id=qa_run.id)
+
+        results = service._runs.complete_run.await_args.kwargs["results"]
+        # Two sections at LlmUsage(10, 5) each → aggregate (20, 10, 30).
+        assert results["provenance"]["tokens"] == {
+            "prompt": 20,
+            "completion": 10,
+            "total": 30,
+        }
+
+    @pytest.mark.asyncio
     async def test_extract_for_run_does_not_advance_even_when_enabled(
         self, service, qa_run, qa_template
     ):

--- a/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.test.tsx
+++ b/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.test.tsx
@@ -20,6 +20,22 @@ describe("RunProvenanceDisclosure", () => {
     expect(screen.getByText(/You are appraising/)).toBeInTheDocument(); // code block
   });
 
+  it("renders prompt/completion token rows with labels, not raw-key generic rows", () => {
+    render(
+      <RunProvenanceDisclosure
+        provenance={{ ...prov, tokensPrompt: 3100, tokensCompletion: 810 }}
+        defaultOpen
+      />,
+    );
+    expect(screen.getByText("Prompt tokens")).toBeInTheDocument();
+    expect(screen.getByText("Completion tokens")).toBeInTheDocument();
+    expect(screen.getByText("3,100")).toBeInTheDocument(); // toLocaleString format
+    expect(screen.getByText("810")).toBeInTheDocument();
+    // Must NOT fall through to the raw-key generic-row fallback.
+    expect(screen.queryByText("tokensPrompt")).not.toBeInTheDocument();
+    expect(screen.queryByText("tokensCompletion")).not.toBeInTheDocument();
+  });
+
   it("collapses by default and toggles", () => {
     render(<RunProvenanceDisclosure provenance={prov} />);
     expect(screen.queryByText("Temperature")).not.toBeInTheDocument();

--- a/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.tsx
+++ b/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.tsx
@@ -40,6 +40,8 @@ const PROVENANCE_REGISTRY: ProvenanceFieldDef[] = [
   {key: 'temperature', labelKey: 'provenanceTemperature', kind: 'scalar'},
   {key: 'outputRetries', labelKey: 'provenanceOutputRetries', kind: 'scalar'},
   {key: 'timeoutSeconds', labelKey: 'provenanceTimeout', kind: 'scalar', format: (v) => `${String(v)}s`},
+  {key: 'tokensPrompt', labelKey: 'provenanceTokensPrompt', kind: 'scalar', format: (v) => Number(v).toLocaleString()},
+  {key: 'tokensCompletion', labelKey: 'provenanceTokensCompletion', kind: 'scalar', format: (v) => Number(v).toLocaleString()},
   {key: 'tokensTotal', labelKey: 'provenanceTokens', kind: 'scalar', format: (v) => Number(v).toLocaleString()},
   {key: 'strategy', labelKey: 'provenanceStrategy', kind: 'scalar'},
   {key: 'promptVersion', labelKey: 'provenancePromptVersion', kind: 'scalar'},

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -855,6 +855,8 @@ export const extraction = {
     provenanceTemperature: 'Temperature',
     provenanceOutputRetries: 'Output retries',
     provenanceTimeout: 'Timeout',
+    provenanceTokensPrompt: 'Prompt tokens',
+    provenanceTokensCompletion: 'Completion tokens',
     provenanceTokens: 'Tokens',
     provenanceStrategy: 'Strategy',
     provenancePromptVersion: 'Prompt version',


### PR DESCRIPTION
## Why

`extract_for_run` wrote provenance tokens as `{total}` only, while every single-section path used `_provenance_with_tokens`'s `{prompt, completion, total}`. The frontend then rendered `tokensPrompt`/`tokensCompletion` (when present) as raw-key generic rows. Deferred from #448's `/code-review`. Builds on #453 (provenance choke-point).

## What changed

- **Backend**: `extract_for_run` aggregates an `LlmUsage` across sections (each `_extract_one_entity_type_for_run` already produces one; skipped sections default to empty via `.get`) and routes its provenance through `_provenance_with_tokens` — the single source of the token shape.
- **Frontend**: registered `tokensPrompt` / `tokensCompletion` in `RunProvenanceDisclosure`'s `PROVENANCE_REGISTRY` with labelled copy ("Prompt tokens" / "Completion tokens"), so they render as proper rows. The service already flattens `tokens.prompt/completion/total` → camelCase.

## Risk

Low. Display + telemetry only — no schema/state change. `total_tokens` (results summary + `BatchExtractionResult`) is untouched; only the provenance token dict changes shape. File-size on `section_extraction_service.py` is net-neutral (no baseline change).

## Test plan

- [x] `make lint-backend` clean
- [x] `uv run pytest tests/unit/test_section_extraction_service.py` — 66 passed, incl. new `test_extract_for_run_provenance_has_full_token_shape` (2 sections → aggregate `{prompt:20, completion:10, total:30}`)
- [x] `npm run typecheck` + `npm run lint` clean
- [x] `npm run test:run` — 964 passed, incl. new `RunProvenanceDisclosure` rows-with-labels (not raw-key generic) case
- [x] Architectural Fitness (file-size unchanged)

## Out of scope

P5 (docstring sweep) ships as a separate PR.