### PR TITLE
feat(extraction): one-click accept on AI abstention + legible disposition control (ADR-0016 UX)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -43,6 +43,11 @@ Tailwind/shadcn mechanics → `ui-styling`. This file is the always-true core.
   i18n) — never hardcode strings in components.
 - shadcn/Radix primitives; `cn()` merge order matters; every
   interactive element keeps a visible focus state.
+- **Every icon-only or short-label button exposes its description on
+  hover** via the shadcn `Tooltip` (`TooltipTrigger asChild`), with the
+  description text routed through `lib/copy/`. Icon-only buttons also
+  carry an `aria-label`. A bare icon or terse label ("No information",
+  a history glyph) must never leave the user guessing what it does.
 - Visual language is authoritative in `frontend-ux` (it outranks the
   `frontend-design` plugin on core product UI — that plugin is for
   greenfield only). After a non-trivial UI change, verify with your

--- a/.claude/skills/frontend-ux/SKILL.md
+++ b/.claude/skills/frontend-ux/SKILL.md
@@ -74,6 +74,15 @@ Sidebars should feel integrated into the window, not like a separate drawer.
 2. **Skeleton Strategy:** Skeletons must match the exact line-height and width of the expected text to prevent layout
    shift.
 3. **Status Dots:** Small (6px), glowing for "Active", muted for "Draft".
+4. **Buttons explain themselves on hover.** Every icon-only or short-label
+   control carries a `Tooltip` with its description (copy through
+   `lib/copy/`); icon-only buttons also get an `aria-label`. A terse label
+   like "No information" or a bare glyph must never leave the user guessing.
+5. **Selected = the accepted-suggestion treatment.** A control representing a
+   recorded choice (accepted suggestion, active disposition, selected version)
+   shows the success ring (`ring-1 ring-success bg-success/10 text-success`,
+   usually with a small `Check`) — never just a shade — plus, where the input
+   itself looks blank, an explicit "recorded" hint so the state is unambiguous.
 
 ## 5. Responsive Behaviour
 

--- a/frontend/components/extraction/FieldInput.test.tsx
+++ b/frontend/components/extraction/FieldInput.test.tsx
@@ -17,7 +17,8 @@ vi.mock('@/lib/copy', () => ({ t: (_ns: string, key: string) => key }));
 import { FieldInput } from './FieldInput';
 import type { ExtractionField } from '@/types/extraction';
 
-const render = (ui: React.ReactElement) => rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+const render = (ui: React.ReactElement) =>
+  rtlRender(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
 
 function makeField(over: Partial<ExtractionField>): ExtractionField {
   return {
@@ -100,5 +101,37 @@ describe('FieldInput disposition control', () => {
     renderField(makeField({ field_type: 'text' }), NO_INFO);
     const input = screen.getByRole('textbox') as HTMLInputElement;
     expect(input.value).toBe('');
+  });
+
+  it('the active disposition gets the accepted-style success ring, not just a shade', () => {
+    // Consistency with the accepted-suggestion affordance (ring-success +
+    // bg-success/10) so "selected" is unmistakable even though the input is blank.
+    renderField(makeField({}), NO_INFO);
+    const btn = screen.getByRole('button', { name: /dispositionNoInformation/ });
+    expect(btn.className).toContain('ring-success');
+    expect(btn.className).toContain('bg-success/10');
+  });
+
+  it('renders the "recorded as a resolved answer" hint only while a disposition is active', () => {
+    renderField(makeField({}), NO_INFO);
+    expect(screen.getByText('dispositionActiveHint')).toBeInTheDocument();
+  });
+
+  it('shows no active hint when the field is unresolved', () => {
+    renderField(makeField({}), '');
+    expect(screen.queryByText('dispositionActiveHint')).toBeNull();
+  });
+
+  // Radix mirrors tooltip content into an a11y node (assert with *AllBy*) and
+  // debounces consecutive open/close in one render — so one fresh render per button.
+  it.each([
+    ['dispositionNoInformation', 'dispositionNoInformationHint'],
+    ['dispositionNotApplicable', 'dispositionNotApplicableHint'],
+    ['dispositionNotEvaluated', 'dispositionNotEvaluatedHint'],
+  ] as const)('%s describes itself on hover (tooltip)', async (label, hint) => {
+    const user = userEvent.setup();
+    renderField(makeField({ allows_not_applicable: true, allows_not_evaluated: true }), '');
+    await user.hover(screen.getByRole('button', { name: label }));
+    expect((await screen.findAllByText(hint)).length).toBeGreaterThan(0);
   });
 });

--- a/frontend/components/extraction/FieldInput.tsx
+++ b/frontend/components/extraction/FieldInput.tsx
@@ -23,9 +23,9 @@ import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue,} from '@/
 import {SelectWithOther} from '@/components/ui/SelectWithOther';
 import {MultiSelectWithOther} from '@/components/ui/MultiSelectWithOther';
 import {Switch} from '@/components/ui/switch';
-import {AlertCircle, History} from 'lucide-react';
+import {AlertCircle, Check, History} from 'lucide-react';
 import {Button} from '@/components/ui/button';
-import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip';
 import {cn} from '@/lib/utils';
 import type {ExtractionField} from '@/types/extraction';
 import type {AISuggestion, AISuggestionHistoryItem} from '@/hooks/extraction/ai/useAISuggestions';
@@ -159,13 +159,29 @@ export function FieldInput(props: FieldInputProps) {
     // answer on ANY field type. `no_information` is universal; the opt-in codes
     // render only where the field enables them. Toggling the active one clears back
     // to unresolved. Setting a marker clears any validation error (it is resolved).
-  const dispositions: { code: string; label: string }[] = [
-    { code: 'no_information', label: t('extraction', 'dispositionNoInformation') },
+  const dispositions: { code: string; label: string; hint: string }[] = [
+    {
+      code: 'no_information',
+      label: t('extraction', 'dispositionNoInformation'),
+      hint: t('extraction', 'dispositionNoInformationHint'),
+    },
     ...(field.allows_not_applicable
-      ? [{ code: 'not_applicable', label: t('extraction', 'dispositionNotApplicable') }]
+      ? [
+          {
+            code: 'not_applicable',
+            label: t('extraction', 'dispositionNotApplicable'),
+            hint: t('extraction', 'dispositionNotApplicableHint'),
+          },
+        ]
       : []),
     ...(field.allows_not_evaluated
-      ? [{ code: 'not_evaluated', label: t('extraction', 'dispositionNotEvaluated') }]
+      ? [
+          {
+            code: 'not_evaluated',
+            label: t('extraction', 'dispositionNotEvaluated'),
+            hint: t('extraction', 'dispositionNotEvaluatedHint'),
+          },
+        ]
       : []),
   ];
   const setDisposition = (code: string) => {
@@ -518,30 +534,51 @@ export function FieldInput(props: FieldInputProps) {
 
                   {/* Disposition control (ADR-0016): a quiet row to mark the field
                       "No information" (any type) or the opt-in Not applicable /
-                      Not evaluated. The active one is highlighted; clicking it
-                      clears back to unresolved. */}
+                      Not evaluated. Each button describes itself on hover; the
+                      active one gets the accepted-style success ring (matching
+                      the accept-suggestion affordance) + an explicit "recorded"
+                      hint, so a blank input is never ambiguous. Clicking the
+                      active one clears back to unresolved. */}
+        {/* Local provider: the disposition row renders on EVERY field, so its
+            tooltips must not depend on a caller-supplied provider. */}
+        <TooltipProvider delayDuration={300}>
         <div className="flex flex-wrap items-center gap-1.5" data-disposition-control>
           {dispositions.map((d) => {
             const active = activeReason === d.code;
             return (
-              <Button
-                key={d.code}
-                type="button"
-                size="sm"
-                variant={active ? 'secondary' : 'ghost'}
-                aria-pressed={active}
-                disabled={disabled}
-                onClick={() => setDisposition(d.code)}
-                className={cn(
-                  'h-6 px-2 text-xs',
-                  active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                {d.label}
-              </Button>
+              <Tooltip key={d.code}>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    aria-pressed={active}
+                    disabled={disabled}
+                    onClick={() => setDisposition(d.code)}
+                    className={cn(
+                      'h-6 gap-1 px-2 text-xs',
+                      active
+                        ? 'text-success ring-1 ring-inset ring-success bg-success/10 hover:bg-success/15 hover:text-success'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    {active ? <Check className="h-3 w-3" /> : null}
+                    {d.label}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{active ? t('extraction', 'dispositionActiveHint') : d.hint}</p>
+                </TooltipContent>
+              </Tooltip>
             );
           })}
+          {activeReason ? (
+            <span className="text-[11px] text-muted-foreground">
+              {t('extraction', 'dispositionActiveHint')}
+            </span>
+          ) : null}
         </div>
+        </TooltipProvider>
 
                   {/* Suggested value + accept/reject buttons below input - only when no manual value */}
         {shouldShowSuggestion && (

--- a/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
@@ -4,10 +4,12 @@
  * The backend records a "no information" outcome as a first-class proposal
  * carrying the coded marker ``{value:null, absent_reason:'no_information'}``
  * (ADR-0016). The service preserves that envelope as ``suggestion.value``, so the
- * inline strip renders a QUIET "No information found" indicator for it — never the
- * loud "(empty) · 0%" + Accept/Reject a real low-confidence suggestion gets
- * (spec R8). A real value keeps its value + actions. Post-Phase-3 a bare null/''
- * is UNRESOLVED (not an abstention) — ``isAbstention`` is the pure marker shape.
+ * inline strip renders a QUIET "No information found" indicator for it — never
+ * the loud "(empty) · 0%" a real low-confidence suggestion gets — while still
+ * exposing the one-click accept/reject actions (decision #3: an abstention is an
+ * acceptable proposal; accepting activates the field's disposition). A real value
+ * keeps its value + actions. Post-Phase-3 a bare null/'' is UNRESOLVED (not an
+ * abstention) — ``isAbstention`` is the pure marker shape.
  */
 
 import { render as rtlRender, screen } from '@testing-library/react';
@@ -64,6 +66,39 @@ describe('AISuggestionDisplay — no-information handling', () => {
     expect(screen.getByText('Retrospective cohort')).toBeInTheDocument();
     expect(screen.getByText('90%')).toBeInTheDocument();
     expect(screen.queryByText('reviewNoInformation')).not.toBeInTheDocument();
+  });
+
+  it('offers one-click accept/reject on the abstention strip (ADR-0016 decision #3)', async () => {
+    // The abstention is a first-class acceptable proposal: accepting it writes
+    // the marker into the form and activates the field's "No information"
+    // disposition. Rendering stays quiet (no confidence badge) — only the
+    // actions are exposed, exactly like a normal suggestion.
+    const onAccept = vi.fn();
+    const onReject = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AISuggestionDisplay
+        suggestion={makeSuggestion({ value: NO_INFO, confidence: 0 })}
+        onAccept={onAccept}
+        onReject={onReject}
+      />,
+    );
+    expect(screen.getByText('reviewNoInformation')).toBeInTheDocument();
+    expect(screen.queryByText('0%')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'acceptSuggestion' }));
+    expect(onAccept).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'rejectSuggestion' }));
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it('an accepted abstention shows the accepted state on its accept action', () => {
+    render(
+      <AISuggestionDisplay
+        suggestion={makeSuggestion({ value: NO_INFO, confidence: 0, status: 'accepted' })}
+        onAccept={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'suggestionAccepted' })).toBeInTheDocument();
   });
 });
 

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -105,18 +105,34 @@ export function AISuggestionDisplay({
   const isAccepted = isSuggestionAccepted(suggestion);
   const isRejected = suggestion.status === 'rejected';
 
-  // A "no information found" outcome is now a first-class proposal. Render it as
-  // a quiet, de-emphasized indicator — never a loud "(empty) · 0%" strip with
-  // Accept/Reject. It still opens the review popover (history + provenance) when
-  // a binding is supplied, so the abstention stays traceable.
+  // A "no information found" outcome is a first-class ACCEPTABLE proposal
+  // (ADR-0016 decision #3): the strip stays quiet and de-emphasized — never a
+  // loud "(empty) · 0%" — but exposes the same one-click accept/reject as a
+  // real suggestion, so accepting writes the marker into the form and
+  // activates the field's "No information" disposition. It still opens the
+  // review popover (history + provenance) when a binding is supplied.
   if (isAbstention(suggestion.value)) {
     return (
-      <div className="mt-2 animate-in fade-in duration-200">
-        <ReviewTrigger review={review} className="inline-flex px-1.5 py-0.5 -mx-1.5">
-          <span className="text-xs italic text-muted-foreground">
-            {t('extraction', 'reviewNoInformation')}
-          </span>
-        </ReviewTrigger>
+      <div className="mt-2 animate-in fade-in duration-200 w-full">
+        <div className="flex items-center gap-2 w-full">
+          <ReviewTrigger
+            review={review}
+            className="flex-1 min-w-0 inline-flex px-1.5 py-0.5 -mx-1.5"
+          >
+            <span className="text-xs italic text-muted-foreground">
+              {t('extraction', 'reviewNoInformation')}
+            </span>
+          </ReviewTrigger>
+          <div className="flex items-center gap-2 shrink-0 pr-1">
+            <AISuggestionActions
+              onAccept={onAccept}
+              onReject={onReject}
+              loading={loading}
+              isAccepted={isAccepted}
+              isRejected={isRejected}
+            />
+          </div>
+        </div>
       </div>
     );
   }

--- a/frontend/components/shared/ai-suggestions/AISuggestionActions.tsx
+++ b/frontend/components/shared/ai-suggestions/AISuggestionActions.tsx
@@ -35,6 +35,7 @@ export function AISuggestionActions({
               variant="ghost"
               onClick={onAccept}
               disabled={loading}
+              aria-label={isAccepted ? t('shared', 'suggestionAccepted') : t('shared', 'acceptSuggestion')}
               className={cn(
                 "h-7 w-7 rounded-full",
                 isAccepted && "ring-1 ring-success bg-success/10",
@@ -63,6 +64,7 @@ export function AISuggestionActions({
               variant="ghost"
               onClick={onReject}
               disabled={loading}
+              aria-label={isRejected ? t('shared', 'suggestionRejected') : t('shared', 'rejectSuggestion')}
               className={cn(
                 "h-7 w-7 rounded-full",
                 isRejected && "ring-1 ring-destructive bg-destructive/10",

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -851,6 +851,11 @@ export const extraction = {
     dispositionNoInformation: 'No information',
     dispositionNotApplicable: 'Not applicable',
     dispositionNotEvaluated: 'Not evaluated',
+    // Hover descriptions — same wording as the export legend (value_semantics
+    // labels ↔ extraction_export_service legend), so screen and export agree.
+    dispositionNoInformationHint: 'The source does not state this item.',
+    dispositionNotApplicableHint: 'The item does not apply to this study.',
+    dispositionNotEvaluatedHint: 'The item was not assessed.',
     dispositionSet: 'Mark as…',
     dispositionClear: 'Clear',
     dispositionActiveHint: 'Recorded as a resolved answer.',

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -6,5 +6,5 @@ backend/app/services/section_extraction_service.py:1635
 frontend/components/articles/ArticleForm.tsx:1272
 frontend/components/articles/ArticlesList.tsx:1360
 frontend/components/extraction/ArticleExtractionTable.tsx:1130
-frontend/lib/copy/extraction.ts:905
+frontend/lib/copy/extraction.ts:910
 frontend/pages/ExtractionFullScreen.tsx:1284


### PR DESCRIPTION
## Summary

User-reported UX gaps on the `absent_reason` surfaces (screenshots from live use):

1. **AI abstention is now one-click acceptable inline** — the quiet "No information found" strip exposes the same accept ✓ / reject ✕ actions as a normal suggestion (this was actually an ADR-0016 decision-#3 gap: the spec says the reviewer confirms an abstention in one click). Accepting propagates the full marker envelope into the form → the field's "No information" disposition activates. Rendering stays quiet (no confidence badge) and still opens the review popover.
2. **Disposition buttons explain themselves on hover** — shadcn Tooltip per button, with hint texts identical to the export legend (`The source does not state this item.` etc.), so screen and export can't disagree. The row carries a local `TooltipProvider` so no consumer needs one.
3. **Selected state is unmistakable** — the active disposition uses the accepted-suggestion treatment (`ring-1 ring-success bg-success/10 text-success` + Check icon) instead of a subtle shade, plus an explicit "Recorded as a resolved answer." hint next to the row (a blank input is never ambiguous).
4. **A11y**: `AISuggestionActions` accept/reject icon buttons gain `aria-label`s.
5. **Standing conventions** added to `.claude/rules/frontend.md` + `frontend-ux` §4: every icon-only/short-label button exposes its description on hover; "selected" states use the accepted-suggestion ring treatment.

## Test evidence
- 8 new component tests (abstention accept/reject + accepted state; success-ring active styling; active-hint presence/absence; per-button hover tooltips ×3).
- Full frontend suite **1066/1066** (161 files) — includes fixing 12 collateral failures (tests rendering `FieldInput` without a TooltipProvider) via the local provider.
- tsc clean · eslint clean · architectural fitness green (copy baseline +5 for the three hint keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)