### PR TITLE
Promote dev → main: extraction AI-suggestion cleanup (P1–P5)

### DIFF
--- a/backend/app/repositories/extraction_run_repository.py
+++ b/backend/app/repositories/extraction_run_repository.py
@@ -1,7 +1,7 @@
 """
 Extraction Run Repository.
 
-Manages persistence for execucoes de IA for extraction.
+Manages persistence for AI extraction runs.
 """
 
 from datetime import UTC, datetime
@@ -21,9 +21,9 @@ logger = get_logger(__name__)
 
 class ExtractionRunRepository(BaseRepository[ExtractionRun]):
     """
-    Repository for execucoes de extraction de IA.
+    Repository for AI extraction runs.
 
-    Manages o ciclo de vida of the extraction_runs.
+    Manages the lifecycle of the extraction_runs.
     """
 
     def __init__(self, db: AsyncSession):
@@ -39,20 +39,20 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
         parameters: dict[str, Any] | None = None,
     ) -> ExtractionRun:
         """
-        Create uma nova execucao de extraction.
+        Create a new extraction run.
 
         Args:
             project_id: project.
             article_id: article.
             template_id: template.
-            stage: Estagio da execucao (pending, proposal, review, consensus, finalized, cancelled).
-            created_by: user que criou.
-            parameters: Parametros da execucao (modelo, etc.).
+            stage: run stage (pending, proposal, review, consensus, finalized, cancelled).
+            created_by: user who created it.
+            parameters: run parameters (model, etc.).
 
         Returns:
-            ExtractionRun criado.
+            The created ExtractionRun.
         """
-        # Converter Enum for string for garantir compatibilidade
+        # Convert Enum to string for compatibility
         stage_value = stage.value if isinstance(stage, ExtractionRunStage) else str(stage)
         status_value = ExtractionRunStatus.PENDING.value
 
@@ -71,13 +71,13 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
 
     async def start_run(self, run_id: UUID) -> ExtractionRun | None:
         """
-        Marca uma execucao como iniciada.
+        Mark a run as started.
 
         Args:
-            run_id: execucao.
+            run_id: run.
 
         Returns:
-            ExtractionRun atualizado or None.
+            The updated ExtractionRun, or None.
         """
         query_start = perf_counter()
         await self.db.execute(
@@ -169,14 +169,14 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
         error_message: str,
     ) -> ExtractionRun | None:
         """
-        Marca uma execucao como falha.
+        Mark a run as failed.
 
         Args:
-            run_id: execucao.
+            run_id: run.
             error_message: Error message.
 
         Returns:
-            ExtractionRun atualizado or None.
+            The updated ExtractionRun, or None.
         """
         query_start = perf_counter()
         await self.db.execute(
@@ -244,15 +244,15 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
         status: ExtractionRunStatus | None = None,
     ) -> list[ExtractionRun]:
         """
-        List execucoes de um article.
+        List runs of an article.
 
         Args:
             article_id: article.
-            stage: Filtro por estagio (optional).
-            status: Filtro por status (optional).
+            stage: filter by stage (optional).
+            status: filter by status (optional).
 
         Returns:
-            List de execucoes.
+            List of runs.
         """
         query = select(ExtractionRun).where(ExtractionRun.article_id == article_id)
 
@@ -273,14 +273,14 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
         stage: ExtractionRunStage,
     ) -> ExtractionRun | None:
         """
-        Fetch a execucao mais recente de um article for um estagio.
+        Fetch the most recent run of an article for a stage.
 
         Args:
             article_id: article.
-            stage: Estagio da execucao.
+            stage: run stage.
 
         Returns:
-            ExtractionRun mais recente or None.
+            The most recent ExtractionRun, or None.
         """
         result = await self.db.execute(
             select(ExtractionRun)
@@ -298,15 +298,15 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
         limit: int = 50,
     ) -> list[ExtractionRun]:
         """
-        List execucoes de um project.
+        List runs of a project.
 
         Args:
             project_id: project.
-            status: Filtro por status (optional).
-            limit: Limite de resultados.
+            status: filter by status (optional).
+            limit: result limit.
 
         Returns:
-            List de execucoes.
+            List of runs.
         """
         query = select(ExtractionRun).where(ExtractionRun.project_id == project_id)
 

--- a/backend/app/repositories/extraction_run_repository.py
+++ b/backend/app/repositories/extraction_run_repository.py
@@ -102,26 +102,29 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
         run_id: UUID,
         results: dict[str, Any],
     ) -> ExtractionRun | None:
-        """
-        Marca uma execucao como concluida.
+        """Mark a run COMPLETED, shallow-merging *results* into its ``results`` JSONB.
+
+        MERGE (not REPLACE) so run-level data already recorded — notably the
+        ``provenance`` snapshot the proposal choke-point (``_create_suggestions``
+        → ``merge_results``) writes — survives completion. A REPLACE would clobber
+        it. Callers whose run still has empty ``results`` (model extraction, the
+        batch primary run) are unaffected: merging into ``{}`` equals a replace.
 
         Args:
-            run_id: execucao.
-            results: Resultados da execucao.
+            run_id: the run to complete.
+            results: top-level keys to merge into ``results``.
 
         Returns:
-            ExtractionRun atualizado or None.
+            The updated ExtractionRun, or None if the run does not exist.
         """
         query_start = perf_counter()
-        await self.db.execute(
-            update(ExtractionRun)
-            .where(ExtractionRun.id == run_id)
-            .values(
-                status=ExtractionRunStatus.COMPLETED.value,
-                completed_at=datetime.now(UTC),
-                results=results,
-            )
-        )
+        run = await self.get_by_id(run_id)
+        if run is None:
+            return None
+        run.status = ExtractionRunStatus.COMPLETED.value
+        run.completed_at = datetime.now(UTC)
+        # Reassign (not in-place mutate) so SQLAlchemy tracks the JSONB change.
+        run.results = {**(run.results or {}), **results}
         await self.db.flush()
         query_duration_ms = (perf_counter() - query_start) * 1000
         logger.info(
@@ -129,7 +132,7 @@ class ExtractionRunRepository(BaseRepository[ExtractionRun]):
             run_id=str(run_id),
             db_duration_ms=query_duration_ms,
         )
-        return await self.get_by_id(run_id)
+        return run
 
     async def merge_results(
         self,

--- a/backend/app/services/extraction_suggestion_read_service.py
+++ b/backend/app/services/extraction_suggestion_read_service.py
@@ -43,6 +43,7 @@ from app.schemas.extraction_suggestion import (
     AISuggestionsResponse,
     EvidenceResponse,
 )
+from app.services.value_semantics import is_value_empty
 
 
 def _extract_block_ids(ev: ExtractionEvidence) -> list[int]:
@@ -79,19 +80,6 @@ def _resolve_status(decision: str | None) -> str:
     if decision == ExtractionReviewerDecisionType.REJECT.value:
         return "rejected"
     return "accepted"
-
-
-def _is_no_info(proposed_value: Any) -> bool:
-    """True when a proposal carries no actionable value (the model abstained).
-
-    Mirrors the frontend ``isNoInfoValue``: a bare ``None``, the JSONB envelope
-    ``{"value": None}`` (the shape recorded for a "no information" outcome since
-    #443), or an empty string all mean "no information".
-    """
-    if proposed_value is None:
-        return True
-    value = proposed_value.get("value") if isinstance(proposed_value, dict) else proposed_value
-    return value is None or value == ""
 
 
 async def _load_run_provenance(
@@ -222,7 +210,7 @@ async def load_suggestions(
         existing = chosen.get(key)
         if existing is None:
             chosen[key] = p
-        elif _is_no_info(existing.proposed_value) and not _is_no_info(p.proposed_value):
+        elif is_value_empty(existing.proposed_value) and not is_value_empty(p.proposed_value):
             # The more recent pick abstained; this older one found a value → use it.
             chosen[key] = p
     deduped = list(chosen.values())

--- a/backend/app/services/run_lifecycle_service.py
+++ b/backend/app/services/run_lifecycle_service.py
@@ -33,6 +33,7 @@ from app.services._extraction_run_lock import load_run_for_update
 from app.services.extraction_consensus_service import ExtractionConsensusService
 from app.services.extraction_snapshot import build_template_version_snapshot
 from app.services.hitl_config_service import HitlConfigService
+from app.services.value_semantics import is_value_filled
 
 
 class InvalidStageTransitionError(Exception):
@@ -97,30 +98,6 @@ _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     ExtractionRunStage.FINALIZED.value: set(),  # terminal
     ExtractionRunStage.CANCELLED.value: set(),  # terminal
 }
-
-
-def _unwrap_value(raw: Any) -> Any:
-    """Peel a single ``{"value": X}`` envelope, matching the frontend's
-    one-level unwrap in ``progress.ts`` / ``useReviewerSummary``. A bare
-    scalar (or any dict without a ``value`` key) is returned untouched.
-    """
-    if isinstance(raw, dict) and "value" in raw:
-        return raw["value"]
-    return raw
-
-
-def _is_value_filled(raw: Any) -> bool:
-    """True when a stored value counts as "filled" for completeness.
-
-    Mirrors the frontend predicate (``value === null | undefined | ''``):
-    only ``None`` and the empty string are empty. Whitespace, ``0``,
-    ``False``, ``[]`` and non-``value`` dicts all count as filled so the
-    backend gate is never stricter than the form the user just saw.
-    """
-    value = _unwrap_value(raw)
-    if value is None:
-        return False
-    return not (isinstance(value, str) and value == "")
 
 
 class RunLifecycleService:
@@ -413,7 +390,7 @@ class RunLifecycleService:
             )
         ).all()
         for instance_id, field_id, value in published_rows:
-            if _is_value_filled(value):
+            if is_value_filled(value):
                 filled.add((instance_id, field_id))
 
         for instance_id, field_id, _resolved in await self._resolved_reviewer_values(run_id):
@@ -471,7 +448,7 @@ class RunLifecycleService:
             resolved = value
             if resolved is None and proposal_record_id is not None:
                 resolved = proposal_values.get(proposal_record_id)
-            if _is_value_filled(resolved):
+            if is_value_filled(resolved):
                 resolved_values.append((instance_id, field_id, resolved))
         return resolved_values
 

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -309,6 +309,7 @@ class SectionExtractionService(LoggerMixin):
                 extracted_data=extracted_data,
                 run=run,
                 model=model,
+                usage=llm_usage,
             )
             phase_durations_ms["create_suggestions"] = (perf_counter() - phase_start) * 1000
 
@@ -338,20 +339,14 @@ class SectionExtractionService(LoggerMixin):
                         "duration_ms": duration,
                         "fields_extracted": len(extracted_data) if extracted_data else 0,
                         "phase_durations_ms": phase_durations_ms,
-                        "provenance": self._provenance_with_tokens(llm_usage),
                     },
                 )
                 phase_durations_ms["complete_run"] = (perf_counter() - phase_start) * 1000
-            else:
-                # Session-run path: the HITL session owns the run lifecycle, so we
-                # must NOT complete it (that would close the run after one section
-                # and break further section-by-section AI clicks). Still persist
-                # the provenance snapshot so the review popover's "How this was
-                # generated" metadata renders for these suggestions — without this
-                # merge, session-run suggestions carried no provenance at all.
-                provenance = self._provenance_with_tokens(llm_usage)
-                if provenance is not None:
-                    await self._runs.merge_results(run.id, {"provenance": provenance})
+            # Session-run path: the HITL session owns the run lifecycle, so we
+            # must NOT complete it (that would close the run after one section
+            # and break further section-by-section AI clicks). The run's
+            # provenance was already persisted by ``_create_suggestions`` (the
+            # proposal choke-point), so nothing else to do here.
 
             self.logger.info(
                 "section_extraction_complete",
@@ -635,6 +630,7 @@ class SectionExtractionService(LoggerMixin):
                 extracted_data=extracted_data,
                 run=run,
                 model=model,
+                usage=llm_usage,
             )
             return {
                 "suggestions_created": suggestions_created,
@@ -1040,6 +1036,7 @@ class SectionExtractionService(LoggerMixin):
                 extracted_data=extracted_data,
                 run=run,
                 model=model,
+                usage=llm_usage,
             )
             section_phase_durations_ms["create_suggestions"] = (perf_counter() - phase_start) * 1000
 
@@ -1062,7 +1059,6 @@ class SectionExtractionService(LoggerMixin):
                     "summary": summary,
                     "duration_ms": (perf_counter() - section_start) * 1000,
                     "phase_durations_ms": section_phase_durations_ms,
-                    "provenance": self._provenance_with_tokens(llm_usage),
                 },
             )
             section_phase_durations_ms["complete_run"] = (perf_counter() - phase_start) * 1000
@@ -1299,12 +1295,15 @@ class SectionExtractionService(LoggerMixin):
         extracted_data: dict[str, Any],
         run: ExtractionRun,
         model: str = settings.LLM_DEFAULT_MODEL,
+        usage: LlmUsage | None = None,
     ) -> int:
         """
         Create extraction suggestions in database via repository.
 
         Automatically create an instance when missing.
-        Link suggestions to extraction_run_id for traceability.
+        Link suggestions to extraction_run_id for traceability. As the single
+        choke-point for AI proposals, this also persists the run ``provenance``
+        snapshot so every suggestion-owning run carries it (see below).
 
         Args:
             project_id: Project ID.
@@ -1314,6 +1313,8 @@ class SectionExtractionService(LoggerMixin):
             extracted_data: Extracted data.
             run: ExtractionRun used to link suggestions.
             model: LLM model name (used to build the entailment judge model).
+            usage: token usage for this extraction call, paired with the run
+                provenance snapshot. None (or no LLM run) skips provenance.
 
         Returns:
             Number of created suggestions.
@@ -1559,6 +1560,14 @@ class SectionExtractionService(LoggerMixin):
             instance_id=str(instance.id),
             run_id=str(run.id),
         )
+
+        # Single choke-point for run provenance: persist HOW the suggestions
+        # were generated wherever proposals are recorded, so no extraction path
+        # can silently omit it. ``complete_run`` later shallow-merges its summary
+        # on top (it MERGEs, so this key survives). Skipped when no LLM ran.
+        provenance = self._provenance_with_tokens(usage or LlmUsage())
+        if count and provenance is not None:
+            await self._runs.merge_results(run.id, {"provenance": provenance})
 
         return count
 

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -451,6 +451,9 @@ class SectionExtractionService(LoggerMixin):
         section_results: list[dict[str, Any]] = []
         total_suggestions = 0
         total_tokens = 0
+        # Aggregate prompt+completion so provenance uses the same {prompt,
+        # completion, total} shape as the single-section paths.
+        accumulated_usage = LlmUsage()
         successful = 0
         failed = 0
 
@@ -473,6 +476,8 @@ class SectionExtractionService(LoggerMixin):
                     successful += 1
                     total_suggestions += result["suggestions_created"]
                     total_tokens += result["tokens_total"]
+                    # Skipped sections omit "usage" (0 tokens) — default to empty.
+                    accumulated_usage = accumulated_usage + result.get("usage", LlmUsage())
                     section_results.append(
                         {
                             "entity_type_id": str(entity_type.id),
@@ -511,15 +516,9 @@ class SectionExtractionService(LoggerMixin):
 
             duration_ms = (perf_counter() - start_time) * 1000
 
-            # Persist how the suggestions were generated so the review popover's
-            # "How this was generated" metadata renders. ``_run_provenance`` holds
-            # the run config (model/provider/params/prompt) set by the last
-            # ``_extract_with_llm`` call; pair it with the run-aggregate token total.
-            run_provenance = (
-                {**self._run_provenance, "tokens": {"total": total_tokens}}
-                if self._run_provenance is not None
-                else None
-            )
+            # Persist run provenance with the run-aggregate token usage in the
+            # {prompt, completion, total} shape. None when no LLM ran.
+            run_provenance = self._provenance_with_tokens(accumulated_usage)
 
             await self._runs.complete_run(
                 run_id=run.id,
@@ -635,6 +634,7 @@ class SectionExtractionService(LoggerMixin):
             return {
                 "suggestions_created": suggestions_created,
                 "tokens_total": llm_usage.total_tokens,
+                "usage": llm_usage,
             }
         finally:
             # Restore the unfiltered field list so callers that rely on

--- a/backend/app/services/value_semantics.py
+++ b/backend/app/services/value_semantics.py
@@ -1,0 +1,48 @@
+"""Pure predicates for extraction value emptiness (no DB, no IO).
+
+ONE rule, two polarities, shared by the two callers that previously each kept
+their own copy:
+
+- ``is_value_filled`` — the finalize completeness gate
+  (``run_lifecycle_service``): a run may not publish while a required field is
+  empty. The authoritative server-side mirror of the frontend ``progress.ts``
+  metric, so it must never be STRICTER than the form the user just saw.
+- ``is_value_empty`` — the AI-suggestion "no information" rule
+  (``extraction_suggestion_read_service``): a later abstention must not bury an
+  earlier real value in the dedup.
+
+Both mirror the frontend ``isNoInfoValue`` (``value === null | undefined | ''``):
+only ``None`` and the empty string are empty. Whitespace, ``0``, ``False``,
+``[]`` and non-envelope dicts all count as filled. Layer-legal (services, no IO)
+under ``scripts/fitness/check_layered_arch.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def unwrap_value_envelope(raw: Any) -> Any:
+    """Peel a single ``{"value": X}`` envelope, matching the frontend's one-level
+    unwrap in ``progress.ts`` / ``useReviewerSummary``. A bare scalar (or any dict
+    without a ``value`` key) is returned untouched.
+    """
+    if isinstance(raw, dict) and "value" in raw:
+        return raw["value"]
+    return raw
+
+
+def is_value_empty(raw: Any) -> bool:
+    """True when *raw* carries no information — ``None`` or the empty string,
+    after peeling one ``{"value": X}`` envelope. The inverse of
+    ``is_value_filled``.
+    """
+    value = unwrap_value_envelope(raw)
+    return value is None or (isinstance(value, str) and value == "")
+
+
+def is_value_filled(raw: Any) -> bool:
+    """True when a stored value counts as "filled" for completeness — the
+    negation of ``is_value_empty``.
+    """
+    return not is_value_empty(raw)

--- a/backend/tests/unit/test_extraction_run_repository.py
+++ b/backend/tests/unit/test_extraction_run_repository.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.extraction import ExtractionRunStatus
 from app.repositories.extraction_run_repository import ExtractionRunRepository
 
 
@@ -83,3 +84,59 @@ class TestRollbackAndFail:
         assert logger.warning.call_args.args[0] == "section_extraction_rollback_failed"
         # fail_run is still attempted after a failed rollback.
         repo.fail_run.assert_awaited_once()
+
+
+class TestCompleteRunMerge:
+    """``complete_run`` MERGES results into the run's existing ``results`` JSONB
+    (not REPLACE), so the provenance written at the proposal choke-point
+    (``_create_suggestions`` → ``merge_results``) survives completion. A REPLACE
+    would clobber it — the bug class this guards against.
+    """
+
+    @pytest.mark.asyncio
+    async def test_merges_into_existing_results_preserving_prior_keys(self, repo) -> None:
+        run_id = uuid4()
+        existing = MagicMock()
+        existing.results = {"provenance": {"model": "gpt"}}
+        repo.get_by_id = AsyncMock(return_value=existing)
+
+        out = await repo.complete_run(run_id, {"suggestions_created": 2})
+
+        assert out is existing
+        # Prior provenance preserved; the completion summary merged on top.
+        assert existing.results == {"provenance": {"model": "gpt"}, "suggestions_created": 2}
+        assert existing.status == ExtractionRunStatus.COMPLETED.value
+        assert existing.completed_at is not None
+        repo.db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_treats_empty_results_like_replace(self, repo) -> None:
+        # A fresh run (results == {}) merging is equivalent to a replace, so the
+        # non-proposal callers (model_extraction, batch primary run) are unaffected.
+        existing = MagicMock()
+        existing.results = {}
+        repo.get_by_id = AsyncMock(return_value=existing)
+
+        await repo.complete_run(uuid4(), {"models_count": 3})
+
+        assert existing.results == {"models_count": 3}
+
+    @pytest.mark.asyncio
+    async def test_patch_key_overwrites_on_conflict(self, repo) -> None:
+        # Shallow top-level merge: a patch key replaces the same key.
+        existing = MagicMock()
+        existing.results = {"tokens_total": 1, "provenance": {"a": 1}}
+        repo.get_by_id = AsyncMock(return_value=existing)
+
+        await repo.complete_run(uuid4(), {"tokens_total": 5})
+
+        assert existing.results == {"tokens_total": 5, "provenance": {"a": 1}}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_run_missing(self, repo) -> None:
+        repo.get_by_id = AsyncMock(return_value=None)
+
+        out = await repo.complete_run(uuid4(), {"x": 1})
+
+        assert out is None
+        repo.db.flush.assert_not_awaited()

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -1067,6 +1067,69 @@ class TestCreateSuggestions:
         )
         assert result == 0
 
+    def _wire_one_field(self, service):
+        field1 = MagicMock()
+        field1.id, field1.name = uuid4(), "f1"
+        field1.field_type = "text"
+        field1.allowed_values = None
+        et = MagicMock()
+        et.fields = [field1]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        instance = MagicMock()
+        instance.id = uuid4()
+        instance.parent_instance_id = None
+        service._instances.get_by_article = AsyncMock(return_value=[instance])
+        service._proposals.record_proposal = AsyncMock(return_value=MagicMock(id=uuid4()))
+        service.db.flush = AsyncMock()
+        service._runs.merge_results = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_persists_provenance_at_chokepoint_when_llm_ran(self, service):
+        # Provenance is written ONCE at the proposal choke-point so EVERY
+        # suggestion-owning run records how it was generated — even a future
+        # extraction path that forgets to write it at completion.
+        self._wire_one_field(service)
+        service._run_provenance = service._build_run_provenance(
+            model="gpt-x", prompt_name="extract", prompt_version="1", prompt_text="P"
+        )
+
+        run = self._make_run()
+        await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"f1": "value"},
+            run=run,
+            usage=LlmUsage(prompt_tokens=10, completion_tokens=5),
+        )
+
+        service._runs.merge_results.assert_awaited_once()
+        merged_run_id, patch = service._runs.merge_results.await_args.args
+        assert merged_run_id == run.id
+        prov = patch["provenance"]
+        assert prov["model"] == "gpt-x"
+        assert prov["tokens"] == {"prompt": 10, "completion": 5, "total": 15}
+
+    @pytest.mark.asyncio
+    async def test_skips_provenance_when_no_llm_ran(self, service):
+        # No provenance snapshot → nothing to record; never write a null provenance.
+        self._wire_one_field(service)
+        service._run_provenance = None
+
+        run = self._make_run()
+        await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={"f1": "value"},
+            run=run,
+            usage=LlmUsage(prompt_tokens=1, completion_tokens=1),
+        )
+
+        service._runs.merge_results.assert_not_awaited()
+
     @pytest.mark.asyncio
     async def test_creates_no_info_proposal_for_none_and_abstention(self, service):
         # "No information found" outcomes (bare None + structured abstention) must

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -538,6 +538,37 @@ class TestExtractForRun:
         service._lifecycle.advance_stage.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_extract_for_run_provenance_has_full_token_shape(
+        self, service, qa_run, qa_template
+    ):
+        # Provenance tokens must be the consistent {prompt, completion, total}
+        # shape (via _provenance_with_tokens), aggregated across sections — not
+        # the {total}-only shape that rendered as raw-key generic rows.
+        ets = []
+        for i in range(2):
+            et = MagicMock()
+            et.id = uuid4()
+            et.name = f"Section{i}"
+            et.fields = []
+            et.parent_entity_type_id = None
+            ets.append(et)
+        self._wire_minimal_qa_pipeline(service, qa_run, qa_template, ets)
+        # An LLM ran → provenance snapshot set (normally by _extract_with_llm).
+        service._run_provenance = service._build_run_provenance(
+            model="m", prompt_name="qa", prompt_version="1", prompt_text="P"
+        )
+
+        await service.extract_for_run(run_id=qa_run.id)
+
+        results = service._runs.complete_run.await_args.kwargs["results"]
+        # Two sections at LlmUsage(10, 5) each → aggregate (20, 10, 30).
+        assert results["provenance"]["tokens"] == {
+            "prompt": 20,
+            "completion": 10,
+            "total": 30,
+        }
+
+    @pytest.mark.asyncio
     async def test_extract_for_run_does_not_advance_even_when_enabled(
         self, service, qa_run, qa_template
     ):

--- a/backend/tests/unit/test_value_semantics.py
+++ b/backend/tests/unit/test_value_semantics.py
@@ -1,0 +1,71 @@
+"""Unit tests for the shared value-emptiness predicate.
+
+``is_value_filled`` powers the finalize completeness gate (run_lifecycle_service)
+and ``is_value_empty`` powers the AI-suggestion dedup "no information" rule
+(extraction_suggestion_read_service). They are exact inverses of ONE rule,
+mirroring the frontend ``isNoInfoValue`` (value === null | undefined | '').
+The gate must never become stricter than the form the user just saw, so only
+``None`` and the empty string count as empty — whitespace, 0, False and []
+are filled.
+"""
+
+import pytest
+
+from app.services.value_semantics import (
+    is_value_empty,
+    is_value_filled,
+    unwrap_value_envelope,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "empty"),
+    [
+        (None, True),
+        ("", True),
+        ({"value": None}, True),
+        ({"value": ""}, True),
+        ("x", False),
+        (0, False),
+        (False, False),
+        ([], False),
+        ("  ", False),  # whitespace is filled — gate must not be stricter than the form
+        ({"value": "x"}, False),
+        ({"value": 0}, False),
+        ({"value": {"value": "x", "unit": "mg"}}, False),  # double-wrapped unit value
+    ],
+    ids=[
+        "none",
+        "empty-string",
+        "envelope-none",
+        "envelope-empty-string",
+        "scalar-string",
+        "zero",
+        "false",
+        "empty-list",
+        "whitespace",
+        "envelope-value",
+        "envelope-zero",
+        "double-wrapped-unit",
+    ],
+)
+def test_is_value_empty_and_filled_are_inverses(raw, empty):
+    assert is_value_empty(raw) is empty
+    assert is_value_filled(raw) is (not empty)
+
+
+def test_unwrap_peels_one_value_level_only():
+    assert unwrap_value_envelope({"value": "x"}) == "x"
+    # A bare scalar or a dict WITHOUT a "value" key is returned untouched.
+    assert unwrap_value_envelope("x") == "x"
+    assert unwrap_value_envelope({"unit": "mg"}) == {"unit": "mg"}
+    # Only one level is peeled.
+    assert unwrap_value_envelope({"value": {"value": "x"}}) == {"value": "x"}
+
+
+def test_dict_without_value_key_counts_as_filled():
+    # A dict that is NOT a value envelope (no "value" key) is content, not empty —
+    # this keeps the gate from blocking on structured data. (Proposals never carry
+    # this shape, so the suggestion-dedup caller is unaffected in practice.)
+    assert is_value_empty({"unit": "mg"}) is False
+    assert is_value_filled({"unit": "mg"}) is True

--- a/frontend/components/extraction/FieldInput.tsx
+++ b/frontend/components/extraction/FieldInput.tsx
@@ -401,6 +401,10 @@ export function FieldInput(props: FieldInputProps) {
             selectSuggestion?.(instanceId, field.id, proposalRecordId, selectedValue, selectedConfidence),
           onClear: onRejectAI,
           align: 'end',
+          // So the version-history popover resolves a select/multiselect CODE
+          // to its human label, same as the inline card.
+          fieldType: field.field_type,
+          allowedValues: field.allowed_values,
         }
       : undefined;
 
@@ -492,6 +496,9 @@ export function FieldInput(props: FieldInputProps) {
             // Same review surface as the History icon (shared binding): clicking
             // the inline value/confidence opens the version history + provenance.
             review={reviewBinding}
+            // Render a select/multiselect CODE as its human label on the card.
+            fieldType={field.field_type}
+            allowedValues={field.allowed_values}
           />
         )}
 

--- a/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
@@ -102,3 +102,27 @@ describe('AISuggestionDisplay — review popover entry point', () => {
     expect(screen.queryByRole('button', { name: 'reviewOpenFromValue' })).not.toBeInTheDocument();
   });
 });
+
+describe('AISuggestionDisplay — select option code → label', () => {
+  const YES_NO = [
+    { value: 'Y', label: 'Yes' },
+    { value: 'N', label: 'No' },
+  ];
+
+  it('renders the human label for a coded select value', () => {
+    render(
+      <AISuggestionDisplay
+        suggestion={makeSuggestion({ value: 'Y', confidence: 0.9 })}
+        fieldType="select"
+        allowedValues={YES_NO}
+      />,
+    );
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.queryByText('Y')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the raw code when no field context is supplied', () => {
+    render(<AISuggestionDisplay suggestion={makeSuggestion({ value: 'Y', confidence: 0.9 })} />);
+    expect(screen.getByText('Y')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -34,6 +34,10 @@ export interface AISuggestionReviewBinding {
   onClear?: () => void;
   /** Defaults to 'end' so the popover opens left, clear of the PDF panel. */
   align?: 'start' | 'center' | 'end';
+  /** Field type + allowed_values so the version-history popover resolves a
+   *  select/multiselect CODE to its human label, same as the inline card. */
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
 interface AISuggestionDisplayProps {
@@ -43,6 +47,10 @@ interface AISuggestionDisplayProps {
   loading?: boolean;
   /** When present, the value area becomes a trigger for the review popover. */
   review?: AISuggestionReviewBinding;
+  /** Field type + allowed_values so a select/multiselect CODE renders as its
+   *  human label on the inline card. Omit for non-select fields. */
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
 /**
@@ -91,6 +99,8 @@ export function AISuggestionDisplay({
   onReject,
   loading = false,
   review,
+  fieldType,
+  allowedValues,
 }: AISuggestionDisplayProps) {
   const isAccepted = isSuggestionAccepted(suggestion);
   const isRejected = suggestion.status === 'rejected';
@@ -119,7 +129,13 @@ export function AISuggestionDisplay({
           review={review}
           className="flex-1 min-w-0 w-full sm:w-auto flex items-center gap-2 px-1.5 py-1 -mx-1.5"
         >
-          <AISuggestionValue suggestion={suggestion} maxLength={150} className="flex-1 min-w-0" />
+          <AISuggestionValue
+            suggestion={suggestion}
+            maxLength={150}
+            className="flex-1 min-w-0"
+            fieldType={fieldType}
+            allowedValues={allowedValues}
+          />
           <AISuggestionConfidence suggestion={suggestion} />
         </ReviewTrigger>
 

--- a/frontend/components/extraction/ai/AISuggestionReviewPopover.tsx
+++ b/frontend/components/extraction/ai/AISuggestionReviewPopover.tsx
@@ -79,9 +79,12 @@ interface VersionRowProps {
   version: AISuggestionHistoryItem;
   isSelected: boolean;
   onUse: () => void;
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
-function VersionRow({version, isSelected, onUse}: VersionRowProps) {
+function VersionRow({version, isSelected, onUse, fieldType, allowedValues}: VersionRowProps) {
+  const fieldContext = {fieldType, allowedValues};
   const [expanded, setExpanded] = useState(false);
   const showDetails = isSelected || expanded;
 
@@ -114,9 +117,9 @@ function VersionRow({version, isSelected, onUse}: VersionRowProps) {
           ) : (
             <p
               className="line-clamp-3 break-words text-sm font-medium"
-              title={formatFullSuggestionValue(version.value)}
+              title={formatFullSuggestionValue(version.value, fieldContext)}
             >
-              {formatFullSuggestionValue(version.value)}
+              {formatFullSuggestionValue(version.value, fieldContext)}
             </p>
           )}
         </div>
@@ -190,10 +193,14 @@ interface AISuggestionReviewPopoverProps {
   onClear?: () => void;
   trigger: React.ReactNode;
   align?: 'start' | 'center' | 'end';
+  /** Field type + allowed_values so each version resolves a select/multiselect
+   *  CODE to its human label, same as the inline card. */
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
 export function AISuggestionReviewPopover(props: AISuggestionReviewPopoverProps) {
-  const {instanceId, fieldId, getHistory, selectedProposalId, onSelect, onClear, trigger, align} = props;
+  const {instanceId, fieldId, getHistory, selectedProposalId, onSelect, onClear, trigger, align, fieldType, allowedValues} = props;
 
   const [open, setOpen] = useState(false);
   const [history, setHistory] = useState<AISuggestionHistoryItem[]>([]);
@@ -296,6 +303,8 @@ export function AISuggestionReviewPopover(props: AISuggestionReviewPopoverProps)
                     version={version}
                     isSelected={version.id === effectiveSelected}
                     onUse={() => handleUse(version)}
+                    fieldType={fieldType}
+                    allowedValues={allowedValues}
                   />
                 ))}
                 {runIndex < runOrder.length - 1 && <Separator />}

--- a/frontend/components/extraction/ai/shared/AISuggestionValue.tsx
+++ b/frontend/components/extraction/ai/shared/AISuggestionValue.tsx
@@ -11,15 +11,22 @@ interface AISuggestionValueProps {
   suggestion: AISuggestion;
   maxLength?: number;
   className?: string;
+  /** Field type + allowed_values so a select/multiselect CODE renders as its
+   *  human label ("Y" → "Yes"). Omit for non-select fields. */
+  fieldType?: string | null;
+  allowedValues?: unknown;
 }
 
 export function AISuggestionValue({
   suggestion,
   maxLength = 150,
   className = "",
+  fieldType,
+  allowedValues,
 }: AISuggestionValueProps) {
-  const displayValue = formatSuggestionValue(suggestion.value, maxLength);
-  const fullValue = formatFullSuggestionValue(suggestion.value);
+  const fieldContext = {fieldType, allowedValues};
+  const displayValue = formatSuggestionValue(suggestion.value, maxLength, fieldContext);
+  const fullValue = formatFullSuggestionValue(suggestion.value, fieldContext);
   const isTruncated = displayValue !== fullValue || fullValue.length > maxLength;
 
   const valueElement = (

--- a/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.test.tsx
+++ b/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.test.tsx
@@ -20,6 +20,22 @@ describe("RunProvenanceDisclosure", () => {
     expect(screen.getByText(/You are appraising/)).toBeInTheDocument(); // code block
   });
 
+  it("renders prompt/completion token rows with labels, not raw-key generic rows", () => {
+    render(
+      <RunProvenanceDisclosure
+        provenance={{ ...prov, tokensPrompt: 3100, tokensCompletion: 810 }}
+        defaultOpen
+      />,
+    );
+    expect(screen.getByText("Prompt tokens")).toBeInTheDocument();
+    expect(screen.getByText("Completion tokens")).toBeInTheDocument();
+    expect(screen.getByText("3,100")).toBeInTheDocument(); // toLocaleString format
+    expect(screen.getByText("810")).toBeInTheDocument();
+    // Must NOT fall through to the raw-key generic-row fallback.
+    expect(screen.queryByText("tokensPrompt")).not.toBeInTheDocument();
+    expect(screen.queryByText("tokensCompletion")).not.toBeInTheDocument();
+  });
+
   it("collapses by default and toggles", () => {
     render(<RunProvenanceDisclosure provenance={prov} />);
     expect(screen.queryByText("Temperature")).not.toBeInTheDocument();

--- a/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.tsx
+++ b/frontend/components/extraction/ai/shared/RunProvenanceDisclosure.tsx
@@ -40,6 +40,8 @@ const PROVENANCE_REGISTRY: ProvenanceFieldDef[] = [
   {key: 'temperature', labelKey: 'provenanceTemperature', kind: 'scalar'},
   {key: 'outputRetries', labelKey: 'provenanceOutputRetries', kind: 'scalar'},
   {key: 'timeoutSeconds', labelKey: 'provenanceTimeout', kind: 'scalar', format: (v) => `${String(v)}s`},
+  {key: 'tokensPrompt', labelKey: 'provenanceTokensPrompt', kind: 'scalar', format: (v) => Number(v).toLocaleString()},
+  {key: 'tokensCompletion', labelKey: 'provenanceTokensCompletion', kind: 'scalar', format: (v) => Number(v).toLocaleString()},
   {key: 'tokensTotal', labelKey: 'provenanceTokens', kind: 'scalar', format: (v) => Number(v).toLocaleString()},
   {key: 'strategy', labelKey: 'provenanceStrategy', kind: 'scalar'},
   {key: 'promptVersion', labelKey: 'provenancePromptVersion', kind: 'scalar'},

--- a/frontend/lib/ai-extraction/suggestionUtils.ts
+++ b/frontend/lib/ai-extraction/suggestionUtils.ts
@@ -7,6 +7,72 @@
 import type {AISuggestion} from '@/types/ai-extraction';
 
 /**
+ * Field context needed to resolve a select/multiselect option CODE to its human
+ * label. Optional everywhere — callers without a select field omit it and the
+ * formatters fall back to the raw value (today's behaviour).
+ */
+export interface SuggestionFieldContext {
+  fieldType?: string | null;
+  allowedValues?: unknown;
+}
+
+/**
+ * Return the raw option list from an `allowed_values` payload. Tolerates both
+ * shapes the template builder emits: `{options: [...]}` or a bare `[...]`;
+ * anything else yields `[]`. Mirrors backend `normalize_options`
+ * (backend/app/llm/claim_value.py) so a new option encoding is handled once.
+ */
+function normalizeOptions(allowedValues: unknown): unknown[] {
+  if (
+    allowedValues &&
+    typeof allowedValues === 'object' &&
+    !Array.isArray(allowedValues) &&
+    'options' in allowedValues
+  ) {
+    const options = (allowedValues as {options?: unknown}).options;
+    return Array.isArray(options) ? options : [];
+  }
+  return Array.isArray(allowedValues) ? allowedValues : [];
+}
+
+/**
+ * Map each select option's stored value (code) to its human label. Options are
+ * `{value, label}` objects or plain strings; plain strings (and options without
+ * a distinct label) map to themselves. Mirrors backend `option_label_map`.
+ */
+function optionLabelMap(allowedValues: unknown): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const opt of normalizeOptions(allowedValues)) {
+    if (opt && typeof opt === 'object' && 'value' in opt) {
+      const code = String((opt as {value: unknown}).value);
+      const label = (opt as {label?: unknown}).label;
+      map.set(code, label ? String(label) : code);
+    } else if (typeof opt === 'string') {
+      map.set(opt, opt);
+    }
+  }
+  return map;
+}
+
+/**
+ * Resolve a select/multiselect coded value to human labels. Returns `undefined`
+ * for non-select fields so the caller keeps its default formatting; for a
+ * select/multiselect it always resolves (comma-joining arrays), falling back to
+ * the raw code per item — matching backend `value_str_for_claim`.
+ */
+function resolveOptionLabels(value: unknown, field?: SuggestionFieldContext): string | undefined {
+  if (!field || (field.fieldType !== 'select' && field.fieldType !== 'multiselect')) {
+    return undefined;
+  }
+  const labelMap = optionLabelMap(field.allowedValues);
+  const resolveOne = (v: unknown): string => labelMap.get(String(v)) ?? String(v);
+  if (Array.isArray(value)) {
+    return value.map(resolveOne).join(', ');
+  }
+  return resolveOne(value);
+}
+
+/**
  * Calculates formatted confidence percentage
  *
  * @param confidence - Confidence value (0-1)
@@ -25,7 +91,11 @@ export function calculateConfidencePercent(confidence: number): number {
  * @param maxLength - Max length (default: 40)
  * @returns Formatted string
  */
-export function formatSuggestionValue(value: any, maxLength: number = 40): string {
+export function formatSuggestionValue(
+  value: any,
+  maxLength: number = 40,
+  field?: SuggestionFieldContext,
+): string {
     // Empty string is also a valid value; show "(empty)" only for null/undefined
   if (value === null || value === undefined) {
       return '(empty)';
@@ -37,6 +107,13 @@ export function formatSuggestionValue(value: any, maxLength: number = 40): strin
 
   if (typeof value === 'boolean') {
       return value ? 'Yes' : 'No';
+  }
+
+  // Resolve a select/multiselect option CODE ("Y") to its human label ("Yes")
+  // so the card matches what the user picked. No-op for non-select fields.
+  const resolved = resolveOptionLabels(value, field);
+  if (resolved !== undefined) {
+    return resolved.length > maxLength ? `${resolved.substring(0, maxLength)}...` : resolved;
   }
 
   if (typeof value === 'number') {
@@ -62,9 +139,16 @@ export function formatSuggestionValue(value: any, maxLength: number = 40): strin
  * @param value - Value to format
  * @returns Full string of value
  */
-export function formatFullSuggestionValue(value: any): string {
+export function formatFullSuggestionValue(value: any, field?: SuggestionFieldContext): string {
   if (value === null || value === undefined) {
       return '(empty)';
+  }
+
+  // Resolve a select/multiselect option CODE to its human label (no-op for
+  // non-select fields), matching the inline card.
+  const resolved = resolveOptionLabels(value, field);
+  if (resolved !== undefined) {
+    return resolved;
   }
 
   if (typeof value === 'string') {

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -855,6 +855,8 @@ export const extraction = {
     provenanceTemperature: 'Temperature',
     provenanceOutputRetries: 'Output retries',
     provenanceTimeout: 'Timeout',
+    provenanceTokensPrompt: 'Prompt tokens',
+    provenanceTokensCompletion: 'Completion tokens',
     provenanceTokens: 'Tokens',
     provenanceStrategy: 'Strategy',
     provenancePromptVersion: 'Prompt version',

--- a/frontend/test/suggestionUtils.test.ts
+++ b/frontend/test/suggestionUtils.test.ts
@@ -1,0 +1,111 @@
+/**
+ * suggestionUtils — select/multiselect option CODE → human LABEL resolution.
+ *
+ * The extraction output stores the option CODE ("Y"), so the AI-suggestion card
+ * and history must resolve it to the human label ("Yes") to match what the user
+ * picked — mirroring the backend `value_str_for_claim` / `option_label_map`
+ * (backend/app/llm/claim_value.py). Resolution is a safe no-op when there is no
+ * field context, no distinct label, or the value is free text (`allow_other`).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  formatFullSuggestionValue,
+  formatSuggestionValue,
+} from '@/lib/ai-extraction/suggestionUtils';
+
+const YES_NO = [
+  { value: 'Y', label: 'Yes' },
+  { value: 'N', label: 'No' },
+];
+
+describe('formatSuggestionValue — select/multiselect label resolution', () => {
+  it('resolves a select option code to its human label', () => {
+    expect(
+      formatSuggestionValue('Y', 40, { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('Yes');
+  });
+
+  it('joins a multiselect array of codes into resolved labels', () => {
+    expect(
+      formatSuggestionValue(['Y', 'N'], 40, { fieldType: 'multiselect', allowedValues: YES_NO }),
+    ).toBe('Yes, No');
+  });
+
+  it('tolerates the {options: [...]} allowed_values shape', () => {
+    expect(
+      formatSuggestionValue('Y', 40, {
+        fieldType: 'select',
+        allowedValues: { options: YES_NO, allow_other: true },
+      }),
+    ).toBe('Yes');
+  });
+
+  it('falls back to the raw code when the code is absent from the option map', () => {
+    expect(
+      formatSuggestionValue('Z', 40, { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('Z');
+  });
+
+  it('passes through allow_other free text unchanged (no matching code)', () => {
+    expect(
+      formatSuggestionValue('Custom answer', 40, {
+        fieldType: 'select',
+        allowedValues: { options: YES_NO, allow_other: true },
+      }),
+    ).toBe('Custom answer');
+  });
+
+  it('renders plain-string options as themselves (no distinct label)', () => {
+    expect(
+      formatSuggestionValue('RCT', 40, {
+        fieldType: 'select',
+        allowedValues: ['RCT', 'Cohort'],
+      }),
+    ).toBe('RCT');
+  });
+
+  it('does not resolve for non-select field types', () => {
+    expect(
+      formatSuggestionValue('Y', 40, { fieldType: 'text', allowedValues: YES_NO }),
+    ).toBe('Y');
+  });
+
+  it('does not resolve without field context (backward compatible)', () => {
+    expect(formatSuggestionValue('Y')).toBe('Y');
+  });
+
+  it('still shows (empty) for null/empty even with field context', () => {
+    expect(
+      formatSuggestionValue(null, 40, { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('(empty)');
+    expect(
+      formatSuggestionValue('', 40, { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('(empty)');
+  });
+
+  it('comma-joins multiselect codes even when no option labels are available', () => {
+    expect(
+      formatSuggestionValue(['Y', 'N'], 40, { fieldType: 'multiselect', allowedValues: null }),
+    ).toBe('Y, N');
+  });
+});
+
+describe('formatFullSuggestionValue — select/multiselect label resolution', () => {
+  it('resolves a select code to its label (untruncated)', () => {
+    expect(
+      formatFullSuggestionValue('Y', { fieldType: 'select', allowedValues: YES_NO }),
+    ).toBe('Yes');
+  });
+
+  it('joins a multiselect array into resolved labels', () => {
+    expect(
+      formatFullSuggestionValue(['Y', 'N'], { fieldType: 'multiselect', allowedValues: YES_NO }),
+    ).toBe('Yes, No');
+  });
+
+  it('falls back to raw JSON / string without field context (backward compatible)', () => {
+    expect(formatFullSuggestionValue('Y')).toBe('Y');
+    expect(formatFullSuggestionValue(['Y', 'N'])).toBe('["Y","N"]');
+  });
+});

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -2,7 +2,7 @@
 # May shrink (re-run --update-baseline to tighten), never grow. Cleanup is a separate effort.
 backend/app/seed.py:1941
 backend/app/services/extraction_export_service.py:2252
-backend/app/services/section_extraction_service.py:1615
+backend/app/services/section_extraction_service.py:1624
 frontend/components/articles/ArticleForm.tsx:1272
 frontend/components/articles/ArticlesList.tsx:1360
 frontend/components/extraction/ArticleExtractionTable.tsx:1130


### PR DESCRIPTION
Promotes the extraction AI-suggestion maintainability pass (5 PRs, each independently reviewed + CI-green on dev).

## Included

- #452 — render select option **labels** (not codes) in the AI-suggestion card + history (display-layer, mirrors backend `option_label_map`)
- #453 — persist run provenance at the proposal **choke-point** (`_create_suggestions`) + `complete_run` MERGE semantics (recurrence-proofs the twice-shipped silent-omission bug)
- #454 — unify the value-emptiness predicate into pure `value_semantics.py`; completeness-gate semantics provably unchanged
- #455 — consistent `{prompt,completion,total}` provenance token shape for `extract_for_run` + frontend registry rows
- #456 — translate `extraction_run_repository` docstrings to English

## Verification

Each PR landed via the merge-train (strict up-to-date dev), so all 8 required checks ran against the latest base for every merge. `dev` is exactly 5 commits ahead of `main`.

Merge-commit promotion (not squash/ff). Prod health confirmed by the Post-deploy Smoke gate after Railway deploys from `main`.