### PR TITLE
fix(tests): run migration round-trips on an ephemeral scratch DB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,67 +219,10 @@ jobs:
         run: bash ../scripts/validate_migration_boundaries.sh
         working-directory: backend
 
+      # Stub content lives in tests/integration/supabase_stub.sql — the same
+      # file the migration round-trip fixture applies to its scratch DB.
       - name: Bootstrap auth schema stub (Supabase auth.users + RLS helpers)
-        run: |
-          psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 <<'SQL'
-          CREATE SCHEMA IF NOT EXISTS auth;
-          -- Supabase's auth.users carries far more columns (instance_id, aud,
-          -- role, encrypted_password, ...). Tests that exercise the JWT path
-          -- — notably test_membership_guards.outsider_user — insert with the
-          -- minimum useful subset, so mirror it in the stub.
-          CREATE TABLE IF NOT EXISTS auth.users (
-            id UUID PRIMARY KEY,
-            email TEXT,
-            instance_id UUID,
-            aud TEXT,
-            role TEXT
-          );
-          -- Stub auth.uid() and auth.role(): real implementations live in
-          -- Supabase's auth schema. They mirror Supabase's readers of the
-          -- request.jwt.* GUCs so RLS probes (set_config claims + SET LOCAL
-          -- ROLE authenticated, e.g. test_reviewer_ready_rls.py) authenticate
-          -- exactly as against a real Supabase Postgres; with no claims set
-          -- they return NULL, which is all `alembic upgrade head` needs.
-          CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
-            LANGUAGE sql STABLE AS $$
-              SELECT coalesce(
-                nullif(current_setting('request.jwt.claim.sub', true), ''),
-                nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
-              )::uuid
-            $$;
-          CREATE OR REPLACE FUNCTION auth.role() RETURNS text
-            LANGUAGE sql STABLE AS $$
-              SELECT coalesce(
-                nullif(current_setting('request.jwt.claim.role', true), ''),
-                nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role'
-              )
-            $$;
-          -- Supabase pre-creates these roles; migrations GRANT to them.
-          DO $$ BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
-              CREATE ROLE anon NOLOGIN;
-            END IF;
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-              CREATE ROLE authenticated NOLOGIN;
-            END IF;
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
-              CREATE ROLE service_role NOLOGIN BYPASSRLS;
-            END IF;
-          END $$;
-          -- storage.objects stub: migration 0003 attaches RLS policies to it.
-          -- Columns mirror what the policies reference (bucket_id, name).
-          CREATE SCHEMA IF NOT EXISTS storage;
-          CREATE TABLE IF NOT EXISTS storage.objects (
-            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-            bucket_id TEXT,
-            name TEXT,
-            owner UUID,
-            created_at TIMESTAMPTZ DEFAULT now(),
-            updated_at TIMESTAMPTZ DEFAULT now(),
-            metadata JSONB
-          );
-          ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
-          SQL
+        run: psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 -f tests/integration/supabase_stub.sql
 
       - name: Apply Alembic migrations
         run: uv run alembic upgrade head
@@ -452,61 +395,10 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --extra dev
 
+      # Stub content lives in tests/integration/supabase_stub.sql — the same
+      # file the migration round-trip fixture applies to its scratch DB.
       - name: Bootstrap auth schema stub
-        run: |
-          psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 <<'SQL'
-          CREATE SCHEMA IF NOT EXISTS auth;
-          -- Supabase's auth.users carries far more columns (instance_id, aud,
-          -- role, encrypted_password, ...). Tests that exercise the JWT path
-          -- — notably test_membership_guards.outsider_user — insert with the
-          -- minimum useful subset, so mirror it in the stub.
-          CREATE TABLE IF NOT EXISTS auth.users (
-            id UUID PRIMARY KEY,
-            email TEXT,
-            instance_id UUID,
-            aud TEXT,
-            role TEXT
-          );
-          CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
-            LANGUAGE sql STABLE AS $$
-              SELECT coalesce(
-                nullif(current_setting('request.jwt.claim.sub', true), ''),
-                nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
-              )::uuid
-            $$;
-          CREATE OR REPLACE FUNCTION auth.role() RETURNS text
-            LANGUAGE sql STABLE AS $$
-              SELECT coalesce(
-                nullif(current_setting('request.jwt.claim.role', true), ''),
-                nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role'
-              )
-            $$;
-          -- Supabase pre-creates these roles; migrations GRANT to them.
-          DO $$ BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
-              CREATE ROLE anon NOLOGIN;
-            END IF;
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-              CREATE ROLE authenticated NOLOGIN;
-            END IF;
-            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
-              CREATE ROLE service_role NOLOGIN BYPASSRLS;
-            END IF;
-          END $$;
-          -- storage.objects stub: migration 0003 attaches RLS policies to it.
-          -- Columns mirror what the policies reference (bucket_id, name).
-          CREATE SCHEMA IF NOT EXISTS storage;
-          CREATE TABLE IF NOT EXISTS storage.objects (
-            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-            bucket_id TEXT,
-            name TEXT,
-            owner UUID,
-            created_at TIMESTAMPTZ DEFAULT now(),
-            updated_at TIMESTAMPTZ DEFAULT now(),
-            metadata JSONB
-          );
-          ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
-          SQL
+        run: psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 -f tests/integration/supabase_stub.sql
 
       - name: Apply Alembic migrations
         run: uv run alembic upgrade head

--- a/backend/tests/integration/supabase_stub.sql
+++ b/backend/tests/integration/supabase_stub.sql
@@ -1,0 +1,67 @@
+-- Supabase auth/storage stub for plain-Postgres databases.
+--
+-- Single source of truth for the bootstrap that CI's backend-test and
+-- backend-e2e jobs apply to their scratch postgres:15 service container
+-- (.github/workflows/ci.yml, "Bootstrap auth schema stub" steps), and that
+-- the migration_db_url fixture in tests/integration/test_migration_roundtrip.py
+-- applies to its ephemeral round-trip database. Idempotent: every statement
+-- is IF NOT EXISTS / OR REPLACE / pg_roles-guarded, so applying it to a
+-- database (or cluster) that already has the real Supabase objects is a no-op.
+
+CREATE SCHEMA IF NOT EXISTS auth;
+-- Supabase's auth.users carries far more columns (instance_id, aud,
+-- role, encrypted_password, ...). Tests that exercise the JWT path
+-- — notably test_membership_guards.outsider_user — insert with the
+-- minimum useful subset, so mirror it in the stub.
+CREATE TABLE IF NOT EXISTS auth.users (
+  id UUID PRIMARY KEY,
+  email TEXT,
+  instance_id UUID,
+  aud TEXT,
+  role TEXT
+);
+-- Stub auth.uid() and auth.role(): real implementations live in
+-- Supabase's auth schema. They mirror Supabase's readers of the
+-- request.jwt.* GUCs so RLS probes (set_config claims + SET LOCAL
+-- ROLE authenticated, e.g. test_reviewer_ready_rls.py) authenticate
+-- exactly as against a real Supabase Postgres; with no claims set
+-- they return NULL, which is all `alembic upgrade head` needs.
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid
+  LANGUAGE sql STABLE AS $$
+    SELECT coalesce(
+      nullif(current_setting('request.jwt.claim.sub', true), ''),
+      nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+    )::uuid
+  $$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text
+  LANGUAGE sql STABLE AS $$
+    SELECT coalesce(
+      nullif(current_setting('request.jwt.claim.role', true), ''),
+      nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role'
+    )
+  $$;
+-- Supabase pre-creates these roles; migrations GRANT to them.
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    CREATE ROLE anon NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    CREATE ROLE service_role NOLOGIN BYPASSRLS;
+  END IF;
+END $$;
+-- storage.objects stub: migration 0003 attaches RLS policies to it.
+-- Columns mirror what the policies reference (bucket_id, name).
+CREATE SCHEMA IF NOT EXISTS storage;
+CREATE TABLE IF NOT EXISTS storage.objects (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  bucket_id TEXT,
+  name TEXT,
+  owner UUID,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  metadata JSONB
+);
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;

--- a/backend/tests/integration/test_migration_roundtrip.py
+++ b/backend/tests/integration/test_migration_roundtrip.py
@@ -1,29 +1,61 @@
 """Integration test: alembic migrations are reversible end-to-end.
 
-Drives ``alembic downgrade -1 → upgrade head`` against the live dev DB
-to verify that ``0002_drop_extracted_values`` (and any future migration
-on top of the squash baseline) round-trips without leaving the schema
-in a different state than where it started.
+Drives ``alembic downgrade <parent> → upgrade head`` to verify that every
+DDL migration on top of the squash baseline round-trips without leaving the
+schema in a different state than where it started.
 
-Skipped automatically if the DB is unreachable (e.g., CI without
-Supabase boot)."""
+The round-trips run against an ephemeral database (``prumo_migration_test``)
+created per test session on the same Postgres server — never against the
+shared dev database. Replaying the chain drops and re-adds columns, and
+every dropped column leaves a permanent ``pg_attribute`` tombstone that
+counts toward Postgres's 1600-column table limit until the table is
+recreated (VACUUM FULL does not clear them), so repeated runs against the
+dev DB eventually die with ``TooManyColumnsError``; the downgrades also
+destroy real data in the columns they drop. The scratch DB is built exactly
+like CI builds its test database: ``supabase_stub.sql`` onto a fresh
+database, then ``alembic upgrade head``.
+"""
 
+import os
 import subprocess
+from collections.abc import AsyncGenerator
 from pathlib import Path
 
+import asyncpg
 import pytest
+import pytest_asyncio
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.core.config import settings
 
 # Repo root is two levels up from this file; alembic must run with cwd=backend/
 _BACKEND_DIR = Path(__file__).resolve().parents[2]
 
+# Same stub CI applies to its scratch postgres before `alembic upgrade head`:
+# auth schema + auth.uid()/auth.role() GUC readers (baseline RLS policies
+# reference them at CREATE POLICY time), Supabase roles, storage.objects.
+_STUB_SQL = Path(__file__).with_name("supabase_stub.sql")
 
-def _run_alembic(*args: str) -> str:
-    """Run ``uv run alembic <args>`` synchronously from backend/."""
+# Fixed name is safe: concurrent pytest sessions are already forbidden for
+# this suite (cross-session advisory locks hang), and setup drops leftovers.
+_SCRATCH_DB_NAME = "prumo_migration_test"
+
+
+def _run_alembic(*args: str, database_url: str) -> str:
+    """Run ``uv run alembic <args>`` from backend/ against ``database_url``.
+
+    Overrides BOTH URL env vars: alembic's env.py prefers DIRECT_DATABASE_URL
+    over DATABASE_URL, and OS env beats backend/.env in pydantic-settings —
+    overriding only one would leak the round-trip onto the dev database.
+    """
+    env = {**os.environ, "DATABASE_URL": database_url, "DIRECT_DATABASE_URL": database_url}
     proc = subprocess.run(
         ["uv", "run", "alembic", *args],
         cwd=str(_BACKEND_DIR),
+        env=env,
         capture_output=True,
         text=True,
         check=False,
@@ -35,8 +67,70 @@ def _run_alembic(*args: str) -> str:
     return proc.stdout
 
 
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def migration_db_url() -> AsyncGenerator[str, None]:
+    """Ephemeral scratch database the round-trips run against; yields its URL.
+
+    DROP/CREATE DATABASE cannot run inside a transaction, so a raw asyncpg
+    connection (autocommit outside explicit transactions) drives the admin
+    statements; ``WITH (FORCE)`` kicks any connection a crashed prior run
+    leaked. The multi-statement stub file goes through asyncpg's simple-query
+    protocol (no-args ``execute``), which allows several statements per call.
+    """
+    admin_dsn = make_url(str(settings.DATABASE_URL)).render_as_string(hide_password=False)
+    scratch_dsn = (
+        make_url(admin_dsn).set(database=_SCRATCH_DB_NAME).render_as_string(hide_password=False)
+    )
+
+    admin = await asyncpg.connect(dsn=admin_dsn)
+    try:
+        await admin.execute(f"DROP DATABASE IF EXISTS {_SCRATCH_DB_NAME} WITH (FORCE)")
+        await admin.execute(f"CREATE DATABASE {_SCRATCH_DB_NAME}")
+    finally:
+        await admin.close()
+
+    scratch = await asyncpg.connect(dsn=scratch_dsn)
+    try:
+        await scratch.execute(_STUB_SQL.read_text())
+    finally:
+        await scratch.close()
+
+    _run_alembic("upgrade", "head", database_url=scratch_dsn)
+    yield scratch_dsn
+
+    admin = await asyncpg.connect(dsn=admin_dsn)
+    try:
+        await admin.execute(f"DROP DATABASE IF EXISTS {_SCRATCH_DB_NAME} WITH (FORCE)")
+    finally:
+        await admin.close()
+
+
+@pytest_asyncio.fixture
+async def migration_session(migration_db_url: str) -> AsyncGenerator[AsyncSession, None]:
+    """Session bound to the scratch DB, for the schema-state assertions.
+
+    Fresh NullPool engine per test, disposed before teardown, so no pooled
+    connection outlives the test and blocks the session-end DROP DATABASE.
+    """
+    url = make_url(migration_db_url).set(drivername="postgresql+asyncpg")
+    # Same sslmode -> ssl rename Settings.async_database_url applies: the
+    # asyncpg driver rejects libpq's sslmode as a connect() kwarg.
+    query = dict(url.query)
+    if "sslmode" in query and "ssl" not in query:
+        query["ssl"] = query.pop("sslmode")
+    engine = create_async_engine(url.set(query=query), echo=False, poolclass=NullPool)
+    sessionmaker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
 @pytest.mark.asyncio
-async def test_migration_0002_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0002_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """Downgrade one revision then upgrade to head; assert the dropped
     objects are restored mid-trip and re-removed by the time we're back
     at head.
@@ -47,7 +141,7 @@ async def test_migration_0002_round_trip(db_session: AsyncSession) -> None:
     captured in ``baseline_v1.sql``.
     """
     pre = (
-        await db_session.execute(
+        await migration_session.execute(
             text(
                 "SELECT 1 FROM information_schema.tables "
                 "WHERE table_schema='public' AND table_name='extracted_values'"
@@ -56,12 +150,12 @@ async def test_migration_0002_round_trip(db_session: AsyncSession) -> None:
     ).scalar()
     assert pre is None, "extracted_values must be absent at HEAD"
 
-    _run_alembic("downgrade", "0001_baseline_v1")
+    _run_alembic("downgrade", "0001_baseline_v1", database_url=migration_db_url)
     try:
         # Below 0002 the legacy table + enum should exist again.
-        await db_session.commit()
+        await migration_session.commit()
         post_down = (
-            await db_session.execute(
+            await migration_session.execute(
                 text(
                     "SELECT 1 FROM information_schema.tables "
                     "WHERE table_schema='public' AND table_name='extracted_values'"
@@ -71,17 +165,17 @@ async def test_migration_0002_round_trip(db_session: AsyncSession) -> None:
         assert post_down == 1, "extracted_values must be restored by downgrade"
 
         enum_row = (
-            await db_session.execute(
+            await migration_session.execute(
                 text("SELECT 1 FROM pg_type WHERE typname = 'extraction_source'")
             )
         ).scalar()
         assert enum_row == 1, "extraction_source enum must be restored by downgrade"
     finally:
-        _run_alembic("upgrade", "head")
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
 
-    await db_session.commit()
+    await migration_session.commit()
     after = (
-        await db_session.execute(
+        await migration_session.execute(
             text(
                 "SELECT 1 FROM information_schema.tables "
                 "WHERE table_schema='public' AND table_name='extracted_values'"
@@ -91,7 +185,9 @@ async def test_migration_0002_round_trip(db_session: AsyncSession) -> None:
     assert after is None, "extracted_values must be re-dropped after upgrade head"
 
     enum_after = (
-        await db_session.execute(text("SELECT 1 FROM pg_type WHERE typname = 'extraction_source'"))
+        await migration_session.execute(
+            text("SELECT 1 FROM pg_type WHERE typname = 'extraction_source'")
+        )
     ).scalar()
     assert enum_after is None, "extraction_source enum must be re-dropped"
 
@@ -105,7 +201,9 @@ _ENUM_PRESENT = text("SELECT 1 FROM pg_type WHERE typname = 'extraction_instance
 
 
 @pytest.mark.asyncio
-async def test_migration_0030_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0030_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """``0030_drop_instance_status`` removes ``extraction_instances.status`` and
     its enum at head; downgrading below 0030 (to its parent ``0029``) restores
     the schema (column + enum, not the data); ``upgrade head`` re-removes both.
@@ -113,30 +211,30 @@ async def test_migration_0030_round_trip(db_session: AsyncSession) -> None:
     correct as later migrations stack on top. Guards against drift between a
     fresh ``alembic upgrade head`` and ``baseline_v1.sql`` (which still ships the
     legacy column)."""
-    assert (await db_session.execute(_COL_PRESENT)).scalar() is None, (
+    assert (await migration_session.execute(_COL_PRESENT)).scalar() is None, (
         "extraction_instances.status must be absent at HEAD"
     )
-    assert (await db_session.execute(_ENUM_PRESENT)).scalar() is None, (
+    assert (await migration_session.execute(_ENUM_PRESENT)).scalar() is None, (
         "extraction_instance_status enum must be absent at HEAD"
     )
 
-    _run_alembic("downgrade", "0029_reviewer_ready_flag")
+    _run_alembic("downgrade", "0029_reviewer_ready_flag", database_url=migration_db_url)
     try:
-        await db_session.commit()
-        assert (await db_session.execute(_COL_PRESENT)).scalar() == 1, (
+        await migration_session.commit()
+        assert (await migration_session.execute(_COL_PRESENT)).scalar() == 1, (
             "downgrade must restore the status column"
         )
-        assert (await db_session.execute(_ENUM_PRESENT)).scalar() == 1, (
+        assert (await migration_session.execute(_ENUM_PRESENT)).scalar() == 1, (
             "downgrade must recreate the extraction_instance_status enum"
         )
     finally:
-        _run_alembic("upgrade", "head")
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
 
-    await db_session.commit()
-    assert (await db_session.execute(_COL_PRESENT)).scalar() is None, (
+    await migration_session.commit()
+    assert (await migration_session.execute(_COL_PRESENT)).scalar() is None, (
         "upgrade head must re-drop the status column"
     )
-    assert (await db_session.execute(_ENUM_PRESENT)).scalar() is None, (
+    assert (await migration_session.execute(_ENUM_PRESENT)).scalar() is None, (
         "upgrade head must re-drop the extraction_instance_status enum"
     )
 
@@ -159,30 +257,32 @@ _OVERRIDE_CHECK_DEF = text(
 
 
 @pytest.mark.asyncio
-async def test_migration_0032_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0032_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """``0032_optional_rationale`` relaxes the CHECK ``manual_override_complete``
     to require only ``value`` (rationale optional). At head the constraint no
     longer mentions ``rationale``; downgrading to the explicit parent ``0031``
     restores the stricter expression; ``upgrade head`` relaxes it again.
     Downgrades to the explicit parent (not ``-1``) so the test stays correct as
     later migrations stack on top."""
-    def_at_head = (await db_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
+    def_at_head = (await migration_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
     assert def_at_head is not None and "rationale" not in def_at_head, (
         f"manual_override_complete must not require rationale at HEAD, got: {def_at_head}"
     )
 
-    _run_alembic("downgrade", "0031_unique_atb_idx")
+    _run_alembic("downgrade", "0031_unique_atb_idx", database_url=migration_db_url)
     try:
-        await db_session.commit()
-        def_down = (await db_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
+        await migration_session.commit()
+        def_down = (await migration_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
         assert def_down is not None and "rationale" in def_down, (
             f"downgrade must restore the rationale requirement, got: {def_down}"
         )
     finally:
-        _run_alembic("upgrade", "head")
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
 
-    await db_session.commit()
-    def_after = (await db_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
+    await migration_session.commit()
+    def_after = (await migration_session.execute(_OVERRIDE_CHECK_DEF)).scalar()
     assert def_after is not None and "rationale" not in def_after, (
         f"upgrade head must re-relax the constraint, got: {def_after}"
     )
@@ -196,31 +296,33 @@ _ARTICLE_FILES_COLS = text(
 
 
 @pytest.mark.asyncio
-async def test_migration_0033_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0033_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """``0033_article_markdown_cols`` adds ``content_markdown`` + ``content_version``
     and drops the dead ``text_raw`` / ``text_html`` columns. Downgrading to the
     explicit parent ``0032_optional_rationale`` inverts the operation; upgrading to
     head applies it again. Downgrades to the explicit parent (not ``-1``) so the
     test stays correct as later migrations stack on top."""
-    cols_at_head = set((await db_session.execute(_ARTICLE_FILES_COLS)).scalars().all())
+    cols_at_head = set((await migration_session.execute(_ARTICLE_FILES_COLS)).scalars().all())
     assert "content_markdown" in cols_at_head, "content_markdown must exist at HEAD"
     assert "content_version" in cols_at_head, "content_version must exist at HEAD"
     assert "text_raw" not in cols_at_head, "text_raw must be dropped at HEAD"
     assert "text_html" not in cols_at_head, "text_html must be dropped at HEAD"
 
-    _run_alembic("downgrade", "0032_optional_rationale")
+    _run_alembic("downgrade", "0032_optional_rationale", database_url=migration_db_url)
     try:
-        await db_session.commit()
-        cols_down = set((await db_session.execute(_ARTICLE_FILES_COLS)).scalars().all())
+        await migration_session.commit()
+        cols_down = set((await migration_session.execute(_ARTICLE_FILES_COLS)).scalars().all())
         assert "text_raw" in cols_down, "downgrade must restore text_raw"
         assert "text_html" in cols_down, "downgrade must restore text_html"
         assert "content_markdown" not in cols_down, "downgrade must drop content_markdown"
         assert "content_version" not in cols_down, "downgrade must drop content_version"
     finally:
-        _run_alembic("upgrade", "head")
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
 
-    await db_session.commit()
-    cols_after = set((await db_session.execute(_ARTICLE_FILES_COLS)).scalars().all())
+    await migration_session.commit()
+    cols_after = set((await migration_session.execute(_ARTICLE_FILES_COLS)).scalars().all())
     assert "content_markdown" in cols_after, "upgrade head must restore content_markdown"
     assert "content_version" in cols_after, "upgrade head must restore content_version"
     assert "text_raw" not in cols_after, "upgrade head must re-drop text_raw"
@@ -235,26 +337,28 @@ _EVIDENCE_ATTR_LABEL_COL = text(
 
 
 @pytest.mark.asyncio
-async def test_migration_0034_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0034_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """``0034_evidence_attr_label`` adds ``extraction_evidence.attribution_label``.
     Downgrading to the explicit parent ``0033_article_markdown_cols`` drops it;
     upgrading to head restores it. Downgrades to the explicit parent (not ``-1``)
     so the test stays correct as later migrations stack on top."""
-    assert (await db_session.execute(_EVIDENCE_ATTR_LABEL_COL)).scalar() == 1, (
+    assert (await migration_session.execute(_EVIDENCE_ATTR_LABEL_COL)).scalar() == 1, (
         "attribution_label must exist at HEAD"
     )
 
-    _run_alembic("downgrade", "0033_article_markdown_cols")
+    _run_alembic("downgrade", "0033_article_markdown_cols", database_url=migration_db_url)
     try:
-        await db_session.commit()
-        assert (await db_session.execute(_EVIDENCE_ATTR_LABEL_COL)).scalar() is None, (
+        await migration_session.commit()
+        assert (await migration_session.execute(_EVIDENCE_ATTR_LABEL_COL)).scalar() is None, (
             "downgrade must drop attribution_label"
         )
     finally:
-        _run_alembic("upgrade", "head")
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
 
-    await db_session.commit()
-    assert (await db_session.execute(_EVIDENCE_ATTR_LABEL_COL)).scalar() == 1, (
+    await migration_session.commit()
+    assert (await migration_session.execute(_EVIDENCE_ATTR_LABEL_COL)).scalar() == 1, (
         "upgrade head must restore attribution_label"
     )
 
@@ -267,25 +371,29 @@ _EVIDENCE_RANK_COL = text(
 
 
 @pytest.mark.asyncio
-async def test_migration_0035_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0035_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """0035 adds extraction_evidence.rank (server_default '0', backfilling
     legacy rows to 0). Downgrade to the explicit parent 0034_evidence_attr_label
     drops it; upgrade head restores it. Backfill is proven by the server_default
     at the column level (no data: SEED seeds no evidence rows and a raw INSERT
     would violate the NOT NULL FKs + workflow_target_present CHECK)."""
-    assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() == 1, "rank must exist at HEAD"
+    assert (await migration_session.execute(_EVIDENCE_RANK_COL)).scalar() == 1, (
+        "rank must exist at HEAD"
+    )
 
-    _run_alembic("downgrade", "0034_evidence_attr_label")
+    _run_alembic("downgrade", "0034_evidence_attr_label", database_url=migration_db_url)
     try:
-        await db_session.commit()
-        assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() is None, (
+        await migration_session.commit()
+        assert (await migration_session.execute(_EVIDENCE_RANK_COL)).scalar() is None, (
             "downgrade must drop rank"
         )
     finally:
-        _run_alembic("upgrade", "head")
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
 
-    await db_session.commit()
-    assert (await db_session.execute(_EVIDENCE_RANK_COL)).scalar() == 1, (
+    await migration_session.commit()
+    assert (await migration_session.execute(_EVIDENCE_RANK_COL)).scalar() == 1, (
         "upgrade head must restore rank"
     )
 
@@ -298,48 +406,53 @@ _FIELD_DISPOSITION_COLS = text(
 
 
 @pytest.mark.asyncio
-async def test_migration_0038_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0038_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """``0038_field_disposition_flags`` adds ``allows_not_applicable`` +
     ``allows_not_evaluated`` (NOT NULL, server_default false). Downgrading to the
     explicit parent ``0037_block_type_figure`` drops both; upgrading to head
     restores them. Downgrades to the explicit parent (not ``-1``) so the test
     stays correct as later migrations stack on top."""
-    cols_at_head = set((await db_session.execute(_FIELD_DISPOSITION_COLS)).scalars().all())
+    cols_at_head = set((await migration_session.execute(_FIELD_DISPOSITION_COLS)).scalars().all())
     assert cols_at_head == {"allows_not_applicable", "allows_not_evaluated"}, (
         "both disposition flag columns must exist at HEAD"
     )
 
-    _run_alembic("downgrade", "0037_block_type_figure")
+    _run_alembic("downgrade", "0037_block_type_figure", database_url=migration_db_url)
     try:
-        await db_session.commit()
-        cols_down = set((await db_session.execute(_FIELD_DISPOSITION_COLS)).scalars().all())
+        await migration_session.commit()
+        cols_down = set((await migration_session.execute(_FIELD_DISPOSITION_COLS)).scalars().all())
         assert cols_down == set(), "downgrade must drop both disposition flag columns"
     finally:
-        _run_alembic("upgrade", "head")
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
 
-    await db_session.commit()
-    cols_after = set((await db_session.execute(_FIELD_DISPOSITION_COLS)).scalars().all())
+    await migration_session.commit()
+    cols_after = set((await migration_session.execute(_FIELD_DISPOSITION_COLS)).scalars().all())
     assert cols_after == {"allows_not_applicable", "allows_not_evaluated"}, (
         "upgrade head must restore both disposition flag columns"
     )
 
 
 @pytest.mark.asyncio
-async def test_migration_0039_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0039_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """``0039_absent_reason_backfill`` is a data-only migration (no schema
     change), so its roundtrip guard is exercised with data in
-    ``test_migration_0039_backfill``. Here we assert the chain is reversible:
+    ``test_migration_0039_backfill`` (which stays on the main DB inside a
+    rolled-back savepoint). Here we assert the chain is reversible:
     downgrade to the explicit parent ``0038_field_disposition_flags`` and back
     to head both succeed without error — this cycle also exercises
     ``0040_published_state_restrict``'s FK flip (DDL) in both directions."""
-    _run_alembic("downgrade", "0038_field_disposition_flags")
+    _run_alembic("downgrade", "0038_field_disposition_flags", database_url=migration_db_url)
     try:
-        await db_session.commit()
+        await migration_session.commit()
     finally:
-        _run_alembic("upgrade", "head")
-    await db_session.commit()
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
+    await migration_session.commit()
     # Head columns from 0038 are still present after the up/down/up cycle.
-    cols = set((await db_session.execute(_FIELD_DISPOSITION_COLS)).scalars().all())
+    cols = set((await migration_session.execute(_FIELD_DISPOSITION_COLS)).scalars().all())
     assert cols == {"allows_not_applicable", "allows_not_evaluated"}
 
 
@@ -352,39 +465,41 @@ _ARTICLE_BLOB_COLS = text(
 
 
 @pytest.mark.asyncio
-async def test_migration_0042_round_trip(db_session: AsyncSession) -> None:
+async def test_migration_0042_round_trip(
+    migration_db_url: str, migration_session: AsyncSession
+) -> None:
     """``0042_drop_article_blob_columns`` drops the three dead BLOB columns
     from ``articles`` (spec 2026-06-20, decision 2). Downgrading to the
     explicit parent ``0041_reviewer_ready_select_rls`` restores the columns
     (structure only, not the data); ``upgrade head`` re-drops them.
     Downgrades to the explicit parent (not ``-1``) so the test stays correct
     as later migrations stack on top."""
-    cols_at_head = set((await db_session.execute(_ARTICLE_BLOB_COLS)).scalars().all())
+    cols_at_head = set((await migration_session.execute(_ARTICLE_BLOB_COLS)).scalars().all())
     assert cols_at_head == set(), "the three blob columns must be absent at HEAD"
 
-    _run_alembic("downgrade", "0041_reviewer_ready_select_rls")
+    _run_alembic("downgrade", "0041_reviewer_ready_select_rls", database_url=migration_db_url)
     try:
-        await db_session.commit()
-        cols_down = set((await db_session.execute(_ARTICLE_BLOB_COLS)).scalars().all())
+        await migration_session.commit()
+        cols_down = set((await migration_session.execute(_ARTICLE_BLOB_COLS)).scalars().all())
         assert cols_down == {
             "pdf_extracted_text",
             "semantic_abstract_text",
             "semantic_fulltext_text",
         }, "downgrade must restore all three blob columns"
     finally:
-        _run_alembic("upgrade", "head")
+        _run_alembic("upgrade", "head", database_url=migration_db_url)
 
-    await db_session.commit()
-    cols_after = set((await db_session.execute(_ARTICLE_BLOB_COLS)).scalars().all())
+    await migration_session.commit()
+    cols_after = set((await migration_session.execute(_ARTICLE_BLOB_COLS)).scalars().all())
     assert cols_after == set(), "upgrade head must re-drop all three blob columns"
 
 
 @pytest.mark.asyncio
-async def test_alembic_head_is_expected_revision() -> None:
+async def test_alembic_head_is_expected_revision(migration_db_url: str) -> None:
     """Pin the head revision id. If a future migration is added without
     updating this assertion, the test reminds us the squash window is
     moving — which is the signal to consider the next squash."""
-    out = _run_alembic("current")
+    out = _run_alembic("current", database_url=migration_db_url)
     # ``alembic current`` prints either ``<revision> (head)`` or just the id;
     # match the revision we expect to live at head.
     assert "0042_drop_article_blob_columns" in out, (


### PR DESCRIPTION
## Why

The alembic round-trip tests (`backend/tests/integration/test_migration_roundtrip.py`) ran `alembic downgrade/upgrade` subprocesses against the **shared local dev database**. Two confirmed consequences:

1. **Permanent catalog pollution.** Every `make test-backend` left ~63 dropped-column tombstones in `pg_attribute` (`feedback_reports` +21/run from 0020's add/drop churn, `article_files` +16, `extraction_fields` +14, `extraction_evidence` +11). Postgres counts tombstones toward the 1600-column limit until the table is recreated — `VACUUM FULL` does **not** clear them (verified empirically). After ~75 runs `feedback_reports` hit the wall: 21 live columns + 1,579 tombstones = 1,600 → `TooManyColumnsError` on any migration touching it.
2. **Silent data destruction.** The downgrades wiped dev data on every run: 0033's downgrade drops/recreates `article_files.content_markdown` (all parsed markdown nulled), and the downgrade-to-0001 drops `article_text_blocks` entirely.

## What changed

- **`backend/tests/integration/supabase_stub.sql` (new)** — the CI auth/storage stub, extracted verbatim from the two duplicated inline heredocs in `ci.yml`. Single source of truth; idempotent.
- **`backend/tests/integration/test_migration_roundtrip.py`** — new session-scoped `migration_db_url` fixture: `DROP/CREATE DATABASE prumo_migration_test WITH (FORCE)` via an autocommit asyncpg admin connection, apply the stub, `alembic upgrade head` — exactly how CI builds its test DB. The 9 DDL round-trip tests + the head-pin test now assert through a function-scoped `migration_session` bound to the scratch DB. `_run_alembic` takes a required `database_url` kwarg and overrides **both** `DATABASE_URL` and `DIRECT_DATABASE_URL` in the subprocess env (alembic's `env.py` prefers `DIRECT_`; OS env beats `backend/.env`). Also fixes the stale module docstring that claimed a skip-when-unreachable mechanism that never existed, and applies the project's `sslmode→ssl` rename when building the asyncpg engine URL.
- **`.github/workflows/ci.yml`** — both stub heredocs (backend-test, backend-e2e) replaced with `psql … -f tests/integration/supabase_stub.sql`.
- **`test_migration_0039_backfill.py` untouched by design** — it needs the committed SEED graph and already runs the data-only migration SQL inside a rolled-back savepoint (zero tombstones).

## Risk

Test-infrastructure only; no app code, no migrations. The scratch DB is created on the same Postgres server the tests already use (CI service-container user and local Supabase `postgres` both have CREATEDB; verified locally with `rolcreatedb=t`). In CI the fixture now runs one extra `alembic upgrade head` (~seconds). Adversarially reviewed (3-dimension fan-out + refutation pass): one confirmed finding (`sslmode` query param would crash the scratch engine on pooler-shaped URLs) — fixed in this PR.

## Test plan

- [x] `make lint-backend` clean (530 files formatted, all checks passed)
- [x] `make test-backend` full suite: **2419 passed, 5 skipped** (same skip set as baseline) in 1m08s
- [x] Round-trip module alone: 11/11 in ~16s
- [x] Main-DB `pg_attribute` tombstone counts byte-identical before/after the full suite (previously +63/run)
- [x] Canary row planted in `article_files.content_markdown` survived the suite (previously nulled by 0033's round-trip); reverted after
- [x] `prumo_migration_test` absent from `pg_database` after the session (teardown drop works)

## Out of scope

- A future squash of the migration chain would reset the ~117 tombstones a single fresh `upgrade head` legitimately leaves (chain-internal add/drop churn) — harmless at current scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)