### PR TITLE
Promote dev to main (absent_reason Phase 0)

### DIFF
--- a/.github/cspell-words.txt
+++ b/.github/cspell-words.txt
@@ -224,3 +224,9 @@ remark
 bleach
 torch
 fitz
+CDISC
+Cochrane
+FHIR
+OMOP
+REASND
+SDTM

--- a/backend/app/services/value_semantics.py
+++ b/backend/app/services/value_semantics.py
@@ -11,15 +11,46 @@ their own copy:
   (``extraction_suggestion_read_service``): a later abstention must not bury an
   earlier real value in the dedup.
 
-Both mirror the frontend ``isNoInfoValue`` (``value === null | undefined | ''``):
-only ``None`` and the empty string are empty. Whitespace, ``0``, ``False``,
-``[]`` and non-envelope dicts all count as filled. Layer-legal (services, no IO)
-under ``scripts/fitness/check_layered_arch.py``.
+A value is empty when, after peeling one ``{"value": X}`` envelope, the value is
+``None`` or the empty string. Whitespace, ``0``, ``False``, ``[]`` and
+non-envelope dicts all count as filled — the frontend
+``frontend/lib/extraction/valueSemantics.ts`` mirrors this rule 1:1 (a shared
+cross-checked test vector keeps the two in lock-step).
+
+**Absent-reason marker (ADR-0016).** A coordinate may also carry a coded
+disposition sibling ``{"value": None, "absent_reason": <code>}`` — the source is
+silent (``no_information``), the item does not apply (``not_applicable``) or was
+not evaluated (``not_evaluated``). A resolved marker counts as **filled** even
+though the typed value stays ``None`` (closing the numeric/date "not reported"
+gap). The reason is validated against the closed :class:`AbsentReason` vocabulary,
+so an out-of-vocabulary string can never sneak a required field past the finalize
+gate. Both the gate and the dedup delegate here, so they inherit the marker with
+no local change. Layer-legal (services, no IO) under
+``scripts/fitness/check_layered_arch.py``.
 """
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any
+
+
+class AbsentReason(StrEnum):
+    """The closed vocabulary of coded "no value, on purpose" dispositions.
+
+    Kept intentionally minimal (three codes, not FHIR ``dataAbsentReason``'s
+    fifteen — YAGNI for evidence extraction). ``no_information`` is available on
+    every field; ``not_applicable`` / ``not_evaluated`` are opt-in per field
+    (surfaced in later phases). Defined once here and mirrored to the frontend
+    via the generated API types once the marker rides a typed response field.
+    """
+
+    NO_INFORMATION = "no_information"
+    NOT_APPLICABLE = "not_applicable"
+    NOT_EVALUATED = "not_evaluated"
+
+
+_ABSENT_REASON_CODES: frozenset[str] = frozenset(r.value for r in AbsentReason)
 
 
 def unwrap_value_envelope(raw: Any) -> Any:
@@ -32,17 +63,34 @@ def unwrap_value_envelope(raw: Any) -> Any:
     return raw
 
 
-def is_value_empty(raw: Any) -> bool:
-    """True when *raw* carries no information — ``None`` or the empty string,
-    after peeling one ``{"value": X}`` envelope. The inverse of
-    ``is_value_filled``.
+def value_absent_reason(raw: Any) -> str | None:
+    """The coded disposition carried by *raw*, or ``None``.
+
+    Returns the ``absent_reason`` sibling only when it is a member of the closed
+    :class:`AbsentReason` vocabulary; an absent, empty, or out-of-vocabulary
+    reason yields ``None`` (so a garbage code is never treated as a resolution).
     """
+    if isinstance(raw, dict):
+        reason = raw.get("absent_reason")
+        if isinstance(reason, str) and reason in _ABSENT_REASON_CODES:
+            return reason
+    return None
+
+
+def is_value_empty(raw: Any) -> bool:
+    """True when *raw* carries no information — no resolved ``absent_reason``
+    marker, and ``None`` or the empty string after peeling one ``{"value": X}``
+    envelope. The inverse of ``is_value_filled``.
+    """
+    if value_absent_reason(raw) is not None:
+        return False
     value = unwrap_value_envelope(raw)
     return value is None or (isinstance(value, str) and value == "")
 
 
 def is_value_filled(raw: Any) -> bool:
     """True when a stored value counts as "filled" for completeness — the
-    negation of ``is_value_empty``.
+    negation of ``is_value_empty`` (a real value, or a resolved ``absent_reason``
+    marker).
     """
     return not is_value_empty(raw)

--- a/backend/tests/unit/test_value_semantics.py
+++ b/backend/tests/unit/test_value_semantics.py
@@ -12,9 +12,11 @@ are filled.
 import pytest
 
 from app.services.value_semantics import (
+    AbsentReason,
     is_value_empty,
     is_value_filled,
     unwrap_value_envelope,
+    value_absent_reason,
 )
 
 
@@ -69,3 +71,78 @@ def test_dict_without_value_key_counts_as_filled():
     # this shape, so the suggestion-dedup caller is unaffected in practice.)
     assert is_value_empty({"unit": "mg"}) is False
     assert is_value_filled({"unit": "mg"}) is True
+
+
+# --- absent_reason marker (ADR-0016 / spec Phase 0) ------------------------
+#
+# A coordinate can now carry a coded disposition sibling
+# ``{"value": None, "absent_reason": <code>}`` meaning the answer is *resolved*
+# (the source is silent / not applicable / not evaluated) even though the typed
+# value stays ``None``. A resolved marker counts as FILLED; a bare ``{value:null}``
+# (no marker) stays empty. The reason is validated against the closed enum, so an
+# out-of-vocabulary string can never sneak a required field past the finalize gate.
+
+
+@pytest.mark.parametrize(
+    ("raw", "empty"),
+    [
+        # every valid disposition code resolves the coordinate → filled
+        ({"value": None, "absent_reason": "no_information"}, False),
+        ({"value": None, "absent_reason": "not_applicable"}, False),
+        ({"value": None, "absent_reason": "not_evaluated"}, False),
+        # a real value alongside a marker still counts as filled
+        ({"value": "x", "absent_reason": "no_information"}, False),
+        # an empty / missing reason is NOT a resolution → still empty
+        ({"value": None, "absent_reason": ""}, True),
+        ({"value": None, "absent_reason": None}, True),
+        ({"value": None}, True),  # bare null, no marker
+        # an out-of-vocabulary code is not a resolution → still empty (gate-safe)
+        ({"value": None, "absent_reason": "garbage"}, True),
+        # a legacy disposition carried IN-BAND as a select value is a non-empty
+        # scalar → filled today and still filled (untouched until Phase 3)
+        ({"value": "No information"}, False),
+        ("No information", False),
+    ],
+    ids=[
+        "marker-no-information",
+        "marker-not-applicable",
+        "marker-not-evaluated",
+        "marker-with-real-value",
+        "marker-empty-reason",
+        "marker-none-reason",
+        "bare-null-no-marker",
+        "marker-unknown-code",
+        "legacy-string-envelope",
+        "legacy-string-scalar",
+    ],
+)
+def test_marker_emptiness(raw, empty):
+    assert is_value_empty(raw) is empty
+    assert is_value_filled(raw) is (not empty)
+
+
+@pytest.mark.parametrize(
+    ("raw", "code"),
+    [
+        ({"value": None, "absent_reason": "no_information"}, "no_information"),
+        ({"value": None, "absent_reason": "not_applicable"}, "not_applicable"),
+        ({"value": None, "absent_reason": "not_evaluated"}, "not_evaluated"),
+        ({"value": None, "absent_reason": ""}, None),  # empty reason
+        ({"value": None, "absent_reason": None}, None),
+        ({"value": None, "absent_reason": "garbage"}, None),  # out of vocabulary
+        ({"value": None}, None),  # no marker
+        ({"value": "x"}, None),  # a real value carries no reason
+        (None, None),
+        ("x", None),
+    ],
+)
+def test_value_absent_reason_returns_only_valid_codes(raw, code):
+    assert value_absent_reason(raw) == code
+
+
+def test_absent_reason_enum_is_the_closed_three_code_vocabulary():
+    assert {r.value for r in AbsentReason} == {
+        "no_information",
+        "not_applicable",
+        "not_evaluated",
+    }

--- a/docs/adr/0016-typed-absent-reason-marker.md
+++ b/docs/adr/0016-typed-absent-reason-marker.md
@@ -1,0 +1,128 @@
+---
+status: proposed
+last_reviewed: 2026-06-30
+owner: '@raphaelfh'
+adr_number: '0016'
+---
+
+# Typed `absent_reason` marker for missing values
+
+> **Status:** Proposed · Date: 2026-06-30 · Deciders: @raphaelfh
+> **Supersedes:** N/A · **Superseded by:** N/A
+> **Amends:** constitution §IX (abstention encoding); refines the emptiness
+> semantics behind [ADR-0009](0009-extraction-finalize-completeness-gate.md) /
+> [ADR-0015](0015-finalize-via-approve-publish.md) (the gate is unchanged; a
+> marker-carrying value now counts as *filled*).
+
+## Context and Problem Statement
+
+A `(instance, field)` value can mean three things the stack collapses into the
+same empty/`null`: **(a)** the AI abstained, **(b)** the field is untouched or
+cleared, and **(c)** the source *affirmatively* does not state the item — a
+real answer in evidence synthesis. Today (c) is half-represented by carrying
+the literal string `"No information"` as a select `allowed_value`
+(`backend/app/seed.py`), which only works because those fields are selects. A
+required **numeric / date / free-text** field the source doesn't report has no
+such option and cannot hold the string, so it is stuck at `null` → blocks
+finalize → indistinguishable from "untouched".
+
+Storing a disposition *as* the value is the REDCap "Missing Data Codes"
+anti-pattern (typed consumers break; codes collide with real values;
+numeric/date exports corrupt). Every durable clinical-data standard we
+researched instead keeps the value type-correct and carries the reason in a
+**separate coded sibling**: HL7 FHIR `dataAbsentReason`, CDISC SDTM
+`--STAT`/`--REASND`, OMOP `concept_id 0` + `*_source_value`. The systematic-
+review field (Cochrane Handbook §5.4.3, Covidence) is unanimous that "not
+reported" must be a first-class recorded answer, never a blank.
+
+## Decision Drivers
+
+- Uniformity across **all** field types, including numeric/date (the gap).
+- No legacy: one representation, no permanent read-shim, no FE/BE drift.
+- Type-correct, collision-proof, machine-typed exports.
+- Preserve the finalize gate's "a human resolves every required field" rule
+  (ADR-0009/0015) and constitution §IX traceability.
+
+## Considered Options
+
+- **A — Type-independent coded marker in a sibling key**
+  (`{value:null, absent_reason:<code>}`), value stays type-correct. *(chosen)*
+- **B — Overload the value** (literal `"No information"` string / sentinel for
+  all types). Rejected: the REDCap anti-pattern — breaks numeric/date typing
+  and export, collides with real values.
+- **C — Domain option only (status quo)**, marker for nothing. Rejected: leaves
+  the numeric/date gap and the two-representations conflation.
+- **Integration M1 (marker only for non-select types) vs M2 (canonical for all,
+  selects map onto it).** Chose **M2** — M1 permanently enshrines two shapes for
+  one concept.
+
+## Decision Outcome
+
+Chosen: **A + M2.** A closed enum `absent_reason ∈ {no_information,
+not_applicable, not_evaluated}` in the value envelope; the value stays
+type-correct (`null` when absent). `is_value_filled` (the single emptiness
+oracle, `value_semantics.py`) treats a non-empty `absent_reason` as **filled**;
+a bare `{value:null}` stays **empty/unresolved**. The frontend routes all
+emptiness/abstention checks through one shared predicate mirroring the backend,
+cross-checked by a shared test vector.
+
+Precise semantics:
+
+- **`no_information`** is available on every field; **`not_applicable`** and
+  **`not_evaluated`** are opt-in per field. `"Unclear"` stays a substantive
+  value.
+- **AI abstention is a first-class acceptable proposal**
+  (`{value:null, absent_reason:"no_information"}`) the reviewer accepts in one
+  click — not bare `null` (**amends §IX**, `constitution.md:154`). The gate
+  stays safe: it counts only human decisions / published values, so a bare AI
+  proposal never self-satisfies a required field. Only `not_found` (not
+  `ambiguous`) maps to the marker. `not_applicable` / `not_evaluated` are
+  **human-only** dispositions (the LLM enum cannot express them once the codes
+  leave `allowed_values`).
+- **Consensus:** distinct answers — different codes diverge (full-envelope
+  agreement key already gives this).
+- **Migration:** a one-time Alembic backfill rewrites stored disposition values
+  → the marker across proposals / decisions / published state, **including
+  finalized runs** — covering **both** encodings (full-word `"No information"` /
+  `"Not applicable"` / `"Not evaluated"` **and** PROBAST abbreviated `NI` / `NA`,
+  `seed.py:155`). Scoped by each run's **frozen template version snapshot**
+  (`version.schema_`), never a live-field or blind-string match, so no
+  legitimate value is touched and finalized history stays lossless. The
+  transitional read-shim is then removed (no permanent legacy).
+
+Delivered in phases (marker-aware readers → write contract + AI marker →
+template/select unification → data migration → export/compare/UX → docs). Full
+design, per-layer detail, and test strategy:
+[`docs/superpowers/specs/2026-06-30-no-information-representation-design.md`](../superpowers/specs/2026-06-30-no-information-representation-design.md).
+
+### Consequences
+
+- Good — one uniform, type-correct, standards-aligned representation across all
+  field types; the numeric/date "not reported" gap is closed; exports render a
+  clear label per disposition; FE/BE emptiness can no longer drift.
+- Good — a required field answered "no information" now finalizes as a resolved
+  answer instead of stranding the run.
+- Bad — a cross-stack change (write-path contract + a data migration touching
+  finalized history) and a residual blind-accept-all risk on AI abstentions,
+  mitigated by UX (distinct rendering, excluded from silent bulk accept) rather
+  than a blocking bare-null.
+- Neutral — three codes only (not FHIR's fifteen); `ambiguous` status stays a
+  needs-attention proposal (a noted future refinement).
+
+## Validation
+
+- `value_semantics` unit table (marker ⇒ filled; bare null ⇒ empty), shared
+  FE/BE vector.
+- Finalize-gate test: numeric resolved to `no_information` finalizes; bare null
+  still blocks; an unaccepted AI marker does not satisfy the gate.
+- Autosave no-regression (hydrated marker not re-POSTed on mount).
+- Consensus (same code agrees, different codes diverge), dedup recency, export
+  label rendering, and an `allowed_values`-scoped migration verified offline
+  (`--sql`) both directions.
+
+## More Information
+
+- Design spec: `docs/superpowers/specs/2026-06-30-no-information-representation-design.md`
+- Constitution §IX: `docs/reference/constitution.md`
+- Emptiness oracle: `backend/app/services/value_semantics.py`
+- Finalize gate: `backend/app/services/run_lifecycle_service.py`

--- a/docs/superpowers/specs/2026-06-30-no-information-representation-design.md
+++ b/docs/superpowers/specs/2026-06-30-no-information-representation-design.md
@@ -1,0 +1,577 @@
+---
+status: draft
+last_reviewed: 2026-06-30
+owner: '@raphaelfh'
+---
+
+> **Status:** Draft — design direction approved in brainstorm 2026-06-30
+> (two adversarial analysis passes + a prior-art research pass:
+> FHIR `dataAbsentReason`, CDISC SDTM, OMOP, REDCap, Cochrane §5.4.3).
+> All five owner decisions + three follow-up clarifications recorded below.
+> Pending written-spec review before `writing-plans`.
+
+# Design: Type-independent "no information" representation (`absent_reason` marker)
+
+## Summary
+
+A field value in prumo can mean three different things that the code today
+collapses into the same empty/`null`:
+
+- **(a) abstention** — an AI run examined the field and found nothing;
+- **(b) untouched / cleared** — nobody has provided a value;
+- **(c) a domain "No information" answer** — the source *affirmatively* does
+  not state the item (a real, first-class finding in evidence synthesis).
+
+The current design half-represents (c) by carrying the literal string
+`"No information"` as a select `allowed_value`
+([`backend/app/seed.py:148-151`](../../../backend/app/seed.py)) — which is the
+**REDCap "store the code as the value" anti-pattern**. It works only because
+those fields are selects; it does **not** generalize to **numeric / date /
+free-text** fields, which have no such option and cannot hold the string. A
+required numeric the source doesn't report (e.g. "sample size: not reported")
+is therefore stuck at `null` → blocks finalize → with no clean, finalizable
+"the source is silent" answer, and no way to tell it apart from "untouched".
+
+This spec adopts the durable pattern used by every clinical-data standard we
+researched — **keep the value type-correct (`null`) and carry the disposition
+in a separate coded sibling** — as a single, uniform, type-independent marker:
+
+```jsonc
+{ "value": <typed value | null>, "absent_reason": "no_information" | "not_applicable" | "not_evaluated" }
+```
+
+`absent_reason` present ⇒ the coordinate is a **resolved** answer (satisfies the
+finalize completeness gate); a bare `{ "value": null }` (no marker, no decision)
+stays **unresolved** (blocks). This closes the numeric/date gap, unifies the
+representation across all field types, retires the string hack (no legacy), and
+makes the abstention a first-class, acceptable AI proposal a reviewer confirms
+in one click.
+
+## Prior art (why a separate coded marker, not an overloaded value)
+
+| Standard | Mechanism | Value stays typed? | Numeric/date? |
+|---|---|---|---|
+| **HL7 FHIR** `dataAbsentReason` | value omitted + sibling coded reason (15-code set) | yes | yes |
+| **CDISC SDTM** "Tests Not Done" | result `NULL` + `--STAT="NOT DONE"` + `--REASND` (separate columns) | yes | yes |
+| **OMOP/OHDSI** | `concept_id = 0` + raw kept in `*_source_value` | yes | yes |
+| **REDCap** Missing Data Codes | code stored **as the literal value** (in-band) | **no** — breaks numeric/date export | fragile |
+| **Cochrane §5.4.3 / Covidence** | "not reported"/"not applicable"/"unclear" as explicit answer options | n/a (all selects) | does not generalize |
+
+Two settled conclusions:
+
+1. **The durable pattern is a separate coded reason with a type-correct value**
+   (FHIR / CDISC / OMOP). REDCap's in-band sentinel is the documented
+   cautionary anti-pattern (typed consumers choke; codes collide with real
+   values; numeric/date exports break). **prumo's current select
+   `"No information"` value is that anti-pattern.**
+2. **The SR field is unanimous on the *principle*:** "not reported" must be a
+   first-class recorded answer, never a blank (Cochrane Handbook §5.4.3:
+   *"Include 'not applicable', 'not reported' and 'cannot tell' options"*).
+   This backs constitution §IX and the goal of counting it as **resolved**,
+   not empty.
+
+Full research (value sets, sources) is captured in the brainstorm workflow
+outputs; the minimal closed vocabulary chosen for prumo is three codes, not
+FHIR's fifteen (YAGNI for evidence extraction).
+
+## Decisions (owner-approved 2026-06-30)
+
+1. **Unification model M2** — the marker is canonical for **all** field types;
+   the select `"No information"` / `"Not applicable"` / `"Not evaluated"`
+   options map onto it. One representation everywhere (no dual shape left
+   behind).
+2. **Migrate all runs, incl. finalized (lossless).** A one-time Alembic data
+   migration rewrites stored `{value:"No information"|"Not applicable"|"Not
+   evaluated"}` → the marker across proposals, reviewer decisions, and
+   published state, so historical exports stay correct and a transitional
+   read-shim can be removed (no permanent legacy path).
+3. **AI abstention is a first-class acceptable input.** The AI records
+   `{value:null, absent_reason:"no_information"}` (with its rationale) as a
+   proposal the reviewer **accepts in one click** — *not* bare `null`.
+   Constitution §IX is amended accordingly (see below).
+4. **Phased delivery**, sequenced so each phase is green + shippable and agents
+   run in a clean order (see Phased plan).
+5. Spec must also cover: no-legacy/maintainability, reviewer comparison,
+   template configuration, export, and extraction + QA UX (all below).
+
+Follow-up clarifications:
+
+- **Template model:** `no_information` is available on **every** field
+  automatically (any source can be silent, incl. numeric/date);
+  `not_applicable` and `not_evaluated` are **opt-in per field** where
+  meaningful. `"Unclear"` stays a **substantive select value** ("present but
+  ambiguous" ≠ absent), not a disposition.
+- **Reviewer comparison:** distinct answers — different `absent_reason` codes
+  diverge; same code agrees; a marker vs a substantive value diverges
+  (consistent with the existing full-envelope agreement key).
+
+## The canonical representation
+
+### Envelope
+
+```jsonc
+// a real value (unchanged)
+{ "value": "Retrospective cohort" }
+{ "value": 240, "unit": "days" }
+// a resolved "no information" answer (any field type)
+{ "value": null, "absent_reason": "no_information" }
+// not applicable / not evaluated (opt-in fields)
+{ "value": null, "absent_reason": "not_applicable" }
+{ "value": null, "absent_reason": "not_evaluated" }
+// unresolved — untouched, or an unaccepted proposal, or a rejected decision
+{ "value": null }   // (or absent coordinate entirely)
+```
+
+- `absent_reason` is a **closed enum**: `no_information | not_applicable |
+  not_evaluated`. Defined once in the backend and mirrored to the FE via the
+  generated API types (never hand-mirrored).
+- The value stays **type-correct** — `null` for a silent numeric/date, never a
+  string sentinel. Collisions are structurally impossible.
+
+### Semantics — one rule, one place
+
+`backend/app/services/value_semantics.py` is the single emptiness oracle
+(centralized in #454). It gains the marker concept in ~one predicate:
+
+- `is_value_filled(raw)` ⇒ **True** when, after peeling one `{value}` envelope,
+  the value is non-empty **OR** the envelope carries a non-empty
+  `absent_reason`.
+- `is_value_empty` stays its exact inverse.
+- A new helper `value_absent_reason(raw)` returns the code (or `None`).
+
+Because the finalize gate ([`run_lifecycle_service.py:372-453`](../../../backend/app/services/run_lifecycle_service.py))
+and the suggestion dedup
+([`extraction_suggestion_read_service.py:199-216`](../../../backend/app/services/extraction_suggestion_read_service.py))
+both delegate emptiness to this oracle, they inherit the marker correctly with
+no local change beyond the two deliberate calls below.
+
+The **frontend gets one shared predicate module** mirroring the backend rule
+1:1 (`frontend/lib/extraction/valueSemantics.ts`), replacing the three
+open-coded copies that drift today:
+
+- `frontend/lib/ai-extraction/suggestionUtils.ts:171` `isNoInfoValue` →
+  re-expressed via the shared predicate and **renamed `isAbstention`** (it tests
+  the abstention *shape*, so a real value never masquerades as one);
+- `frontend/lib/extraction/progress.ts:127` + `computeRowProgress` inline
+  checks → the shared predicate (or the progress bar diverges from the gate —
+  the "40%, can't submit" bug class the file's own docstring warns about);
+- `frontend/lib/ai-extraction/valueParser.ts` `extractValue` / `isEmptyValue`
+  → fold into the shared module.
+
+A **shared cross-checked test vector** is asserted identically by
+`backend/tests/unit/test_value_semantics.py` and the new FE
+`valueSemantics.test.ts`, so the two implementations are *mechanically* kept in
+lock-step (replacing today's "the docstring says they mirror"). The vector must
+cover **all three shapes** that coexist during the migration window: (1) marker
+`{value:null, absent_reason:X}` ⇒ filled/abstention; (2) a legacy disposition
+string as a select value ⇒ filled (until Phase 3); (3) bare `{value:null}` / `''`
+⇒ unresolved.
+
+### Carrying `absent_reason` end-to-end on the frontend
+
+The FE predicate consolidation is necessary but **not sufficient** — today every
+FE unwrap peels `{value}` and **discards** the sibling key, so a marker cannot
+round-trip:
+
+- `frontend/services/aiSuggestionService.ts:47` `unwrapValue` → `raw['value'] ?? ''`
+- `frontend/services/extractionValueService.ts:27` → `raw.value ?? null`
+- `frontend/lib/ai-extraction/valueParser.ts:14,20` `extractValue` → `value.value`
+- `frontend/components/runs/ConsensusPanel.tsx:115` — a **fourth** open-coded
+  `{value}` peel on the divergence-display surface.
+
+So the FE must carry the marker as data, not collapse it:
+
+- The `AISuggestion` model keeps `absent_reason` (from the full
+  `proposed_value` envelope); `isAbstention` and the no-info card read the
+  **code**, not the unwrapped scalar, so `no_information` / `not_applicable` /
+  `not_evaluated` render distinctly.
+- The **form in-memory value** for a resolved disposition is the **full
+  envelope** `{value:null, absent_reason:<code>}` (not a bare `null`), and the
+  autosave **baseline is built from the same un-peeled shape**, so R7 holds
+  (baseline == current on mount; editing an adjacent field never restripes the
+  marker coord). `extractValueForSave` → `writeRunFieldValue` thread
+  `absent_reason` (Phase 1 write contract).
+- `progress.ts` currently **pre-unwraps** into `valueMap` (`:126-136,192-200`)
+  *before* the emptiness test — the shared predicate must instead receive the
+  **raw envelope** (peel-and-test in one place, matching the backend), or the
+  marker is stripped before the predicate sees it and the shared vector passes
+  while the real call site is wrong.
+- Audit every remaining `"value" in` peel (grep) and route it through the
+  shared module.
+
+### Gate safety (why this does not weaken finalize)
+
+The finalize gate only ever counts **human decisions and published values**,
+never raw AI proposals — verified: `_filled_coords` requires an
+`ExtractionReviewerState` / `ExtractionPublishedState` row
+([`run_lifecycle_service.py:372-399`](../../../backend/app/services/run_lifecycle_service.py)),
+created only by `record_decision`. So an AI-proposed
+`{value:null, absent_reason:"no_information"}` **cannot self-satisfy** a
+required field; a human must accept it (exactly like the select
+`"No information"` flow today).
+
+The residual risk of decision #3 (an AI abstention that looks acceptable being
+**blind accept-all'd** — e.g. a parser silently dropping a section, producing
+8 fabricated "not reported" findings) is addressed in the **UX section**
+(abstention proposals rendered visibly distinct, no confidence badge, not
+silently bundled into a one-click bulk accept), not by re-introducing a
+blocking bare-null. This is the deliberate trade the owner chose.
+
+## AI recording change (constitution §IX)
+
+Today the recording loop
+([`section_extraction_service.py:1416-1492`](../../../backend/app/services/section_extraction_service.py))
+coerces `inner_value = None` on the abstention branch (`value is None` or
+`status ∈ {not_found, ambiguous}`) and writes bare `{value:null}`.
+
+New behaviour (Phase 1 **splits** the `is_no_info` predicate at
+`section_extraction_service.py:1431-1433`, which today folds `not_found` **and**
+`ambiguous` into one bare-null branch):
+
+- **`status = not_found` / `value = None`** → record
+  `{value:null, absent_reason:"no_information"}` (keep the rationale; evidence
+  stays absent). This is the acceptable AI abstention proposal (decision #3).
+- **`status = ambiguous`** ("present but conflicting") is **not** "absent" and
+  must **stop sharing** the abstention branch: it stays a needs-attention
+  proposal — a `found`-style value with low/zero confidence and **no marker**,
+  so it still blocks the gate; where the field offers `"Unclear"` the model may
+  pick that substantive value. On a field with no `"Unclear"` option, ambiguous
+  persists as a low-confidence proposal with **no** `absent_reason` (never
+  silently collapsed to `no_information`). A recording test pins that ambiguous
+  gets no marker.
+- A **`found`** value (incl. an in-domain `"No information"` select code with a
+  supporting quote) flows as a normal value through the entailment gate; the
+  select-mapping step (Phase 2) normalizes a chosen disposition code to the
+  marker. Note this `found`-"No information" branch is only reachable during the
+  transitional window — once Phase 2 removes the disposition codes from
+  `allowed_values`, the model's `value` `Literal` can no longer carry them.
+- **AI never proposes `not_applicable` / `not_evaluated`.** The LLM output
+  `status` is `Literal['found','not_found','ambiguous']` and `value` is
+  `Literal[allowed_values] | None` ([schema.py:73-125](../../../backend/app/llm/schema.py));
+  once the disposition codes leave `allowed_values`, the only AI-expressible
+  disposition is `no_information` (via `not_found`). `not_applicable` and
+  `not_evaluated` are therefore **human-only dispositions** in this design —
+  intentional; extending the LLM vocabulary is out of scope.
+
+### §IX amendment (proposed wording)
+
+§IX (`docs/reference/constitution.md:149`, "Transparency & Traceability of
+AI-Assisted Decisions") today pins abstention to bare `{value:null}` in one
+bullet (`:154`). Replace that bullet with the two concepts it currently
+conflates:
+
+> - A **domain "no information" / disposition answer** — that the source does
+>   not state the item, or the item is not applicable / not evaluated — is a
+>   first-class recorded proposal carrying a coded `absent_reason`
+>   (`{value:null, absent_reason:<code>}`) with its rationale. A reviewer
+>   accepts it like any AI version; it counts as a **resolved** value.
+> - A **genuine unresolved state** — no proposal, an unaccepted proposal, or a
+>   rejected decision — carries no disposition and is **not** a silent drop: the
+>   proposal trail records that the run examined the field.
+
+The ADR (0016) records the decision; the constitution edit lands in the doc
+phase.
+
+## Template configuration
+
+- **`no_information` is universal.** Every field — select, multiselect, text,
+  number, date — exposes a "No information" affordance that sets
+  `absent_reason:"no_information"`. It is no longer a manually-added
+  `allowed_value`; the template builder stops needing (and stops offering) the
+  string option.
+- **`not_applicable` / `not_evaluated` are opt-in per field.** A field's config
+  gains two booleans (`allows_not_applicable`, `allows_not_evaluated`) on the
+  `ExtractionField` model ([`backend/app/models/extraction.py`](../../../backend/app/models/extraction.py)),
+  default off, surfaced in the template builder for signaling-question style
+  fields (PROBAST/CHARMS). **These columns are a SQLAlchemy model change ⇒ their
+  own Alembic migration** (revision id ≤ 32 chars), landed in **Phase 2** and
+  **distinct** from the Phase-3 data backfill. The template-version **snapshot
+  builder must copy the flags into `version.schema_`** so the frozen snapshot,
+  the finalize gate, and the builder UI stay consistent. Only enabled
+  dispositions render on the field.
+- **`"Unclear"` stays a substantive select option** (present-but-ambiguous, a
+  real answer), untouched.
+
+**Seed changes — the full disposition inventory (both encodings).** The
+literal-string sets are only half of it; PROBAST encodes the same dispositions
+as abbreviated codes. Every disposition source and its target code:
+
+| Seed source (`backend/app/seed.py`) | Members → disposition | Kept substantive |
+|---|---|---|
+| `_YES_NO_NI` (`:149`) | `"No information"` → `no_information` | `Yes`, `No` |
+| `_YES_NO_NOTEVAL_NI` (`:151`) | `"No information"` → `no_information`; `"Not evaluated"` → `not_evaluated` | `Yes`, `No` |
+| `_YES_NO_NOTAPP_NI` (`:150`) | `"No information"` → `no_information`; `"Not applicable"` → `not_applicable` | `Yes`, `No` |
+| `_YES_NO_UNCLEAR` (`:148`) | `"No information"` → `no_information` | `Yes`, `No`, **`Unclear`** |
+| `_PROBAST_SIGNALING` (`:155`) | `"NI"` → `no_information`; `"NA"` → `not_applicable` | `Y`, `PY`, `PN`, `N` |
+| `_QUADAS2_SIGNALING` (`:160`), `_QUADAS2_JUDGMENT` (`:162`) | none | `Y`/`N`/`Unclear`, `Low`/`High`/`Unclear` |
+| inline `allowed=[...]` lists carrying the literal strings | same as above | — |
+
+Drop the disposition members from these lists (and the inline lists), set the
+opt-in flags on fields that carried `NA`/`Not applicable` / `Not evaluated`, and
+feed this exact mapping into the Phase-3 backfill (both full-word and
+abbreviated encodings), so **no in-band disposition survives** in any encoding.
+
+## Reviewer comparison (consensus / divergence)
+
+- Consensus agreement keys on the full resolved envelope
+  (`json.dumps(resolved, sort_keys=True)`,
+  [`run_lifecycle_service.py:310-328`](../../../backend/app/services/run_lifecycle_service.py)),
+  so distinct-answers semantics fall out **for free** — **but only because**
+  the marker envelope is persisted verbatim into `ExtractionReviewerDecision.value`
+  and `ExtractionPublishedState.value` (the Phase-1 write contract). The
+  consensus key at `:321` and `_filled_coords` at `:388` hash that stored
+  envelope; if a marker collapsed to `null` in those columns, two different
+  codes would both hash as `null` and wrongly **agree**. This persistence is the
+  load-bearing precondition, called out in Phase 1.
+- Two reviewers agree only when value **and** `absent_reason` match;
+  `no_information` vs `not_applicable` diverge; a marker vs a substantive value
+  diverges.
+- Frontend divergence display (the FE-only "≥2 reviewers disagree" cue) must
+  read `absent_reason` — including the fourth `{value}` unwrap in
+  `ConsensusPanel.tsx:115` — so a disposition divergence renders legibly, not as
+  two blank-looking cells.
+- Add a consensus test: two reviewers on the same code agree and publish; two
+  on different codes stay unresolved.
+
+## Export
+
+- `resolve_value`
+  ([`backend/app/services/exports/value_envelope.py`](../../../backend/app/services/exports/value_envelope.py))
+  gains a branch that must be placed **at the top**, *before* the exact
+  key-set matches `== {"value"}` (`:56`) and `== {"value","unit"}` (`:64`) —
+  keyed on `"absent_reason" in raw and raw.get("absent_reason")` — returning the
+  stable label. Otherwise a marker (`{value:null, absent_reason:X}`, key-set
+  `{value, absent_reason}`) falls through to the catch-all dict-stringify
+  (`:84-85`) and leaks `"value: None; absent_reason: no_information"` into a
+  cell — the failure the module's own "never returns a dict" invariant forbids.
+  An export test asserts a marker never hits the `{value}` unwrap and never
+  dict-stringifies.
+- The front-matter legend
+  ([`extraction_export_service.py:1827-1832`](../../../backend/app/services/extraction_export_service.py))
+  today has one disposition row (`"No information"`). It gains **three** rows,
+  worded to match the label `resolve_value` emits **exactly** (so cell and
+  legend can't drift):
+  - `No information` — "The source does not state this item."
+  - `Not applicable` — "The item does not apply to this study."
+  - `Not evaluated` — "The item was not assessed."
+  `"(blank)"` keeps its distinct meaning (no value / rejected).
+- **Appraisal worst-case roll-up.** The QA appraisal Overall
+  (`build_appraisal_summary`, `extraction_export_service.py:276-339`; verdict
+  selection `_is_verdict` + severity rank in the appraisal-summary helper)
+  currently ranks an unknown label as most-severe. `_is_verdict` requires *all*
+  a field's `allowed_values` to be risk labels, so today's signaling `NI`/`NA`
+  fields are excluded — but under this design `no_information` is available on
+  **every** field, including a verdict field. **New work (Phase 4):** a
+  disposition-marked verdict must be treated as *excluded / unknown* in the
+  worst-case rank, **never** most-severe (a `no_information` risk verdict must
+  not silently force a Critical Overall). A test locks this.
+- Net: exports stay **clear and simple** — one label per disposition, the value
+  column stays type-clean, and a downstream consumer never reverse-engineers a
+  sentinel.
+
+## UX (extraction + QA — both share the suggestion path)
+
+- **Set a disposition on any field.** `FieldInput` gains a small, unobtrusive
+  "No information" control on **all** field types (number/date/text have none
+  today), plus the opt-in `Not applicable` / `Not evaluated` where the field
+  enables them. Selecting it writes the marker; clearing it returns to
+  unresolved.
+- **AI abstention proposal is visibly distinct.** An AI
+  `{absent_reason:"no_information"}` proposal renders as a quiet, labelled
+  "No information" suggestion **without** a confidence badge and marked "no
+  evidence", so a reviewer can accept it with one click but is never misled
+  into reading it as a confident finding. It is **not** silently swept into a
+  bulk "accept all" — bulk-accept excludes or separately confirms abstention
+  proposals (the decision-#3 accept-all safeguard).
+- **QA / extraction parity.** Replace the divergent header counts
+  (`QualityAssessmentFullScreen.tsx:634` counts all;
+  `ExtractionFullScreen.tsx:506` filters no-info) with one shared
+  `countActionableSuggestions` selector. Under decision #3 an **unresolved
+  abstention proposal IS actionable** (it needs a human accept), so it **counts**
+  as pending — reversing today's `ExtractionFullScreen:506` exclusion (whose
+  comment must be reconciled). "Actionable" therefore = "an unresolved AI
+  proposal awaiting a human decision", abstention included; what changes for
+  abstentions is *rendering* (distinct, no confidence badge) and *bulk-accept*
+  (excluded), **not** the count.
+- `isAbstention` (renamed from `isNoInfoValue`) drives the quiet-strip and
+  no-info-card rendering in `AISuggestionDisplay` / `AISuggestionReviewPopover`
+  through the shared predicate.
+
+## No-legacy & maintainability
+
+- **One representation** end-to-end after migration — the string hack is gone,
+  and there is no permanent read-shim (the transitional tolerance in Phase 0 is
+  removed in Phase 3).
+- **One emptiness rule per side**, mechanically cross-checked (shared test
+  vector) — the FE/BE drift hazard and the three open-coded FE copies are
+  eliminated, not relocated.
+- **Vocabulary matches the concept** — `isAbstention`, `absent_reason`; §IX and
+  the architecture doc use the same terms.
+- **Typed contract** — `absent_reason` is a backend enum surfaced via the
+  generated API types (`npm run generate:api-types`); no hand-mirrored strings.
+
+## Two deliberate behaviour calls (resolved)
+
+1. **Dedup** (`extraction_suggestion_read_service.py:213`): a coded AI
+   abstention is now `is_value_empty == False`, so it is a real value in the
+   "later abstention must not bury an earlier value" rule. **Resolved:** a
+   coded `no_information` is a genuine answer and may win by recency like any
+   value; only a bare `{value:null}` (no marker) is still treated as buryable.
+   Update the Step-2 comment to state the value-vs-value recency rule.
+2. **Consensus agreement** (above): different codes diverge. **Resolved** by
+   decision (distinct answers).
+
+## Phased plan (sequenced for clean agent hand-offs)
+
+Each phase is independently green + shippable; readers that must understand the
+new shape ship together (fan-out-once). `writing-plans` expands each into tasks.
+
+- **Phase 0 — Marker-aware, read-tolerant (behaviour-preserving).**
+  Backend `value_semantics` + `absent_reason` enum + `value_absent_reason`
+  helper; finalize gate + dedup inherit. FE shared `valueSemantics.ts`; route
+  `progress.ts` (stop pre-unwrapping — pass the raw envelope), `valueParser`,
+  `aiSuggestionService.unwrapValue`, and every other `"value" in` peel through
+  it. **Rename `isNoInfoValue → isAbstention` as a UNION predicate for the
+  transitional window:** `absent_reason` present **OR** legacy-empty
+  (`null`/`undefined`/`''`). This *preserves today's truth table* — critical,
+  because no markers exist yet (abstentions are still bare `null`/`''` until
+  Phase 1+3), so a pure marker-shape test would break the quiet no-info strip
+  and re-inflate the pending count across the whole window. **Audit the three
+  `isAbstention` call sites in this phase** (`AISuggestionDisplay:112`,
+  `AISuggestionReviewPopover:91`, `ExtractionFullScreen:506`) with a
+  behaviour-unchanged snapshot/count test — do **not** defer them to Phase 4.
+  Readers tolerate **three** shapes: marker, legacy disposition string, bare
+  null/`''`. *Ships behaviour-neutral.*
+- **Phase 1 — Write-path contract + AI marker.** Thread `absent_reason`
+  through `extractValueForSave → writeRunFieldValue → /proposals & /decisions`
+  request schemas; **persist the full marker envelope verbatim into
+  `ExtractionReviewerDecision.value` and `ExtractionPublishedState.value`** (the
+  consensus/gate precondition); regenerate API types. **Split** the
+  `is_no_info` branch (`section_extraction_service.py:1431-1433`): only
+  `not_found`/bare-`None` → `{value:null, absent_reason:"no_information"}`;
+  `ambiguous` falls through as a low-confidence needs-attention proposal with no
+  marker. Round-trip + recording tests (incl. "ambiguous gets no marker").
+- **Phase 2 — Template config + select unification.** New `allows_not_applicable`
+  / `allows_not_evaluated` boolean columns on `ExtractionField` — **their own
+  Alembic migration** (≤ 32 chars) + snapshot-builder propagation into
+  `version.schema_`. `no_information` global affordance; opt-in flags + builder
+  UI; select write path maps a chosen disposition (full-word **and** PROBAST
+  `NI`/`NA`) to the marker; seed lists updated per the mapping table
+  (`"Unclear"` kept). AI can now only express `no_information` (codes gone from
+  the enum); `not_applicable`/`not_evaluated` are human-only.
+- **Phase 3 — Data migration (Alembic, all runs incl. finalized).** Rewrite
+  stored disposition values → marker across `ExtractionProposalRecord.proposed_value`,
+  `ExtractionReviewerDecision.value`, and `ExtractionPublishedState.value`,
+  scoped by the **frozen per-run template version snapshot** (`version.schema_`,
+  the source the gate/export already trust — `run_lifecycle_service.py:341`),
+  **not** the live `extraction_fields` (which Phase 2 mutated). Mirror the read
+  resolution: an `accept_proposal` decision with a null `value` inherits
+  correctness from its migrated proposal (no double-handle). Never a blind
+  string match. Then **narrow `isAbstention` to the pure marker-shape** and
+  remove the legacy-string/bare-null read tolerance (the shim). Bump the
+  migration-head line + `last_reviewed` in
+  `docs/reference/extraction-hitl-architecture.md` (Alembic only, never
+  Supabase MCP).
+- **Phase 4 — Export, reviewer-compare, UX.** `resolve_value` top-branch +
+  three legend rows; appraisal worst-case excludes a marker verdict; FE
+  divergence display + `ConsensusPanel:115` read `absent_reason`; extraction + QA
+  UX (field affordance on all types, distinct abstention rendering, bulk-accept
+  safeguard, shared `countActionableSuggestions`).
+- **Phase 5 — Docs.** ADR-0016 finalized, constitution §IX amended, architecture
+  doc updated. (Doc stubs land with their phase; this phase closes them out.)
+
+Transitional window: between Phase 1 (new writes produce the marker) and Phase 3
+(data migrated + shim removed + predicate narrowed), readers tolerate **three**
+shapes (marker, legacy disposition string, bare null) — a bounded migration
+scaffold, not permanent legacy.
+
+## Test strategy (evidence before "done")
+
+- **`value_semantics`** unit table incl. the three shapes: `{value:null,
+  absent_reason:X}` ⇒ filled; legacy disposition string ⇒ filled;
+  `{value:null}`/`''` ⇒ empty. Shared vector mirrored on FE `valueSemantics.test.ts`.
+- **Finalize gate:** a required numeric resolved to `no_information` (via
+  human decision) finalizes; the same field bare-null still blocks; an
+  *unaccepted* AI marker proposal does **not** satisfy the gate.
+- **Recording (Phase 1):** `not_found` → `no_information` marker; **`ambiguous`
+  gets no marker** (stays needs-attention); `found` value preserved.
+- **Autosave no-regression:** the form value + baseline for a resolved
+  disposition are the **full envelope**; baseline == current on mount (no
+  re-POST); saving an adjacent field does not restripe the marker coord. New R7
+  cases in `frontend/lib/extraction/autosaveDirty.test.ts`.
+- **Dedup:** a newer coded abstention vs an older real value (recency rule);
+  a bare-null still buryable.
+- **Consensus:** same code agrees + publishes; different codes stay unresolved
+  (asserts the marker is persisted into decision/published `value`).
+- **Export:** marker renders as its exact legend label in CONSENSUS /
+  SINGLE_USER / ALL_USERS matrices and **hits the top branch, never the
+  `{value}` unwrap / dict-stringify**; `"(blank)"` stays distinct; a
+  `no_information` on a verdict field is **excluded** from the appraisal
+  worst-case Overall (not most-severe).
+- **Migration:** a *finalized* run with `"No information"` (and PROBAST `"NI"`)
+  → marker, scoped via the **frozen version snapshot**; a finalized run whose
+  *live* template changed still migrates correctly; an `accept_proposal`
+  decision whose value lives on the proposal migrates once; a legitimate value
+  equal to a disposition string on a field whose (snapshot) domain lacks it is
+  untouched; offline `--sql` both directions.
+- **API contract:** regenerate `frontend/types/api/schema.d.ts`; the
+  `api-contract` CI job stays green.
+
+## Risks & mitigations
+
+- **Blind accept-all of AI abstentions** (decision #3 residual) → UX: distinct
+  rendering, no confidence badge, excluded from silent bulk accept.
+- **Migration mutates finalized history** → lossless rewrite (semantics
+  preserved), `allowed_values`-scoped so no legitimate value is touched;
+  `--sql` reviewed both directions before apply.
+- **FE/BE predicate drift** → shared cross-checked test vector; FE routes
+  through one module.
+- **Ambiguous status** mis-mapped to `no_information` → Phase 1 **splits** the
+  recording branch so `ambiguous` never receives the marker (stays a
+  low-confidence, gate-blocking proposal); pinned by a recording test.
+- **Marker lost on the FE read/write path** (the unwraps discard the sibling
+  key) → the FE carries the full envelope end-to-end (model, form state,
+  autosave baseline, `ConsensusPanel`), verified by the R7 and round-trip tests.
+- **Phase 0 silently changing count/strip behaviour** → the transitional
+  `isAbstention` is a truth-preserving UNION; call sites audited in Phase 0.
+
+## Out of scope
+
+- The FHIR-complete 15-code vocabulary (only three codes for now).
+- Any change to `"Unclear"` (stays a substantive value).
+- Widening beyond the no-information representation and its direct consumers.
+- Relaxing the finalize completeness gate.
+
+## Evidence index (file:line)
+
+- Recording coercion: `backend/app/services/section_extraction_service.py:1416-1492`
+- Emptiness oracle: `backend/app/services/value_semantics.py`
+- Finalize gate: `backend/app/services/run_lifecycle_service.py:330-453`;
+  consensus key `:310-328`
+- Dedup: `backend/app/services/extraction_suggestion_read_service.py:199-216`
+- Export: `backend/app/services/exports/value_envelope.py:56,64,84-85`
+  (exact-key-set branches + catch-all); legend
+  `backend/app/services/extraction_export_service.py:1827-1832`; appraisal
+  worst-case `extraction_export_service.py:276-339` + `_is_verdict` / severity
+  rank in the appraisal-summary helper
+- Seed dispositions (both encodings): `backend/app/seed.py:148-151`
+  (`_YES_NO_*`), `:155` (`_PROBAST_SIGNALING` `NI`/`NA`), `:160,162` (QUADAS2),
+  signaling fields `~:1451-1623` (+ inline `allowed=`)
+- Field model (opt-in flag columns): `backend/app/models/extraction.py`
+- Frozen version snapshot (migration scope source):
+  `run_lifecycle_service.py:341` (`version.schema_`)
+- LLM schema (value is `Literal[codes] | None`, status enum):
+  `backend/app/llm/schema.py:48-125`; recording branch
+  `backend/app/services/section_extraction_service.py:1431-1454`
+- FE unwraps (all discard the sibling key): `frontend/services/aiSuggestionService.ts:45-49`,
+  `frontend/services/extractionValueService.ts:27`,
+  `frontend/lib/ai-extraction/valueParser.ts:14,52`,
+  `frontend/components/runs/ConsensusPanel.tsx:115`
+- FE predicate + copies: `frontend/lib/ai-extraction/suggestionUtils.ts:171`,
+  `frontend/lib/extraction/progress.ts:127,192-200`
+- Autosave: `frontend/hooks/runs/useAutoSaveProposals.ts`,
+  `frontend/lib/extraction/autosaveDirty.ts`
+- Screens: `frontend/pages/ExtractionFullScreen.tsx:506`,
+  `frontend/pages/QualityAssessmentFullScreen.tsx:634`
+- Constitution §IX (title `:149`, abstention bullet `:154`):
+  `docs/reference/constitution.md`

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -16,7 +16,7 @@ import {AISuggestionActions} from '@/components/shared/ai-suggestions';
 import {AISuggestionConfidence} from './shared/AISuggestionConfidence';
 import {AISuggestionValue} from './shared/AISuggestionValue';
 import {AISuggestionReviewPopover} from './AISuggestionReviewPopover';
-import {isNoInfoValue, isSuggestionAccepted} from '@/lib/ai-extraction/suggestionUtils';
+import {isAbstention, isSuggestionAccepted} from '@/lib/ai-extraction/suggestionUtils';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
 
@@ -109,7 +109,7 @@ export function AISuggestionDisplay({
   // a quiet, de-emphasized indicator — never a loud "(empty) · 0%" strip with
   // Accept/Reject. It still opens the review popover (history + provenance) when
   // a binding is supplied, so the abstention stays traceable.
-  if (isNoInfoValue(suggestion.value)) {
+  if (isAbstention(suggestion.value)) {
     return (
       <div className="mt-2 animate-in fade-in duration-200">
         <ReviewTrigger review={review} className="inline-flex px-1.5 py-0.5 -mx-1.5">

--- a/frontend/components/extraction/ai/AISuggestionReviewPopover.tsx
+++ b/frontend/components/extraction/ai/AISuggestionReviewPopover.tsx
@@ -24,7 +24,7 @@ import {Separator} from '@/components/ui/separator';
 import {cn} from '@/lib/utils';
 import {t} from '@/lib/copy';
 import type {AISuggestionHistoryItem, EvidenceCitation} from '@/types/ai-extraction';
-import {formatFullSuggestionValue, isNoInfoValue} from '@/lib/ai-extraction/suggestionUtils';
+import {formatFullSuggestionValue, isAbstention} from '@/lib/ai-extraction/suggestionUtils';
 import {useReaderLocate} from '@/hooks/extraction/useReaderLocate';
 import {AIPopoverShell} from './shared/AIPopoverShell';
 import {RunProvenanceDisclosure} from './shared/RunProvenanceDisclosure';
@@ -88,7 +88,7 @@ function VersionRow({version, isSelected, onUse, fieldType, allowedValues}: Vers
   const [expanded, setExpanded] = useState(false);
   const showDetails = isSelected || expanded;
 
-  const noInfo = isNoInfoValue(version.value);
+  const noInfo = isAbstention(version.value);
   const hasReasoning = !!version.reasoning?.trim();
   const evidence = version.evidence ?? [];
   const hasEvidence = evidence.length > 0 && !!evidence[0]?.text?.trim();

--- a/frontend/lib/ai-extraction/suggestionUtils.ts
+++ b/frontend/lib/ai-extraction/suggestionUtils.ts
@@ -5,6 +5,7 @@
  */
 
 import type {AISuggestion} from '@/types/ai-extraction';
+import {valueAbsentReason} from '@/lib/extraction/valueSemantics';
 
 /**
  * Field context needed to resolve a select/multiselect option CODE to its human
@@ -163,13 +164,41 @@ export function formatFullSuggestionValue(value: any, field?: SuggestionFieldCon
 }
 
 /**
- * A "no information found" outcome — the model abstained for this field. The
- * backend records it as `{value: null}`, which the service unwraps to `''`, so
- * null, undefined and empty-string all mean no-info. Used to render a quiet
- * indicator instead of a misleading "(empty) · 0%" suggestion strip.
+ * True when a suggestion's value has the **abstention shape** — the model found
+ * no information for this field. Used to render a quiet indicator instead of a
+ * misleading "(empty) · 0%" suggestion strip.
+ *
+ * A transitional UNION predicate (spec Phase 0): a resolved `absent_reason`
+ * marker OR the legacy-empty forms (`null` / `undefined` / `''`). Today the
+ * backend records an abstention as bare `{value:null}` which the service unwraps
+ * to `''`, so the marker branch is dormant and this collapses to the previous
+ * `isNoInfoValue` truth table — behaviour-neutral. Once Phase 1 writes markers
+ * and Phase 3 removes the legacy tolerance, this narrows to the pure marker
+ * shape so a real value can never masquerade as an abstention.
  */
-export function isNoInfoValue(value: unknown): boolean {
-  return value === null || value === undefined || value === '';
+export function isAbstention(value: unknown): boolean {
+  return (
+    valueAbsentReason(value) !== null ||
+    value === null ||
+    value === undefined ||
+    value === ''
+  );
+}
+
+/**
+ * Count of suggestions carrying a substantive (non-abstention) value — the
+ * "actionable pending" header metric. A "no information found" proposal is
+ * recorded provenance, not something to act on, so it is excluded here.
+ *
+ * NOTE (Phase 4): the shared cross-surface `countActionableSuggestions` selector
+ * will treat an unresolved abstention as actionable (it needs a human accept) and
+ * REVERSE this exclusion; this Phase-0 helper preserves today's count exactly.
+ */
+export function countNonAbstentionSuggestions(
+  suggestions: Record<string, AISuggestion> | AISuggestion[],
+): number {
+  const list = Array.isArray(suggestions) ? suggestions : Object.values(suggestions);
+  return list.filter((s) => !isAbstention(s.value)).length;
 }
 
 /**

--- a/frontend/lib/ai-extraction/valueParser.test.ts
+++ b/frontend/lib/ai-extraction/valueParser.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Characterization tests for `valueParser` — pinned BEFORE routing its envelope
+ * peel + emptiness check through the shared `valueSemantics` module, so the
+ * refactor is provably behaviour-neutral. `FieldInput.tsx` (its only consumer)
+ * depends on `extractValue` / `extractUnit` / `isEmptyValue` / `isValidNumber`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractUnit,
+  extractValue,
+  isEmptyValue,
+  isValidNumber,
+  normalizeValue,
+  toNumber,
+  toString,
+} from './valueParser';
+
+describe('extractValue — one-level envelope peel', () => {
+  it('peels {value} and {value, unit}, leaves scalars and non-envelopes', () => {
+    expect(extractValue({ value: 'x' })).toBe('x');
+    expect(extractValue({ value: 'x', unit: 'mg' })).toBe('x');
+    expect(extractValue({ value: 0 })).toBe(0);
+    expect(extractValue('x')).toBe('x');
+    expect(extractValue(0)).toBe(0);
+    expect(extractValue({ unit: 'mg' })).toEqual({ unit: 'mg' });
+  });
+
+  it('coerces null / undefined to null', () => {
+    expect(extractValue(null)).toBeNull();
+    expect(extractValue(undefined)).toBeNull();
+  });
+});
+
+describe('extractUnit', () => {
+  it('reads the unit sibling, else null', () => {
+    expect(extractUnit({ value: 'x', unit: 'mg' })).toBe('mg');
+    expect(extractUnit({ value: 'x' })).toBeNull();
+    expect(extractUnit('x')).toBeNull();
+    expect(extractUnit(null)).toBeNull();
+    expect(extractUnit({ unit: '' })).toBeNull();
+  });
+});
+
+describe('isEmptyValue', () => {
+  const empty = [null, undefined, '', { value: null }, { value: '' }];
+  const filled = ['x', 0, { value: 'x' }, { value: 0 }, '  ', { unit: 'mg' }];
+
+  for (const v of empty) {
+    it(`empty: ${JSON.stringify(v)}`, () => expect(isEmptyValue(v)).toBe(true));
+  }
+  for (const v of filled) {
+    it(`filled: ${JSON.stringify(v)}`, () => expect(isEmptyValue(v)).toBe(false));
+  }
+});
+
+describe('isValidNumber', () => {
+  it('validates numbers through the envelope', () => {
+    expect(isValidNumber('5')).toBe(true);
+    expect(isValidNumber(5)).toBe(true);
+    expect(isValidNumber({ value: '5' })).toBe(true);
+    expect(isValidNumber(0)).toBe(true);
+    expect(isValidNumber('abc')).toBe(false);
+    expect(isValidNumber('')).toBe(false);
+    expect(isValidNumber(null)).toBe(false);
+  });
+});
+
+describe('normalizeValue / toNumber / toString (unchanged helpers)', () => {
+  it('normalizeValue collapses empty to null, else the extracted value', () => {
+    expect(normalizeValue({ value: '' })).toBeNull();
+    expect(normalizeValue({ value: 'x' })).toBe('x');
+  });
+  it('toNumber returns the number or null', () => {
+    expect(toNumber({ value: '7' })).toBe(7);
+    expect(toNumber('nope')).toBeNull();
+  });
+  it('toString returns the placeholder for empty', () => {
+    expect(toString({ value: '' }, '—')).toBe('—');
+    expect(toString({ value: 'x' })).toBe('x');
+  });
+});

--- a/frontend/lib/ai-extraction/valueParser.ts
+++ b/frontend/lib/ai-extraction/valueParser.ts
@@ -5,6 +5,8 @@
  * (object {value, unit}, raw value, etc.)
  */
 
+import { isValueEmpty, unwrapValueEnvelope } from '@/lib/extraction/valueSemantics';
+
 /**
  * Extracts the value from a {value, unit} object or returns the raw value
  *
@@ -15,14 +17,9 @@ export function extractValue(value: any): any {
   if (value === null || value === undefined) {
     return null;
   }
-
-    // If object with 'value' property, extract it
-  if (typeof value === 'object' && 'value' in value) {
-    return value.value;
-  }
-
-    // Otherwise return raw value
-  return value;
+  // Peel one {value} envelope via the shared oracle; a bare scalar / non-envelope
+  // dict is returned untouched.
+  return unwrapValueEnvelope(value);
 }
 
 /**
@@ -44,14 +41,15 @@ export function extractUnit(value: any): string | null {
 }
 
 /**
- * Checks if a value is empty (null, undefined or empty string)
+ * Checks if a value is empty (null, undefined or empty string) — delegates to
+ * the shared emptiness oracle so a resolved `absent_reason` marker counts as
+ * filled and the FE/BE rule can no longer drift.
  *
  * @param value - Value to check
  * @returns true if value is empty
  */
 export function isEmptyValue(value: any): boolean {
-  const extracted = extractValue(value);
-  return extracted === null || extracted === undefined || extracted === '';
+  return isValueEmpty(value);
 }
 
 /**

--- a/frontend/lib/extraction/progress.test.ts
+++ b/frontend/lib/extraction/progress.test.ts
@@ -56,6 +56,25 @@ describe('computeRequiredFieldProgress', () => {
     expect(r.completedFields).toBe(0);
   });
 
+  it('a unit-bearing but empty required number field is EMPTY on the header (realigned with the finalize gate)', () => {
+    // {value:'', unit} / {value:null, unit} used to slip through the header's
+    // inline object check as "filled" while the backend gate treated it as empty
+    // — the form could read complete yet fail to finalize. The shared oracle peels
+    // the envelope, so header and gate now agree. A real unit value still counts.
+    const entityTypes = [et('e1', [field('n', true)])];
+    expect(
+      computeRequiredFieldProgress({ i1_n: { value: '', unit: 'mg' } }, entityTypes).completedFields,
+    ).toBe(0);
+    expect(
+      computeRequiredFieldProgress({ i1_n: { value: null, unit: 'mg' } }, entityTypes)
+        .completedFields,
+    ).toBe(0);
+    expect(
+      computeRequiredFieldProgress({ i1_n: { value: '5', unit: 'mg' } }, entityTypes)
+        .completedFields,
+    ).toBe(1);
+  });
+
   it('optional fields are ignored in numerator and denominator', () => {
     const entityTypes = [et('e1', [field('req', true), field('opt', false)])];
     const r = computeRequiredFieldProgress({ i1_req: 'x', i1_opt: 'y' }, entityTypes);
@@ -194,6 +213,30 @@ describe('computeRowProgress (article/row level — shared by both list tables)'
     expect(
       computeRowProgress([inst('i1', 'e1')], [val('i1', 'f1', { value: '' })], entityTypes),
     ).toBe(0);
+  });
+
+  it('double-wrapped unit envelope {value:{value,unit}} counts as filled (peel-in-predicate)', () => {
+    // The row path no longer pre-unwraps; the shared oracle peels one level, so a
+    // unit value stays filled — mirrors the backend `double-wrapped-unit` vector.
+    expect(
+      computeRowProgress(
+        [inst('i1', 'e1')],
+        [val('i1', 'f1', { value: { value: 'x', unit: 'mg' } })],
+        entityTypes,
+      ),
+    ).toBe(50);
+  });
+
+  it('a resolved absent_reason marker counts a required field as filled', () => {
+    // A silent numeric resolved to "no information" — value stays null, but the
+    // marker resolves the coordinate, so the row progresses (the numeric/date gap).
+    expect(
+      computeRowProgress(
+        [inst('i1', 'e1')],
+        [val('i1', 'f1', { value: null, absent_reason: 'no_information' })],
+        entityTypes,
+      ),
+    ).toBe(50);
   });
 
   it('no instances => 0%', () => {

--- a/frontend/lib/extraction/progress.ts
+++ b/frontend/lib/extraction/progress.ts
@@ -1,4 +1,5 @@
 import type { ExtractionField } from '@/types/extraction';
+import { isValueEmpty } from '@/lib/extraction/valueSemantics';
 
 /**
  * Minimal projection of an entity type needed for progress computation.
@@ -124,7 +125,10 @@ export function computeRequiredFieldProgress(
 
   let completedRequired = 0;
   for (const [key, value] of Object.entries(values)) {
-    if (value === null || value === undefined || value === '') continue;
+    // Emptiness via the shared oracle (peels the {value} envelope and honours a
+    // resolved absent_reason marker) — so a marker coordinate counts as filled
+    // and the metric can no longer drift from the finalize gate.
+    if (isValueEmpty(value)) continue;
     const sep = key.indexOf('_');
     if (sep < 0) continue;
     const fieldId = key.slice(sep + 1);
@@ -191,12 +195,10 @@ export function computeRowProgress(
 
   const valueMap: Record<string, unknown> = {};
   for (const v of values) {
-    const raw = v.value;
-    const unwrapped =
-      raw && typeof raw === 'object' && 'value' in (raw as Record<string, unknown>)
-        ? (raw as { value: unknown }).value
-        : raw;
-    valueMap[`${v.instance_id}_${v.field_id}`] = unwrapped;
+    // Store the RAW envelope; computeRequiredFieldProgress peels + tests emptiness
+    // in one place (the shared oracle), so an absent_reason marker is not stripped
+    // before the predicate sees it.
+    valueMap[`${v.instance_id}_${v.field_id}`] = v.value;
   }
   const instanceIdsByEntityType = new Map<string, Set<string>>();
   for (const inst of instances) {

--- a/frontend/lib/extraction/valueSemantics.test.ts
+++ b/frontend/lib/extraction/valueSemantics.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared FE/BE emptiness + absent_reason vector.
+ *
+ * This file asserts the SAME truth table as the backend
+ * `backend/tests/unit/test_value_semantics.py`, so the two implementations of
+ * the "is this coordinate filled?" rule are kept mechanically in lock-step
+ * (replacing the old "the docstring says they mirror"). Any drift here or there
+ * flips a row and one suite goes red.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  isValueEmpty,
+  isValueFilled,
+  unwrapValueEnvelope,
+  valueAbsentReason,
+} from './valueSemantics';
+
+describe('isValueEmpty / isValueFilled — the shared cross-checked vector', () => {
+  const cases: Array<[string, unknown, boolean]> = [
+    // legacy emptiness (mirrors the backend base table; FE also has `undefined`)
+    ['null', null, true],
+    ['undefined', undefined, true],
+    ['empty-string', '', true],
+    ['envelope-none', { value: null }, true],
+    ['envelope-empty-string', { value: '' }, true],
+    ['envelope-undefined', { value: undefined }, true],
+    ['scalar-string', 'x', false],
+    ['zero', 0, false],
+    ['false', false, false],
+    ['empty-list', [], false],
+    ['whitespace', '  ', false],
+    ['envelope-value', { value: 'x' }, false],
+    ['envelope-zero', { value: 0 }, false],
+    ['double-wrapped-unit', { value: { value: 'x', unit: 'mg' } }, false],
+    ['dict-without-value-key', { unit: 'mg' }, false],
+    // absent_reason marker (ADR-0016) — a resolved disposition counts as filled
+    ['marker-no-information', { value: null, absent_reason: 'no_information' }, false],
+    ['marker-not-applicable', { value: null, absent_reason: 'not_applicable' }, false],
+    ['marker-not-evaluated', { value: null, absent_reason: 'not_evaluated' }, false],
+    ['marker-with-real-value', { value: 'x', absent_reason: 'no_information' }, false],
+    ['marker-empty-reason', { value: null, absent_reason: '' }, true],
+    ['marker-unknown-code', { value: null, absent_reason: 'garbage' }, true],
+    // legacy in-band disposition string (untouched until Phase 3) → filled
+    ['legacy-string-envelope', { value: 'No information' }, false],
+    ['legacy-string-scalar', 'No information', false],
+  ];
+
+  for (const [id, raw, empty] of cases) {
+    it(`${id} → ${empty ? 'empty' : 'filled'}`, () => {
+      expect(isValueEmpty(raw)).toBe(empty);
+      expect(isValueFilled(raw)).toBe(!empty);
+    });
+  }
+});
+
+describe('valueAbsentReason — only valid closed-vocabulary codes', () => {
+  const cases: Array<[string, unknown, string | null]> = [
+    ['no_information', { value: null, absent_reason: 'no_information' }, 'no_information'],
+    ['not_applicable', { value: null, absent_reason: 'not_applicable' }, 'not_applicable'],
+    ['not_evaluated', { value: null, absent_reason: 'not_evaluated' }, 'not_evaluated'],
+    ['empty-reason', { value: null, absent_reason: '' }, null],
+    ['unknown-code', { value: null, absent_reason: 'garbage' }, null],
+    ['no-marker', { value: null }, null],
+    ['real-value', { value: 'x' }, null],
+    ['bare-null', null, null],
+    ['bare-scalar', 'x', null],
+  ];
+
+  for (const [id, raw, code] of cases) {
+    it(`${id} → ${code ?? 'null'}`, () => {
+      expect(valueAbsentReason(raw)).toBe(code);
+    });
+  }
+});
+
+describe('unwrapValueEnvelope — peels exactly one {value} level', () => {
+  it('peels one level and leaves a bare scalar / non-envelope dict untouched', () => {
+    expect(unwrapValueEnvelope({ value: 'x' })).toBe('x');
+    expect(unwrapValueEnvelope('x')).toBe('x');
+    expect(unwrapValueEnvelope({ unit: 'mg' })).toEqual({ unit: 'mg' });
+    // only one level (a double-wrapped unit envelope keeps its inner unit)
+    expect(unwrapValueEnvelope({ value: { value: 'x', unit: 'mg' } })).toEqual({
+      value: 'x',
+      unit: 'mg',
+    });
+    // an array is not an envelope even though `'value' in []` is false
+    expect(unwrapValueEnvelope(['a'])).toEqual(['a']);
+  });
+});

--- a/frontend/lib/extraction/valueSemantics.ts
+++ b/frontend/lib/extraction/valueSemantics.ts
@@ -1,0 +1,62 @@
+/**
+ * THE frontend emptiness + absent_reason predicate — the single source of truth
+ * for "does this coordinate hold a value?", mirroring the backend oracle
+ * `backend/app/services/value_semantics.py` 1:1. A shared cross-checked test
+ * vector (`valueSemantics.test.ts` ⇔ `test_value_semantics.py`) keeps the two
+ * implementations mechanically in lock-step, replacing the three open-coded
+ * copies that used to drift.
+ *
+ * Empty ⇔ no resolved `absent_reason` marker AND, after peeling one `{value}`
+ * envelope, the value is `null` / `undefined` / `''`. Whitespace, `0`, `false`,
+ * `[]` and non-envelope dicts are all filled.
+ *
+ * A coordinate may carry a coded disposition sibling
+ * `{ value: null, absent_reason: <code> }` (ADR-0016) — the source is silent, or
+ * the item is not applicable / not evaluated. A resolved marker counts as
+ * **filled** even though the typed value stays `null`. The reason is validated
+ * against the closed vocabulary, so a garbage code never counts.
+ */
+
+/**
+ * The closed `absent_reason` vocabulary. Phase 1 will replace this local list
+ * with the generated `AbsentReason` type once the marker rides a typed API
+ * response field (`frontend/types/api/schema.d.ts`); until then it is defined
+ * once here, matching the backend `AbsentReason` StrEnum.
+ */
+const ABSENT_REASON_CODES = ['no_information', 'not_applicable', 'not_evaluated'] as const;
+const ABSENT_REASON_SET = new Set<string>(ABSENT_REASON_CODES);
+
+/** Peel a single `{value: X}` envelope; a bare scalar / non-envelope dict / array is returned untouched. */
+export function unwrapValueEnvelope(raw: unknown): unknown {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw) && 'value' in raw) {
+    return (raw as { value: unknown }).value;
+  }
+  return raw;
+}
+
+/**
+ * The coded disposition carried by `raw`, or `null`. Only a member of the closed
+ * vocabulary counts — an absent, empty, or out-of-vocabulary reason yields `null`
+ * (so a garbage code is never treated as a resolution).
+ */
+export function valueAbsentReason(raw: unknown): string | null {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw) && 'absent_reason' in raw) {
+    const reason = (raw as { absent_reason: unknown }).absent_reason;
+    if (typeof reason === 'string' && ABSENT_REASON_SET.has(reason)) {
+      return reason;
+    }
+  }
+  return null;
+}
+
+/** True when `raw` carries no information — no resolved marker, and null/undefined/'' after one peel. */
+export function isValueEmpty(raw: unknown): boolean {
+  if (valueAbsentReason(raw) !== null) return false;
+  const value = unwrapValueEnvelope(raw);
+  return value === null || value === undefined || value === '';
+}
+
+/** True when a stored value counts as "filled" — a real value or a resolved marker. The inverse of `isValueEmpty`. */
+export function isValueFilled(raw: unknown): boolean {
+  return !isValueEmpty(raw);
+}

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -46,7 +46,7 @@ import {useExtractionProgress} from '@/hooks/extraction/useExtractionProgress';
 import {useAutoSaveProposals} from '@/hooks/runs';
 import {useAISuggestions} from '@/hooks/extraction/ai/useAISuggestions';
 import {useRunAIExtraction} from '@/hooks/extraction/ai/useRunAIExtraction';
-import {isNoInfoValue} from '@/lib/ai-extraction/suggestionUtils';
+import {countNonAbstentionSuggestions} from '@/lib/ai-extraction/suggestionUtils';
 import {useFullAIExtraction} from '@/hooks/extraction/useFullAIExtraction';
 import {useComparisonPermissions} from '@/hooks/shared/useComparisonPermissions';
 import {
@@ -503,7 +503,7 @@ export default function ExtractionFullScreen() {
   // recorded provenance, not something to act on, so it must not inflate the
   // header count. Memoized: this screen re-renders on every field keystroke.
   const aiPendingCount = useMemo(
-    () => Object.values(aiSuggestions).filter((s) => !isNoInfoValue(s.value)).length,
+    () => countNonAbstentionSuggestions(aiSuggestions),
     [aiSuggestions],
   );
 

--- a/frontend/services/aiSuggestionService.ts
+++ b/frontend/services/aiSuggestionService.ts
@@ -20,6 +20,7 @@ import type {
 } from '@/types/ai-extraction';
 import { getSuggestionKey } from '@/types/ai-extraction';
 import { APIError } from '@/lib/ai-extraction/errors';
+import { unwrapValueEnvelope } from '@/lib/extraction/valueSemantics';
 import type { components } from '@/types/api/schema';
 
 type AISuggestionItem = components['schemas']['AISuggestionItem'];
@@ -43,9 +44,10 @@ function mapEvidenceList(
 }
 
 function unwrapValue(raw: { [key: string]: unknown } | null | undefined): unknown {
+  // One shared peel; the null/absent envelope collapses to '' as before.
+  // (Phase 1 will carry the absent_reason sibling instead of discarding it here.)
   if (raw === null || raw === undefined) return '';
-  if ('value' in raw) return raw['value'] ?? '';
-  return raw;
+  return unwrapValueEnvelope(raw) ?? '';
 }
 
 /**

--- a/frontend/services/extractionValueService.ts
+++ b/frontend/services/extractionValueService.ts
@@ -15,6 +15,7 @@
  * so by the time the form opens, decisions can be written immediately.
  */
 import { apiClient } from '@/integrations/api';
+import { unwrapValueEnvelope } from '@/lib/extraction/valueSemantics';
 import type { RunSummaryResponse, ArticleRunRef } from '@/hooks/runs/types';
 
 export interface RunRef {
@@ -25,11 +26,9 @@ export interface RunRef {
 }
 
 export function unwrapValue(raw: unknown): unknown {
+  // One shared peel; a null/absent envelope collapses to null as before.
   if (raw === null || raw === undefined) return null;
-  if (typeof raw === 'object' && raw !== null && 'value' in raw) {
-    return (raw as { value: unknown }).value ?? null;
-  }
-  return raw;
+  return unwrapValueEnvelope(raw) ?? null;
 }
 
 export const ExtractionValueService = {

--- a/frontend/test/services/aiSuggestionService.test.ts
+++ b/frontend/test/services/aiSuggestionService.test.ts
@@ -200,6 +200,17 @@ describe('AISuggestionService.loadSuggestions', () => {
     expect(sug.evidence).toBeUndefined(); // evidence=null → undefined
   });
 
+  it('unwraps a no-information proposal {value:null} to the empty abstention shape', async () => {
+    // Routing unwrapValue through the shared envelope oracle must keep the
+    // null→'' collapse the abstention rendering relies on (isAbstention('') → true).
+    (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      suggestions: [makeItem({ proposed_value: { value: null } })],
+      count: 1,
+    });
+    const result = await AISuggestionService.loadSuggestions('art-1', ['inst-1']);
+    expect(result.suggestions['inst-1_f-1'].value).toBe('');
+  });
+
   it('maps evidence list when present (single item)', async () => {
     (apiClient as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       suggestions: [

--- a/frontend/test/services/extractionValueService.test.ts
+++ b/frontend/test/services/extractionValueService.test.ts
@@ -4,9 +4,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@/integrations/api', () => ({ apiClient: vi.fn() }));
 
 import { apiClient } from '@/integrations/api';
-import { ExtractionValueService } from '@/services/extractionValueService';
+import { ExtractionValueService, unwrapValue } from '@/services/extractionValueService';
 
 const apiClientMock = apiClient as unknown as ReturnType<typeof vi.fn>;
+
+// ---------------------------------------------------------------------------
+// unwrapValue — routed through the shared envelope oracle; null-collapse kept
+// ---------------------------------------------------------------------------
+
+describe('unwrapValue', () => {
+  it('peels one {value} envelope and collapses a null/absent inner to null', () => {
+    expect(unwrapValue({ value: 'x' })).toBe('x');
+    expect(unwrapValue({ value: 0 })).toBe(0);
+    expect(unwrapValue({ value: null })).toBeNull();
+    expect(unwrapValue(null)).toBeNull();
+    expect(unwrapValue(undefined)).toBeNull();
+    expect(unwrapValue('x')).toBe('x');
+    expect(unwrapValue({ unit: 'mg' })).toEqual({ unit: 'mg' }); // non-envelope dict untouched
+  });
+});
 
 beforeEach(() => {
   apiClientMock.mockReset();

--- a/frontend/test/suggestionUtils.test.ts
+++ b/frontend/test/suggestionUtils.test.ts
@@ -9,9 +9,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import type { AISuggestion } from '@/types/ai-extraction';
 import {
+  countNonAbstentionSuggestions,
   formatFullSuggestionValue,
   formatSuggestionValue,
+  isAbstention,
 } from '@/lib/ai-extraction/suggestionUtils';
 
 const YES_NO = [
@@ -88,6 +91,49 @@ describe('formatSuggestionValue — select/multiselect label resolution', () => 
     expect(
       formatSuggestionValue(['Y', 'N'], 40, { fieldType: 'multiselect', allowedValues: null }),
     ).toBe('Y, N');
+  });
+});
+
+describe('isAbstention — transitional union predicate (Phase 0 behaviour-neutral)', () => {
+  // The call sites pass the already-unwrapped scalar suggestion.value, so this
+  // must collapse to the old isNoInfoValue truth table (no markers exist yet).
+  it('legacy-empty scalars are abstentions', () => {
+    expect(isAbstention(null)).toBe(true);
+    expect(isAbstention(undefined)).toBe(true);
+    expect(isAbstention('')).toBe(true);
+  });
+
+  it('substantive scalars are NOT abstentions (incl. 0 and false)', () => {
+    expect(isAbstention('x')).toBe(false);
+    expect(isAbstention(0)).toBe(false);
+    expect(isAbstention(false)).toBe(false);
+    expect(isAbstention('No information')).toBe(false); // legacy in-band select value
+  });
+
+  it('forward-looking: a resolved marker envelope is an abstention; a garbage code is not', () => {
+    expect(isAbstention({ value: null, absent_reason: 'no_information' })).toBe(true);
+    expect(isAbstention({ value: null, absent_reason: 'garbage' })).toBe(false);
+  });
+});
+
+describe('countNonAbstentionSuggestions — the actionable-pending header metric', () => {
+  const sug = (value: unknown) => ({ value }) as AISuggestion;
+
+  it('excludes abstentions, counts substantive values (array form)', () => {
+    expect(
+      countNonAbstentionSuggestions([sug('x'), sug(null), sug(''), sug('y'), sug(0)]),
+    ).toBe(3);
+  });
+
+  it('accepts the keyed record the screen holds', () => {
+    expect(
+      countNonAbstentionSuggestions({ a: sug('x'), b: sug(null), c: sug('') }),
+    ).toBe(1);
+  });
+
+  it('empty input is zero', () => {
+    expect(countNonAbstentionSuggestions([])).toBe(0);
+    expect(countNonAbstentionSuggestions({})).toBe(0);
   });
 });
 


### PR DESCRIPTION
Promotes the marker-aware value-emptiness plumbing (absent_reason Phase 0, #458) to production.

**Contents** (dev is exactly one commit ahead of main):
- `200e5969` feat(extraction): marker-aware value-emptiness plumbing (absent_reason Phase 0)

**Readiness:**
- dev CI fully green (13 checks: lints, backend/frontend tests, backend+frontend E2E, api-contract, docs-ci, Docker build)
- Behaviour-neutral read plumbing (no markers written until Phase 1) + one corrective form-header↔finalize-gate realignment (tested)
- No schema/RLS/migration change — code + docs only
- Preflight: prod infra healthy (Railway /health 200, worker+Redis ready, Vercel Ready); migration drift clean; the standing Supabase advisor backlog is pre-existing and unrelated to this change

Merge-commit promotion (dev→main cannot fast-forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)