### PR TITLE
Promote dev to main — ADR-0016 Phase 5 docs + abstention/disposition UX

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -43,6 +43,11 @@ Tailwind/shadcn mechanics → `ui-styling`. This file is the always-true core.
   i18n) — never hardcode strings in components.
 - shadcn/Radix primitives; `cn()` merge order matters; every
   interactive element keeps a visible focus state.
+- **Every icon-only or short-label button exposes its description on
+  hover** via the shadcn `Tooltip` (`TooltipTrigger asChild`), with the
+  description text routed through `lib/copy/`. Icon-only buttons also
+  carry an `aria-label`. A bare icon or terse label ("No information",
+  a history glyph) must never leave the user guessing what it does.
 - Visual language is authoritative in `frontend-ux` (it outranks the
   `frontend-design` plugin on core product UI — that plugin is for
   greenfield only). After a non-trivial UI change, verify with your

--- a/.claude/skills/frontend-ux/SKILL.md
+++ b/.claude/skills/frontend-ux/SKILL.md
@@ -74,6 +74,15 @@ Sidebars should feel integrated into the window, not like a separate drawer.
 2. **Skeleton Strategy:** Skeletons must match the exact line-height and width of the expected text to prevent layout
    shift.
 3. **Status Dots:** Small (6px), glowing for "Active", muted for "Draft".
+4. **Buttons explain themselves on hover.** Every icon-only or short-label
+   control carries a `Tooltip` with its description (copy through
+   `lib/copy/`); icon-only buttons also get an `aria-label`. A terse label
+   like "No information" or a bare glyph must never leave the user guessing.
+5. **Selected = the accepted-suggestion treatment.** A control representing a
+   recorded choice (accepted suggestion, active disposition, selected version)
+   shows the success ring (`ring-1 ring-success bg-success/10 text-success`,
+   usually with a small `Check`) — never just a shade — plus, where the input
+   itself looks blank, an explicit "recorded" hint so the state is unambiguous.
 
 ## 5. Responsive Behaviour
 

--- a/backend/app/llm/prompts/quality_assessment.py
+++ b/backend/app/llm/prompts/quality_assessment.py
@@ -12,9 +12,9 @@ _SYSTEM_TEMPLATE = (
     "choose strictly from the field's allowed values, justify your "
     "choice with a one or two-sentence reasoning, and include a short "
     "verbatim quote from the article as evidence whenever possible. "
-    "Be conservative: when the article does not provide enough "
-    "information to decide, prefer the value that captures uncertainty "
-    "(e.g., 'No information' or 'Probably no') over guessing. "
+    "Be conservative: when the article gives only a weak or indirect "
+    "signal, prefer the allowed value that captures uncertainty "
+    "(e.g., 'PN' or 'Unclear') over guessing. "
     'If the article does not contain the value, set status="not_found", value=null, and evidence=null'
     ' — do NOT invent a value or a quote. Use status="ambiguous" when the value is present but'
     ' unclear or conflicting. Only set status="found" when you can quote a passage that supports'

--- a/backend/app/services/value_semantics.py
+++ b/backend/app/services/value_semantics.py
@@ -41,8 +41,10 @@ class AbsentReason(StrEnum):
     Kept intentionally minimal (three codes, not FHIR ``dataAbsentReason``'s
     fifteen — YAGNI for evidence extraction). ``no_information`` is available on
     every field; ``not_applicable`` / ``not_evaluated`` are opt-in per field
-    (surfaced in later phases). Defined once here and mirrored to the frontend
-    via the generated API types once the marker rides a typed response field.
+    (``allows_not_applicable`` / ``allows_not_evaluated``, surfaced by
+    ``FieldInput``). Mirrored by hand in
+    ``frontend/lib/extraction/valueSemantics.ts``; the shared cross-checked test
+    vector keeps the two vocabularies in lock-step.
     """
 
     NO_INFORMATION = "no_information"

--- a/backend/tests/unit/test_value_semantics.py
+++ b/backend/tests/unit/test_value_semantics.py
@@ -3,10 +3,12 @@
 ``is_value_filled`` powers the finalize completeness gate (run_lifecycle_service)
 and ``is_value_empty`` powers the AI-suggestion dedup "no information" rule
 (extraction_suggestion_read_service). They are exact inverses of ONE rule,
-mirroring the frontend ``isNoInfoValue`` (value === null | undefined | '').
+mirrored 1:1 by ``frontend/lib/extraction/valueSemantics.ts``
+(``isValueEmpty`` / ``isValueFilled``); the shared cross-checked test vector
+(this file ⇔ ``valueSemantics.test.ts``) keeps the two in lock-step.
 The gate must never become stricter than the form the user just saw, so only
 ``None`` and the empty string count as empty — whitespace, 0, False and []
-are filled.
+are filled. A resolved ``absent_reason`` marker also counts as filled.
 """
 
 import pytest
@@ -99,8 +101,10 @@ def test_dict_without_value_key_counts_as_filled():
         ({"value": None}, True),  # bare null, no marker
         # an out-of-vocabulary code is not a resolution → still empty (gate-safe)
         ({"value": None, "absent_reason": "garbage"}, True),
-        # a legacy disposition carried IN-BAND as a select value is a non-empty
-        # scalar → filled today and still filled (untouched until Phase 3)
+        # a disposition string carried in-band is just a non-empty scalar → filled
+        # (stored data was migrated by 0039; the emptiness rule never interprets
+        # strings — only the domain-scoped write normalizer converts a picked
+        # legacy option)
         ({"value": "No information"}, False),
         ("No information", False),
     ],

--- a/docs/adr/0016-typed-absent-reason-marker.md
+++ b/docs/adr/0016-typed-absent-reason-marker.md
@@ -1,13 +1,13 @@
 ---
-status: proposed
-last_reviewed: 2026-06-30
+status: accepted
+last_reviewed: 2026-07-02
 owner: '@raphaelfh'
 adr_number: '0016'
 ---
 
 # Typed `absent_reason` marker for missing values
 
-> **Status:** Proposed · Date: 2026-06-30 · Deciders: @raphaelfh
+> **Status:** Accepted · Date: 2026-06-30 · Deciders: @raphaelfh
 > **Supersedes:** N/A · **Superseded by:** N/A
 > **Amends:** constitution §IX (abstention encoding); refines the emptiness
 > semantics behind [ADR-0009](0009-extraction-finalize-completeness-gate.md) /
@@ -90,9 +90,12 @@ Precise semantics:
   legitimate value is touched and finalized history stays lossless. The
   transitional read-shim is then removed (no permanent legacy).
 
-Delivered in phases (marker-aware readers → write contract + AI marker →
-template/select unification → data migration → export/compare/UX → docs). Full
-design, per-layer detail, and test strategy:
+Delivered in phases, all shipped to production 2026-07-01/02: Phase 0
+marker-aware readers (#458), Phase 1 write contract + AI marker (#460), Phases
+2–3 template/select unification + data migration `0039_absent_reason_backfill`
+with read-shim removal (#462), Phase 4 export/reviewer-compare/UX (#466);
+Phase 5 docs closes with this amendment (constitution §IX amended, v2.2.0).
+Full design, per-layer detail, and test strategy:
 [`docs/superpowers/specs/2026-06-30-no-information-representation-design.md`](../superpowers/specs/2026-06-30-no-information-representation-design.md).
 
 ### Consequences

--- a/docs/reference/constitution.md
+++ b/docs/reference/constitution.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-02
 owner: '@raphaelfh'
 ---
 
@@ -151,7 +151,8 @@ All API responses MUST use a uniform envelope format.
 Every AI-assisted value MUST be explainable and every human choice MUST be auditable.
 
 - Each AI suggestion records **how it was generated** — a run-level provenance snapshot (ran-by user, provider/model, extraction strategy + the prompt actually sent, sampling params, token usage) stored in `extraction_runs.results['provenance']` and surfaced to the reviewer.
-- A "no information" / abstention outcome is a **first-class recorded proposal** (`proposed_value={"value": null}` with its rationale), not a silent drop — the absence of a finding is itself traceable evidence the run examined the field.
+- A **domain "no information" / disposition answer** — that the source does not state the item, or the item is not applicable / not evaluated — is a first-class recorded proposal carrying a coded `absent_reason` (`{"value": null, "absent_reason": <code>}`) with its rationale ([ADR-0016](../adr/0016-typed-absent-reason-marker.md)). A reviewer accepts it like any AI version; it counts as a **resolved** value.
+- A **genuine unresolved state** — no proposal, an unaccepted proposal, or a rejected decision — carries no disposition and is **not** a silent drop: the proposal trail records that the run examined the field.
 - Every human selection of an AI version is **append-only**: the `ExtractionReviewerDecision` trail records who chose which `proposal_record_id` and when; switching versions never rewrites history.
 - Surfacing provenance is **data-driven and forward-compatible**: new provenance fields render without a UI change, so adding traceability never requires a schema or component migration first.
 
@@ -238,8 +239,14 @@ This constitution is the authoritative reference for all architectural and proce
 - Added complexity beyond what a principle prescribes MUST be justified in the PR description.
 - Use `CLAUDE.md` as the runtime development guidance companion to this constitution.
 
-**Version**: 2.1.1 | **Ratified**: 2026-02-16 | **Last Amended**: 2026-06-20
+**Version**: 2.2.0 | **Ratified**: 2026-02-16 | **Last Amended**: 2026-07-02
 
+> 2.2.0: §IX abstention bullet split into the two concepts it conflated
+> (ADR-0016) — a coded-`absent_reason` disposition answer is a first-class
+> **resolved** proposal (`{"value": null, "absent_reason": <code>}`), distinct
+> from a genuine unresolved state (bare null / unaccepted / rejected), which
+> carries no disposition. Replaces the bare `{"value": null}` abstention pin.
+>
 > 2.1.1: the CI-Pipeline section was re-pointed to ci.yml — it had drifted to
 > a stale 5-job list with `--cov-fail-under=70` while the tooling table (and CI)
 > already enforced 62. ci.yml is the source of truth for the enforced gate set.

--- a/docs/reference/extraction-hitl-architecture.md
+++ b/docs/reference/extraction-hitl-architecture.md
@@ -1,12 +1,12 @@
 ---
 status: stable
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-02
 owner: '@raphaelfh'
 ---
 
 # Extraction-Centric HITL Architecture
 
-> **Status:** Stable · Last reviewed: 2026-06-28 · Owner: @raphaelfh
+> **Status:** Stable · Last reviewed: 2026-07-02 · Owner: @raphaelfh
 > Canonical reference for the data-extraction and quality-assessment stack post the 2026-04-27 unification. Read this before touching anything in `extraction_*`, `extraction_runs`, the workflow tables, or the Quality-Assessment flow.
 
 ## 1. Why this exists
@@ -110,6 +110,24 @@ All tables live in the `public` schema with RLS enabled. Migration head:
 `ls backend/alembic/versions/` for the current head — and bump this line
 in any PR that adds an `extraction_*` migration).
 
+### Value envelope & `absent_reason` marker (ADR-0016)
+
+Every workflow value column (`proposed_value`, decision `value`, published
+`value`) is a JSONB envelope
+`{"value": <typed | null>, "unit"?: <str>, "absent_reason"?: "no_information" | "not_applicable" | "not_evaluated"}`.
+The value stays **type-correct** — `null` when absent, never a string sentinel.
+A coded `absent_reason` sibling marks a **resolved** "no value, on purpose"
+answer (the source is silent / not applicable / not evaluated) and counts as
+**filled** for the finalize gate; a bare `{"value": null}` (no marker) stays
+**unresolved**. `backend/app/services/value_semantics.py` is the single
+emptiness oracle (enum, labels, write-time normalizer), mirrored 1:1 by
+`frontend/lib/extraction/valueSemantics.ts` via a shared cross-checked test
+vector. `no_information` is available on every field; `not_applicable` /
+`not_evaluated` are opt-in per field. Historical in-band disposition strings
+(`"No information"`, PROBAST `NI`/`NA`) were rewritten to the marker by
+migration `0039_absent_reason_backfill`. Decision record:
+[ADR-0016](../adr/0016-typed-absent-reason-marker.md).
+
 ### Core HITL tables (introduced pre-squash 0010 → 0012; evolving — see migration head above)
 
 | Table | Append-only? | Purpose |
@@ -131,6 +149,7 @@ in any PR that adds an `extraction_*` migration).
 | `project_extraction_templates` | + `kind`, unique `(id, kind)` | 0011 |
 | `extraction_runs` | + `kind`, `version_id` FK, `hitl_config_snapshot`; composite FK `(template_id, kind)` enforces template-run kind coherence; stage enum reconstructed | 0011 + 0014 |
 | `extraction_evidence` | + `run_id`, `proposal_record_id`, `reviewer_decision_id`, `consensus_decision_id`. Legacy `target_type`/`target_id` columns dropped in 0017; CHECK now requires the workflow path. | 0013 + 0017 |
+| `extraction_fields` | + `allows_not_applicable`, `allows_not_evaluated` opt-in disposition flags (ADR-0016; copied into `version.schema_` by the snapshot builder) | 0038 |
 
 ### Legacy tables — fully removed
 
@@ -339,7 +358,9 @@ QUADAS-2 are seeded as `extraction_templates_global` rows with
 - **Domain** = an `EntityType` (Participants, Predictors, Outcome,
   Analysis, Overall), all `cardinality='one'`.
 - **Signaling question** = a `Field` of type `select`, with
-  `allowed_values=['Y','PY','PN','N','NI','NA']` (PROBAST) or
+  `allowed_values=['Y','PY','PN','N']` (PROBAST; the historical `NI`/`NA`
+  options are now coded dispositions — `no_information` is universal and
+  `not_applicable` is the per-field opt-in flag, ADR-0016) or
   `['Y','N','Unclear']` (QUADAS-2).
 - **Risk of Bias / Applicability concerns** = two summary `select`
   fields per domain, `allowed_values=['Low','High','Unclear']`. Manual in

--- a/docs/superpowers/specs/2026-06-30-no-information-representation-design.md
+++ b/docs/superpowers/specs/2026-06-30-no-information-representation-design.md
@@ -1,14 +1,18 @@
 ---
-status: draft
-last_reviewed: 2026-06-30
+status: shipped
+last_reviewed: 2026-07-02
 owner: '@raphaelfh'
 ---
 
-> **Status:** Draft — design direction approved in brainstorm 2026-06-30
-> (two adversarial analysis passes + a prior-art research pass:
-> FHIR `dataAbsentReason`, CDISC SDTM, OMOP, REDCap, Cochrane §5.4.3).
-> All five owner decisions + three follow-up clarifications recorded below.
-> Pending written-spec review before `writing-plans`.
+> **Status:** Shipped — Phases 0–4 delivered to production 2026-07-01/02
+> (#458 marker-aware readers, #460 write contract + AI marker, #462
+> template/select unification + migration `0039_absent_reason_backfill`,
+> #466 export/reviewer-compare/UX); Phase 5 docs closed with the
+> [ADR-0016](../../adr/0016-typed-absent-reason-marker.md) acceptance and the
+> constitution §IX amendment (v2.2.0). Retained as the design record —
+> design direction was approved in brainstorm 2026-06-30 (two adversarial
+> analysis passes + a prior-art research pass: FHIR `dataAbsentReason`,
+> CDISC SDTM, OMOP, REDCap, Cochrane §5.4.3).
 
 # Design: Type-independent "no information" representation (`absent_reason` marker)
 

--- a/frontend/components/extraction/FieldInput.test.tsx
+++ b/frontend/components/extraction/FieldInput.test.tsx
@@ -17,7 +17,8 @@ vi.mock('@/lib/copy', () => ({ t: (_ns: string, key: string) => key }));
 import { FieldInput } from './FieldInput';
 import type { ExtractionField } from '@/types/extraction';
 
-const render = (ui: React.ReactElement) => rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+const render = (ui: React.ReactElement) =>
+  rtlRender(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
 
 function makeField(over: Partial<ExtractionField>): ExtractionField {
   return {
@@ -100,5 +101,37 @@ describe('FieldInput disposition control', () => {
     renderField(makeField({ field_type: 'text' }), NO_INFO);
     const input = screen.getByRole('textbox') as HTMLInputElement;
     expect(input.value).toBe('');
+  });
+
+  it('the active disposition gets the accepted-style success ring, not just a shade', () => {
+    // Consistency with the accepted-suggestion affordance (ring-success +
+    // bg-success/10) so "selected" is unmistakable even though the input is blank.
+    renderField(makeField({}), NO_INFO);
+    const btn = screen.getByRole('button', { name: /dispositionNoInformation/ });
+    expect(btn.className).toContain('ring-success');
+    expect(btn.className).toContain('bg-success/10');
+  });
+
+  it('renders the "recorded as a resolved answer" hint only while a disposition is active', () => {
+    renderField(makeField({}), NO_INFO);
+    expect(screen.getByText('dispositionActiveHint')).toBeInTheDocument();
+  });
+
+  it('shows no active hint when the field is unresolved', () => {
+    renderField(makeField({}), '');
+    expect(screen.queryByText('dispositionActiveHint')).toBeNull();
+  });
+
+  // Radix mirrors tooltip content into an a11y node (assert with *AllBy*) and
+  // debounces consecutive open/close in one render — so one fresh render per button.
+  it.each([
+    ['dispositionNoInformation', 'dispositionNoInformationHint'],
+    ['dispositionNotApplicable', 'dispositionNotApplicableHint'],
+    ['dispositionNotEvaluated', 'dispositionNotEvaluatedHint'],
+  ] as const)('%s describes itself on hover (tooltip)', async (label, hint) => {
+    const user = userEvent.setup();
+    renderField(makeField({ allows_not_applicable: true, allows_not_evaluated: true }), '');
+    await user.hover(screen.getByRole('button', { name: label }));
+    expect((await screen.findAllByText(hint)).length).toBeGreaterThan(0);
   });
 });

--- a/frontend/components/extraction/FieldInput.tsx
+++ b/frontend/components/extraction/FieldInput.tsx
@@ -23,9 +23,9 @@ import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue,} from '@/
 import {SelectWithOther} from '@/components/ui/SelectWithOther';
 import {MultiSelectWithOther} from '@/components/ui/MultiSelectWithOther';
 import {Switch} from '@/components/ui/switch';
-import {AlertCircle, History} from 'lucide-react';
+import {AlertCircle, Check, History} from 'lucide-react';
 import {Button} from '@/components/ui/button';
-import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip';
 import {cn} from '@/lib/utils';
 import type {ExtractionField} from '@/types/extraction';
 import type {AISuggestion, AISuggestionHistoryItem} from '@/hooks/extraction/ai/useAISuggestions';
@@ -159,13 +159,29 @@ export function FieldInput(props: FieldInputProps) {
     // answer on ANY field type. `no_information` is universal; the opt-in codes
     // render only where the field enables them. Toggling the active one clears back
     // to unresolved. Setting a marker clears any validation error (it is resolved).
-  const dispositions: { code: string; label: string }[] = [
-    { code: 'no_information', label: t('extraction', 'dispositionNoInformation') },
+  const dispositions: { code: string; label: string; hint: string }[] = [
+    {
+      code: 'no_information',
+      label: t('extraction', 'dispositionNoInformation'),
+      hint: t('extraction', 'dispositionNoInformationHint'),
+    },
     ...(field.allows_not_applicable
-      ? [{ code: 'not_applicable', label: t('extraction', 'dispositionNotApplicable') }]
+      ? [
+          {
+            code: 'not_applicable',
+            label: t('extraction', 'dispositionNotApplicable'),
+            hint: t('extraction', 'dispositionNotApplicableHint'),
+          },
+        ]
       : []),
     ...(field.allows_not_evaluated
-      ? [{ code: 'not_evaluated', label: t('extraction', 'dispositionNotEvaluated') }]
+      ? [
+          {
+            code: 'not_evaluated',
+            label: t('extraction', 'dispositionNotEvaluated'),
+            hint: t('extraction', 'dispositionNotEvaluatedHint'),
+          },
+        ]
       : []),
   ];
   const setDisposition = (code: string) => {
@@ -518,30 +534,51 @@ export function FieldInput(props: FieldInputProps) {
 
                   {/* Disposition control (ADR-0016): a quiet row to mark the field
                       "No information" (any type) or the opt-in Not applicable /
-                      Not evaluated. The active one is highlighted; clicking it
-                      clears back to unresolved. */}
+                      Not evaluated. Each button describes itself on hover; the
+                      active one gets the accepted-style success ring (matching
+                      the accept-suggestion affordance) + an explicit "recorded"
+                      hint, so a blank input is never ambiguous. Clicking the
+                      active one clears back to unresolved. */}
+        {/* Local provider: the disposition row renders on EVERY field, so its
+            tooltips must not depend on a caller-supplied provider. */}
+        <TooltipProvider delayDuration={300}>
         <div className="flex flex-wrap items-center gap-1.5" data-disposition-control>
           {dispositions.map((d) => {
             const active = activeReason === d.code;
             return (
-              <Button
-                key={d.code}
-                type="button"
-                size="sm"
-                variant={active ? 'secondary' : 'ghost'}
-                aria-pressed={active}
-                disabled={disabled}
-                onClick={() => setDisposition(d.code)}
-                className={cn(
-                  'h-6 px-2 text-xs',
-                  active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                {d.label}
-              </Button>
+              <Tooltip key={d.code}>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    aria-pressed={active}
+                    disabled={disabled}
+                    onClick={() => setDisposition(d.code)}
+                    className={cn(
+                      'h-6 gap-1 px-2 text-xs',
+                      active
+                        ? 'text-success ring-1 ring-inset ring-success bg-success/10 hover:bg-success/15 hover:text-success'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    {active ? <Check className="h-3 w-3" /> : null}
+                    {d.label}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{active ? t('extraction', 'dispositionActiveHint') : d.hint}</p>
+                </TooltipContent>
+              </Tooltip>
             );
           })}
+          {activeReason ? (
+            <span className="text-[11px] text-muted-foreground">
+              {t('extraction', 'dispositionActiveHint')}
+            </span>
+          ) : null}
         </div>
+        </TooltipProvider>
 
                   {/* Suggested value + accept/reject buttons below input - only when no manual value */}
         {shouldShowSuggestion && (

--- a/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.test.tsx
@@ -4,10 +4,12 @@
  * The backend records a "no information" outcome as a first-class proposal
  * carrying the coded marker ``{value:null, absent_reason:'no_information'}``
  * (ADR-0016). The service preserves that envelope as ``suggestion.value``, so the
- * inline strip renders a QUIET "No information found" indicator for it — never the
- * loud "(empty) · 0%" + Accept/Reject a real low-confidence suggestion gets
- * (spec R8). A real value keeps its value + actions. Post-Phase-3 a bare null/''
- * is UNRESOLVED (not an abstention) — ``isAbstention`` is the pure marker shape.
+ * inline strip renders a QUIET "No information found" indicator for it — never
+ * the loud "(empty) · 0%" a real low-confidence suggestion gets — while still
+ * exposing the one-click accept/reject actions (decision #3: an abstention is an
+ * acceptable proposal; accepting activates the field's disposition). A real value
+ * keeps its value + actions. Post-Phase-3 a bare null/'' is UNRESOLVED (not an
+ * abstention) — ``isAbstention`` is the pure marker shape.
  */
 
 import { render as rtlRender, screen } from '@testing-library/react';
@@ -64,6 +66,39 @@ describe('AISuggestionDisplay — no-information handling', () => {
     expect(screen.getByText('Retrospective cohort')).toBeInTheDocument();
     expect(screen.getByText('90%')).toBeInTheDocument();
     expect(screen.queryByText('reviewNoInformation')).not.toBeInTheDocument();
+  });
+
+  it('offers one-click accept/reject on the abstention strip (ADR-0016 decision #3)', async () => {
+    // The abstention is a first-class acceptable proposal: accepting it writes
+    // the marker into the form and activates the field's "No information"
+    // disposition. Rendering stays quiet (no confidence badge) — only the
+    // actions are exposed, exactly like a normal suggestion.
+    const onAccept = vi.fn();
+    const onReject = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AISuggestionDisplay
+        suggestion={makeSuggestion({ value: NO_INFO, confidence: 0 })}
+        onAccept={onAccept}
+        onReject={onReject}
+      />,
+    );
+    expect(screen.getByText('reviewNoInformation')).toBeInTheDocument();
+    expect(screen.queryByText('0%')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'acceptSuggestion' }));
+    expect(onAccept).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'rejectSuggestion' }));
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it('an accepted abstention shows the accepted state on its accept action', () => {
+    render(
+      <AISuggestionDisplay
+        suggestion={makeSuggestion({ value: NO_INFO, confidence: 0, status: 'accepted' })}
+        onAccept={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'suggestionAccepted' })).toBeInTheDocument();
   });
 });
 

--- a/frontend/components/extraction/ai/AISuggestionDisplay.tsx
+++ b/frontend/components/extraction/ai/AISuggestionDisplay.tsx
@@ -105,18 +105,34 @@ export function AISuggestionDisplay({
   const isAccepted = isSuggestionAccepted(suggestion);
   const isRejected = suggestion.status === 'rejected';
 
-  // A "no information found" outcome is now a first-class proposal. Render it as
-  // a quiet, de-emphasized indicator — never a loud "(empty) · 0%" strip with
-  // Accept/Reject. It still opens the review popover (history + provenance) when
-  // a binding is supplied, so the abstention stays traceable.
+  // A "no information found" outcome is a first-class ACCEPTABLE proposal
+  // (ADR-0016 decision #3): the strip stays quiet and de-emphasized — never a
+  // loud "(empty) · 0%" — but exposes the same one-click accept/reject as a
+  // real suggestion, so accepting writes the marker into the form and
+  // activates the field's "No information" disposition. It still opens the
+  // review popover (history + provenance) when a binding is supplied.
   if (isAbstention(suggestion.value)) {
     return (
-      <div className="mt-2 animate-in fade-in duration-200">
-        <ReviewTrigger review={review} className="inline-flex px-1.5 py-0.5 -mx-1.5">
-          <span className="text-xs italic text-muted-foreground">
-            {t('extraction', 'reviewNoInformation')}
-          </span>
-        </ReviewTrigger>
+      <div className="mt-2 animate-in fade-in duration-200 w-full">
+        <div className="flex items-center gap-2 w-full">
+          <ReviewTrigger
+            review={review}
+            className="flex-1 min-w-0 inline-flex px-1.5 py-0.5 -mx-1.5"
+          >
+            <span className="text-xs italic text-muted-foreground">
+              {t('extraction', 'reviewNoInformation')}
+            </span>
+          </ReviewTrigger>
+          <div className="flex items-center gap-2 shrink-0 pr-1">
+            <AISuggestionActions
+              onAccept={onAccept}
+              onReject={onReject}
+              loading={loading}
+              isAccepted={isAccepted}
+              isRejected={isRejected}
+            />
+          </div>
+        </div>
       </div>
     );
   }

--- a/frontend/components/shared/ai-suggestions/AISuggestionActions.tsx
+++ b/frontend/components/shared/ai-suggestions/AISuggestionActions.tsx
@@ -35,6 +35,7 @@ export function AISuggestionActions({
               variant="ghost"
               onClick={onAccept}
               disabled={loading}
+              aria-label={isAccepted ? t('shared', 'suggestionAccepted') : t('shared', 'acceptSuggestion')}
               className={cn(
                 "h-7 w-7 rounded-full",
                 isAccepted && "ring-1 ring-success bg-success/10",
@@ -63,6 +64,7 @@ export function AISuggestionActions({
               variant="ghost"
               onClick={onReject}
               disabled={loading}
+              aria-label={isRejected ? t('shared', 'suggestionRejected') : t('shared', 'rejectSuggestion')}
               className={cn(
                 "h-7 w-7 rounded-full",
                 isRejected && "ring-1 ring-destructive bg-destructive/10",

--- a/frontend/e2e/flows/extraction-value-coherence.ui.e2e.ts
+++ b/frontend/e2e/flows/extraction-value-coherence.ui.e2e.ts
@@ -50,8 +50,9 @@ interface RunDetailResponse {
 // actually display it. The CHARMS ``data_source`` field (the first
 // entity_type/field in the seeded template) accepts:
 //   ['Prospective cohort', 'Retrospective cohort', 'Case-control',
-//    'Case series', 'RCT', 'Registry', 'No information']
-// Mirrors the production bug repro on article 5573e7f3.
+//    'Case series', 'RCT', 'Registry']
+// ("No information" is no longer an option — it is the coded absent_reason
+// disposition, ADR-0016.) Mirrors the production bug repro on article 5573e7f3.
 const TYPED_VALUE = "Case series";
 
 test.describe("Extraction value coherence (H1 end-to-end)", () => {

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -851,6 +851,11 @@ export const extraction = {
     dispositionNoInformation: 'No information',
     dispositionNotApplicable: 'Not applicable',
     dispositionNotEvaluated: 'Not evaluated',
+    // Hover descriptions — same wording as the export legend (value_semantics
+    // labels ↔ extraction_export_service legend), so screen and export agree.
+    dispositionNoInformationHint: 'The source does not state this item.',
+    dispositionNotApplicableHint: 'The item does not apply to this study.',
+    dispositionNotEvaluatedHint: 'The item was not assessed.',
     dispositionSet: 'Mark as…',
     dispositionClear: 'Clear',
     dispositionActiveHint: 'Recorded as a resolved answer.',

--- a/frontend/lib/extraction/valueSemantics.test.ts
+++ b/frontend/lib/extraction/valueSemantics.test.ts
@@ -41,7 +41,9 @@ describe('isValueEmpty / isValueFilled — the shared cross-checked vector', () 
     ['marker-with-real-value', { value: 'x', absent_reason: 'no_information' }, false],
     ['marker-empty-reason', { value: null, absent_reason: '' }, true],
     ['marker-unknown-code', { value: null, absent_reason: 'garbage' }, true],
-    // legacy in-band disposition string (untouched until Phase 3) → filled
+    // a disposition string carried in-band is just a non-empty scalar → filled
+    // (stored data was migrated by 0039; the emptiness rule never interprets
+    // strings — only the write-time normalizer converts a picked legacy option)
     ['legacy-string-envelope', { value: 'No information' }, false],
     ['legacy-string-scalar', 'No information', false],
   ];

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -6,5 +6,5 @@ backend/app/services/section_extraction_service.py:1635
 frontend/components/articles/ArticleForm.tsx:1272
 frontend/components/articles/ArticlesList.tsx:1360
 frontend/components/extraction/ArticleExtractionTable.tsx:1130
-frontend/lib/copy/extraction.ts:905
+frontend/lib/copy/extraction.ts:910
 frontend/pages/ExtractionFullScreen.tsx:1284


### PR DESCRIPTION
Promotes `dev` to `main`. Carries:

- **#468** — ADR-0016 Phase 5 closeout: ADR accepted, constitution §IX amended (v2.2.0), architecture-doc marker section, design spec → shipped, QA-prompt legacy purge (11 sweep findings fixed).
- **#469** — abstention/disposition UX: one-click accept on the AI "No information found" strip (decision #3), hover descriptions on disposition buttons (legend-aligned), accepted-style success ring on the active disposition, aria-labels, standing hover-description convention.

Both merged to dev with full CI green (strict up-to-date); #469's only red was a docling-parser flake, green on rerun. Prod currently healthy (/health 200, frontend 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)