### PR TITLE
ci(backend): cache docling models and run pytest HF-offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,12 @@ jobs:
       ENCRYPTION_KEY: test_encryption_key_32_characters
       DEBUG: "true"
       CORS_ORIGINS: "http://localhost:5173"
+      # docling resolves layout/TableFormer models from this dir instead of
+      # downloading from HuggingFace Hub at parse time (same mechanism as the
+      # Railway image, backend/Dockerfile). Populated by the cache/prefetch
+      # steps below. /home/runner is $HOME on ubuntu-latest — env values are
+      # not tilde-expanded, so the path is spelled out.
+      DOCLING_ARTIFACTS_PATH: /home/runner/.cache/docling-models
 
     steps:
       - uses: actions/checkout@v7
@@ -152,6 +158,59 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --frozen --extra dev
+
+      # test_docling_parser.py needs the docling layout + TableFormer weights.
+      # Downloading them from HuggingFace Hub at test time made the suite
+      # depend on live HF availability — it flaked twice in 15 minutes on
+      # 2026-07-02 (runs 28564620843 / 28565105365, LocalEntryNotFoundError
+      # from an HF 5xx/timeout). Cache the weights keyed on the pinned docling
+      # version; on a miss, prefetch with retries BEFORE pytest so the only
+      # network-dependent step is one that can retry cleanly. The pytest step
+      # then runs HF-offline (mirrors backend/Dockerfile: prefetch +
+      # DOCLING_ARTIFACTS_PATH + HF_HUB_OFFLINE), so a resolution problem
+      # fails fast in the prefetch step instead of flaking mid-suite.
+      - name: Resolve docling version (models cache key)
+        id: docling-version
+        run: |
+          # `|| true` keeps a no-match from tripping errexit/pipefail before
+          # the explicit guard below can produce a readable error.
+          VERSION=$(grep -Eo 'docling==[0-9][0-9.]*' pyproject.toml | head -1 | cut -d= -f3 || true)
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::could not resolve the pinned docling version from backend/pyproject.toml"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache docling models
+        id: docling-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/docling-models
+          key: docling-models-${{ runner.os }}-${{ steps.docling-version.outputs.version }}
+
+      - name: Prefetch docling models (layout + TableFormer)
+        if: steps.docling-cache.outputs.cache-hit != 'true'
+        run: |
+          # Same model set as the Railway image (backend/Dockerfile): the
+          # OCR-disabled standard pipeline only needs layout + TableFormer.
+          for attempt in 1 2 3; do
+            uv run python -c "
+          from pathlib import Path
+          from docling.utils.model_downloader import download_models
+          download_models(
+              output_dir=Path('${DOCLING_ARTIFACTS_PATH}'),
+              with_layout=True,
+              with_tableformer=True,
+              with_code_formula=False,
+              with_picture_classifier=False,
+              with_rapidocr=False,
+              with_easyocr=False,
+          )" && exit 0
+            echo "docling model prefetch attempt ${attempt} failed; retrying in 20s"
+            sleep 20
+          done
+          echo "::error::docling model prefetch failed after 3 attempts — HF Hub is likely down"
+          exit 1
 
       - name: Install Postgres client (psql)
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
@@ -241,6 +300,13 @@ jobs:
       #     must hit 85%. Modules where bug = data loss / BOLA / HITL state
       #     corruption cannot regress even by a percentage point.
       - name: Run tests with coverage
+        env:
+          # Models come from DOCLING_ARTIFACTS_PATH (cache/prefetch steps
+          # above); forbid any runtime HF download so a missing model is a
+          # deterministic failure here, never a network flake. Mirrors the
+          # runtime stage of backend/Dockerfile.
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
         run: |
           uv run pytest tests/ \
             --cov=app \


### PR DESCRIPTION
## Why

`test_docling_parser.py::test_docling_parses_blocks_with_valid_invariants` downloads the docling layout + TableFormer weights from HuggingFace Hub mid-suite, so Backend Tests fails whenever HF times out or 5xxs — it flaked twice within 15 minutes on 2026-07-02 (runs [28564620843](https://github.com/raphaelfh/prumo/actions/runs/28564620843) / [28565105365](https://github.com/raphaelfh/prumo/actions/runs/28565105365), `LocalEntryNotFoundError`) and blocked two merges during the ADR-0016 train. The Railway image already solved this with a build-time prefetch (#394); this PR mirrors that mechanism in CI.

## What changed

All in the **Backend Tests** job of `.github/workflows/ci.yml`:

- **Cache**: `actions/cache` on `~/.cache/docling-models`, keyed `docling-models-<os>-<pinned docling version>` (version grepped from `backend/pyproject.toml`, so the key auto-rolls when the pin bumps — e.g. Dependabot #408).
- **Prefetch on miss**: the same `download_models(with_layout, with_tableformer)` call as `backend/Dockerfile`, wrapped in 3 attempts with 20s backoff. The only network-dependent step is now one that retries cleanly, before pytest.
- **Offline pytest**: job-level `DOCLING_ARTIFACTS_PATH` + step-level `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` on the test step, mirroring the Dockerfile runtime stage. A resolution gap becomes a deterministic prefetch failure, never a mid-suite flake.

## Risk

CI-only; no app code, no migrations. Worst case is a red prefetch step when HF is fully down on a cache-miss run — which today would have been a confusing mid-suite flake instead. docling is the only HuggingFace consumer in the backend (grep: zero other `huggingface|transformers|from_pretrained` hits in `app/` and `tests/`), so the offline env cannot starve anything else. Cache is ~506MB, well under the 10GB repo cap.

## Test plan

- [x] Verified against pinned docling 2.104.0 locally: exact prefetch command populated a scratch dir (506MB), then `DoclingParser().parse(fixture)` succeeded with `HF_HUB_OFFLINE=1` and an **empty** `HF_HOME` — `OFFLINE PARSE OK: 4 blocks across pages [1, 2]`
- [x] Confirmed the env-var chain in the installed package: `AppSettings().artifacts_path` picks up `DOCLING_ARTIFACTS_PATH`; consumed at `docling/pipeline/base_pipeline.py:59-60`
- [x] Both run-scripts simulated under GitHub's bash flags (`-e -o pipefail`): success, retry-exhaustion (exit 1 after 3 attempts), and missing-pin guard paths
- [ ] This PR's first CI run: cache miss → prefetch downloads → suite green
- [ ] Second run: log shows `Cache restored from key: docling-models-Linux-2.104.0`, prefetch step skipped

No doc change needed (CI-only; no ADR — reuses the accepted #394 pattern).

## Out of scope

The Docker build's own prefetch layer (`backend/Dockerfile` RUN step) can also hit HF when the buildx layer cache misses — different job (Backend Docker Build), much rarer, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)