### PR TITLE
feat(extraction): absent_reason write-path contract + AI no_information marker (ADR-0016 Phase 1)

### DIFF
--- a/backend/app/services/exports/value_envelope.py
+++ b/backend/app/services/exports/value_envelope.py
@@ -18,9 +18,21 @@ from __future__ import annotations
 from typing import Any, Protocol, runtime_checkable
 
 from app.models.extraction import ExtractionFieldType
+from app.services.value_semantics import AbsentReason, value_absent_reason
 
 # An openpyxl-writable scalar. NEVER a dict, NEVER a list.
 ResolvedScalar = str | int | float | bool | None
+
+
+# Stable per-code labels for a coded absent_reason disposition (ADR-0016). A
+# marker resolves to one of these instead of leaking a dict-stringify into a
+# cell. Sourced from the AbsentReason enum so the codes can't drift; the Phase-4
+# export legend reuses these exact strings so cell and legend can't diverge.
+_ABSENT_REASON_LABELS: dict[str, str] = {
+    AbsentReason.NO_INFORMATION.value: "No information",
+    AbsentReason.NOT_APPLICABLE.value: "Not applicable",
+    AbsentReason.NOT_EVALUATED.value: "Not evaluated",
+}
 
 
 @runtime_checkable
@@ -44,6 +56,18 @@ def resolve_value(raw: Any, *, field: _FieldLike | None = None) -> ResolvedScala
     """
     if raw is None:
         return None
+
+    # --- coded absent_reason marker (ADR-0016) ---------------------------
+    # A resolved disposition ({"value": null, "absent_reason": <code>}) is a
+    # first-class answer, not a value. Emit its stable label BEFORE the
+    # {"value"} / {"value", "unit"} key-set branches below, so a marker never
+    # reaches the catch-all dict-stringify (which would leak
+    # "value: None; absent_reason: no_information" into a cell). Only a
+    # closed-vocabulary code counts — value_absent_reason validates it, so a
+    # garbage reason falls through and never fabricates a disposition label.
+    reason = value_absent_reason(raw)
+    if reason is not None:
+        return _ABSENT_REASON_LABELS[reason]
 
     # --- Recursive single-wrap {"value": inner} ---------------------------
     # Handles {"value": x}, double-wrapped {"value": {"value": x}}, and

--- a/backend/app/services/extraction_suggestion_read_service.py
+++ b/backend/app/services/extraction_suggestion_read_service.py
@@ -197,13 +197,16 @@ async def load_suggestions(
     proposals = (await db.execute(proposal_stmt)).scalars().all()
 
     # --- Step 2: dedup to latest-per-(instance_id, field_id) ---
-    # A later run that abstained ("no information" → proposed_value
-    # {"value": null}, recorded as a first-class proposal since #443) must NOT
-    # bury an earlier run's real value in the inline strip. Prefer the most
-    # recent proposal that carries a value; fall back to the most recent no-info
-    # proposal only when no run ever found one. The full trail (including the
-    # abstention) stays available via get_suggestion_history. ``proposals`` is
-    # ordered newest-first, so dict insertion order keeps the latest per coord.
+    # Value-vs-value recency: the newest proposal that CARRIES A VALUE wins.
+    # "Carries a value" is the shared emptiness oracle (``is_value_empty``), so a
+    # coded ``no_information`` marker (ADR-0016) counts as a genuine answer and
+    # may win by recency like any real value — only a *bare* ``{"value": null}``
+    # abstention (no marker) is buryable and must NOT overwrite an earlier
+    # resolved value. So: prefer the newest non-empty proposal (real value OR
+    # marker); fall back to the newest bare-null only when no run ever resolved
+    # the coord. The full trail stays available via get_suggestion_history.
+    # ``proposals`` is ordered newest-first, so dict insertion order keeps the
+    # latest per coord.
     chosen: dict[tuple[UUID, UUID], ExtractionProposalRecord] = {}
     for p in proposals:
         key = (p.instance_id, p.field_id)
@@ -211,7 +214,8 @@ async def load_suggestions(
         if existing is None:
             chosen[key] = p
         elif is_value_empty(existing.proposed_value) and not is_value_empty(p.proposed_value):
-            # The more recent pick abstained; this older one found a value → use it.
+            # The newer pick is a bare-null abstention; this older one resolved
+            # the coord (a real value OR a coded marker) → keep the resolved one.
             chosen[key] = p
     deduped = list(chosen.values())
 

--- a/backend/app/services/section_extraction_service.py
+++ b/backend/app/services/section_extraction_service.py
@@ -59,6 +59,7 @@ from app.services.evidence_anchor_service import build_anchor
 from app.services.extraction_prompt_input import build_prompt_input
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.run_lifecycle_service import RunLifecycleService
+from app.services.value_semantics import AbsentReason
 
 # Maximum number of evidence rows written per extracted field.
 EVIDENCE_CAP = 3
@@ -1424,12 +1425,16 @@ class SectionExtractionService(LoggerMixin):
                 )
                 continue
 
-            # "No information found": a bare None or a structured abstention
-            # (status not_found / ambiguous). Record it as a first-class proposal
-            # (value=None) so the run's outcome is traceable to the reviewer,
-            # instead of silently dropping the field.
+            # "No information found": a bare None or a structured not_found
+            # abstention. Record it as a first-class proposal carrying the coded
+            # no-information marker (built below) so the run's outcome is
+            # traceable to the reviewer, instead of silently dropping the field.
+            # ``ambiguous`` ("present but conflicting") is deliberately excluded
+            # (ADR-0016 Phase 1): it is not "absent", so it stays a
+            # needs-attention proposal with a value and no marker — still
+            # blocking the finalize gate.
             is_no_info = value is None or (
-                isinstance(value, dict) and value.get("status") in ("not_found", "ambiguous")
+                isinstance(value, dict) and value.get("status") == "not_found"
             )
 
             confidence_score: float | None = None
@@ -1479,7 +1484,13 @@ class SectionExtractionService(LoggerMixin):
             # JSONB column on proposed_value is dict-typed; always wrap so
             # scalars/lists round-trip predictably and the frontend can read
             # `proposed_value.value` uniformly.
-            proposed_value = {"value": inner_value}
+            proposed_value: dict[str, Any] = {"value": inner_value}
+            if is_no_info:
+                # A resolved "no information" disposition: the typed value stays
+                # null and the coded ``absent_reason`` sibling marks it as an
+                # affirmative "the source is silent" answer (ADR-0016), so the
+                # coordinate counts as filled once a reviewer accepts it.
+                proposed_value["absent_reason"] = AbsentReason.NO_INFORMATION.value
 
             proposal = await self._proposals.record_proposal(
                 run_id=run.id,

--- a/backend/tests/integration/test_absent_reason_gate.py
+++ b/backend/tests/integration/test_absent_reason_gate.py
@@ -1,0 +1,260 @@
+"""Integration tests for the ADR-0016 ``absent_reason`` marker on the
+finalize-gate / publish round-trip (Phase 1).
+
+These pin the load-bearing Phase-1 invariants against the REAL schema (JSONB
+verbatim persistence, the gate's ``is_value_filled`` delegation):
+
+A. **Round-trip + gate satisfaction.** An AI ``no_information`` marker proposal,
+   once a reviewer accepts it and consensus publishes it, persists *verbatim*
+   into ``ExtractionPublishedState.value`` and counts as a *filled* coord — so a
+   required field the source is silent on can finalize (closing the
+   numeric/date "not reported" gap). The marker must NOT collapse to ``null`` in
+   the published column (or two different disposition codes would hash equal in
+   the consensus key).
+B. **Bare-null still blocks.** A bare ``{"value": null}`` decision (no marker)
+   stays unresolved — the gate must distinguish it from a resolved marker.
+C. **An unaccepted marker proposal does not self-satisfy the gate.** A raw AI /
+   system marker proposal with no reviewer decision is an orphan the gate never
+   counts (the fabrication-safety property; also the reopen-carried-marker case,
+   where a published marker re-seeds as a ``source='system'`` proposal that must
+   be re-accepted before it re-finalizes).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.extraction import ExtractionRun, ExtractionRunStage, TemplateKind
+from app.models.extraction_workflow import (
+    ExtractionConsensusMode,
+    ExtractionProposalSource,
+    ExtractionReviewerDecisionType,
+)
+from app.services.extraction_consensus_service import ExtractionConsensusService
+from app.services.extraction_proposal_service import ExtractionProposalService
+from app.services.extraction_review_service import ExtractionReviewService
+from app.services.hitl_session_service import HITLSessionService
+from app.services.run_lifecycle_service import RunLifecycleService
+
+_MARKER = {"value": None, "absent_reason": "no_information"}
+
+
+async def _coords(
+    db: AsyncSession,
+) -> tuple[UUID, UUID, UUID, UUID, UUID, UUID] | None:
+    """Resolve (project, article, extraction-template, manager, instance, field)
+    for a seeded extraction template that has at least one instance + field.
+    Mirrors ``test_extraction_manual_only_flow._coords``; tests skip when the
+    dev DB is not seeded."""
+    project_id = (
+        await db.execute(
+            text(
+                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM "
+                "public.project_extraction_templates t JOIN public.extraction_entity_types et "
+                "ON et.project_template_id = t.id JOIN public.extraction_fields f "
+                "ON f.entity_type_id = et.id JOIN public.extraction_instances i "
+                "ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
+            )
+        )
+    ).scalar()
+    article_id = (
+        await db.execute(
+            text("SELECT id FROM public.articles WHERE project_id = :pid LIMIT 1"),
+            {"pid": project_id},
+        )
+    ).scalar()
+    template_id = (
+        await db.execute(
+            text(
+                "SELECT id FROM public.project_extraction_templates "
+                "WHERE kind = 'extraction' AND project_id = :pid LIMIT 1"
+            ),
+            {"pid": project_id},
+        )
+    ).scalar()
+    profile_id = (
+        await db.execute(
+            text(
+                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' "
+                "AND pm.project_id = :pid LIMIT 1"
+            ),
+            {"pid": project_id},
+        )
+    ).scalar()
+    if not all((project_id, article_id, template_id, profile_id)):
+        return None
+    pair = (
+        await db.execute(
+            text(
+                """
+                SELECT i.id, f.id
+                FROM public.extraction_instances i
+                JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
+                JOIN public.extraction_fields f ON f.entity_type_id = et.id
+                WHERE i.template_id = :tid
+                LIMIT 1
+                """
+            ),
+            {"tid": template_id},
+        )
+    ).first()
+    if pair is None:
+        return None
+    return (
+        UUID(str(project_id)),
+        UUID(str(article_id)),
+        UUID(str(template_id)),
+        UUID(str(profile_id)),
+        UUID(str(pair[0])),
+        UUID(str(pair[1])),
+    )
+
+
+async def _fresh_extract_run(db: AsyncSession, fx: tuple[UUID, ...]) -> ExtractionRun:
+    """Clear leaked runs for the coord and open a fresh EXTRACT-stage run."""
+    project_id, article_id, template_id, profile_id = fx[0], fx[1], fx[2], fx[3]
+    await db.execute(
+        text(
+            "DELETE FROM public.extraction_runs WHERE project_id = :pid "
+            "AND article_id = :aid AND template_id = :tid"
+        ),
+        {"pid": str(project_id), "aid": str(article_id), "tid": str(template_id)},
+    )
+    session = await HITLSessionService(db).open_or_resume(
+        kind=TemplateKind.EXTRACTION,
+        project_id=project_id,
+        article_id=article_id,
+        user_id=profile_id,
+        project_template_id=template_id,
+    )
+    run = await db.get(ExtractionRun, session.run_id)
+    assert run is not None
+    assert run.stage == ExtractionRunStage.EXTRACT.value
+    return run
+
+
+@pytest.mark.asyncio
+async def test_accepted_marker_round_trips_to_published_and_fills_gate(
+    db_session: AsyncSession,
+) -> None:
+    fx = await _coords(db_session)
+    if fx is None:
+        pytest.skip("Missing fixtures.")
+    _project, _article, _template, profile_id, instance_id, field_id = fx
+
+    run = await _fresh_extract_run(db_session, fx)
+    lifecycle = RunLifecycleService(db_session)
+
+    # AI records a no_information marker proposal (the Phase-1 recording split).
+    proposal = await ExtractionProposalService(db_session).record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value=_MARKER,
+        rationale="not stated in the article",
+    )
+    assert proposal.proposed_value == _MARKER
+
+    # A reviewer accepts it in one click (the decision carries no value of its
+    # own — the meaning rides the proposal).
+    decision = await ExtractionReviewService(db_session).record_decision(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        reviewer_id=profile_id,
+        decision=ExtractionReviewerDecisionType.ACCEPT_PROPOSAL,
+        proposal_record_id=proposal.id,
+    )
+
+    # Gate resolver sees the accepted marker as a resolved (filled) value,
+    # inherited verbatim from the proposal — so the coord satisfies the gate.
+    resolved = await lifecycle._resolved_reviewer_values(run.id)
+    by_coord = {(i, f): v for i, f, v in resolved}
+    assert by_coord.get((instance_id, field_id)) == _MARKER
+    assert (instance_id, field_id) in await lifecycle._filled_coords(run.id)
+
+    # Publish via consensus (select the accepting decision) and assert the
+    # marker survives VERBATIM into ExtractionPublishedState.value.
+    await lifecycle.advance_stage(
+        run_id=run.id,
+        target_stage=ExtractionRunStage.CONSENSUS,
+        user_id=profile_id,
+    )
+    _consensus, published = await ExtractionConsensusService(db_session).record_consensus(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        consensus_user_id=profile_id,
+        mode=ExtractionConsensusMode.SELECT_EXISTING,
+        selected_decision_id=decision.id,
+    )
+    assert published.value == _MARKER
+    # The published marker keeps the coord filled for the finalize gate.
+    assert (instance_id, field_id) in await lifecycle._filled_coords(run.id)
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_bare_null_decision_stays_unfilled(db_session: AsyncSession) -> None:
+    fx = await _coords(db_session)
+    if fx is None:
+        pytest.skip("Missing fixtures.")
+    _project, _article, _template, profile_id, instance_id, field_id = fx
+
+    run = await _fresh_extract_run(db_session, fx)
+    lifecycle = RunLifecycleService(db_session)
+
+    # A bare-null edit (no marker) is unresolved — it must NOT count as filled,
+    # the exact contrast to the accepted marker above.
+    await ExtractionReviewService(db_session).record_decision(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        reviewer_id=profile_id,
+        decision=ExtractionReviewerDecisionType.EDIT,
+        value={"value": None},
+    )
+    resolved = {(i, f) for i, f, _ in await lifecycle._resolved_reviewer_values(run.id)}
+    assert (instance_id, field_id) not in resolved
+    assert (instance_id, field_id) not in await lifecycle._filled_coords(run.id)
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_unaccepted_marker_proposal_does_not_fill_gate(
+    db_session: AsyncSession,
+) -> None:
+    fx = await _coords(db_session)
+    if fx is None:
+        pytest.skip("Missing fixtures.")
+    _project, _article, _template, _profile, instance_id, field_id = fx
+
+    run = await _fresh_extract_run(db_session, fx)
+    lifecycle = RunLifecycleService(db_session)
+
+    # A raw AI marker proposal with NO reviewer decision is an orphan: the gate
+    # counts only published values and current reviewer decisions, never a bare
+    # proposal. This is the fabrication-safety property (a parser dropping a
+    # section → many "not reported" markers cannot self-finalize a run) and the
+    # reopen case (a carried marker re-seeds as a source='system' proposal that
+    # must be re-accepted before it re-finalizes).
+    await ExtractionProposalService(db_session).record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value=_MARKER,
+    )
+    assert (instance_id, field_id) not in await lifecycle._filled_coords(run.id)
+
+    # And a foreign coord never leaks in either.
+    assert (uuid4(), field_id) not in await lifecycle._filled_coords(run.id)
+
+    await db_session.rollback()

--- a/backend/tests/integration/test_section_extraction_evidence.py
+++ b/backend/tests/integration/test_section_extraction_evidence.py
@@ -245,9 +245,10 @@ async def test_abstention_records_no_info_proposal(
     db_session_real: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A not_found field records ONE no-info proposal (value=None, no
-    confidence) with 0 evidence rows — the abstention is now a first-class,
-    traceable outcome instead of a silent drop."""
+    """A not_found field records ONE no-info proposal carrying the coded
+    ``{value:null, absent_reason:"no_information"}`` marker (ADR-0016 Phase 1),
+    no confidence, 0 evidence rows — the abstention is a first-class, resolved,
+    traceable outcome instead of a silent drop or a bare null."""
 
     async def _stub_gate(**_kwargs: Any) -> str:
         return "entailed"
@@ -310,9 +311,10 @@ async def test_abstention_records_no_info_proposal(
         )
     ).first()
     assert proposed is not None
-    # The inner value is null (never the status dict); confidence dropped (a
-    # not_found 0.0 reads as a misleading 0%); the "why not found" reasoning kept.
-    assert proposed.proposed_value == {"value": None}
+    # The inner value is null with the coded no-information marker (never the
+    # status dict); confidence dropped (a not_found 0.0 reads as a misleading
+    # 0%); the "why not found" reasoning kept.
+    assert proposed.proposed_value == {"value": None, "absent_reason": "no_information"}
     assert proposed.confidence_score is None
     assert proposed.rationale == "Not mentioned."
 

--- a/backend/tests/integration/test_suggestion_read.py
+++ b/backend/tests/integration/test_suggestion_read.py
@@ -658,6 +658,132 @@ async def test_load_suggestions_latest_no_info_keeps_earlier_real_value(
 
 
 @pytest.mark.asyncio
+async def test_load_suggestions_newer_marker_wins_over_older_value(
+    db_session: AsyncSession,
+) -> None:
+    """ADR-0016: a coded ``no_information`` marker is a GENUINE answer, so unlike
+    a bare-null abstention it MAY win by recency over an older real value. The
+    dedup delegates emptiness to ``is_value_empty``, which treats a marker as
+    filled — so the newest non-empty proposal (here the marker) wins. Contrast
+    with the bare-null case above, where the older real value is preserved."""
+    marker = {"value": None, "absent_reason": "no_information"}
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+    manager_id = SEED.primary_profile
+
+    lifecycle = RunLifecycleService(db_session)
+    run = await lifecycle.create_run(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        project_template_id=SEED.primary_template,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.EXTRACT, user_id=manager_id
+    )
+
+    proposal_svc = ExtractionProposalService(db_session)
+    older = await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": "REAL-VALUE"},
+    )
+    await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value=marker,  # the AI re-ran and now says "no information"
+    )
+    await db_session.flush()
+    await db_session.execute(
+        text(
+            "UPDATE public.extraction_proposal_records "
+            "SET created_at = created_at - interval '1 second' WHERE id = :id"
+        ),
+        {"id": str(older.id)},
+    )
+    await db_session.flush()
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=manager_id,
+        run_id=run.id,
+    )
+    assert result.count == 1
+    assert result.suggestions[0].proposed_value == marker, (
+        "A newer coded marker is a genuine answer and should win by recency — "
+        "only a bare {'value': null} is buryable."
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_suggestions_newer_bare_null_does_not_bury_marker(
+    db_session: AsyncSession,
+) -> None:
+    """The mirror of the above: an earlier resolved ``no_information`` marker is
+    a genuine value, so a later *bare-null* abstention (no marker) must NOT bury
+    it — the marker is preferred exactly like a real value would be."""
+    marker = {"value": None, "absent_reason": "no_information"}
+    instance_id = SEED.primary_instance
+    field_id = SEED.primary_field
+    manager_id = SEED.primary_profile
+
+    lifecycle = RunLifecycleService(db_session)
+    run = await lifecycle.create_run(
+        project_id=SEED.primary_project,
+        article_id=SEED.primary_article,
+        project_template_id=SEED.primary_template,
+        user_id=manager_id,
+    )
+    await lifecycle.advance_stage(
+        run_id=run.id, target_stage=ExtractionRunStage.EXTRACT, user_id=manager_id
+    )
+
+    proposal_svc = ExtractionProposalService(db_session)
+    older = await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value=marker,
+    )
+    await proposal_svc.record_proposal(
+        run_id=run.id,
+        instance_id=instance_id,
+        field_id=field_id,
+        source=ExtractionProposalSource.AI,
+        proposed_value={"value": None},  # bare-null abstention, no marker
+    )
+    await db_session.flush()
+    await db_session.execute(
+        text(
+            "UPDATE public.extraction_proposal_records "
+            "SET created_at = created_at - interval '1 second' WHERE id = :id"
+        ),
+        {"id": str(older.id)},
+    )
+    await db_session.flush()
+
+    result = await load_suggestions(
+        db_session,
+        [instance_id],
+        article_id=SEED.primary_article,
+        caller_id=manager_id,
+        run_id=run.id,
+    )
+    assert result.count == 1
+    assert result.suggestions[0].proposed_value == marker, (
+        "A later bare-null abstention buried an earlier resolved marker — the "
+        "marker is a genuine value and must be preferred."
+    )
+
+
+@pytest.mark.asyncio
 async def test_load_suggestions_all_no_info_returns_no_info(
     db_session: AsyncSession,
 ) -> None:

--- a/backend/tests/unit/test_section_extraction_service.py
+++ b/backend/tests/unit/test_section_extraction_service.py
@@ -1163,10 +1163,13 @@ class TestCreateSuggestions:
 
     @pytest.mark.asyncio
     async def test_creates_no_info_proposal_for_none_and_abstention(self, service):
-        # "No information found" outcomes (bare None + structured abstention) must
-        # be recorded as first-class proposals (value=None) so the run is
-        # traceable — not silently dropped. Never wrap the status dict; drop the
-        # misleading not_found confidence; keep the "why not found" reasoning.
+        # "No information found" outcomes (bare None + status=not_found) are
+        # recorded as first-class proposals carrying the coded no-information
+        # marker ``{value:null, absent_reason:"no_information"}`` (ADR-0016
+        # Phase 1) so the run is traceable and the coordinate counts as a
+        # *resolved* abstention — not silently dropped and not a bare null.
+        # Never wrap the status dict; drop the misleading not_found confidence;
+        # keep the "why not found" reasoning.
         f1, f2 = uuid4(), uuid4()
         field1, field2 = MagicMock(), MagicMock()
         field1.id, field1.name = f1, "f1"
@@ -1207,11 +1210,69 @@ class TestCreateSuggestions:
         )
         assert result == 2
         by_field = {k["field_id"]: k for k in recorded}
-        assert by_field[f1]["proposed_value"] == {"value": None}
+        assert by_field[f1]["proposed_value"] == {
+            "value": None,
+            "absent_reason": "no_information",
+        }
         assert by_field[f1]["confidence_score"] is None
-        assert by_field[f2]["proposed_value"] == {"value": None}
+        assert by_field[f2]["proposed_value"] == {
+            "value": None,
+            "absent_reason": "no_information",
+        }
         assert by_field[f2]["confidence_score"] is None  # no misleading 0% on a no-info card
         assert by_field[f2]["rationale"] == "not stated in the article"
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_status_records_no_marker(self, service):
+        # ADR-0016 Phase 1 splits the recording branch: ``status='ambiguous'``
+        # ("present but conflicting") is NOT "absent". It must stay a
+        # needs-attention proposal — a found-style value with its confidence
+        # preserved and NO ``absent_reason`` marker — so it still blocks the
+        # finalize gate (never silently collapsed to no_information).
+        f1 = uuid4()
+        field1 = MagicMock()
+        field1.id, field1.name = f1, "f1"
+        et = MagicMock()
+        et.fields = [field1]
+        service._entity_types.get_with_fields = AsyncMock(return_value=et)
+        instance = MagicMock()
+        instance.id = uuid4()
+        instance.parent_instance_id = None
+        service._instances.get_by_article = AsyncMock(return_value=[instance])
+        recorded: list[dict] = []
+
+        async def _rec(**kwargs):
+            recorded.append(kwargs)
+            return MagicMock(id=uuid4())
+
+        service._proposals.record_proposal = AsyncMock(side_effect=_rec)
+        service.db.flush = AsyncMock()
+
+        run = self._make_run()
+        result = await service._create_suggestions(
+            project_id=run.project_id,
+            article_id=run.article_id,
+            entity_type_id=uuid4(),
+            parent_instance_id=None,
+            extracted_data={
+                "f1": {
+                    "status": "ambiguous",
+                    "value": "Maybe A or B",
+                    "reasoning": "two conflicting statements",
+                    "confidence": 0.3,
+                    "evidence": [],
+                },
+            },
+            run=run,
+        )
+        assert result == 1
+        prop = recorded[0]
+        # No marker — the value is preserved and the confidence survives so the
+        # card reads as a real low-confidence proposal, not a resolved abstention.
+        assert "absent_reason" not in prop["proposed_value"]
+        assert prop["proposed_value"] == {"value": "Maybe A or B"}
+        assert prop["confidence_score"] == 0.3
+        assert prop["rationale"] == "two conflicting statements"
 
     def test_build_run_provenance_shape(self, service):
         # Run provenance is a flat snapshot of how the suggestions were

--- a/backend/tests/unit/test_value_envelope.py
+++ b/backend/tests/unit/test_value_envelope.py
@@ -98,8 +98,56 @@ def test_boolean_without_field_is_native_bool() -> None:
 
 
 def test_no_information_sentinel_preserved() -> None:
+    # Legacy pre-migration select string (no absent_reason sibling) still
+    # resolves to its literal — the marker guard must NOT intercept it.
     assert resolve_value("No information") == "No information"
     assert resolve_value({"value": "No information"}) == "No information"
+
+
+def test_absent_reason_marker_renders_stable_label() -> None:
+    # ADR-0016: a coded disposition marker ({value: null, absent_reason: X})
+    # resolves to its stable label — NOT to a dict-stringify. Guard is pulled
+    # forward from Phase 4 so Phase-1 marker writes never leak into a cell.
+    assert resolve_value({"value": None, "absent_reason": "no_information"}) == "No information"
+    assert resolve_value({"value": None, "absent_reason": "not_applicable"}) == "Not applicable"
+    assert resolve_value({"value": None, "absent_reason": "not_evaluated"}) == "Not evaluated"
+
+
+def test_absent_reason_marker_never_dict_stringifies() -> None:
+    # The exact leak this guard prevents: without it, the {value, absent_reason}
+    # key-set matches no branch and falls to the catch-all "; ".join dict
+    # rendering → "value: None; absent_reason: no_information" in a cell.
+    out = resolve_value({"value": None, "absent_reason": "no_information"})
+    assert out == "No information"
+    assert "absent_reason" not in str(out)
+    assert not isinstance(out, dict)
+
+
+def test_absent_reason_marker_wins_over_value_keyset() -> None:
+    # Defensive: even if a marker somehow carried a non-null value, the
+    # disposition label takes precedence over the {"value"} unwrap (the branch
+    # is placed at the top of resolve_value).
+    assert resolve_value({"value": "stray", "absent_reason": "no_information"}) == "No information"
+
+
+def test_every_absent_reason_code_has_a_label() -> None:
+    # Drift guard: a new AbsentReason member without an export label would
+    # otherwise KeyError into a cell. Fail loudly here instead.
+    from app.services.exports.value_envelope import _ABSENT_REASON_LABELS
+    from app.services.value_semantics import AbsentReason
+
+    for code in AbsentReason:
+        assert code.value in _ABSENT_REASON_LABELS
+        assert isinstance(_ABSENT_REASON_LABELS[code.value], str)
+
+
+def test_out_of_vocab_absent_reason_is_not_treated_as_marker() -> None:
+    # A garbage absent_reason is not a resolution: value_absent_reason returns
+    # None, so this falls through to the catch-all (still a clean string, never
+    # a dict) — it must NOT render a fabricated disposition label.
+    out = resolve_value({"value": None, "absent_reason": "lol"})
+    assert not isinstance(out, dict)
+    assert out not in {"No information", "Not applicable", "Not evaluated"}
 
 
 def test_never_returns_dict() -> None:

--- a/frontend/hooks/runs/useAutoSaveProposals.ts
+++ b/frontend/hooks/runs/useAutoSaveProposals.ts
@@ -206,6 +206,7 @@ export function useAutoSaveProposals(
             value: actualValue,
             unit,
             isOther,
+            absentReason,
           } = extractValueForSave(valueData);
           const writeValue = isOther
             ? actualValue
@@ -229,6 +230,7 @@ export function useAutoSaveProposals(
             fieldId,
             normalizedValue: normalized,
             useDecisionEndpoint,
+            absentReason,
           }).then(() => {
             lastSavedByKeyRef.current[key] = JSON.stringify(valueData ?? null);
           });

--- a/frontend/lib/extraction/autosaveDirty.test.ts
+++ b/frontend/lib/extraction/autosaveDirty.test.ts
@@ -53,4 +53,23 @@ describe('selectDirtyEntries', () => {
     const baseline = { i1_f1: 'Retrospective cohort' };
     expect(selectDirtyEntries(values, {}, baseline)).toEqual([['i1_f1', null]]);
   });
+
+  // R7 (ADR-0016): a resolved disposition hydrates the form to the FULL marker
+  // envelope `{value:null, absent_reason:<code>}` and seeds the baseline from the
+  // same shape. current === baseline on mount → NOT dirty (no spurious re-POST
+  // that would restripe the marker coord).
+  it('does not echo a hydrated full-envelope marker on mount (R7)', () => {
+    const marker = { value: null, absent_reason: 'no_information' };
+    const values = { i1_f1: marker };
+    const baseline = { i1_f1: marker };
+    expect(selectDirtyEntries(values, {}, baseline)).toEqual([]);
+  });
+
+  it('does not restripe a marker coord when an adjacent field is edited', () => {
+    const marker = { value: null, absent_reason: 'no_information' };
+    const values = { i1_f1: marker, i2_f2: 'edited' };
+    const baseline = { i1_f1: marker, i2_f2: 'original' };
+    // Only the adjacent coord is dirty; the untouched marker coord is preserved.
+    expect(selectDirtyEntries(values, {}, baseline)).toEqual([['i2_f2', 'edited']]);
+  });
 });

--- a/frontend/lib/extraction/valueSemantics.ts
+++ b/frontend/lib/extraction/valueSemantics.ts
@@ -18,10 +18,12 @@
  */
 
 /**
- * The closed `absent_reason` vocabulary. Phase 1 will replace this local list
- * with the generated `AbsentReason` type once the marker rides a typed API
- * response field (`frontend/types/api/schema.d.ts`); until then it is defined
- * once here, matching the backend `AbsentReason` StrEnum.
+ * The closed `absent_reason` vocabulary, defined once here (matching the backend
+ * `AbsentReason` StrEnum) and kept in lock-step with it by the shared FE/BE test
+ * vector. This is NOT hand-mirroring a *generated* type: the marker rides the
+ * untyped `dict[str, Any]` value envelope, so no `AbsentReason` symbol appears
+ * in `frontend/types/api/schema.d.ts`. A later phase that types the envelope
+ * would let this import the generated enum instead.
  */
 const ABSENT_REASON_CODES = ['no_information', 'not_applicable', 'not_evaluated'] as const;
 const ABSENT_REASON_SET = new Set<string>(ABSENT_REASON_CODES);

--- a/frontend/lib/validations/selectOther.test.ts
+++ b/frontend/lib/validations/selectOther.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractValueForSave } from './selectOther';
+
+// ADR-0016 Phase 1 write contract: extractValueForSave must carry the
+// `absent_reason` disposition sibling out of the `{value}` envelope so a
+// resolved "no information" marker can round-trip through writeRunFieldValue,
+// instead of being stripped to a bare null on save.
+describe('extractValueForSave — absent_reason marker', () => {
+  it('carries the absent_reason sibling from a marker envelope', () => {
+    const result = extractValueForSave({
+      value: null,
+      absent_reason: 'no_information',
+    });
+    expect(result).toEqual({
+      value: null,
+      unit: null,
+      isOther: false,
+      absentReason: 'no_information',
+    });
+  });
+
+  it('returns absentReason null for a plain value envelope (no fabrication)', () => {
+    const result = extractValueForSave({ value: 'Retrospective cohort' });
+    expect(result.value).toBe('Retrospective cohort');
+    expect(result.absentReason).toBeNull();
+    expect(result.isOther).toBe(false);
+  });
+
+  it('returns absentReason null for a bare scalar', () => {
+    expect(extractValueForSave('hello').absentReason).toBeNull();
+  });
+
+  it('preserves unit and reports absentReason null for a number+unit envelope', () => {
+    const result = extractValueForSave({ value: 240, unit: 'days' });
+    expect(result.value).toBe(240);
+    expect(result.unit).toBe('days');
+    expect(result.absentReason).toBeNull();
+  });
+
+  it('does not touch the "other" path — absentReason null, structure preserved', () => {
+    const other = { selected: 'other', other_text: 'freetext' };
+    const result = extractValueForSave(other);
+    expect(result.isOther).toBe(true);
+    expect(result.value).toEqual(other);
+    expect(result.absentReason).toBeNull();
+  });
+});

--- a/frontend/lib/validations/selectOther.ts
+++ b/frontend/lib/validations/selectOther.ts
@@ -115,6 +115,11 @@ export interface ExtractedValueResult {
     value: any; // Value to save (can be "other" object or simple value)
   unit: string | null;
   isOther: boolean;
+  // ADR-0016: the coded `absent_reason` disposition sibling, carried out of the
+  // `{value}` envelope so a resolved "no information" marker round-trips through
+  // writeRunFieldValue instead of being stripped to a bare null. null when the
+  // value is a real value / "other" / bare scalar.
+  absentReason: string | null;
 }
 
 export function extractValueForSave(valueData: any): ExtractedValueResult {
@@ -122,20 +127,23 @@ export function extractValueForSave(valueData: any): ExtractedValueResult {
   const isOther = isOtherValue(valueData);
 
   if (isOther) {
-      // Preserve full structure
+      // Preserve full structure ("other" values never carry a disposition).
     return {
       value: valueData,
       unit: null,
-      isOther: true
+      isOther: true,
+      absentReason: null
     };
   }
 
-    // Check if object with unit (number field)
+    // Check if object with unit (number field) or a disposition marker. The
+    // `absent_reason` sibling rides alongside `value` in the same envelope.
   if (typeof valueData === 'object' && valueData !== null && 'value' in valueData) {
     return {
       value: valueData.value,
       unit: 'unit' in valueData ? valueData.unit : null,
-      isOther: false
+      isOther: false,
+      absentReason: valueData.absent_reason ?? null
     };
   }
 
@@ -143,7 +151,8 @@ export function extractValueForSave(valueData: any): ExtractedValueResult {
   return {
     value: valueData,
     unit: null,
-    isOther: false
+    isOther: false,
+    absentReason: null
   };
 }
 

--- a/frontend/services/aiSuggestionService.ts
+++ b/frontend/services/aiSuggestionService.ts
@@ -45,7 +45,12 @@ function mapEvidenceList(
 
 function unwrapValue(raw: { [key: string]: unknown } | null | undefined): unknown {
   // One shared peel; the null/absent envelope collapses to '' as before.
-  // (Phase 1 will carry the absent_reason sibling instead of discarding it here.)
+  // Deliberately lossy in Phase 1: a marker's absent_reason sibling is dropped
+  // here, so AISuggestion.value is '' for an AI no_information proposal. That
+  // still renders as the quiet no-info strip via the transitional-union
+  // `isAbstention` (bare-'' branch), and acceptance rides the proposal_record_id
+  // (not this scalar). Carrying the code onto AISuggestion for distinct
+  // no_information / not_applicable rendering is Phase 4 (the UX phase).
   if (raw === null || raw === undefined) return '';
   return unwrapValueEnvelope(raw) ?? '';
 }

--- a/frontend/services/extractionRunService.ts
+++ b/frontend/services/extractionRunService.ts
@@ -138,6 +138,13 @@ export interface WriteProposalParams {
   normalizedValue: unknown;
   /** When true, writes a ReviewerDecision (extraction in 'extract'); otherwise writes a human proposal. */
   useDecisionEndpoint: boolean;
+  /**
+   * ADR-0016: the coded `absent_reason` disposition to carry in the value
+   * envelope (`{value, absent_reason}`). Present only for a resolved "no
+   * information" marker; omitted (null/undefined) for every ordinary value so a
+   * legacy write never gains a spurious `absent_reason` key.
+   */
+  absentReason?: string | null;
 }
 
 /**
@@ -153,22 +160,28 @@ export interface WriteProposalParams {
 export async function writeRunFieldValue(
   params: WriteProposalParams,
 ): Promise<void> {
-  const {runId, instanceId, fieldId, normalizedValue, useDecisionEndpoint} = params;
+  const {runId, instanceId, fieldId, normalizedValue, useDecisionEndpoint, absentReason} =
+    params;
   const endpoint = useDecisionEndpoint
     ? `/api/v1/runs/${runId}/decisions`
     : `/api/v1/runs/${runId}/proposals`;
+  // Merge the disposition sibling only when present, so an ordinary value never
+  // gains a spurious `absent_reason` key (ADR-0016 write contract).
+  const valueEnvelope = absentReason
+    ? {value: normalizedValue, absent_reason: absentReason}
+    : {value: normalizedValue};
   const body = useDecisionEndpoint
     ? {
         instance_id: instanceId,
         field_id: fieldId,
         decision: 'edit' as const,
-        value: {value: normalizedValue},
+        value: valueEnvelope,
       }
     : {
         instance_id: instanceId,
         field_id: fieldId,
         source: 'human' as const,
-        proposed_value: {value: normalizedValue},
+        proposed_value: valueEnvelope,
       };
   await apiClient(endpoint, {method: 'POST', body, keepalive: true});
 }

--- a/frontend/test/services/extractionRunService.test.ts
+++ b/frontend/test/services/extractionRunService.test.ts
@@ -18,7 +18,11 @@ vi.mock('@/integrations/api', () => ({
   apiClient: apiClientMock,
 }));
 
-import {extractForRun, getExtractionJobStatus} from '@/services/extractionRunService';
+import {
+  extractForRun,
+  getExtractionJobStatus,
+  writeRunFieldValue,
+} from '@/services/extractionRunService';
 
 const BASE_PARAMS = {
   projectId: 'proj-1',
@@ -141,5 +145,78 @@ describe('getExtractionJobStatus', () => {
     apiClientMock.mockRejectedValueOnce(new Error('timeout'));
     const result = await getExtractionJobStatus('job-1');
     expect(result.ok).toBe(false);
+  });
+});
+
+// ADR-0016 Phase 1 write contract: writeRunFieldValue merges the absent_reason
+// disposition into the value envelope for BOTH the decision and proposal
+// endpoints, but only when a code is present — a legacy write must never gain a
+// spurious `absent_reason` key.
+describe('writeRunFieldValue — absent_reason threading', () => {
+  beforeEach(() => {
+    apiClientMock.mockReset();
+    apiClientMock.mockResolvedValue(undefined);
+  });
+
+  const lastBody = (): Record<string, unknown> =>
+    apiClientMock.mock.calls.at(-1)![1].body;
+
+  it('merges absent_reason into the decision value envelope', async () => {
+    await writeRunFieldValue({
+      runId: 'r1',
+      instanceId: 'i1',
+      fieldId: 'f1',
+      normalizedValue: null,
+      useDecisionEndpoint: true,
+      absentReason: 'no_information',
+    });
+    expect(apiClientMock).toHaveBeenCalledWith(
+      '/api/v1/runs/r1/decisions',
+      expect.anything(),
+    );
+    expect(lastBody().value).toEqual({value: null, absent_reason: 'no_information'});
+  });
+
+  it('merges absent_reason into the proposal proposed_value envelope', async () => {
+    await writeRunFieldValue({
+      runId: 'r1',
+      instanceId: 'i1',
+      fieldId: 'f1',
+      normalizedValue: null,
+      useDecisionEndpoint: false,
+      absentReason: 'no_information',
+    });
+    expect(apiClientMock).toHaveBeenCalledWith(
+      '/api/v1/runs/r1/proposals',
+      expect.anything(),
+    );
+    expect(lastBody().proposed_value).toEqual({
+      value: null,
+      absent_reason: 'no_information',
+    });
+  });
+
+  it('omits absent_reason entirely for a legacy decision write (no key)', async () => {
+    await writeRunFieldValue({
+      runId: 'r1',
+      instanceId: 'i1',
+      fieldId: 'f1',
+      normalizedValue: 'a value',
+      useDecisionEndpoint: true,
+    });
+    expect(lastBody().value).toEqual({value: 'a value'});
+    expect(lastBody().value).not.toHaveProperty('absent_reason');
+  });
+
+  it('omits absent_reason entirely for a legacy proposal write (no key)', async () => {
+    await writeRunFieldValue({
+      runId: 'r1',
+      instanceId: 'i1',
+      fieldId: 'f1',
+      normalizedValue: 'a value',
+      useDecisionEndpoint: false,
+    });
+    expect(lastBody().proposed_value).toEqual({value: 'a value'});
+    expect(lastBody().proposed_value).not.toHaveProperty('absent_reason');
   });
 });

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -2,7 +2,7 @@
 # May shrink (re-run --update-baseline to tighten), never grow. Cleanup is a separate effort.
 backend/app/seed.py:1941
 backend/app/services/extraction_export_service.py:2252
-backend/app/services/section_extraction_service.py:1624
+backend/app/services/section_extraction_service.py:1635
 frontend/components/articles/ArticleForm.tsx:1272
 frontend/components/articles/ArticlesList.tsx:1360
 frontend/components/extraction/ArticleExtractionTable.tsx:1130


### PR DESCRIPTION
## What & why

Phase 1 of the type-independent **"no information"** representation (ADR-0016 / [spec](docs/superpowers/specs/2026-06-30-no-information-representation-design.md)). Closes the numeric/date "not reported" gap: an AI abstention on a required field the source is silent on can now be **accepted and finalized**, instead of sticking at bare-`null` → blocked.

Phase 0 (marker-aware read plumbing) shipped in #458. This is the **write-path contract + AI marker**.

## Changes
- **AI recording split** (`section_extraction_service.py`): `not_found` / bare-`None` → `{value:null, absent_reason:"no_information"}` (a resolved, finalizable proposal with its rationale); **`ambiguous` stops sharing that branch** — it stays a needs-attention value with **no marker**, still gate-blocking.
- **FE write contract**: `extractValueForSave` carries the `absent_reason` sibling; `writeRunFieldValue` merges it into the value envelope for both `/decisions` and `/proposals` — **only when present** (no spurious key on legacy writes); `useAutoSaveProposals` threads it through.
- **Verbatim persistence**: no code change needed — request bodies are `dict[str,Any]` and `record_decision`/`record_proposal`/`record_consensus` already store the envelope unchanged; proven by an integration round-trip into `ExtractionPublishedState.value`.

## Deviation from strict phasing (deliberate, flagged)
The spec queues the `resolve_value` export fix for Phase 4, but that phasing is a bug: **the phase that first *writes* the marker must make the one dict-stringifying *reader* tolerant of it.** Without it, a published marker (`{value, absent_reason}` key-set) falls through to the catch-all dict-stringify and leaks `value: None; absent_reason: no_information` into an xlsx cell — reachable in Phase 1 via the AI-metadata sheet (every AI proposal on a finalized run) and the accepted-marker value maps. I pulled forward **only** the minimal ~6-line `resolve_value` top-branch (label lookup via the existing `value_absent_reason` oracle) + an export test. The Phase-4 legend rows and appraisal worst-case roll-up stay queued (a cell reading `No information` is self-explanatory without them).

## No migration
JSONB payload shape change only — no SQLAlchemy model change, so **no Alembic migration** and no roundtrip head-pin bump. The `ExtractionField` opt-in columns are Phase 2.

## Evidence (all green)
- BE unit: recording split (`not_found`→marker, **`ambiguous`→no marker**, `found` preserved); export guard (marker→label, **never dict-stringifies**, legacy `"No information"` string untouched, out-of-vocab rejected).
- BE integration (real DB): marker round-trips **verbatim** to `PublishedState.value` + counts as filled (gate satisfied); bare-null stays unfilled; **an unaccepted marker proposal cannot self-satisfy the gate** (fabrication-safety); dedup treats a marker as a genuine value (wins by recency, bare-null buryable).
- FE unit: `extractValueForSave` sibling read (+ negatives for other/scalar/unit); `writeRunFieldValue` merge + **conditional-key negative**; R7 autosave full-envelope marker (no re-POST, no restripe).
- `tsc`, `eslint`, `ruff`, `ruff format`, all 10 arch-fitness checks, `generate:api-types` (no-op). Adversarial code review over the diff: **0 defects**.

## Review notes
- A 5-lens adversarial **plan** panel + a 3-lens adversarial **code** review (each finding verified) informed this diff.
- `AbsentReason` does **not** newly appear in the generated OpenAPI types: the value envelope stays `dict[str,Any]` (spec: "raw jsonb envelope"), so the FE keeps its Phase-0 local vocabulary, kept in lock-step by the shared FE/BE test vector. The two forward-looking comments were retargeted accordingly.
- `aiSuggestionService.unwrapValue` stays deliberately lossy in Phase 1 (a marker renders as the quiet no-info strip via the union `isAbstention`; distinct `no_information`/`not_applicable` rendering is Phase 4).
- Constitution §IX text still pins abstention to bare `{value:null}`; the doc edit lands in Phase 5 (ADR-0016 records the intent).
- `check_file_size.baseline` bumped one line (`section_extraction_service.py` +11, an already-oversized file) — surgical, no unrelated tightening.

Phases 2-5 remain queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)