### PR TITLE
fix(templates): propagate config edits to article extraction/QA forms

### DIFF
--- a/backend/app/api/v1/endpoints/project_templates.py
+++ b/backend/app/api/v1/endpoints/project_templates.py
@@ -8,6 +8,11 @@
   by configuration flows that enable QA tools.
 * ``PATCH /api/v1/projects/{project_id}/templates/{template_id}`` — toggle
   ``is_active`` (e.g. disable a QA tool in Configuration).
+* ``POST /api/v1/projects/{project_id}/templates/{template_id}/republish-version``
+  — publish the live section/field structure as a new active
+  ``extraction_template_versions`` row. Called by the configuration UI after
+  every section/field edit (the edits themselves go through PostgREST), so
+  article forms — which render from the run's version snapshot — pick them up.
 
 These are project-scoped. ``POST /api/v1/hitl/sessions`` is per-article run
 lifecycle and is separate.
@@ -23,6 +28,7 @@ from app.schemas.common import ApiResponse
 from app.schemas.hitl_session import (
     CloneTemplateRequest,
     CloneTemplateResponse,
+    RepublishTemplateVersionResponse,
     TemplateKind,
     UpdateTemplateActiveRequest,
     UpdateTemplateActiveResponse,
@@ -36,6 +42,7 @@ from app.services.template_clone_service import (
     TemplateCloneService,
     TemplateNotFoundError,
 )
+from app.services.template_version_service import TemplateVersionService
 
 router = APIRouter()
 
@@ -109,5 +116,45 @@ async def update_project_template_active(
         raise HTTPException(status_code=400, detail=str(e)) from e
     return ApiResponse.success(
         result,
+        trace_id=getattr(request.state, "trace_id", None),
+    )
+
+
+@router.post(
+    "/{project_id}/templates/{template_id}/republish-version",
+)
+async def republish_template_version(
+    project_id: UUID,
+    template_id: UUID,
+    request: Request,
+    db: DbSession,
+    current_user_sub: UUID = Depends(require_project_manager),
+) -> ApiResponse[RepublishTemplateVersionResponse]:
+    """Publish the live template structure as a new active version.
+
+    Idempotent when nothing changed (returns the current active version
+    without spawning rows). Runs still in an editable stage
+    (``pending``/``extract``) are re-pinned to the new version so open
+    article forms render the edit; runs from ``consensus`` on keep the
+    version they were assessed under. Manager-gated like the sibling
+    endpoints — section/field editing is project-wide configuration.
+    """
+    service = TemplateVersionService(db)
+    try:
+        result = await service.republish(
+            project_id=project_id,
+            project_template_id=template_id,
+            user_id=current_user_sub,
+        )
+    except TemplateNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    await db.commit()
+    return ApiResponse.success(
+        RepublishTemplateVersionResponse(
+            version_id=result.version_id,
+            version=result.version,
+            changed=result.changed,
+            repinned_run_count=result.repinned_run_count,
+        ),
         trace_id=getattr(request.state, "trace_id", None),
     )

--- a/backend/app/schemas/hitl_session.py
+++ b/backend/app/schemas/hitl_session.py
@@ -52,6 +52,13 @@ class CloneTemplateResponse(BaseModel):
     created: bool
 
 
+class RepublishTemplateVersionResponse(BaseModel):
+    version_id: UUID
+    version: int
+    changed: bool
+    repinned_run_count: int
+
+
 class UpdateTemplateActiveRequest(BaseModel):
     is_active: bool
 

--- a/backend/app/services/hitl_session_service.py
+++ b/backend/app/services/hitl_session_service.py
@@ -35,7 +35,7 @@ from app.services.template_clone_service import (
 )
 
 
-async def _take_advisory_xact_lock(db: AsyncSession, left: UUID, right: UUID) -> None:
+async def take_advisory_xact_lock(db: AsyncSession, left: UUID, right: UUID) -> None:
     """Take a transaction-scoped advisory lock keyed by (left, right).
 
     Uses Postgres' built-in ``hashtextextended`` to derive a bigint
@@ -113,7 +113,7 @@ class HITLSessionService:
         )
 
         entity_types = await self._project_entity_types(project_template_id)
-        instances = await self._ensure_instances(
+        instances = await self.ensure_instances(
             project_id=project_id,
             article_id=article_id,
             project_template_id=project_template_id,
@@ -196,7 +196,7 @@ class HITLSessionService:
         )
         return list((await self.db.execute(stmt)).scalars().all())
 
-    async def _ensure_instances(
+    async def ensure_instances(
         self,
         *,
         project_id: UUID,
@@ -211,7 +211,7 @@ class HITLSessionService:
         # transaction-scoped, so it is released on commit / rollback and
         # does not require explicit cleanup. The same lock also protects
         # the active-run lookup in ``_reuse_or_create_run`` (issue #70).
-        await _take_advisory_xact_lock(self.db, article_id, project_template_id)
+        await take_advisory_xact_lock(self.db, article_id, project_template_id)
 
         existing_stmt = select(ExtractionInstance).where(
             ExtractionInstance.article_id == article_id,
@@ -284,7 +284,7 @@ class HITLSessionService:
 
         Maintains the invariant: for every parent instance, every
         cardinality='one' child entity type has exactly one matching
-        instance under it. The original ``_ensure_instances`` only seeded
+        instance under it. The original ``ensure_instances`` only seeded
         top-level singletons; it never touched children. That left a gap:
 
         * A manager adds a new sub-section under ``prediction_models`` in
@@ -378,7 +378,7 @@ class HITLSessionService:
 
         Concurrency note (issue #70): callers always go through
         ``open_or_resume`` so the (article, template) advisory lock taken
-        in ``_ensure_instances`` is already held for this transaction;
+        in ``ensure_instances`` is already held for this transaction;
         the active-run SELECT below cannot race with itself.
         """
         active_stmt = (

--- a/backend/app/services/run_lifecycle_service.py
+++ b/backend/app/services/run_lifecycle_service.py
@@ -126,8 +126,19 @@ class RunLifecycleService:
                 f"article {article_id} does not belong to project {project_id}"
             )
 
-        # Resolve template (for kind) — must exist and belong to the same project
-        template = await self.db.get(ProjectExtractionTemplate, project_template_id)
+        # Resolve template (for kind) — must exist and belong to the same
+        # project. FOR SHARE so the active-version resolution below
+        # serializes with TemplateVersionService.republish (FOR UPDATE on
+        # the same row): without it a run created concurrently with a
+        # republish could pin the just-deactivated version and miss the
+        # re-pin UPDATE (which only sees committed runs).
+        template = (
+            await self.db.execute(
+                select(ProjectExtractionTemplate)
+                .where(ProjectExtractionTemplate.id == project_template_id)
+                .with_for_update(read=True)
+            )
+        ).scalar_one_or_none()
         if template is None or template.project_id != project_id:
             raise TemplateNotFoundError(f"Template {project_template_id} not found")
 
@@ -526,7 +537,14 @@ class RunLifecycleService:
             return existing_child, False
 
         # 1. Resolve the active version (lazy-create if the template was
-        #    born outside the backfill path).
+        #    born outside the backfill path). FOR SHARE on the template row
+        #    first, so this serializes with TemplateVersionService.republish
+        #    — same rationale as create_run.
+        await self.db.execute(
+            select(ProjectExtractionTemplate.id)
+            .where(ProjectExtractionTemplate.id == old_run.template_id)
+            .with_for_update(read=True)
+        )
         version_stmt = select(ExtractionTemplateVersion).where(
             ExtractionTemplateVersion.project_template_id == old_run.template_id,
             ExtractionTemplateVersion.is_active.is_(True),

--- a/backend/app/services/template_clone_service.py
+++ b/backend/app/services/template_clone_service.py
@@ -23,6 +23,12 @@ class TemplateNotFoundError(Exception):
     """The supplied global template id does not exist or has the wrong kind."""
 
 
+def _snapshot_structure_counts(version: ExtractionTemplateVersion) -> tuple[int, int]:
+    """Entity-type and field counts recorded in a version snapshot."""
+    entity_types = (version.schema_ or {}).get("entity_types", [])
+    return len(entity_types), sum(len(et.get("fields", [])) for et in entity_types)
+
+
 class TemplateClone:
     """Result envelope returned by ``TemplateCloneService.clone``."""
 
@@ -73,36 +79,37 @@ class TemplateCloneService:
         existing = await self._find_existing_clone(project_id, global_template_id)
         if existing is not None:
             entity_types, fields = await self._project_template_structure_counts(existing.id)
-            global_et, global_field = await self._global_template_structure_counts(
-                global_template_id
-            )
             version = await self._active_version(existing.id)
-            # Heal partial / drifted clones. Two cases bring us here:
+            # The deferred constraint trigger
+            # ``project_extraction_templates_active_version`` (migration
+            # 0004) makes a template-without-active-version state
+            # unrepresentable, so this lookup is a hard guarantee.
+            assert version is not None, (
+                f"Active-version invariant violated for project_extraction_template "
+                f"{existing.id}; the DB trigger should have prevented this."
+            )
+            snapshot_et, snapshot_field = _snapshot_structure_counts(version)
+            # Heal existing clones. Drift is measured against the template's
+            # ACTIVE SNAPSHOT, never against the global template — deliberate
+            # config edits are republished as a new version
+            # (``TemplateVersionService.republish``), so a healthy edited
+            # template has live == snapshot. Two heal cases:
             #   1. Zero-state — the clone row exists but its live structure
-            #      was never inserted (legacy data, aborted clone).
-            #   2. Partial drift — the live structure exists but is smaller
-            #      than the global (some entity_types / fields were deleted
-            #      out-of-band, or a previous clone aborted mid-way). The
-            #      production CHARMS bug (project bc055915, live=1 vs
-            #      snapshot=14) is the canonical example.
-            # In both cases we wipe the partial state and re-insert from
-            # the global template. The snapshot is then re-emitted to
-            # match the freshly inserted live structure. CASCADE on
-            # ``extraction_entity_types`` clears any orphan
-            # ``extraction_instances`` / proposals tied to the partial rows
-            # — acceptable since those instances pointed at a structure
-            # that no longer reflects user intent.
-            drifted = entity_types != global_et or fields != global_field
-            if drifted:
-                if entity_types > 0 or fields > 0:
-                    await self.db.execute(
-                        text(
-                            "DELETE FROM public.extraction_entity_types "
-                            "WHERE project_template_id = CAST(:tid AS uuid)"
-                        ),
-                        {"tid": str(existing.id)},
-                    )
-                    await self.db.flush()
+            #      was never inserted (legacy data, aborted clone). Rebuild
+            #      from the global template: an empty clone is unusable and
+            #      factory state is strictly better. A legacy clone may carry
+            #      an empty placeholder snapshot (live == snapshot == 0), so
+            #      zero-state gets its own clause.
+            #   2. Non-empty drift (live counts != snapshot counts) — publish
+            #      the LIVE structure as a new version. Never wipe: with
+            #      user-editable templates a count mismatch is
+            #      indistinguishable from a deliberate edit whose republish
+            #      call was lost, and the historical wipe-and-rebuild
+            #      destroyed customizations (and 500'd on the RESTRICT FK
+            #      whenever instances existed). Live is authoritative; true
+            #      factory recovery is an explicit delete + re-import.
+            zero_state = entity_types == 0 and fields == 0
+            if zero_state:
                 global_entity_types = await self._global_entity_types(global_template_id)
                 field_count = await self._insert_project_structure_from_global(
                     project_template_id=existing.id,
@@ -115,17 +122,27 @@ class TemplateCloneService:
                 entity_types = len(global_entity_types)
                 fields = field_count
                 version = await self._active_version(existing.id)
-            # The deferred constraint trigger
-            # ``project_extraction_templates_active_version`` (migration
-            # 0004) makes a template-without-active-version state
-            # unrepresentable — every transaction that creates one must
-            # also create an active version row by COMMIT, or the whole
-            # transaction aborts. So this lookup is a hard guarantee,
-            # not a defensive check.
-            assert version is not None, (
-                f"Active-version invariant violated for project_extraction_template "
-                f"{existing.id}; the DB trigger should have prevented this."
-            )
+                assert version is not None, (
+                    f"Heal left project_extraction_template {existing.id} "
+                    f"without an active version."
+                )
+            elif entity_types != snapshot_et or fields != snapshot_field:
+                # Local import: template_version_service imports this module
+                # (TemplateNotFoundError), so a top-level import would cycle.
+                from app.services.template_version_service import (
+                    TemplateVersionService,
+                )
+
+                republished = await TemplateVersionService(self.db).republish(
+                    project_id=project_id,
+                    project_template_id=existing.id,
+                    user_id=user_id,
+                )
+                version = await self.db.get(ExtractionTemplateVersion, republished.version_id)
+                assert version is not None, (
+                    f"Self-heal republish left project_extraction_template "
+                    f"{existing.id} without an active version."
+                )
             # Re-importing a template re-activates it (user intent: "use
             # this template now"). For extraction kind, also enforce the
             # single-active invariant by deactivating siblings *before*
@@ -406,38 +423,6 @@ class TemplateCloneService:
         for f in rows:
             buckets[f.entity_type_id].append(f)
         return buckets
-
-    async def _global_template_structure_counts(
-        self,
-        global_template_id: UUID,
-    ) -> tuple[int, int]:
-        """Entity-type and field counts for a global template in one round
-        trip. Used as the canonical reference for heal drift detection —
-        if a clone's live counts don't match these, structure was lost.
-        """
-        row = (
-            await self.db.execute(
-                text(
-                    """
-                    SELECT
-                        (
-                            SELECT COUNT(*)::bigint
-                            FROM public.extraction_entity_types et
-                            WHERE et.template_id = CAST(:gid AS uuid)
-                        ) AS entity_type_count,
-                        (
-                            SELECT COUNT(*)::bigint
-                            FROM public.extraction_fields f
-                            INNER JOIN public.extraction_entity_types et
-                                ON et.id = f.entity_type_id
-                            WHERE et.template_id = CAST(:gid AS uuid)
-                        ) AS field_count
-                    """
-                ),
-                {"gid": str(global_template_id)},
-            )
-        ).one()
-        return int(row[0]), int(row[1])
 
     async def _project_template_structure_counts(
         self,

--- a/backend/app/services/template_version_service.py
+++ b/backend/app/services/template_version_service.py
@@ -1,0 +1,232 @@
+"""Publish the live template structure as a new active version.
+
+Template configuration edits (sections/fields/flags) are written by the
+frontend through the Supabase client, so they never pass through the API
+— and until this service existed, nothing ever refreshed
+``extraction_template_versions.schema_``. Every run (including brand-new
+ones) kept rendering the schema frozen at clone time.
+
+``republish`` closes that gap: it snapshots the live structure into a NEW
+version row (v+1, active), leaves prior rows untouched (runs from
+``consensus`` on stay pinned to the schema they were assessed under),
+re-pins runs still in an editable stage (``pending`` / ``extract``) so
+open extraction/QA forms pick up the edit, and materializes the singleton
+instances a re-pinned run needs for any newly added section (otherwise
+the ADR-0009 finalize gate — which counts required fields per EXISTING
+instance — would silently skip the new section).
+"""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.extraction import (
+    ExtractionEntityType,
+    ExtractionRun,
+    ExtractionRunStage,
+    ProjectExtractionTemplate,
+)
+from app.models.extraction_versioning import ExtractionTemplateVersion
+from app.services.extraction_snapshot import build_template_version_snapshot
+from app.services.hitl_session_service import (
+    HITLSessionService,
+    take_advisory_xact_lock,
+)
+from app.services.template_clone_service import TemplateNotFoundError
+
+__all__ = ["RepublishResult", "TemplateNotFoundError", "TemplateVersionService"]
+
+_EDITABLE_STAGES = (
+    ExtractionRunStage.PENDING.value,
+    ExtractionRunStage.EXTRACT.value,
+)
+
+
+class RepublishResult:
+    """Result envelope returned by ``TemplateVersionService.republish``."""
+
+    def __init__(
+        self,
+        *,
+        version_id: UUID,
+        version: int,
+        changed: bool,
+        repinned_run_count: int,
+    ) -> None:
+        self.version_id = version_id
+        self.version = version
+        self.changed = changed
+        self.repinned_run_count = repinned_run_count
+
+
+class TemplateVersionService:
+    """Owns the template-version publish lifecycle for project templates."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def republish(
+        self,
+        *,
+        project_id: UUID,
+        project_template_id: UUID,
+        user_id: UUID,
+    ) -> RepublishResult:
+        # BOLA defense (unlocked read): validate ownership before taking any
+        # lock, so a caller who is only a manager elsewhere can never lock —
+        # or even match — a foreign project's template row.
+        owned = (
+            await self.db.execute(
+                select(ProjectExtractionTemplate.id).where(
+                    ProjectExtractionTemplate.id == project_template_id,
+                    ProjectExtractionTemplate.project_id == project_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if owned is None:
+            raise TemplateNotFoundError(f"Template {project_template_id} not found")
+
+        # Lock ordering mirrors HITLSessionService.open_or_resume — advisory
+        # (article, template) locks FIRST (sorted for a deterministic global
+        # order), THEN the template row. open_or_resume holds the advisory
+        # lock while create_run takes the template row FOR SHARE; taking the
+        # template FOR UPDATE before the advisory locks here would invert
+        # that order and deadlock.
+        run_pairs = (
+            await self.db.execute(
+                select(ExtractionRun.project_id, ExtractionRun.article_id)
+                .where(
+                    ExtractionRun.template_id == project_template_id,
+                    ExtractionRun.stage.in_(_EDITABLE_STAGES),
+                )
+                .distinct()
+            )
+        ).all()
+        for _, article_id in sorted(run_pairs, key=lambda pair: str(pair[1])):
+            await take_advisory_xact_lock(self.db, article_id, project_template_id)
+
+        # Serialization: FOR UPDATE so two concurrent republishes cannot both
+        # compute the same next version number (unique on
+        # (project_template_id, version)), and so run creation (FOR SHARE on
+        # this row) cannot pin a version this transaction is deactivating.
+        await self.db.execute(
+            select(ProjectExtractionTemplate.id)
+            .where(ProjectExtractionTemplate.id == project_template_id)
+            .with_for_update()
+        )
+
+        snapshot = await build_template_version_snapshot(self.db, project_template_id)
+
+        current = (
+            await self.db.execute(
+                select(ExtractionTemplateVersion).where(
+                    ExtractionTemplateVersion.project_template_id == project_template_id,
+                    ExtractionTemplateVersion.is_active.is_(True),
+                )
+            )
+        ).scalar_one_or_none()
+
+        if current is not None and current.schema_ == snapshot:
+            # Nothing changed — don't spawn version rows, but still re-pin:
+            # runs created before this service existed may sit on an older
+            # version even though the active snapshot is current.
+            repinned = await self._repin_editable_runs(project_template_id, current.id)
+            if repinned:
+                await self._materialize_singleton_instances(
+                    project_template_id=project_template_id,
+                    run_pairs=run_pairs,
+                    user_id=user_id,
+                )
+            return RepublishResult(
+                version_id=current.id,
+                version=current.version,
+                changed=False,
+                repinned_run_count=repinned,
+            )
+
+        max_version = (
+            await self.db.execute(
+                select(func.max(ExtractionTemplateVersion.version)).where(
+                    ExtractionTemplateVersion.project_template_id == project_template_id
+                )
+            )
+        ).scalar_one()
+        if current is not None:
+            # The partial unique index (one active per template) is checked
+            # on flush — deactivate before inserting the successor.
+            current.is_active = False
+            await self.db.flush()
+
+        new_version = ExtractionTemplateVersion(
+            project_template_id=project_template_id,
+            version=(max_version or 0) + 1,
+            schema_=snapshot,
+            published_at=datetime.now(UTC),
+            published_by=user_id,
+            is_active=True,
+        )
+        self.db.add(new_version)
+        await self.db.flush()
+
+        repinned = await self._repin_editable_runs(project_template_id, new_version.id)
+        await self._materialize_singleton_instances(
+            project_template_id=project_template_id,
+            run_pairs=run_pairs,
+            user_id=user_id,
+        )
+        return RepublishResult(
+            version_id=new_version.id,
+            version=new_version.version,
+            changed=True,
+            repinned_run_count=repinned,
+        )
+
+    async def _repin_editable_runs(self, project_template_id: UUID, version_id: UUID) -> int:
+        result = await self.db.execute(
+            update(ExtractionRun)
+            .where(
+                ExtractionRun.template_id == project_template_id,
+                ExtractionRun.stage.in_(_EDITABLE_STAGES),
+                ExtractionRun.version_id != version_id,
+            )
+            .values(version_id=version_id)
+        )
+        return result.rowcount or 0
+
+    async def _materialize_singleton_instances(
+        self,
+        *,
+        project_template_id: UUID,
+        run_pairs: list,
+        user_id: UUID,
+    ) -> None:
+        """Seed missing cardinality-one instances for every re-pinned run.
+
+        Reuses ``HITLSessionService.ensure_instances`` (the session-open
+        seeding path) per affected article; idempotent, and the advisory
+        lock it re-takes is already held by this transaction.
+        """
+        if not run_pairs:
+            return
+        entity_types = list(
+            (
+                await self.db.execute(
+                    select(ExtractionEntityType)
+                    .where(ExtractionEntityType.project_template_id == project_template_id)
+                    .order_by(ExtractionEntityType.sort_order)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        session_service = HITLSessionService(self.db)
+        for run_project_id, article_id in run_pairs:
+            await session_service.ensure_instances(
+                project_id=run_project_id,
+                article_id=article_id,
+                project_template_id=project_template_id,
+                entity_types=entity_types,
+                user_id=user_id,
+            )

--- a/backend/app/services/template_version_service.py
+++ b/backend/app/services/template_version_service.py
@@ -17,9 +17,10 @@ instance — would silently skip the new section).
 """
 
 from datetime import UTC, datetime
+from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import func, select, update
+from sqlalchemy import CursorResult, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.extraction import (
@@ -94,16 +95,19 @@ class TemplateVersionService:
         # lock while create_run takes the template row FOR SHARE; taking the
         # template FOR UPDATE before the advisory locks here would invert
         # that order and deadlock.
-        run_pairs = (
-            await self.db.execute(
-                select(ExtractionRun.project_id, ExtractionRun.article_id)
-                .where(
-                    ExtractionRun.template_id == project_template_id,
-                    ExtractionRun.stage.in_(_EDITABLE_STAGES),
+        run_pairs: list[tuple[UUID, UUID]] = [
+            (row.project_id, row.article_id)
+            for row in (
+                await self.db.execute(
+                    select(ExtractionRun.project_id, ExtractionRun.article_id)
+                    .where(
+                        ExtractionRun.template_id == project_template_id,
+                        ExtractionRun.stage.in_(_EDITABLE_STAGES),
+                    )
+                    .distinct()
                 )
-                .distinct()
-            )
-        ).all()
+            ).all()
+        ]
         for _, article_id in sorted(run_pairs, key=lambda pair: str(pair[1])):
             await take_advisory_xact_lock(self.db, article_id, project_template_id)
 
@@ -193,13 +197,15 @@ class TemplateVersionService:
             )
             .values(version_id=version_id)
         )
-        return result.rowcount or 0
+        # execute() types the return as Result[Any]; an UPDATE yields a
+        # CursorResult at runtime, which carries rowcount.
+        return cast("CursorResult[Any]", result).rowcount or 0
 
     async def _materialize_singleton_instances(
         self,
         *,
         project_template_id: UUID,
-        run_pairs: list,
+        run_pairs: list[tuple[UUID, UUID]],
         user_id: UUID,
     ) -> None:
         """Seed missing cardinality-one instances for every re-pinned run.

--- a/backend/tests/integration/test_template_clone_service.py
+++ b/backend/tests/integration/test_template_clone_service.py
@@ -1,21 +1,28 @@
 """Integration tests for ``TemplateCloneService``.
 
-Specifically covers the heal path: when a project_extraction_templates
-row exists but its live structure (entity_types + fields) drifts from
-the immutable snapshot in ``extraction_template_versions.schema``,
-re-invoking ``clone`` rebuilds the structure to match.
+Covers the heal path for existing clones. The contract (revised when
+templates became user-editable):
 
-The current heal trigger only fires when live count = 0 ("clone was
-born empty"). This file pins down the broader contract: any drift
-between snapshot and live, including partial state (some entity_types
-present but fewer than the snapshot), triggers heal. The repro is the
-production CHARMS project ``bc055915`` whose clone has 1 entity_type
-live but 14 in the snapshot — pre-fix, the heal stays silent.
+* **Zero-state** (live structure empty) → rebuild from the global
+  template. A clone born empty is unusable; factory state is strictly
+  better.
+* **Non-empty drift** (live counts != active snapshot counts) → publish
+  the LIVE structure as a new active version (self-heal the snapshot).
+  Never wipe: with editable templates, a count mismatch is
+  indistinguishable from a deliberate edit whose republish failed, and
+  the old wipe-and-rebuild-from-global path destroyed user
+  customizations (and 500'd on the RESTRICT FK whenever instances
+  existed). Live is authoritative.
+
+The production CHARMS project ``bc055915`` (live=1 vs snapshot=14 after
+an out-of-band loss) now self-heals the *snapshot* to match live rather
+than resurrecting factory structure; true structure recovery is an
+explicit re-import after deleting the template.
 """
 
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import select, text
@@ -73,15 +80,15 @@ async def test_clone_creates_full_structure_when_fresh(db_session: AsyncSession)
 
 
 @pytest.mark.asyncio
-async def test_clone_heals_partial_structure_drift_against_snapshot(
+async def test_clone_selfheals_snapshot_from_live_on_drift(
     db_session: AsyncSession,
 ) -> None:
-    """H3 — Invariant I-3: a clone whose live entity_type count drifts
-    from its active version snapshot triggers heal on re-clone.
+    """Non-empty drift publishes LIVE as the new snapshot — never wipes.
 
-    Repros production bug (project bc055915): the clone has 14 entity
-    types in the snapshot but only 1 in the live tables. The current
-    heal only fires on zero-state, so the drift goes undetected.
+    bc055915-shaped state: 14 entity types in the snapshot but only 1
+    live. Re-cloning must keep the 1 live entity type (a count mismatch
+    is indistinguishable from a deliberate edit whose republish failed)
+    and roll the active snapshot forward to match live.
     """
     if (
         await db_session.execute(
@@ -96,7 +103,6 @@ async def test_clone_heals_partial_structure_drift_against_snapshot(
     await _clean_project_clones(db_session, project_id)
     service = TemplateCloneService(db_session)
 
-    # 1. Initial healthy clone.
     initial = await service.clone(
         project_id=project_id,
         global_template_id=CHARMS_GLOBAL_ID,
@@ -104,13 +110,10 @@ async def test_clone_heals_partial_structure_drift_against_snapshot(
         kind=TemplateKind.EXTRACTION,
     )
     project_template_id = initial.project_template_id
-    snapshot_et_count = initial.entity_type_count
-    snapshot_field_count = initial.field_count
-    assert snapshot_et_count == 14
+    assert initial.entity_type_count == 14
 
-    # 2. Simulate the production drift: delete all but one entity_type
-    #    (and its fields) from the live tables, leaving the snapshot
-    #    intact. Mirrors the bc055915 state (snapshot=14, live=1).
+    # Simulate the drift: delete all but one entity_type from the live
+    # tables, leaving the snapshot intact (snapshot=14, live=1).
     keep_et_id = (
         await db_session.execute(
             select(ExtractionEntityType.id)
@@ -128,23 +131,6 @@ async def test_clone_heals_partial_structure_drift_against_snapshot(
     )
     await db_session.flush()
 
-    live_et_count = (
-        (
-            await db_session.execute(
-                select(ExtractionEntityType).where(
-                    ExtractionEntityType.project_template_id == project_template_id
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    assert len(live_et_count) == 1, "drift simulation expected exactly 1 live entity_type"
-
-    # 3. Re-clone with the same (project, global_template_id). Heal must
-    #    detect the drift and rebuild the live structure to match the
-    #    snapshot. Without the H3 fix, this is a no-op and the drift
-    #    persists.
     healed = await service.clone(
         project_id=project_id,
         global_template_id=CHARMS_GLOBAL_ID,
@@ -155,13 +141,11 @@ async def test_clone_heals_partial_structure_drift_against_snapshot(
     assert healed.project_template_id == project_template_id, (
         "Heal must reuse the existing clone, not fork a new one."
     )
-    assert healed.entity_type_count == snapshot_et_count, (
-        f"After heal, live entity_type count ({healed.entity_type_count}) "
-        f"must match snapshot ({snapshot_et_count}). Drift not detected."
+    assert healed.entity_type_count == 1, (
+        "Non-empty drift must NOT resurrect factory structure — live is "
+        "authoritative once templates are user-editable."
     )
-    assert healed.field_count == snapshot_field_count
 
-    # Defence-in-depth: the live table count must also match the report.
     live_after = (
         (
             await db_session.execute(
@@ -173,7 +157,102 @@ async def test_clone_heals_partial_structure_drift_against_snapshot(
         .scalars()
         .all()
     )
-    assert len(live_after) == snapshot_et_count
+    assert len(live_after) == 1, "re-clone must not wipe or rebuild live structure"
+
+    active = (
+        await db_session.execute(
+            select(ExtractionTemplateVersion).where(
+                ExtractionTemplateVersion.project_template_id == project_template_id,
+                ExtractionTemplateVersion.is_active.is_(True),
+            )
+        )
+    ).scalar_one()
+    snapshot_ets = (active.schema_ or {}).get("entity_types", [])
+    assert len(snapshot_ets) == 1, "active snapshot must be re-published from live"
+    assert active.version == 2, "self-heal publishes a NEW version, never mutates v1"
+    assert active.id == healed.version_id
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_reclone_selfheals_unsnapshotted_edit_without_wiping(
+    db_session: AsyncSession,
+) -> None:
+    """A live edit whose republish call was lost (e.g. network blip after
+    the PostgREST write) must survive a re-import: the heal publishes the
+    live structure instead of treating the mismatch as corruption."""
+    if (
+        await db_session.execute(
+            text("SELECT 1 FROM public.profiles WHERE id = :id"),
+            {"id": str(SEED.primary_profile)},
+        )
+    ).scalar() is None:
+        pytest.skip("Missing fixtures.")
+    project_id = SEED.secondary_project
+    user_id = SEED.primary_profile
+
+    await _clean_project_clones(db_session, project_id)
+    service = TemplateCloneService(db_session)
+
+    initial = await service.clone(
+        project_id=project_id,
+        global_template_id=CHARMS_GLOBAL_ID,
+        user_id=user_id,
+        kind=TemplateKind.EXTRACTION,
+    )
+
+    et_id = (
+        await db_session.execute(
+            select(ExtractionEntityType.id)
+            .where(ExtractionEntityType.project_template_id == initial.project_template_id)
+            .order_by(ExtractionEntityType.sort_order)
+            .limit(1)
+        )
+    ).scalar_one()
+    field_id = uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO public.extraction_fields "
+            "(id, entity_type_id, name, label, field_type, is_required, sort_order) "
+            "VALUES (:id, :et, 'orphan_edit', 'Orphan edit', 'text', false, 999)"
+        ),
+        {"id": str(field_id), "et": str(et_id)},
+    )
+    await db_session.flush()
+
+    recloned = await service.clone(
+        project_id=project_id,
+        global_template_id=CHARMS_GLOBAL_ID,
+        user_id=user_id,
+        kind=TemplateKind.EXTRACTION,
+    )
+    assert recloned.project_template_id == initial.project_template_id
+
+    survived = (
+        await db_session.execute(
+            text("SELECT 1 FROM public.extraction_fields WHERE id = :id"),
+            {"id": str(field_id)},
+        )
+    ).scalar()
+    assert survived == 1, "unsnapshotted edit was wiped by the heal"
+
+    active = (
+        await db_session.execute(
+            select(ExtractionTemplateVersion).where(
+                ExtractionTemplateVersion.project_template_id == initial.project_template_id,
+                ExtractionTemplateVersion.is_active.is_(True),
+            )
+        )
+    ).scalar_one()
+    snapshot_field_names = {
+        f["name"]
+        for et in (active.schema_ or {}).get("entity_types", [])
+        for f in et.get("fields", [])
+    }
+    assert "orphan_edit" in snapshot_field_names, (
+        "heal must publish the live structure so the drift is repaired"
+    )
 
     await db_session.rollback()
 

--- a/backend/tests/integration/test_template_version_republish.py
+++ b/backend/tests/integration/test_template_version_republish.py
@@ -1,0 +1,482 @@
+"""Integration tests for ``TemplateVersionService.republish``.
+
+Template edits happen through the Supabase client (PostgREST) and never
+touched ``extraction_template_versions`` — so every run (including brand
+new ones) rendered the schema frozen at clone time. ``republish``
+publishes the live structure as a NEW active version (v+1), leaving the
+prior version row untouched (runs from ``consensus`` on stay pinned to
+the schema they were assessed under), and re-pins runs still in an
+editable stage (``pending`` / ``extract``) to the new version.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import TokenPayload, get_current_user
+from app.main import app
+from app.models.extraction import ExtractionEntityType, TemplateKind
+from app.models.extraction_versioning import ExtractionTemplateVersion
+from app.services.template_clone_service import TemplateCloneService
+from app.services.template_version_service import (
+    TemplateNotFoundError,
+    TemplateVersionService,
+)
+from tests.integration.conftest import SEED
+
+CHARMS_GLOBAL_ID = UUID("000c0000-0000-0000-0000-000000000001")
+
+
+async def _clean_project_clones(db: AsyncSession, project_id: UUID) -> None:
+    await db.execute(
+        text("DELETE FROM public.project_extraction_templates WHERE project_id = :pid"),
+        {"pid": str(project_id)},
+    )
+
+
+async def _clone_charms(db: AsyncSession, project_id: UUID, user_id: UUID):
+    return await TemplateCloneService(db).clone(
+        project_id=project_id,
+        global_template_id=CHARMS_GLOBAL_ID,
+        user_id=user_id,
+        kind=TemplateKind.EXTRACTION,
+    )
+
+
+async def _first_entity_type_id(db: AsyncSession, project_template_id: UUID) -> UUID:
+    return (
+        await db.execute(
+            select(ExtractionEntityType.id)
+            .where(ExtractionEntityType.project_template_id == project_template_id)
+            .order_by(ExtractionEntityType.sort_order)
+            .limit(1)
+        )
+    ).scalar_one()
+
+
+async def _add_field_like_postgrest(db: AsyncSession, entity_type_id: UUID, name: str) -> UUID:
+    """Simulate the config UI's direct PostgREST insert of a new field."""
+    field_id = uuid4()
+    await db.execute(
+        text(
+            "INSERT INTO public.extraction_fields "
+            "(id, entity_type_id, name, label, field_type, is_required, sort_order, "
+            " allow_other, allows_not_applicable, allows_not_evaluated) "
+            "VALUES (:id, :et, :name, :label, 'text', false, 999, true, true, true)"
+        ),
+        {"id": str(field_id), "et": str(entity_type_id), "name": name, "label": name},
+    )
+    await db.flush()
+    return field_id
+
+
+def _snapshot_field_names(version: ExtractionTemplateVersion) -> set[str]:
+    return {
+        f["name"]
+        for et in (version.schema_ or {}).get("entity_types", [])
+        for f in et.get("fields", [])
+    }
+
+
+@pytest.mark.asyncio
+async def test_republish_creates_new_active_version_and_preserves_old(
+    db_session: AsyncSession,
+) -> None:
+    """An edit + republish yields v2 (active, containing the new field with
+    its disposition flags) while v1 survives untouched and inactive."""
+    project_id = SEED.secondary_project
+    user_id = SEED.primary_profile
+    await _clean_project_clones(db_session, project_id)
+    clone = await _clone_charms(db_session, project_id, user_id)
+
+    et_id = await _first_entity_type_id(db_session, clone.project_template_id)
+    await _add_field_like_postgrest(db_session, et_id, "late_added_field")
+
+    result = await TemplateVersionService(db_session).republish(
+        project_id=project_id,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+
+    versions = (
+        (
+            await db_session.execute(
+                select(ExtractionTemplateVersion)
+                .where(ExtractionTemplateVersion.project_template_id == clone.project_template_id)
+                .order_by(ExtractionTemplateVersion.version)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [v.version for v in versions] == [1, 2]
+    v1, v2 = versions
+    assert v1.id == clone.version_id
+    assert v1.is_active is False
+    assert "late_added_field" not in _snapshot_field_names(v1), (
+        "v1 must stay frozen — republish must not mutate the old snapshot"
+    )
+    assert v2.is_active is True
+    assert result.version_id == v2.id
+    assert result.version == 2
+    assert "late_added_field" in _snapshot_field_names(v2)
+
+    new_field = next(
+        f
+        for et in v2.schema_["entity_types"]
+        for f in et.get("fields", [])
+        if f["name"] == "late_added_field"
+    )
+    assert new_field["allow_other"] is True
+    assert new_field["allows_not_applicable"] is True
+    assert new_field["allows_not_evaluated"] is True
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_republish_is_noop_when_snapshot_current(db_session: AsyncSession) -> None:
+    """Republishing without live changes must not spawn version rows."""
+    project_id = SEED.secondary_project
+    user_id = SEED.primary_profile
+    await _clean_project_clones(db_session, project_id)
+    clone = await _clone_charms(db_session, project_id, user_id)
+
+    service = TemplateVersionService(db_session)
+    first = await service.republish(
+        project_id=project_id,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+    second = await service.republish(
+        project_id=project_id,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+    assert first.version_id == clone.version_id, "no changes → keep the clone version"
+    assert second.version_id == clone.version_id
+    count = (
+        (
+            await db_session.execute(
+                select(ExtractionTemplateVersion.id).where(
+                    ExtractionTemplateVersion.project_template_id == clone.project_template_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(count) == 1
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_republish_repins_editable_runs_but_not_finalized(
+    db_session: AsyncSession,
+) -> None:
+    """Runs in pending/extract move to the new version; runs from consensus
+    onward keep the version they were assessed under."""
+    from app.services.run_lifecycle_service import RunLifecycleService
+
+    project_id = SEED.secondary_project
+    user_id = SEED.primary_profile
+    await _clean_project_clones(db_session, project_id)
+    clone = await _clone_charms(db_session, project_id, user_id)
+
+    article_ids = []
+    for i in range(2):
+        aid = uuid4()
+        await db_session.execute(
+            text(
+                "INSERT INTO public.articles (id, project_id, title, row_version) "
+                "VALUES (:id, :pid, :title, 1)"
+            ),
+            {"id": str(aid), "pid": str(project_id), "title": f"republish art {i}"},
+        )
+        article_ids.append(aid)
+    await db_session.flush()
+
+    lifecycle = RunLifecycleService(db_session)
+    editable_run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_ids[0],
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+    frozen_run = await lifecycle.create_run(
+        project_id=project_id,
+        article_id=article_ids[1],
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+    await db_session.execute(
+        text("UPDATE public.extraction_runs SET stage = 'extract' WHERE id = :id"),
+        {"id": str(editable_run.id)},
+    )
+    await db_session.execute(
+        text("UPDATE public.extraction_runs SET stage = 'finalized' WHERE id = :id"),
+        {"id": str(frozen_run.id)},
+    )
+    await db_session.flush()
+
+    et_id = await _first_entity_type_id(db_session, clone.project_template_id)
+    await _add_field_like_postgrest(db_session, et_id, "repin_field")
+
+    result = await TemplateVersionService(db_session).republish(
+        project_id=project_id,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+    assert result.repinned_run_count == 1
+
+    rows = dict(
+        (
+            await db_session.execute(
+                text("SELECT id, version_id FROM public.extraction_runs WHERE id IN (:a, :b)"),
+                {"a": str(editable_run.id), "b": str(frozen_run.id)},
+            )
+        ).all()
+    )
+    assert str(rows[editable_run.id]) == str(result.version_id)
+    assert str(rows[frozen_run.id]) == str(clone.version_id)
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_republish_materializes_instances_for_new_singleton_section(
+    db_session: AsyncSession,
+) -> None:
+    """A new cardinality-one section added mid-run must get an instance for
+    every re-pinned run's article — otherwise the ADR-0009 finalize gate
+    (which counts required fields per EXISTING instance) silently skips
+    the new section and a run can finalize with it empty."""
+    from app.services.run_lifecycle_service import RunLifecycleService
+
+    project_id = SEED.secondary_project
+    user_id = SEED.primary_profile
+    await _clean_project_clones(db_session, project_id)
+    clone = await _clone_charms(db_session, project_id, user_id)
+
+    aid = uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, 'instance-backfill article', 1)"
+        ),
+        {"id": str(aid), "pid": str(project_id)},
+    )
+    await db_session.flush()
+    run = await RunLifecycleService(db_session).create_run(
+        project_id=project_id,
+        article_id=aid,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+    await db_session.execute(
+        text("UPDATE public.extraction_runs SET stage = 'extract' WHERE id = :id"),
+        {"id": str(run.id)},
+    )
+    await db_session.flush()
+
+    new_section_id = uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO public.extraction_entity_types "
+            "(id, project_template_id, name, label, cardinality, role, sort_order, "
+            " is_required) "
+            "VALUES (:id, :tid, 'funding', 'Funding', 'one', 'study_section', 999, true)"
+        ),
+        {"id": str(new_section_id), "tid": str(clone.project_template_id)},
+    )
+    await db_session.flush()
+
+    await TemplateVersionService(db_session).republish(
+        project_id=project_id,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+
+    instance = (
+        await db_session.execute(
+            text(
+                "SELECT 1 FROM public.extraction_instances "
+                "WHERE article_id = :aid AND entity_type_id = :et"
+            ),
+            {"aid": str(aid), "et": str(new_section_id)},
+        )
+    ).scalar()
+    assert instance == 1, (
+        "republish re-pinned the run to a snapshot containing the new section "
+        "but materialized no instance for it — the finalize completeness gate "
+        "would skip the section entirely"
+    )
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_run_created_after_republish_uses_new_version(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.run_lifecycle_service import RunLifecycleService
+
+    project_id = SEED.secondary_project
+    user_id = SEED.primary_profile
+    await _clean_project_clones(db_session, project_id)
+    clone = await _clone_charms(db_session, project_id, user_id)
+
+    et_id = await _first_entity_type_id(db_session, clone.project_template_id)
+    await _add_field_like_postgrest(db_session, et_id, "post_edit_field")
+    result = await TemplateVersionService(db_session).republish(
+        project_id=project_id,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+
+    aid = uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO public.articles (id, project_id, title, row_version) "
+            "VALUES (:id, :pid, 'post-republish article', 1)"
+        ),
+        {"id": str(aid), "pid": str(project_id)},
+    )
+    await db_session.flush()
+    run = await RunLifecycleService(db_session).create_run(
+        project_id=project_id,
+        article_id=aid,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+    assert run.version_id == result.version_id
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_republish_rejects_template_from_other_project(
+    db_session: AsyncSession,
+) -> None:
+    """BOLA: a template id from another project must 404, not republish."""
+    user_id = SEED.primary_profile
+    await _clean_project_clones(db_session, SEED.secondary_project)
+    clone = await _clone_charms(db_session, SEED.secondary_project, user_id)
+
+    with pytest.raises(TemplateNotFoundError):
+        await TemplateVersionService(db_session).republish(
+            project_id=SEED.primary_project,
+            project_template_id=clone.project_template_id,
+            user_id=user_id,
+        )
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_reclone_preserves_republished_user_edits(
+    db_session: AsyncSession,
+) -> None:
+    """Heal must not wipe deliberate edits: once an edit is republished
+    (live == active snapshot), re-cloning the same global template is a
+    no-op — the user's field survives. Pre-fix, heal compared live counts
+    to the GLOBAL template and wiped any customized clone."""
+    project_id = SEED.secondary_project
+    user_id = SEED.primary_profile
+    await _clean_project_clones(db_session, project_id)
+    clone = await _clone_charms(db_session, project_id, user_id)
+
+    et_id = await _first_entity_type_id(db_session, clone.project_template_id)
+    field_id = await _add_field_like_postgrest(db_session, et_id, "user_custom_field")
+    await TemplateVersionService(db_session).republish(
+        project_id=project_id,
+        project_template_id=clone.project_template_id,
+        user_id=user_id,
+    )
+
+    recloned = await _clone_charms(db_session, project_id, user_id)
+    assert recloned.project_template_id == clone.project_template_id
+
+    still_there = (
+        await db_session.execute(
+            text("SELECT 1 FROM public.extraction_fields WHERE id = :id"),
+            {"id": str(field_id)},
+        )
+    ).scalar()
+    assert still_there == 1, (
+        "re-clone wiped a republished user edit — heal must compare live "
+        "structure to the ACTIVE SNAPSHOT, not to the global template"
+    )
+
+    await db_session.rollback()
+
+
+@pytest_asyncio.fixture
+async def auth_as_profile(
+    db_session: AsyncSession,
+) -> AsyncGenerator[UUID, None]:
+    """JWT sub must be a real profile id (manager on the seeded projects)."""
+    del db_session  # kept for fixture-dependency ordering; the seed runs first
+    profile_id = SEED.primary_profile
+
+    async def override_get_current_user() -> TokenPayload:
+        return TokenPayload(
+            sub=str(profile_id),
+            email="test@example.com",
+            role="authenticated",
+            aal="aal1",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield profile_id
+
+
+@pytest.mark.asyncio
+async def test_republish_endpoint_publishes_edit(
+    db_session: AsyncSession,
+    db_client: AsyncClient,
+    auth_as_profile: UUID,
+) -> None:
+    project_id = SEED.secondary_project
+    await _clean_project_clones(db_session, project_id)
+    clone = await _clone_charms(db_session, project_id, auth_as_profile)
+    et_id = await _first_entity_type_id(db_session, clone.project_template_id)
+    await _add_field_like_postgrest(db_session, et_id, "endpoint_field")
+
+    res = await db_client.post(
+        f"/api/v1/projects/{project_id}/templates/{clone.project_template_id}/republish-version"
+    )
+    assert res.status_code == 200, res.text
+    data = res.json()["data"]
+    assert data["version"] == 2
+    assert data["changed"] is True
+    assert UUID(data["version_id"]) != clone.version_id
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_republish_endpoint_404_for_foreign_template(
+    db_session: AsyncSession,
+    db_client: AsyncClient,
+    auth_as_profile: UUID,
+) -> None:
+    """BOLA: republishing a template through another project's URL is 404."""
+    await _clean_project_clones(db_session, SEED.secondary_project)
+    clone = await _clone_charms(db_session, SEED.secondary_project, auth_as_profile)
+
+    res = await db_client.post(
+        f"/api/v1/projects/{SEED.primary_project}/templates/"
+        f"{clone.project_template_id}/republish-version"
+    )
+    assert res.status_code == 404, res.text
+
+    await db_session.rollback()

--- a/docs/reference/extraction-hitl-architecture.md
+++ b/docs/reference/extraction-hitl-architecture.md
@@ -45,8 +45,16 @@ extracting.
 When a Run is created it captures two immutable snapshots: `version_id`
 (an `ExtractionTemplateVersion` row freezing the entity_types + fields
 tree) and `hitl_config_snapshot` (a JSONB copy of the resolved
-`reviewer_count` / `consensus_rule` / `arbitrator_id`). Editing the
-template afterwards never affects existing runs.
+`reviewer_count` / `consensus_rule` / `arbitrator_id`). Version rows are
+immutable, but the *pin* is stage-aware: template configuration edits
+republish the live structure as a new active version
+(`TemplateVersionService.republish`, called by the config UI after every
+section/field mutation via
+`POST /projects/{id}/templates/{tid}/republish-version`), and the
+republish re-pins runs still in an **editable** stage
+(`pending`/`extract`) to the new version so open extraction/QA forms
+render the edit. Runs in `consensus`/`finalized` keep the version they
+were assessed under — editing the template never affects them.
 
 ### 2.1 User-facing vocabulary (do not leak "Run")
 
@@ -347,7 +355,7 @@ The extraction **Import template** dialog reads `extraction_templates_global` th
 | ------ | ---------------- |
 | **UI** | Calls `POST /api/v1/projects/{project_id}/templates/clone` with `global_template_id` and `kind=extraction` (JWT via `apiClient`). The UI may still load the global row first to validate that the id exists in the catalogue. |
 | **Service** | `TemplateCloneService.clone` is **idempotent** on `(project_id, global_template_id)`: first call creates the project row, `extraction_entity_types`, `extraction_fields`, and exactly one active version; later calls return the existing clone and current counts. |
-| **Heal** | If a clone row exists but has zero entity types or fields (partial/legacy data), the service rebuilds structure from the global template and updates the active version snapshot. |
+| **Heal** | Drift is measured against the **active version snapshot**, never the global template. Zero-state clones (empty live structure) rebuild from the global. Non-empty drift (e.g. an edit whose republish call was lost) **self-heals by publishing the live structure** as a new version (`TemplateVersionService.republish`) — never wipe-and-rebuild: with user-editable templates a count mismatch is indistinguishable from a deliberate edit, and the historical wipe destroyed customizations. Factory recovery = delete the template and re-import. |
 
 Configuration flows for QA tools may call the same clone endpoint before sessions; session lifecycle for QA vs extraction is in §5.
 
@@ -543,6 +551,11 @@ publish, AI), keep it in the page-specific component.
     global → project clone (idempotent on
     `(project_id, global_template_id)`). Validates the global template's
     `kind` matches what the caller asked for.
+  - `app/services/template_version_service.py` — `republish`: freezes the
+    live structure into a new active `ExtractionTemplateVersion` (v+1;
+    prior rows untouched) and re-pins `pending`/`extract` runs to it.
+    Surface for `POST /projects/{id}/templates/{tid}/republish-version`,
+    called by the config UI after every section/field edit.
   - `app/services/hitl_session_service.py` — one-shot HITL setup for
     both kinds: clones (QA only) + seeds top-level instances + opens
     or resumes a Run + advances to EXTRACT. Surface for

--- a/frontend/components/extraction/ExtractionInterface.tsx
+++ b/frontend/components/extraction/ExtractionInterface.tsx
@@ -6,6 +6,7 @@
  */
 
 import {useEffect, useState} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
 import {useSearchParams} from 'react-router-dom';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card';
 import {Button} from '@/components/ui/button';
@@ -27,6 +28,8 @@ import {TemplateConfigEditor} from './TemplateConfigEditor';
 import {useAuth} from '@/contexts/AuthContext';
 import {CreateCustomTemplateDialog, ImportTemplateDialog} from './dialogs';
 import {loadProjectArticles} from '@/services/articlesService';
+import {runsKeys} from '@/hooks/runs/types';
+import {templateEntityTypesKeys} from '@/lib/query-keys/extraction';
 import {toast} from 'sonner';
 import {t} from '@/lib/copy';
 
@@ -36,6 +39,7 @@ interface ExtractionInterfaceProps {
 
 export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
   const { user } = useAuth();
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
 
     // Read tab from URL or use default
@@ -545,6 +549,11 @@ export function ExtractionInterface({ projectId }: ExtractionInterfaceProps) {
         initialTemplateId={importInitialTemplateId}
         onTemplateImported={async (templateId?: string) => {
             setImportInitialTemplateId(null);
+            // Import may have healed/rewritten the clone's structure — the
+            // live-structure and run-view caches must not keep serving the
+            // pre-import shape.
+            void queryClient.invalidateQueries({queryKey: templateEntityTypesKeys.all});
+            void queryClient.invalidateQueries({queryKey: runsKeys.all});
             // Refresh templates without reloading the page
           const updatedTemplates = await refreshTemplates() || [];
             // Stay on configuration tab

--- a/frontend/components/extraction/FieldsManager.tsx
+++ b/frontend/components/extraction/FieldsManager.tsx
@@ -31,9 +31,12 @@ import type {ExtractionField} from '@/types/extraction';
 interface FieldsManagerProps {
   entityTypeId: string;
   sectionName?: string;
+  /** Project template owning the section — enables the republish-on-edit
+   * flow that pushes config changes into article forms. */
+  templateId?: string;
 }
 
-export function FieldsManager({ entityTypeId, sectionName }: FieldsManagerProps) {
+export function FieldsManager({ entityTypeId, sectionName, templateId }: FieldsManagerProps) {
   const { project } = useProject();
   const projectId = project?.id || '';
 
@@ -50,7 +53,7 @@ export function FieldsManager({ entityTypeId, sectionName }: FieldsManagerProps)
     validateField,
     createOtherSpecifyField,
     removeOtherSpecifyField,
-  } = useFieldManagement({ entityTypeId, projectId });
+  } = useFieldManagement({ entityTypeId, projectId, templateId });
 
   // Estado local centralizado
   const { state, actions } = useFieldsManagerState();

--- a/frontend/components/extraction/TemplateConfigEditor.tsx
+++ b/frontend/components/extraction/TemplateConfigEditor.tsx
@@ -24,6 +24,7 @@ import {t} from '@/lib/copy';
 import {FieldsManager} from './FieldsManager';
 import {AddSectionDialog, ImportTemplateDialog, RemoveSectionDialog} from './dialogs';
 import {ExtractionEntityType} from '@/types/extraction';
+import {useTemplateRepublish} from '@/hooks/extraction/useTemplateRepublish';
 
 interface TemplateConfigEditorProps {
   projectId: string;
@@ -39,6 +40,7 @@ export function TemplateConfigEditor({ projectId, templateId }: TemplateConfigEd
   const [removingSectionId, setRemovingSectionId] = useState<string | null>(null);
   const [removingSectionName, setRemovingSectionName] = useState('');
   const [showImportDialog, setShowImportDialog] = useState(false);
+  const { republish } = useTemplateRepublish(projectId, templateId);
 
   const loadEntityTypes = async () => {
     setLoading(true);
@@ -80,6 +82,7 @@ export function TemplateConfigEditor({ projectId, templateId }: TemplateConfigEd
     }
     toast.success(t('extraction', 'labelUpdatedSuccess'));
     setEditingId(null);
+    void republish();
     await loadEntityTypes();
   };
 
@@ -95,12 +98,14 @@ export function TemplateConfigEditor({ projectId, templateId }: TemplateConfigEd
 
   const handleSectionAdded = () => {
     setShowAddSectionDialog(false);
+    void republish();
     loadEntityTypes();
   };
 
   const handleSectionRemoved = () => {
     setRemovingSectionId(null);
     setRemovingSectionName('');
+    void republish();
     loadEntityTypes();
   };
 
@@ -264,9 +269,10 @@ export function TemplateConfigEditor({ projectId, templateId }: TemplateConfigEd
 
                     {/* Campos deste entity type */}
                     <div className="border-t pt-4">
-                      <FieldsManager 
+                      <FieldsManager
                         entityTypeId={entityType.id}
                         sectionName={entityType.label}
+                        templateId={templateId}
                       />
                     </div>
 
@@ -294,9 +300,10 @@ export function TemplateConfigEditor({ projectId, templateId }: TemplateConfigEd
                                 </div>
                               </CardHeader>
                               <CardContent>
-                                <FieldsManager 
+                                <FieldsManager
                                   entityTypeId={child.id}
                                   sectionName={child.label}
+                                  templateId={templateId}
                                 />
                               </CardContent>
                             </Card>
@@ -385,6 +392,10 @@ export function TemplateConfigEditor({ projectId, templateId }: TemplateConfigEd
         onOpenChange={setShowImportDialog}
         onTemplateImported={() => {
           setShowImportDialog(false);
+          // Import may have healed/rewritten structure — republish is a
+          // server-side no-op when current, but re-pins stale runs and
+          // invalidates the form caches either way.
+          void republish();
           loadEntityTypes();
         }}
       />

--- a/frontend/hooks/extraction/useFieldManagement.ts
+++ b/frontend/hooks/extraction/useFieldManagement.ts
@@ -34,17 +34,23 @@ import {
   deleteField as deleteFieldService,
   reorderFields as reorderFieldsService,
 } from '@/services/extractionFieldService';
+import {useTemplateRepublish} from '@/hooks/extraction/useTemplateRepublish';
 
 interface UseFieldManagementProps {
   entityTypeId: string;
   projectId: string;
+  /** Project template owning the section. When provided, every successful
+   * mutation republishes the template version so article forms see it. */
+  templateId?: string;
 }
 
 export function useFieldManagement({
   entityTypeId,
   projectId,
+  templateId,
 }: UseFieldManagementProps) {
   const { user } = useAuth();
+  const { republish } = useTemplateRepublish(projectId, templateId);
   const [fields, setFields] = useState<ExtractionField[]>([]);
   const [loading, setLoading] = useState(true);
   const [permissions, setPermissions] = useState<PermissionCheckResult>({
@@ -200,6 +206,9 @@ export function useFieldManagement({
     const createdField = result.data;
     setFields(prev => [...prev, createdField]);
     toast.success(t('extraction', 'fieldAddedSuccess').replace('{{label}}', createdField.label));
+    // Fire-and-forget: the edit itself already succeeded; publishing to
+    // article forms happens in the background (failure toasts on its own).
+    void republish();
     return createdField;
   };
 
@@ -254,6 +263,7 @@ export function useFieldManagement({
 
     const createdField = result.data;
     setFields(prev => [...prev, createdField]);
+    void republish();
     return createdField;
   };
 
@@ -295,6 +305,7 @@ export function useFieldManagement({
       prev.map(field => (field.id === fieldId ? updatedField : field))
     );
     toast.success(t('extraction', 'fieldUpdatedSuccess'));
+    void republish();
     return updatedField;
   };
 
@@ -327,6 +338,7 @@ export function useFieldManagement({
 
     setFields(prev => prev.filter(field => field.id !== fieldId));
     toast.success(t('extraction', 'fieldRemovedSuccess'));
+    void republish();
     return true;
   };
 
@@ -386,6 +398,7 @@ export function useFieldManagement({
     // Reload fields to ensure correct order
     await loadFields();
     toast.success(t('extraction', 'fieldsReorderSuccess'));
+    void republish();
     return true;
   };
 

--- a/frontend/hooks/extraction/useTemplateEntityTypes.ts
+++ b/frontend/hooks/extraction/useTemplateEntityTypes.ts
@@ -13,6 +13,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { supabase } from '@/integrations/supabase/client';
+import { templateEntityTypesKeys } from '@/lib/query-keys/extraction';
 import type { ExtractionField } from '@/types/extraction';
 
 export interface TemplateEntityTypeWithFields {
@@ -20,11 +21,7 @@ export interface TemplateEntityTypeWithFields {
   fields: ExtractionField[];
 }
 
-export const templateEntityTypesKeys = {
-  all: ['template-entity-types'] as const,
-  byTemplate: (templateId: string) =>
-    ['template-entity-types', templateId] as const,
-};
+export { templateEntityTypesKeys };
 
 export function useTemplateEntityTypes(templateId: string | null | undefined) {
   const query = useQuery({

--- a/frontend/hooks/extraction/useTemplateRepublish.ts
+++ b/frontend/hooks/extraction/useTemplateRepublish.ts
@@ -1,0 +1,50 @@
+/**
+ * Publish the live template structure as a new active version after a
+ * configuration edit.
+ *
+ * Section/field edits are written through PostgREST, but the per-article
+ * extraction/QA forms render from the run's frozen version snapshot
+ * (`extraction_template_versions.schema_`). Without a republish the edit
+ * never reaches any form — not even for brand-new runs. The backend also
+ * re-pins runs still in an editable stage (pending/extract) to the new
+ * version, so this hook invalidates the run-view cache afterwards.
+ *
+ * @module hooks/extraction/useTemplateRepublish
+ */
+
+import {useQueryClient} from '@tanstack/react-query';
+import {toast} from 'sonner';
+import {t} from '@/lib/copy';
+import {runsKeys} from '@/hooks/runs/types';
+import {templateEntityTypesKeys} from '@/lib/query-keys/extraction';
+import {republishTemplateVersion} from '@/services/templateService';
+
+export function useTemplateRepublish(
+  projectId: string | undefined,
+  templateId: string | undefined,
+) {
+  const queryClient = useQueryClient();
+
+  /**
+   * Fire the republish + cache invalidation. Resolves quietly on success;
+   * toasts on failure (the structural edit itself already succeeded — the
+   * user must know the forms may lag behind).
+   */
+  const republish = async (): Promise<void> => {
+    if (!projectId || !templateId) return;
+
+    const result = await republishTemplateVersion(projectId, templateId);
+    if (!result.ok) {
+      console.error('[useTemplateRepublish] republish failed:', result.error);
+      toast.error(t('extraction', 'errors_republishTemplate'));
+      return;
+    }
+
+    await queryClient.invalidateQueries({queryKey: runsKeys.all});
+    await queryClient.invalidateQueries({
+      queryKey: templateEntityTypesKeys.byTemplate(templateId),
+    });
+  };
+
+  return {republish};
+}

--- a/frontend/hooks/runs/types.ts
+++ b/frontend/hooks/runs/types.ts
@@ -165,6 +165,10 @@ export interface RunViewFieldResponse {
   allow_other: boolean;
   other_label: string | null;
   other_placeholder: string | null;
+  /** ADR-0016 opt-in disposition flags — gate the "Not applicable" /
+   * "Not evaluated" markers in FieldInput. */
+  allows_not_applicable: boolean;
+  allows_not_evaluated: boolean;
 }
 
 export interface RunViewEntityType {

--- a/frontend/lib/copy/extraction.ts
+++ b/frontend/lib/copy/extraction.ts
@@ -178,6 +178,8 @@ export const extraction = {
     errors_removeField: 'Error removing field',
     errors_reorderFields: 'Error reordering',
     errors_cloneTemplate: 'Error cloning template',
+    errors_republishTemplate:
+      'The change was saved, but publishing it to article forms failed. It will be published with your next configuration change.',
     errors_createTemplate: 'Error creating template',
     errors_updateTemplateStatus: 'Error updating status',
     templateClonedSuccess: 'Template "{{name}}" cloned successfully!',

--- a/frontend/lib/extraction/runViewAdapters.ts
+++ b/frontend/lib/extraction/runViewAdapters.ts
@@ -47,6 +47,8 @@ function fieldFromRunView(
     allow_other: f.allow_other,
     other_label: f.other_label,
     other_placeholder: f.other_placeholder,
+    allows_not_applicable: f.allows_not_applicable,
+    allows_not_evaluated: f.allows_not_evaluated,
   };
 }
 

--- a/frontend/lib/query-keys/extraction.ts
+++ b/frontend/lib/query-keys/extraction.ts
@@ -33,3 +33,14 @@ export const extractionKeys = {
   job: (jobId: string) =>
     [...extractionKeys.all, 'section-job', jobId] as const,
 } as const;
+
+/**
+ * Key factory for live template structure reads (entity types + fields).
+ * Lives here (not in the hook) so republish flows can invalidate without
+ * importing the hook module's supabase dependency chain.
+ */
+export const templateEntityTypesKeys = {
+  all: ['template-entity-types'] as const,
+  byTemplate: (templateId: string) =>
+    ['template-entity-types', templateId] as const,
+};

--- a/frontend/services/templateService.ts
+++ b/frontend/services/templateService.ts
@@ -11,11 +11,38 @@
  * @module services/templateService
  */
 
+import {apiClient} from '@/integrations/api/client';
 import {supabase} from '@/integrations/supabase/client';
 import type {ErrorResult} from '@/lib/error-utils';
 import {toResult} from '@/lib/error-utils';
+import type {components} from '@/types/api/schema';
 
 // --- Types ---
+
+export type RepublishTemplateVersionResponse =
+  components['schemas']['RepublishTemplateVersionResponse'];
+
+/**
+ * Publish the live template structure as a new active version.
+ *
+ * Section/field edits go straight to PostgREST, but article forms render
+ * from the run's frozen version snapshot — call this after every
+ * structural mutation so the snapshot (and runs still in an editable
+ * stage) pick up the edit.
+ */
+export async function republishTemplateVersion(
+  projectId: string,
+  templateId: string,
+): Promise<ErrorResult<RepublishTemplateVersionResponse>> {
+  return toResult(
+    async () =>
+      apiClient<RepublishTemplateVersionResponse>(
+        `/api/v1/projects/${projectId}/templates/${templateId}/republish-version`,
+        {method: 'POST'},
+      ),
+    'republishTemplateVersion',
+  );
+}
 
 export interface EntityTypeWithCount {
   id: string;

--- a/frontend/test/hooks/useFieldManagement.republish.test.tsx
+++ b/frontend/test/hooks/useFieldManagement.republish.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Field mutations must republish the template version.
+ *
+ * Template edits are written through PostgREST, so nothing on the backend
+ * sees them; article forms render from the run's frozen version snapshot.
+ * After every successful field mutation the hook must POST
+ * /templates/{id}/republish-version (via templateService) and invalidate the
+ * run-view cache so open forms refetch the new schema.
+ */
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react';
+import type {ReactElement, ReactNode} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/services/extractionFieldService', () => ({
+  checkProjectPermissions: vi.fn(),
+  loadEntityTypeFields: vi.fn(),
+  validateFieldImpact: vi.fn(),
+  insertField: vi.fn(),
+  updateField: vi.fn(),
+  deleteField: vi.fn(),
+  reorderFields: vi.fn(),
+}));
+vi.mock('@/services/templateService', () => ({
+  republishTemplateVersion: vi.fn(),
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({user: {id: 'user-1'}}),
+}));
+vi.mock('sonner', () => ({
+  toast: {error: vi.fn(), success: vi.fn()},
+}));
+
+import {
+  checkProjectPermissions,
+  insertField,
+  loadEntityTypeFields,
+  updateField,
+  validateFieldImpact,
+  deleteField,
+} from '@/services/extractionFieldService';
+import {republishTemplateVersion} from '@/services/templateService';
+import {runsKeys} from '@/hooks/runs/types';
+import {useFieldManagement} from '@/hooks/extraction/useFieldManagement';
+
+const permissionsMock = checkProjectPermissions as unknown as ReturnType<typeof vi.fn>;
+const loadFieldsMock = loadEntityTypeFields as unknown as ReturnType<typeof vi.fn>;
+const insertMock = insertField as unknown as ReturnType<typeof vi.fn>;
+const updateMock = updateField as unknown as ReturnType<typeof vi.fn>;
+const deleteMock = deleteField as unknown as ReturnType<typeof vi.fn>;
+const validateMock = validateFieldImpact as unknown as ReturnType<typeof vi.fn>;
+const republishMock = republishTemplateVersion as unknown as ReturnType<typeof vi.fn>;
+
+const FIELD = {
+  id: 'f-1',
+  entity_type_id: 'et-1',
+  name: 'sample_size',
+  label: 'Sample size',
+  description: null,
+  field_type: 'text',
+  is_required: false,
+  validation_schema: {},
+  allowed_values: null,
+  unit: null,
+  allowed_units: null,
+  llm_description: null,
+  sort_order: 1,
+  created_at: '2024-01-01T00:00:00Z',
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false}},
+  });
+  const wrapper = ({children}: {children: ReactNode}): ReactElement => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return {wrapper, queryClient};
+}
+
+function renderFieldManagement() {
+  const {wrapper, queryClient} = createWrapper();
+  const rendered = renderHook(
+    () =>
+      useFieldManagement({
+        entityTypeId: 'et-1',
+        projectId: 'proj-1',
+        templateId: 'tpl-1',
+      }),
+    {wrapper},
+  );
+  return {...rendered, queryClient};
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  permissionsMock.mockResolvedValue({
+    ok: true,
+    data: {canView: true, canEdit: true, canDelete: true, canCreate: true, role: 'manager'},
+  });
+  loadFieldsMock.mockResolvedValue({ok: true, data: [FIELD]});
+  validateMock.mockResolvedValue({
+    ok: true,
+    data: {
+      canDelete: true,
+      canUpdate: true,
+      canChangeType: true,
+      extractedValuesCount: 0,
+      affectedArticles: [],
+    },
+  });
+  republishMock.mockResolvedValue({
+    ok: true,
+    data: {version_id: 'v-2', version: 2, changed: true, repinned_run_count: 1},
+  });
+});
+
+describe('useFieldManagement — republish after mutations', () => {
+  it('republishes the template version after a successful addField', async () => {
+    insertMock.mockResolvedValue({
+      ok: true,
+      data: {...FIELD, id: 'f-new', name: 'new_field', label: 'New field'},
+    });
+    const {result} = renderFieldManagement();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await result.current.addField({
+      name: 'new_field',
+      label: 'New field',
+      field_type: 'text',
+      is_required: false,
+      sort_order: 2,
+    });
+
+    expect(republishMock).toHaveBeenCalledWith('proj-1', 'tpl-1');
+  });
+
+  it('republishes after a successful updateField and invalidates the runs cache', async () => {
+    updateMock.mockResolvedValue({ok: true, data: {...FIELD, label: 'Renamed'}});
+    const {result, queryClient} = renderFieldManagement();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    await result.current.updateField('f-1', {label: 'Renamed'});
+
+    expect(republishMock).toHaveBeenCalledWith('proj-1', 'tpl-1');
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({queryKey: runsKeys.all}),
+      ),
+    );
+  });
+
+  it('republishes after a successful deleteField', async () => {
+    deleteMock.mockResolvedValue({ok: true, data: undefined});
+    const {result} = renderFieldManagement();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await result.current.deleteField('f-1');
+
+    expect(republishMock).toHaveBeenCalledWith('proj-1', 'tpl-1');
+  });
+
+  it('does NOT republish when the mutation fails', async () => {
+    updateMock.mockResolvedValue({ok: false, error: {message: 'boom'}});
+    const {result} = renderFieldManagement();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await result.current.updateField('f-1', {label: 'Renamed'});
+
+    expect(republishMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/test/lib/runViewAdapters.test.ts
+++ b/frontend/test/lib/runViewAdapters.test.ts
@@ -62,6 +62,8 @@ function makeRunViewResponse(
           allow_other: false,
           other_label: null,
           other_placeholder: null,
+          allows_not_applicable: false,
+          allows_not_evaluated: false,
         },
       ],
     },
@@ -147,6 +149,22 @@ describe('entityTypesFromRunView', () => {
     expect(f.allow_other).toBe(false);
     expect(f.other_label).toBeNull();
     expect(f.other_placeholder).toBeNull();
+  });
+
+  it('carries the ADR-0016 disposition flags through to the form field', () => {
+    // Regression: fieldFromRunView dropped allows_not_applicable /
+    // allows_not_evaluated, so FieldInput never rendered the "Not
+    // applicable" / "Not evaluated" markers on the extraction page even
+    // when the template opted in.
+    const view = makeRunViewResponse();
+    view.entity_types[0].fields[0] = {
+      ...view.entity_types[0].fields[0],
+      allows_not_applicable: true,
+      allows_not_evaluated: true,
+    };
+    const [et] = entityTypesFromRunView(view);
+    expect(et.fields[0].allows_not_applicable).toBe(true);
+    expect(et.fields[0].allows_not_evaluated).toBe(true);
   });
 
   it('sets created_at placeholder from run.created_at on entity type', () => {

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -1406,6 +1406,54 @@
         "title": "ApiResponse[ProposalRecordResponse]",
         "type": "object"
       },
+      "ApiResponse_RepublishTemplateVersionResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RepublishTemplateVersionResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Dados da resposta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ErrorDetail"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Error details"
+          },
+          "ok": {
+            "description": "Indica se a operacao foi bem-sucedida",
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "rastreamento",
+            "title": "Trace Id"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "ApiResponse[RepublishTemplateVersionResponse]",
+        "type": "object"
+      },
       "ApiResponse_ReviewerDecisionResponse_": {
         "properties": {
           "data": {
@@ -4678,6 +4726,35 @@
           "version"
         ],
         "title": "PublishedStateResponse",
+        "type": "object"
+      },
+      "RepublishTemplateVersionResponse": {
+        "properties": {
+          "changed": {
+            "title": "Changed",
+            "type": "boolean"
+          },
+          "repinned_run_count": {
+            "title": "Repinned Run Count",
+            "type": "integer"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          },
+          "version_id": {
+            "format": "uuid",
+            "title": "Version Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version_id",
+          "version",
+          "changed",
+          "repinned_run_count"
+        ],
+        "title": "RepublishTemplateVersionResponse",
         "type": "object"
       },
       "ReviewerDecisionResponse": {
@@ -8045,6 +8122,65 @@
           }
         ],
         "summary": "Update Project Template Active",
+        "tags": [
+          "project-templates"
+        ]
+      }
+    },
+    "/api/v1/projects/{project_id}/templates/{template_id}/republish-version": {
+      "post": {
+        "description": "Publish the live template structure as a new active version.\n\nIdempotent when nothing changed (returns the current active version\nwithout spawning rows). Runs still in an editable stage\n(``pending``/``extract``) are re-pinned to the new version so open\narticle forms render the edit; runs from ``consensus`` on keep the\nversion they were assessed under. Manager-gated like the sibling\nendpoints \u2014 section/field editing is project-wide configuration.",
+        "operationId": "republish_template_version_api_v1_projects__project_id__templates__template_id__republish_version_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Project Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "template_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Template Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_RepublishTemplateVersionResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "Supabase JWT": []
+          }
+        ],
+        "summary": "Republish Template Version",
         "tags": [
           "project-templates"
         ]

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -664,6 +664,33 @@ export interface paths {
         patch: operations["update_project_template_active_api_v1_projects__project_id__templates__template_id__patch"];
         trace?: never;
     };
+    "/api/v1/projects/{project_id}/templates/{template_id}/republish-version": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Republish Template Version
+         * @description Publish the live template structure as a new active version.
+         *
+         *     Idempotent when nothing changed (returns the current active version
+         *     without spawning rows). Runs still in an editable stage
+         *     (``pending``/``extract``) are re-pinned to the new version so open
+         *     article forms render the edit; runs from ``consensus`` on keep the
+         *     version they were assessed under. Manager-gated like the sibling
+         *     endpoints — section/field editing is project-wide configuration.
+         */
+        post: operations["republish_template_version_api_v1_projects__project_id__templates__template_id__republish_version_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/runs": {
         parameters: {
             query?: never;
@@ -1550,6 +1577,23 @@ export interface components {
         ApiResponse_ProposalRecordResponse_: {
             /** @description Dados da resposta */
             data?: components["schemas"]["ProposalRecordResponse"] | null;
+            /** @description Error details */
+            error?: components["schemas"]["ErrorDetail"] | null;
+            /**
+             * Ok
+             * @description Indica se a operacao foi bem-sucedida
+             */
+            ok: boolean;
+            /**
+             * Trace Id
+             * @description rastreamento
+             */
+            trace_id?: string | null;
+        };
+        /** ApiResponse[RepublishTemplateVersionResponse] */
+        ApiResponse_RepublishTemplateVersionResponse_: {
+            /** @description Dados da resposta */
+            data?: components["schemas"]["RepublishTemplateVersionResponse"] | null;
             /** @description Error details */
             error?: components["schemas"]["ErrorDetail"] | null;
             /**
@@ -3034,6 +3078,20 @@ export interface components {
             };
             /** Version */
             version: number;
+        };
+        /** RepublishTemplateVersionResponse */
+        RepublishTemplateVersionResponse: {
+            /** Changed */
+            changed: boolean;
+            /** Repinned Run Count */
+            repinned_run_count: number;
+            /** Version */
+            version: number;
+            /**
+             * Version Id
+             * Format: uuid
+             */
+            version_id: string;
         };
         /** ReviewerDecisionResponse */
         ReviewerDecisionResponse: {
@@ -4853,6 +4911,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiResponse_UpdateTemplateActiveResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    republish_template_version_api_v1_projects__project_id__templates__template_id__republish_version_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiResponse_RepublishTemplateVersionResponse_"];
                 };
             };
             /** @description Validation Error */

--- a/scripts/fitness/check_file_size.baseline
+++ b/scripts/fitness/check_file_size.baseline
@@ -6,6 +6,6 @@ backend/app/services/section_extraction_service.py:1635
 frontend/components/articles/ArticleForm.tsx:1272
 frontend/components/articles/ArticlesList.tsx:1360
 frontend/components/extraction/ArticleExtractionTable.tsx:1130
-frontend/lib/copy/extraction.ts:910
+frontend/lib/copy/extraction.ts:912
 frontend/pages/ExtractionFullScreen.tsx:1310
 frontend/pages/QualityAssessmentFullScreen.tsx:841


### PR DESCRIPTION
## Why

Template configuration edits (new sections/fields, allow "Other (specify)", allow "Not applicable", allow "Not evaluated") never appeared in the per-article extraction/QA forms — not even for articles opened after the edit. Edits are written via PostgREST, nothing ever refreshed the active `extraction_template_versions.schema_`, and run views render from the run's frozen snapshot (`extraction_run_read_service._entity_types_for_run`). A second, latent landmine: the clone heal compared live structure to the **global** template, so any customized clone was one re-import / QA session open away from a destructive wipe.

## What changed

**Backend**
- `app/services/template_version_service.py` (new): `republish` freezes the live structure into a NEW active version (v+1; prior rows never mutated — `consensus`/`finalized` runs stay pinned), re-pins `pending`/`extract` runs, and materializes missing singleton instances via `HITLSessionService.ensure_instances` (otherwise the ADR-0009 finalize gate — per EXISTING instance — silently skips a newly added required section). Lock ordering mirrors session open: advisory `(article, template)` locks first (sorted), then the template row `FOR UPDATE`; ownership is validated with an unlocked read before any lock.
- `POST /projects/{project_id}/templates/{template_id}/republish-version` (manager-gated, 404 on cross-project ids) in `project_templates.py`.
- `run_lifecycle_service.create_run`/`reopen_run` take `FOR SHARE` on the template row so version resolution serializes with a concurrent republish (a run could otherwise pin the just-deactivated version and miss the re-pin UPDATE).
- `template_clone_service` heal: drift is now measured against the **active snapshot**; non-empty drift self-heals by **publishing live** (never wipe-and-rebuild — indistinguishable from a deliberate edit whose republish was lost, and the old wipe 500'd on the RESTRICT FK whenever instances existed). Zero-state clones still rebuild from the global. This also self-heals templates edited before this fix.

**Frontend**
- `RunViewFieldResponse` + `fieldFromRunView` now carry `allows_not_applicable`/`allows_not_evaluated` — the backend already serialized them; the hand-written adapter dropped them, so the NA/NE markers never rendered on the extraction page (QA reads live PostgREST structure, which is why ADR-0016 worked there).
- `useTemplateRepublish` (new) fires after every config mutation (field add/update/delete/reorder, other-specify, section add/remove/label, template import) — fire-and-forget after the success toast — and invalidates `runsKeys` + `templateEntityTypesKeys` (factory moved to `lib/query-keys/extraction.ts`).

**Docs**: `extraction-hitl-architecture.md` §2 (stage-aware pinning), clone-heal row, services list updated.

## Risk

- **Re-pin semantics change**: runs in `pending`/`extract` now follow template edits (this is the reported expectation); `consensus`/`finalized` stay frozen — version rows are still immutable.
- **Heal contract change**: bc055915-style corruption (live < snapshot, out-of-band loss) no longer factory-resets on re-clone; live is authoritative and the snapshot self-heals. Factory recovery = delete template + re-import. Pinned in `test_template_clone_service.py` with rationale.
- Known limitation (same as before for other writers): global seed updates no longer force-refresh existing clones (the old path 500'd on in-use templates anyway).

## Test plan

- [x] `backend: uv run pytest` — 2429 passed, 5 skipped (includes 9 new tests: republish v+1/no-op/re-pin/instances/BOLA/endpoint; heal self-heal ×2)
- [x] `npm run test:run` — 1126 passed (new: adapter disposition-flag test, useFieldManagement republish wiring ×4)
- [x] `npx tsc -p tsconfig.app.json --noEmit`, `npm run lint`, `ruff check` + `format --check` — clean
- [x] Fitness gates green (file-size baseline updated for the copy dictionary, +2 lines)
- [ ] Manual: edit a field's flags in Configuration → open the article form → new section/field/markers render

## Out of scope

- Moving section/field CRUD behind the API (read/write-path consolidation) — republish-on-edit is the interim contract.
- A backfill republish for templates edited before this fix: they self-heal on the next config edit, re-import, or QA session open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)