### PR TITLE
fix(runs): blind-gate reviewers_ready — no peer ids for blind callers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,14 +235,25 @@ jobs:
             role TEXT
           );
           -- Stub auth.uid() and auth.role(): real implementations live in
-          -- Supabase's auth schema. Alembic migrations reference these via
-          -- RLS policies, so we need them defined for `alembic upgrade head`
-          -- to succeed in CI. Returning NULL is fine for migration time —
-          -- tests don't exercise RLS via these helpers.
+          -- Supabase's auth schema. They mirror Supabase's readers of the
+          -- request.jwt.* GUCs so RLS probes (set_config claims + SET LOCAL
+          -- ROLE authenticated, e.g. test_reviewer_ready_rls.py) authenticate
+          -- exactly as against a real Supabase Postgres; with no claims set
+          -- they return NULL, which is all `alembic upgrade head` needs.
           CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
-            LANGUAGE sql STABLE AS $$ SELECT NULL::uuid $$;
+            LANGUAGE sql STABLE AS $$
+              SELECT coalesce(
+                nullif(current_setting('request.jwt.claim.sub', true), ''),
+                nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+              )::uuid
+            $$;
           CREATE OR REPLACE FUNCTION auth.role() RETURNS text
-            LANGUAGE sql STABLE AS $$ SELECT NULL::text $$;
+            LANGUAGE sql STABLE AS $$
+              SELECT coalesce(
+                nullif(current_setting('request.jwt.claim.role', true), ''),
+                nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role'
+              )
+            $$;
           -- Supabase pre-creates these roles; migrations GRANT to them.
           DO $$ BEGIN
             IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
@@ -457,9 +468,19 @@ jobs:
             role TEXT
           );
           CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
-            LANGUAGE sql STABLE AS $$ SELECT NULL::uuid $$;
+            LANGUAGE sql STABLE AS $$
+              SELECT coalesce(
+                nullif(current_setting('request.jwt.claim.sub', true), ''),
+                nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+              )::uuid
+            $$;
           CREATE OR REPLACE FUNCTION auth.role() RETURNS text
-            LANGUAGE sql STABLE AS $$ SELECT NULL::text $$;
+            LANGUAGE sql STABLE AS $$
+              SELECT coalesce(
+                nullif(current_setting('request.jwt.claim.role', true), ''),
+                nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role'
+              )
+            $$;
           -- Supabase pre-creates these roles; migrations GRANT to them.
           DO $$ BEGIN
             IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN

--- a/backend/alembic/versions/0041_reviewer_ready_select_rls.py
+++ b/backend/alembic/versions/0041_reviewer_ready_select_rls.py
@@ -1,0 +1,80 @@
+"""Reviewer-scope the extraction_reviewer_ready SELECT policy
+
+Revision ID: 0041_reviewer_ready_select_rls
+Revises: 0040_published_state_restrict
+Create Date: 2026-07-02
+
+Closes the residual blind-participation leak found by the 2026-07-02 security
+review (finding 2). 0029 created the table with a project-member-scoped SELECT
+on the rationale that "knowing someone is 'done' leaks no values"; the review
+reversed that judgment — WHO marked ready is peer-attributable participation
+metadata under the blind contract (ADR-0012), so a blind reviewer hitting
+PostgREST directly could learn which peers marked ready even after the API
+scrub (``ExtractionReviewerReadyService.ready_summary_from``) landed.
+
+The new policy self-scopes exactly like 0025 does for the workflow tables: a
+member may SELECT a ready row only when (a) they authored it (``reviewer_id =
+auth.uid()``), (b) they are a project ``manager``/``consensus`` arbitrator
+(``is_project_arbitrator``, from 0025 — RLS deliberately stays looser than the
+API's per-kind manager toggle, ADR-0012's API-stricter-than-RLS split), or
+(c) the run is ``finalized``. INSERT/UPDATE policies were already self-scoped
+in 0029 and are untouched. The backend reads this table as ``service_role``
+(RLS bypassed) and the frontend never reads it via PostgREST, so the change is
+behavior-neutral for the app — it closes the devtools path only.
+"""
+
+from alembic import op
+
+revision = "0041_reviewer_ready_select_rls"
+down_revision = "0040_published_state_restrict"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Same shape as 0025: join only extraction_runs (carries project_id AND
+    # stage; no policy cycle). is_project_arbitrator exists since 0025 with
+    # EXECUTE granted to authenticated.
+    op.execute(
+        'DROP POLICY IF EXISTS "extraction_reviewer_ready_select" '
+        "ON public.extraction_reviewer_ready;"
+    )
+    op.execute(
+        """
+        CREATE POLICY "extraction_reviewer_ready_select"
+            ON public.extraction_reviewer_ready
+            FOR SELECT USING (
+                EXISTS (
+                    SELECT 1 FROM public.extraction_runs r
+                    WHERE r.id = extraction_reviewer_ready.run_id
+                      AND public.is_project_member(r.project_id, auth.uid())
+                      AND (
+                            r.stage = 'finalized'::public.extraction_run_stage
+                         OR public.is_project_arbitrator(r.project_id, auth.uid())
+                         OR extraction_reviewer_ready.reviewer_id = auth.uid()
+                      )
+                )
+            );
+        """
+    )
+
+
+def downgrade() -> None:
+    # Restore the 0029 project-member-scoped SELECT verbatim.
+    op.execute(
+        'DROP POLICY IF EXISTS "extraction_reviewer_ready_select" '
+        "ON public.extraction_reviewer_ready;"
+    )
+    op.execute(
+        """
+        CREATE POLICY "extraction_reviewer_ready_select"
+            ON public.extraction_reviewer_ready
+            FOR SELECT USING (
+                EXISTS (
+                    SELECT 1 FROM public.extraction_runs r
+                    WHERE r.id = extraction_reviewer_ready.run_id
+                      AND public.is_project_member(r.project_id, auth.uid())
+                )
+            );
+        """
+    )

--- a/backend/app/api/v1/endpoints/extraction_runs.py
+++ b/backend/app/api/v1/endpoints/extraction_runs.py
@@ -320,14 +320,18 @@ async def mark_run_ready(
 
     Advisory only — it never advances the run (the manager opens consensus
     manually). Membership-gated AND reviewer-role-gated (a read-only viewer
-    cannot mark ready). Returns the "N/M reviewers ready" hint.
+    cannot mark ready). Returns the "N/M reviewers ready" hint with
+    ``reviewers_ready`` scoped to the caller's own entry (this response is the
+    caller's toggle echo; an unblinded caller reads the full list via /view).
     """
     run = await _load_run_and_check_member(db, run_id, current_user_sub)
     await ensure_project_reviewer(db, run.project_id, current_user_sub)
     service = ExtractionReviewerReadyService(db)
     await service.mark_ready(run_id=run_id, reviewer_id=current_user_sub, is_ready=body.ready)
     summary = await service.ready_summary_from(
-        run_id=run_id, hitl_config_snapshot=run.hitl_config_snapshot
+        run_id=run_id,
+        hitl_config_snapshot=run.hitl_config_snapshot,
+        caller_id=current_user_sub,
     )
     await db.commit()
     return ApiResponse.success(RunReadyStateResponse(**summary), trace_id=_trace(request))

--- a/backend/app/schemas/extraction_run.py
+++ b/backend/app/schemas/extraction_run.py
@@ -127,7 +127,9 @@ class RunReadyStateResponse(BaseModel):
 
     ``reviewer_count`` is ``max(hitl_config reviewer_count, ready_count)`` so the
     hint never reads "N of M" with N > M (the configured count is often the inert
-    default of 1)."""
+    default of 1). ``reviewers_ready`` is blind-gated (ADR-0012): it carries only
+    the caller's own entry unless the caller is unblinded — the counts stay
+    aggregate."""
 
     ready_count: int
     reviewer_count: int
@@ -265,6 +267,9 @@ class RunViewResponse(RunDetailResponse):
     current_values: list[RunViewCurrentValue]
     instances: list[RunViewInstance]
     # Per-reviewer "ready" hint (advisory; see RunReadyStateResponse).
+    # reviewers_ready is blind-gated on peers_revealed: a blind caller gets
+    # only their own entry (enough for the Mark-ready self-check), never peer
+    # ids; the counts stay aggregate.
     ready_count: int = 0
     reviewer_count: int = 0
     reviewers_ready: list[UUID] = Field(default_factory=list)

--- a/backend/app/services/extraction_reviewer_ready_service.py
+++ b/backend/app/services/extraction_reviewer_ready_service.py
@@ -23,18 +23,30 @@ class ExtractionReviewerReadyService:
         await self._repo.upsert(run_id=run_id, reviewer_id=reviewer_id, is_ready=is_ready)
 
     async def ready_summary_from(
-        self, *, run_id: UUID, hitl_config_snapshot: dict[str, Any] | None
+        self,
+        *,
+        run_id: UUID,
+        hitl_config_snapshot: dict[str, Any] | None,
+        caller_id: UUID,
+        include_peers: bool = False,
     ) -> dict[str, Any]:
-        """The "N/M reviewers ready" hint. SINGLE home of the ``M`` rule (D3).
+        """The "N/M reviewers ready" hint. SINGLE home of the ``M`` rule (D3)
+        and of the blind scrub on ``reviewers_ready``.
 
         ``N`` = reviewers with ``is_ready``; ``M`` = ``max(configured reviewer_count,
         N)`` so the hint never reads N > M when more reviewers mark ready than the
         (often inert, default-1) configured count.
+
+        WHO marked ready is peer-attributable participation metadata under the
+        blind contract (ADR-0012), so ``reviewers_ready`` carries only the
+        caller's own entry unless ``include_peers`` (the run-view passes its
+        effective unblind). The counts stay aggregate — N/M leaks no identity.
         """
         ready = await self._repo.ready_reviewer_ids(run_id)
         reviewer_count = int((hitl_config_snapshot or {}).get("reviewer_count") or 1)
+        visible = ready if include_peers else [uid for uid in ready if uid == caller_id]
         return {
             "ready_count": len(ready),
             "reviewer_count": max(reviewer_count, len(ready)),
-            "reviewers_ready": ready,
+            "reviewers_ready": visible,
         }

--- a/backend/app/services/extraction_run_read_service.py
+++ b/backend/app/services/extraction_run_read_service.py
@@ -371,8 +371,13 @@ async def build_run_view(
     )
     instances = await _instances_for_run(db, detail.run)
     if detail.run.stage in _READY_HINT_STAGES:
+        # include_peers reuses detail.peers_revealed (the single blind source),
+        # so the reviewers_ready scrub cannot drift from the row filter.
         ready = await ExtractionReviewerReadyService(db).ready_summary_from(
-            run_id=run_id, hitl_config_snapshot=detail.run.hitl_config_snapshot
+            run_id=run_id,
+            hitl_config_snapshot=detail.run.hitl_config_snapshot,
+            caller_id=caller_id,
+            include_peers=detail.peers_revealed,
         )
     else:
         ready = {"ready_count": 0, "reviewer_count": 0, "reviewers_ready": []}

--- a/backend/tests/integration/test_build_run_view.py
+++ b/backend/tests/integration/test_build_run_view.py
@@ -11,6 +11,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.services.extraction_reviewer_ready_service import ExtractionReviewerReadyService
 from app.services.extraction_run_read_service import build_run_view
 from tests.integration.conftest import SEED
 from tests.integration.test_blind_review_isolation import (
@@ -32,6 +33,34 @@ async def test_build_run_view_blinds_peer_in_review(db_session: AsyncSession) ->
     assert reviewer_a not in reviewer_ids, "build_run_view leaked a peer decision"
     assert view.entity_types, "entity_types tree must be populated"
     assert isinstance(view.current_values, list)
+
+
+@pytest.mark.asyncio
+async def test_build_run_view_blind_caller_ready_ids_self_scoped(
+    db_session: AsyncSession,
+) -> None:
+    """WHO marked ready is peer-attributable participation metadata: a blind
+    caller's reviewers_ready must carry only their own entry, while the
+    aggregate ready_count stays intact (the N/M hint leaks no identity)."""
+    built = await _build_two_reviewer_review_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, reviewer_b = built
+
+    ready_service = ExtractionReviewerReadyService(db_session)
+    await ready_service.mark_ready(run_id=run_id, reviewer_id=reviewer_a, is_ready=True)
+    await ready_service.mark_ready(run_id=run_id, reviewer_id=reviewer_b, is_ready=True)
+
+    blind = await build_run_view(db_session, run_id, caller_id=reviewer_b, can_see_peers=False)
+    assert blind.ready_count == 2, "the aggregate count must survive the blind scrub"
+    assert blind.reviewers_ready == [reviewer_b], (
+        "blind leak: a plain reviewer received a peer's ready-participation id"
+    )
+
+    unblinded = await build_run_view(db_session, run_id, caller_id=reviewer_b, can_see_peers=True)
+    assert set(unblinded.reviewers_ready) == {reviewer_a, reviewer_b}, (
+        "an unblinded caller must still see the full ready list"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_extraction_runs_ready_api.py
+++ b/backend/tests/integration/test_extraction_runs_ready_api.py
@@ -114,6 +114,48 @@ async def test_mark_ready_admits_non_manager_reviewer(
 
 
 @pytest.mark.asyncio
+async def test_blind_reviewer_payload_has_no_peer_ready_ids(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_manager: UUID,
+) -> None:
+    """Blind contract (ADR-0012): WHO marked ready is peer-attributable
+    participation metadata. A blind reviewer's /view and /ready payloads must
+    carry only their own id in reviewers_ready; the aggregate ready_count
+    stays intact."""
+    if not await _seeded(db_session):
+        pytest.skip("Missing fixtures.")
+    run_id = await _create_run(db_client)
+    adv = await db_client.post(f"/api/v1/runs/{run_id}/advance", json={"target_stage": "extract"})
+    assert adv.status_code == 200, adv.text
+
+    # The manager marks ready first (a peer participation the reviewer must not see).
+    res = await db_client.post(f"/api/v1/runs/{run_id}/ready", json={"ready": True})
+    assert res.status_code == 200, res.text
+
+    _auth_as(SEED.reviewer_profile)  # a plain (blind) project reviewer
+
+    # The blind reviewer's own mark-ready echo: aggregate counts, own id only.
+    res = await db_client.post(f"/api/v1/runs/{run_id}/ready", json={"ready": True})
+    assert res.status_code == 200, res.text
+    data = res.json()["data"]
+    assert data["ready_count"] == 2
+    assert data["reviewers_ready"] == [str(SEED.reviewer_profile)], (
+        "blind leak: POST /ready returned a peer's id to a blind reviewer"
+    )
+
+    # The run-view payload: same scrub, same intact aggregate.
+    view = await db_client.get(f"/api/v1/runs/{run_id}/view")
+    assert view.status_code == 200, view.text
+    vdata = view.json()["data"]
+    assert vdata["ready_count"] == 2
+    assert vdata["reviewers_ready"] == [str(SEED.reviewer_profile)], (
+        "blind leak: /view returned a peer's id in reviewers_ready to a blind reviewer"
+    )
+    assert str(auth_as_manager) not in vdata["reviewers_ready"]
+
+
+@pytest.mark.asyncio
 async def test_mark_ready_rejects_non_member(
     db_client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -351,8 +351,8 @@ async def test_alembic_head_is_expected_revision() -> None:
     out = _run_alembic("current")
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
-    assert "0040_published_state_restrict" in out, (
-        f"Expected head revision '0040_published_state_restrict', got:\n{out}"
+    assert "0041_reviewer_ready_select_rls" in out, (
+        f"Expected head revision '0041_reviewer_ready_select_rls', got:\n{out}"
     )
 
 

--- a/backend/tests/integration/test_reviewer_ready_rls.py
+++ b/backend/tests/integration/test_reviewer_ready_rls.py
@@ -1,0 +1,162 @@
+"""RLS probes for ``extraction_reviewer_ready`` (blind participation metadata).
+
+The 2026-07-02 security review (finding 2) reversed 0029's "knowing someone is
+'done' leaks no values" rationale: WHO marked ready is peer-attributable
+participation metadata under the blind contract (ADR-0012). The API path is
+scrubbed in ``ExtractionReviewerReadyService.ready_summary_from``; these
+probes pin the PostgREST/devtools path — the SELECT policy must self-scope by
+``reviewer_id`` with the 0025 arbitrator/finalized carve-outs, so both read
+paths encode the identical predicate (architecture doc §3).
+
+Probes run as the ``authenticated`` role with a real JWT sub, mirroring
+``test_blind_review_isolation.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.extraction_reviewer_ready_service import ExtractionReviewerReadyService
+from tests.integration.test_blind_review_isolation import (
+    _build_two_reviewer_review_run,
+)
+
+
+async def _ready_two_reviewer_run(
+    db: AsyncSession,
+) -> tuple[UUID, UUID, UUID] | None:
+    """The two-reviewer EXTRACT-stage run with BOTH reviewers marked ready."""
+    built = await _build_two_reviewer_review_run(db)
+    if built is None:
+        return None
+    run_id, reviewer_a, reviewer_b = built
+    service = ExtractionReviewerReadyService(db)
+    await service.mark_ready(run_id=run_id, reviewer_id=reviewer_a, is_ready=True)
+    await service.mark_ready(run_id=run_id, reviewer_id=reviewer_b, is_ready=True)
+    await db.flush()
+    return run_id, reviewer_a, reviewer_b
+
+
+async def _visible_ready_rows(
+    db: AsyncSession, *, as_user: UUID, run_id: UUID, reviewer_id: UUID
+) -> int:
+    """Count ready rows for ``reviewer_id`` visible to ``as_user`` under RLS."""
+    try:
+        await db.execute(
+            text("SELECT set_config('request.jwt.claims', :claims, true)"),
+            {"claims": json.dumps({"sub": str(as_user), "role": "authenticated"})},
+        )
+        await db.execute(text("SET LOCAL ROLE authenticated"))
+        return (
+            await db.execute(
+                text(
+                    "SELECT count(*) FROM public.extraction_reviewer_ready "
+                    "WHERE run_id = :rid AND reviewer_id = :reviewer"
+                ),
+                {"rid": str(run_id), "reviewer": str(reviewer_id)},
+            )
+        ).scalar_one()
+    finally:
+        await db.execute(text("RESET ROLE"))
+
+
+@pytest.mark.asyncio
+async def test_blind_reviewer_cannot_read_peer_ready_rows(
+    db_session: AsyncSession,
+) -> None:
+    built = await _ready_two_reviewer_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, reviewer_b = built
+
+    own = await _visible_ready_rows(
+        db_session, as_user=reviewer_b, run_id=run_id, reviewer_id=reviewer_b
+    )
+    assert own == 1, "a reviewer must keep reading their OWN ready row"
+
+    peer = await _visible_ready_rows(
+        db_session, as_user=reviewer_b, run_id=run_id, reviewer_id=reviewer_a
+    )
+    assert peer == 0, (
+        "blind leak via PostgREST: a plain reviewer can read a peer's ready "
+        f"row ({peer} row(s) visible). The SELECT policy must self-scope by reviewer_id."
+    )
+
+
+@pytest.mark.asyncio
+async def test_arbitrator_reads_all_ready_rows(db_session: AsyncSession) -> None:
+    """A manager/consensus arbitrator keeps full visibility (0025 carve-out) —
+    RLS deliberately stays looser than the API's manager-toggle policy
+    (ADR-0012: manager blindness is a UX policy, not a security boundary)."""
+    built = await _ready_two_reviewer_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, _reviewer_b = built
+
+    manager = (
+        await db_session.execute(
+            text(
+                "SELECT pm.user_id FROM public.project_members pm "
+                "JOIN public.extraction_runs r ON r.project_id = pm.project_id "
+                "WHERE r.id = :rid AND pm.role = 'manager' LIMIT 1"
+            ),
+            {"rid": str(run_id)},
+        )
+    ).scalar()
+    if manager is None:
+        pytest.skip("Seed graph incomplete")
+
+    peer = await _visible_ready_rows(
+        db_session, as_user=UUID(str(manager)), run_id=run_id, reviewer_id=reviewer_a
+    )
+    assert peer == 1, "an arbitrator must see every reviewer's ready row"
+
+
+@pytest.mark.asyncio
+async def test_finalized_run_reveals_ready_rows(db_session: AsyncSession) -> None:
+    built = await _ready_two_reviewer_run(db_session)
+    if built is None:
+        pytest.skip("Seed graph incomplete")
+    run_id, reviewer_a, reviewer_b = built
+
+    await db_session.execute(
+        text("UPDATE public.extraction_runs SET stage = 'finalized' WHERE id = :id"),
+        {"id": str(run_id)},
+    )
+    await db_session.flush()
+
+    peer = await _visible_ready_rows(
+        db_session, as_user=reviewer_b, run_id=run_id, reviewer_id=reviewer_a
+    )
+    assert peer == 1, (
+        "finalized runs must reveal ready rows (the policy gates on stage, not blanket-hide peers)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reviewer_ready_select_policy_is_reviewer_scoped(
+    db_session: AsyncSession,
+) -> None:
+    """Structural guard: the SELECT policy must reference the row's
+    reviewer_id (self-scoping), mirroring the 0025 pattern on
+    extraction_reviewer_decisions."""
+    expr = (
+        await db_session.execute(
+            text(
+                "SELECT pg_get_expr(p.polqual, p.polrelid) "
+                "FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid "
+                "WHERE c.relname = 'extraction_reviewer_ready' "
+                "AND p.polname = 'extraction_reviewer_ready_select'"
+            )
+        )
+    ).scalar()
+    assert expr is not None, "SELECT policy missing"
+    assert "reviewer_id" in expr, (
+        "Blind leak: extraction_reviewer_ready_select does not self-scope "
+        f"by reviewer_id. Current policy: {expr}"
+    )

--- a/docs/reference/extraction-hitl-architecture.md
+++ b/docs/reference/extraction-hitl-architecture.md
@@ -106,7 +106,7 @@ and `extraction_instance_status` enum were dropped in HITL Phase 3 (migration
 ## 3. Database — final schema
 
 All tables live in the `public` schema with RLS enabled. Migration head:
-`0040_published_state_restrict` (post-squash numbering; run
+`0041_reviewer_ready_select_rls` (post-squash numbering; run
 `ls backend/alembic/versions/` for the current head — and bump this line
 in any PR that adds an `extraction_*` migration).
 
@@ -470,10 +470,10 @@ publish, AI), keep it in the page-specific component.
   WHO marked ready is peer-attributable participation metadata (ADR-0012): the
   API scrubs `reviewers_ready` to the caller's own entry unless the caller is
   unblinded (`peers_revealed`); the counts stay aggregate. Single home of the
-  scrub: `ExtractionReviewerReadyService.ready_summary_from`. NOTE the RLS
-  SELECT on this table is still project-member-scoped (0029's "knowing someone
-  is done leaks no values" rationale predates the scrub), so the API is
-  deliberately stricter than RLS here pending a 0029 revisit.
+  scrub: `ExtractionReviewerReadyService.ready_summary_from`. The RLS SELECT
+  (`0041`, superseding 0029's member-wide read) self-scopes with the 0025
+  carve-outs (own row OR arbitrator OR finalized), so both read paths encode
+  the reviewer↔reviewer boundary in lockstep.
 - **managers_see_reviewers** — Per-kind manager blind-review policy on
   `projects.settings` (`{extraction, quality_assessment}`, both default
   `false` = managers blind). Read **live** by the API read path

--- a/docs/reference/extraction-hitl-architecture.md
+++ b/docs/reference/extraction-hitl-architecture.md
@@ -467,6 +467,13 @@ publish, AI), keep it in the page-specific component.
   (`extraction_reviewer_ready`, ADR-0015). Toggled via `POST /runs/{id}/ready`
   (membership + reviewer-role gated); does **not** gate any transition. The run
   view exposes an `N/M reviewers ready` hint (`M = max(reviewer_count, N)`).
+  WHO marked ready is peer-attributable participation metadata (ADR-0012): the
+  API scrubs `reviewers_ready` to the caller's own entry unless the caller is
+  unblinded (`peers_revealed`); the counts stay aggregate. Single home of the
+  scrub: `ExtractionReviewerReadyService.ready_summary_from`. NOTE the RLS
+  SELECT on this table is still project-member-scoped (0029's "knowing someone
+  is done leaks no values" rationale predates the scrub), so the API is
+  deliberately stricter than RLS here pending a 0029 revisit.
 - **managers_see_reviewers** — Per-kind manager blind-review policy on
   `projects.settings` (`{extraction, quality_assessment}`, both default
   `false` = managers blind). Read **live** by the API read path

--- a/frontend/hooks/runs/types.ts
+++ b/frontend/hooks/runs/types.ts
@@ -55,6 +55,8 @@ export interface MarkReadyRequest {
 export interface RunReadyStateResponse {
   ready_count: number;
   reviewer_count: number;
+  /** Blind-gated (ADR-0012): only the caller's own entry unless unblinded —
+   * enough for the self-check; the counts stay aggregate. */
   reviewers_ready: string[];
 }
 
@@ -205,7 +207,9 @@ export interface RunViewResponse extends RunDetailResponse {
   current_values: RunViewCurrentValue[];
   instances: RunViewInstanceResponse[];
   /** "N/M reviewers ready" hint (advisory; readiness gates nothing). Optional in
-   * the type only so fixtures need not construct it; backend always sends it. */
+   * the type only so fixtures need not construct it; backend always sends it.
+   * reviewers_ready is blind-gated (ADR-0012): a blind caller gets only their
+   * own entry, never peer ids. */
   ready_count?: number;
   reviewer_count?: number;
   reviewers_ready?: string[];

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -4817,7 +4817,7 @@
         "type": "object"
       },
       "RunReadyStateResponse": {
-        "description": "The \"N/M reviewers ready\" hint. Advisory only \u2014 readiness gates nothing.\n\n``reviewer_count`` is ``max(hitl_config reviewer_count, ready_count)`` so the\nhint never reads \"N of M\" with N > M (the configured count is often the inert\ndefault of 1).",
+        "description": "The \"N/M reviewers ready\" hint. Advisory only \u2014 readiness gates nothing.\n\n``reviewer_count`` is ``max(hitl_config reviewer_count, ready_count)`` so the\nhint never reads \"N of M\" with N > M (the configured count is often the inert\ndefault of 1). ``reviewers_ready`` is blind-gated (ADR-0012): it carries only\nthe caller's own entry unless the caller is unblinded \u2014 the counts stay\naggregate.",
         "properties": {
           "ready_count": {
             "title": "Ready Count",
@@ -8427,7 +8427,7 @@
     },
     "/api/v1/runs/{run_id}/ready": {
       "post": {
-        "description": "Toggle the caller's per-reviewer \"ready\" signal for a run.\n\nAdvisory only \u2014 it never advances the run (the manager opens consensus\nmanually). Membership-gated AND reviewer-role-gated (a read-only viewer\ncannot mark ready). Returns the \"N/M reviewers ready\" hint.",
+        "description": "Toggle the caller's per-reviewer \"ready\" signal for a run.\n\nAdvisory only \u2014 it never advances the run (the manager opens consensus\nmanually). Membership-gated AND reviewer-role-gated (a read-only viewer\ncannot mark ready). Returns the \"N/M reviewers ready\" hint with\n``reviewers_ready`` scoped to the caller's own entry (this response is the\ncaller's toggle echo; an unblinded caller reads the full list via /view).",
         "operationId": "mark_run_ready_api_v1_runs__run_id__ready_post",
         "parameters": [
           {

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -810,7 +810,9 @@ export interface paths {
          *
          *     Advisory only — it never advances the run (the manager opens consensus
          *     manually). Membership-gated AND reviewer-role-gated (a read-only viewer
-         *     cannot mark ready). Returns the "N/M reviewers ready" hint.
+         *     cannot mark ready). Returns the "N/M reviewers ready" hint with
+         *     ``reviewers_ready`` scoped to the caller's own entry (this response is the
+         *     caller's toggle echo; an unblinded caller reads the full list via /view).
          */
         post: operations["mark_run_ready_api_v1_runs__run_id__ready_post"];
         delete?: never;
@@ -3099,7 +3101,9 @@ export interface components {
          *
          *     ``reviewer_count`` is ``max(hitl_config reviewer_count, ready_count)`` so the
          *     hint never reads "N of M" with N > M (the configured count is often the inert
-         *     default of 1).
+         *     default of 1). ``reviewers_ready`` is blind-gated (ADR-0012): it carries only
+         *     the caller's own entry unless the caller is unblinded — the counts stay
+         *     aggregate.
          */
         RunReadyStateResponse: {
             /** Ready Count */


### PR DESCRIPTION
## Why

The run-view payload (`GET /runs/{id}/view`, and the QA session-open embed) shipped the raw `reviewers_ready` user-id list to every caller, `POST /runs/{id}/ready` echoed the same list, and the RLS SELECT on `extraction_reviewer_ready` allowed any project member to read peer ready rows via PostgREST. A blind reviewer could learn WHICH peers marked ready — participation metadata the blind contract (ADR-0012) should not expose by id. Found in the 2026-07-02 run-header declutter security review (finding 2). This PR closes **both layers in lockstep** (architecture doc §3 rule).

## What changed

**API layer (single home of the scrub)**

- `ExtractionReviewerReadyService.ready_summary_from` now takes `caller_id` + `include_peers`: `reviewers_ready` carries only the caller's own entry unless peers are revealed (backend/app/services/extraction_reviewer_ready_service.py). Counts stay aggregate — the N/M hint leaks no identity.
- `build_run_view` passes its already-computed `peers_revealed` as `include_peers`, so the gate reuses the single blind source and cannot drift from the row filter (backend/app/services/extraction_run_read_service.py:374).
- `POST /runs/{id}/ready` stays caller-scoped always (the response is the caller's toggle echo; an unblinded caller reads the full list via `/view`).
- Schema docstrings document the contract; API types regenerated (docstring-only diff). Response **shape** unchanged — the frontend self-check (`reviewers_ready.includes(currentUserId)`, `ExtractionFullScreen.tsx:1080`) works as-is because the caller's own entry is preserved.

**RLS layer (migration `0041_reviewer_ready_select_rls`)**

- Supersedes 0029's member-wide SELECT (whose "knowing someone is done leaks no values" rationale this review reversed). Mirrors the 0025 pattern exactly: own row OR `is_project_arbitrator` OR finalized run. INSERT/UPDATE unchanged (already self-scoped in 0029).
- Architecture doc: ReviewerReady entry documents the scrub + lockstep RLS; migration-head line bumped; head-pin test updated.

## Risk

Read-path scoping + one RLS policy replace; no table/column change, no write-path change. The backend reads `extraction_reviewer_ready` as `service_role` (RLS bypassed) and the frontend never reads it via PostgREST (verified), so 0041 is behavior-neutral for the app — it closes the devtools path only. Unblinded callers (consensus members, managers with reveal, arbitrator in consensus, finalized runs) still get the full list on `/view`; RLS deliberately keeps the manager-as-arbitrator carve-out per ADR-0012's API-stricter-than-RLS split. Migration verified offline (`--sql`) both directions and roundtripped in the suite.

## Test plan

- [x] New integration tests, written RED first:
  - blind reviewer's `/view` + `/ready` payloads contain no peer ids while `ready_count` stays aggregate; unblinded caller keeps the full list (`test_build_run_view.py`, `test_extraction_runs_ready_api.py`)
  - RLS probes as `authenticated` + JWT sub (`test_reviewer_ready_rls.py`): blind reviewer denied peer rows but keeps own; arbitrator sees all; finalized reveals; structural policy-expression guard
- [x] `make test-backend` — 2418 passed, 5 skipped (includes migration roundtrip through 0041)
- [x] `make lint-backend` clean
- [x] `npm run test:run` — 1099 passed; `npx tsc --noEmit` clean
- [x] `npm run generate:api-types` — committed, docstring-only diff

## Out of scope

None — the RLS follow-up originally chip-filed from this finding is folded in here so both layers land as one lockstep unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)