### PR TITLE
docs(extraction): ADR-0016 Phase 5 closeout — accept ADR, amend constitution §IX, purge last legacy

### DIFF
--- a/backend/app/llm/prompts/quality_assessment.py
+++ b/backend/app/llm/prompts/quality_assessment.py
@@ -12,9 +12,9 @@ _SYSTEM_TEMPLATE = (
     "choose strictly from the field's allowed values, justify your "
     "choice with a one or two-sentence reasoning, and include a short "
     "verbatim quote from the article as evidence whenever possible. "
-    "Be conservative: when the article does not provide enough "
-    "information to decide, prefer the value that captures uncertainty "
-    "(e.g., 'No information' or 'Probably no') over guessing. "
+    "Be conservative: when the article gives only a weak or indirect "
+    "signal, prefer the allowed value that captures uncertainty "
+    "(e.g., 'PN' or 'Unclear') over guessing. "
     'If the article does not contain the value, set status="not_found", value=null, and evidence=null'
     ' — do NOT invent a value or a quote. Use status="ambiguous" when the value is present but'
     ' unclear or conflicting. Only set status="found" when you can quote a passage that supports'

--- a/backend/app/services/value_semantics.py
+++ b/backend/app/services/value_semantics.py
@@ -41,8 +41,10 @@ class AbsentReason(StrEnum):
     Kept intentionally minimal (three codes, not FHIR ``dataAbsentReason``'s
     fifteen — YAGNI for evidence extraction). ``no_information`` is available on
     every field; ``not_applicable`` / ``not_evaluated`` are opt-in per field
-    (surfaced in later phases). Defined once here and mirrored to the frontend
-    via the generated API types once the marker rides a typed response field.
+    (``allows_not_applicable`` / ``allows_not_evaluated``, surfaced by
+    ``FieldInput``). Mirrored by hand in
+    ``frontend/lib/extraction/valueSemantics.ts``; the shared cross-checked test
+    vector keeps the two vocabularies in lock-step.
     """
 
     NO_INFORMATION = "no_information"

--- a/backend/tests/unit/test_value_semantics.py
+++ b/backend/tests/unit/test_value_semantics.py
@@ -3,10 +3,12 @@
 ``is_value_filled`` powers the finalize completeness gate (run_lifecycle_service)
 and ``is_value_empty`` powers the AI-suggestion dedup "no information" rule
 (extraction_suggestion_read_service). They are exact inverses of ONE rule,
-mirroring the frontend ``isNoInfoValue`` (value === null | undefined | '').
+mirrored 1:1 by ``frontend/lib/extraction/valueSemantics.ts``
+(``isValueEmpty`` / ``isValueFilled``); the shared cross-checked test vector
+(this file ⇔ ``valueSemantics.test.ts``) keeps the two in lock-step.
 The gate must never become stricter than the form the user just saw, so only
 ``None`` and the empty string count as empty — whitespace, 0, False and []
-are filled.
+are filled. A resolved ``absent_reason`` marker also counts as filled.
 """
 
 import pytest
@@ -99,8 +101,10 @@ def test_dict_without_value_key_counts_as_filled():
         ({"value": None}, True),  # bare null, no marker
         # an out-of-vocabulary code is not a resolution → still empty (gate-safe)
         ({"value": None, "absent_reason": "garbage"}, True),
-        # a legacy disposition carried IN-BAND as a select value is a non-empty
-        # scalar → filled today and still filled (untouched until Phase 3)
+        # a disposition string carried in-band is just a non-empty scalar → filled
+        # (stored data was migrated by 0039; the emptiness rule never interprets
+        # strings — only the domain-scoped write normalizer converts a picked
+        # legacy option)
         ({"value": "No information"}, False),
         ("No information", False),
     ],

--- a/docs/adr/0016-typed-absent-reason-marker.md
+++ b/docs/adr/0016-typed-absent-reason-marker.md
@@ -1,13 +1,13 @@
 ---
-status: proposed
-last_reviewed: 2026-06-30
+status: accepted
+last_reviewed: 2026-07-02
 owner: '@raphaelfh'
 adr_number: '0016'
 ---
 
 # Typed `absent_reason` marker for missing values
 
-> **Status:** Proposed · Date: 2026-06-30 · Deciders: @raphaelfh
+> **Status:** Accepted · Date: 2026-06-30 · Deciders: @raphaelfh
 > **Supersedes:** N/A · **Superseded by:** N/A
 > **Amends:** constitution §IX (abstention encoding); refines the emptiness
 > semantics behind [ADR-0009](0009-extraction-finalize-completeness-gate.md) /
@@ -90,9 +90,12 @@ Precise semantics:
   legitimate value is touched and finalized history stays lossless. The
   transitional read-shim is then removed (no permanent legacy).
 
-Delivered in phases (marker-aware readers → write contract + AI marker →
-template/select unification → data migration → export/compare/UX → docs). Full
-design, per-layer detail, and test strategy:
+Delivered in phases, all shipped to production 2026-07-01/02: Phase 0
+marker-aware readers (#458), Phase 1 write contract + AI marker (#460), Phases
+2–3 template/select unification + data migration `0039_absent_reason_backfill`
+with read-shim removal (#462), Phase 4 export/reviewer-compare/UX (#466);
+Phase 5 docs closes with this amendment (constitution §IX amended, v2.2.0).
+Full design, per-layer detail, and test strategy:
 [`docs/superpowers/specs/2026-06-30-no-information-representation-design.md`](../superpowers/specs/2026-06-30-no-information-representation-design.md).
 
 ### Consequences

--- a/docs/reference/constitution.md
+++ b/docs/reference/constitution.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-02
 owner: '@raphaelfh'
 ---
 
@@ -151,7 +151,8 @@ All API responses MUST use a uniform envelope format.
 Every AI-assisted value MUST be explainable and every human choice MUST be auditable.
 
 - Each AI suggestion records **how it was generated** — a run-level provenance snapshot (ran-by user, provider/model, extraction strategy + the prompt actually sent, sampling params, token usage) stored in `extraction_runs.results['provenance']` and surfaced to the reviewer.
-- A "no information" / abstention outcome is a **first-class recorded proposal** (`proposed_value={"value": null}` with its rationale), not a silent drop — the absence of a finding is itself traceable evidence the run examined the field.
+- A **domain "no information" / disposition answer** — that the source does not state the item, or the item is not applicable / not evaluated — is a first-class recorded proposal carrying a coded `absent_reason` (`{"value": null, "absent_reason": <code>}`) with its rationale ([ADR-0016](../adr/0016-typed-absent-reason-marker.md)). A reviewer accepts it like any AI version; it counts as a **resolved** value.
+- A **genuine unresolved state** — no proposal, an unaccepted proposal, or a rejected decision — carries no disposition and is **not** a silent drop: the proposal trail records that the run examined the field.
 - Every human selection of an AI version is **append-only**: the `ExtractionReviewerDecision` trail records who chose which `proposal_record_id` and when; switching versions never rewrites history.
 - Surfacing provenance is **data-driven and forward-compatible**: new provenance fields render without a UI change, so adding traceability never requires a schema or component migration first.
 
@@ -238,8 +239,14 @@ This constitution is the authoritative reference for all architectural and proce
 - Added complexity beyond what a principle prescribes MUST be justified in the PR description.
 - Use `CLAUDE.md` as the runtime development guidance companion to this constitution.
 
-**Version**: 2.1.1 | **Ratified**: 2026-02-16 | **Last Amended**: 2026-06-20
+**Version**: 2.2.0 | **Ratified**: 2026-02-16 | **Last Amended**: 2026-07-02
 
+> 2.2.0: §IX abstention bullet split into the two concepts it conflated
+> (ADR-0016) — a coded-`absent_reason` disposition answer is a first-class
+> **resolved** proposal (`{"value": null, "absent_reason": <code>}`), distinct
+> from a genuine unresolved state (bare null / unaccepted / rejected), which
+> carries no disposition. Replaces the bare `{"value": null}` abstention pin.
+>
 > 2.1.1: the CI-Pipeline section was re-pointed to ci.yml — it had drifted to
 > a stale 5-job list with `--cov-fail-under=70` while the tooling table (and CI)
 > already enforced 62. ci.yml is the source of truth for the enforced gate set.

--- a/docs/reference/extraction-hitl-architecture.md
+++ b/docs/reference/extraction-hitl-architecture.md
@@ -1,12 +1,12 @@
 ---
 status: stable
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-02
 owner: '@raphaelfh'
 ---
 
 # Extraction-Centric HITL Architecture
 
-> **Status:** Stable · Last reviewed: 2026-06-28 · Owner: @raphaelfh
+> **Status:** Stable · Last reviewed: 2026-07-02 · Owner: @raphaelfh
 > Canonical reference for the data-extraction and quality-assessment stack post the 2026-04-27 unification. Read this before touching anything in `extraction_*`, `extraction_runs`, the workflow tables, or the Quality-Assessment flow.
 
 ## 1. Why this exists
@@ -110,6 +110,24 @@ All tables live in the `public` schema with RLS enabled. Migration head:
 `ls backend/alembic/versions/` for the current head — and bump this line
 in any PR that adds an `extraction_*` migration).
 
+### Value envelope & `absent_reason` marker (ADR-0016)
+
+Every workflow value column (`proposed_value`, decision `value`, published
+`value`) is a JSONB envelope
+`{"value": <typed | null>, "unit"?: <str>, "absent_reason"?: "no_information" | "not_applicable" | "not_evaluated"}`.
+The value stays **type-correct** — `null` when absent, never a string sentinel.
+A coded `absent_reason` sibling marks a **resolved** "no value, on purpose"
+answer (the source is silent / not applicable / not evaluated) and counts as
+**filled** for the finalize gate; a bare `{"value": null}` (no marker) stays
+**unresolved**. `backend/app/services/value_semantics.py` is the single
+emptiness oracle (enum, labels, write-time normalizer), mirrored 1:1 by
+`frontend/lib/extraction/valueSemantics.ts` via a shared cross-checked test
+vector. `no_information` is available on every field; `not_applicable` /
+`not_evaluated` are opt-in per field. Historical in-band disposition strings
+(`"No information"`, PROBAST `NI`/`NA`) were rewritten to the marker by
+migration `0039_absent_reason_backfill`. Decision record:
+[ADR-0016](../adr/0016-typed-absent-reason-marker.md).
+
 ### Core HITL tables (introduced pre-squash 0010 → 0012; evolving — see migration head above)
 
 | Table | Append-only? | Purpose |
@@ -131,6 +149,7 @@ in any PR that adds an `extraction_*` migration).
 | `project_extraction_templates` | + `kind`, unique `(id, kind)` | 0011 |
 | `extraction_runs` | + `kind`, `version_id` FK, `hitl_config_snapshot`; composite FK `(template_id, kind)` enforces template-run kind coherence; stage enum reconstructed | 0011 + 0014 |
 | `extraction_evidence` | + `run_id`, `proposal_record_id`, `reviewer_decision_id`, `consensus_decision_id`. Legacy `target_type`/`target_id` columns dropped in 0017; CHECK now requires the workflow path. | 0013 + 0017 |
+| `extraction_fields` | + `allows_not_applicable`, `allows_not_evaluated` opt-in disposition flags (ADR-0016; copied into `version.schema_` by the snapshot builder) | 0038 |
 
 ### Legacy tables — fully removed
 
@@ -339,7 +358,9 @@ QUADAS-2 are seeded as `extraction_templates_global` rows with
 - **Domain** = an `EntityType` (Participants, Predictors, Outcome,
   Analysis, Overall), all `cardinality='one'`.
 - **Signaling question** = a `Field` of type `select`, with
-  `allowed_values=['Y','PY','PN','N','NI','NA']` (PROBAST) or
+  `allowed_values=['Y','PY','PN','N']` (PROBAST; the historical `NI`/`NA`
+  options are now coded dispositions — `no_information` is universal and
+  `not_applicable` is the per-field opt-in flag, ADR-0016) or
   `['Y','N','Unclear']` (QUADAS-2).
 - **Risk of Bias / Applicability concerns** = two summary `select`
   fields per domain, `allowed_values=['Low','High','Unclear']`. Manual in

--- a/docs/superpowers/specs/2026-06-30-no-information-representation-design.md
+++ b/docs/superpowers/specs/2026-06-30-no-information-representation-design.md
@@ -1,14 +1,18 @@
 ---
-status: draft
-last_reviewed: 2026-06-30
+status: shipped
+last_reviewed: 2026-07-02
 owner: '@raphaelfh'
 ---
 
-> **Status:** Draft — design direction approved in brainstorm 2026-06-30
-> (two adversarial analysis passes + a prior-art research pass:
-> FHIR `dataAbsentReason`, CDISC SDTM, OMOP, REDCap, Cochrane §5.4.3).
-> All five owner decisions + three follow-up clarifications recorded below.
-> Pending written-spec review before `writing-plans`.
+> **Status:** Shipped — Phases 0–4 delivered to production 2026-07-01/02
+> (#458 marker-aware readers, #460 write contract + AI marker, #462
+> template/select unification + migration `0039_absent_reason_backfill`,
+> #466 export/reviewer-compare/UX); Phase 5 docs closed with the
+> [ADR-0016](../../adr/0016-typed-absent-reason-marker.md) acceptance and the
+> constitution §IX amendment (v2.2.0). Retained as the design record —
+> design direction was approved in brainstorm 2026-06-30 (two adversarial
+> analysis passes + a prior-art research pass: FHIR `dataAbsentReason`,
+> CDISC SDTM, OMOP, REDCap, Cochrane §5.4.3).
 
 # Design: Type-independent "no information" representation (`absent_reason` marker)
 

--- a/frontend/e2e/flows/extraction-value-coherence.ui.e2e.ts
+++ b/frontend/e2e/flows/extraction-value-coherence.ui.e2e.ts
@@ -50,8 +50,9 @@ interface RunDetailResponse {
 // actually display it. The CHARMS ``data_source`` field (the first
 // entity_type/field in the seeded template) accepts:
 //   ['Prospective cohort', 'Retrospective cohort', 'Case-control',
-//    'Case series', 'RCT', 'Registry', 'No information']
-// Mirrors the production bug repro on article 5573e7f3.
+//    'Case series', 'RCT', 'Registry']
+// ("No information" is no longer an option — it is the coded absent_reason
+// disposition, ADR-0016.) Mirrors the production bug repro on article 5573e7f3.
 const TYPED_VALUE = "Case series";
 
 test.describe("Extraction value coherence (H1 end-to-end)", () => {

--- a/frontend/lib/extraction/valueSemantics.test.ts
+++ b/frontend/lib/extraction/valueSemantics.test.ts
@@ -41,7 +41,9 @@ describe('isValueEmpty / isValueFilled — the shared cross-checked vector', () 
     ['marker-with-real-value', { value: 'x', absent_reason: 'no_information' }, false],
     ['marker-empty-reason', { value: null, absent_reason: '' }, true],
     ['marker-unknown-code', { value: null, absent_reason: 'garbage' }, true],
-    // legacy in-band disposition string (untouched until Phase 3) → filled
+    // a disposition string carried in-band is just a non-empty scalar → filled
+    // (stored data was migrated by 0039; the emptiness rule never interprets
+    // strings — only the write-time normalizer converts a picked legacy option)
     ['legacy-string-envelope', { value: 'No information' }, false],
     ['legacy-string-scalar', 'No information', false],
   ];


### PR DESCRIPTION
## Summary

**Phase 5 — the final slice of ADR-0016** (`absent_reason` marker; Phases 0–4 all shipped to prod). Driven by an adversarial repo-wide legacy sweep (3 finder lenses × per-finding verification): **11 confirmed findings, 0 refuted — all fixed here**.

### Docs closeout
- **ADR-0016 → `accepted`** + delivery record (phases, PRs, migration `0039`).
- **Constitution §IX amended (v2.1.1 → v2.2.0, MINOR per the amendment procedure)**: the abstention bullet is split into the two concepts it conflated — a coded-`absent_reason` disposition answer is a first-class **resolved** proposal; a genuine unresolved state (bare null / unaccepted / rejected) carries no disposition. Changelog note added.
- **Architecture doc**: new *Value envelope & `absent_reason` marker* subsection under §3; `extraction_fields` disposition-flag row (0038) in the evolved-tables table; the PROBAST example no longer lists the retired `NI`/`NA` options.
- **Design spec → `shipped`** with a delivery banner.

### Legacy purged (verified leftovers)
- **QA LLM prompt** ([quality_assessment.py](backend/app/llm/prompts/quality_assessment.py)) no longer steers the model toward the retired `'No information'` / `'Probably no'` strings — now the allowed uncertainty codes (`'PN'`/`'Unclear'`) with the `status="not_found"` marker path. The structured-output schema already forbade the retired values, so this is instruction hygiene; the prompt `content_version` bumps as expected (provenance-correct).
- Stale transitional comments removed: `isNoInfoValue` docstring reference, two "untouched until Phase 3" vector comments (BE + FE), the "surfaced in later phases" enum docstring, and an e2e comment still listing `'No information'` in `allowed_values`.

## Test evidence
- Backend: prompt + value-semantics suites 55 passed; ruff clean.
- Frontend: `valueSemantics.test.ts` 33 passed.
- Docs gates locally: frontmatter check pass, markdownlint clean, cspell 0 issues.
- Architectural fitness: all gates green.
- Sweep verification: every finding independently confirmed against the code before fixing.

No behavioural change except the QA prompt wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)