### PR TITLE
fix(consensus): gate finalize on run-level completeness, not caller's form

### DIFF
--- a/frontend/components/runs/ConsensusResolutionPanel.tsx
+++ b/frontend/components/runs/ConsensusResolutionPanel.tsx
@@ -31,7 +31,6 @@ export interface ConsensusResolutionPanelProps {
   reviewerAvatarById: Record<string, string | null | undefined>;
   /** Every required template coordKey (`${instance}::${field}`) — drives required gaps + finalize gate. */
   requiredCoords: string[];
-  isComplete: boolean;
   isResolving: boolean;
   isFinalizing: boolean;
   peersRevealed: boolean;
@@ -62,7 +61,6 @@ export function ConsensusResolutionPanel({
   reviewerLabelById,
   reviewerAvatarById,
   requiredCoords,
-  isComplete,
   isResolving,
   isFinalizing,
   peersRevealed,
@@ -83,7 +81,6 @@ export function ConsensusResolutionPanel({
     ),
     participantCount: summary.reviewers.length,
     requiredCoords,
-    isComplete,
   });
 
   return (

--- a/frontend/hooks/extraction/useConsensusReconciliation.ts
+++ b/frontend/hooks/extraction/useConsensusReconciliation.ts
@@ -20,6 +20,14 @@ import { t } from '@/lib/copy';
 
 export interface ConsensusReconciliation {
   requiredCoords: string[];
+  /**
+   * Run-level required-field completeness: every required coord has a reviewer
+   * decision or a published value (published states are written for every
+   * consensus decision, so adopted-peer resolutions count). This is the signal
+   * the header finalize gate must use — NOT the caller-scoped form `isComplete`,
+   * which strands an arbitrator who resolved required fields by adopting peers.
+   */
+  requiredFieldsResolved: boolean;
   expectedReviewerCount: number;
   finalizeWarning: { shouldWarn: boolean; confirmMessage: string };
 }
@@ -85,6 +93,7 @@ export function useConsensusReconciliation(params: {
 
   return {
     requiredCoords,
+    requiredFieldsResolved: reconciliation.requiredGaps.length === 0,
     expectedReviewerCount,
     finalizeWarning: { shouldWarn: warning.shouldWarn, confirmMessage },
   };

--- a/frontend/lib/extraction/stageTransition.ts
+++ b/frontend/lib/extraction/stageTransition.ts
@@ -5,9 +5,17 @@ import type { StageTransition } from '@/components/runs/header/RunHeaderContext'
 export interface BuildTransitionArgs {
   stage: ExtractionRunStage | null;
   canResolveConflicts: boolean;
+  /** Caller-scoped form completeness — drives the EXTRACT-stage reviewer gate. */
   isComplete: boolean;
   completed: number;
   total: number;
+  /**
+   * Run-level required-field completeness (published ∪ every reviewer's
+   * decision) — drives the CONSENSUS finalize gate. Distinct from `isComplete`:
+   * an arbitrator who resolved required fields by adopting peers has an
+   * incomplete personal form yet a complete run. Mirrors the backend gate.
+   */
+  consensusComplete: boolean;
   /** Every diverging coord has a consensus decision (reviewerSummary-derived). */
   divergencesResolved: boolean;
   /** The caller is in reviewers_ready (reflects the Mark-ready button label). */
@@ -18,7 +26,12 @@ export interface BuildTransitionArgs {
   onOpenConsensus: () => void | Promise<void>;
   /** Consensus, manager/consensus: publish-all then finalize (one action). */
   onApproveFinalize: () => void | Promise<void>;
-  onGuide: () => void;
+  /**
+   * Blocked-click affordance. The optional message lets each gate surface the
+   * copy that matches its own tooltip (extract vs consensus), so the toast never
+   * contradicts the reason shown on hover.
+   */
+  onGuide: (message?: string) => void;
 }
 
 function makeTransition(
@@ -29,7 +42,7 @@ function makeTransition(
   completed: number,
   total: number,
   advance: () => void | Promise<void>,
-  onGuide: () => void,
+  onGuide: (message?: string) => void,
 ): StageTransition {
   if (isComplete) {
     return { to, label, tooltip, gate: { ok: true }, onAdvance: advance };
@@ -54,6 +67,7 @@ export function buildExtractionTransition(args: BuildTransitionArgs): StageTrans
     isComplete,
     completed,
     total,
+    consensusComplete,
     divergencesResolved,
     isReady,
     onMarkReady,
@@ -96,19 +110,25 @@ export function buildExtractionTransition(args: BuildTransitionArgs): StageTrans
   if (stage === 'consensus' && canResolveConflicts) {
     const label = t('extraction', 'runHeaderApproveFinalize');
     const tooltip = t('extraction', 'runHeaderApproveFinalizeTooltip');
-    if (isComplete && divergencesResolved) {
+    // Run-level completeness (consensusComplete), NOT the caller-scoped
+    // isComplete: the run is finalizable once every required coord is resolved
+    // run-wide, even if this arbitrator's own form is sparse.
+    if (consensusComplete && divergencesResolved) {
       return { to: 'finalized', label, tooltip, gate: { ok: true }, onAdvance: onApproveFinalize };
     }
+    const reason = t('extraction', 'runHeaderApproveBlocked');
     return {
       to: 'finalized',
       label,
       tooltip,
       gate: {
         ok: false,
-        reason: t('extraction', 'runHeaderApproveBlocked'),
+        reason,
         remaining: Math.max(0, total - completed),
       },
-      onAdvance: onGuide,
+      // Toast the gate's own reason so it matches the tooltip (the shared
+      // onGuide default copy is the extract-stage message).
+      onAdvance: () => onGuide(reason),
     };
   }
 

--- a/frontend/lib/runs/reconciliation.test.ts
+++ b/frontend/lib/runs/reconciliation.test.ts
@@ -14,7 +14,6 @@ const baseParams = {
   decisionCountByCoord: new Map<string, number>(),
   participantCount: 2,
   requiredCoords: [] as string[],
-  isComplete: true,
 };
 
 describe('deriveConsensusResolution', () => {
@@ -60,7 +59,7 @@ describe('deriveConsensusResolution', () => {
     expect(v.canFinalize).toBe(false);
   });
 
-  it('canFinalize: conflicts resolved + no required gap + complete + >=1 decision', () => {
+  it('canFinalize: conflicts resolved + no required gap + >=1 decision', () => {
     const v = deriveConsensusResolution({
       ...baseParams,
       divergentCoords: new Set(['i1::f1']),
@@ -70,16 +69,22 @@ describe('deriveConsensusResolution', () => {
     expect(v.canFinalize).toBe(true);
   });
 
-  it('canFinalize false when isComplete=false or no consensus decision exists', () => {
+  it('canFinalize false when no consensus decision exists', () => {
     expect(deriveConsensusResolution({ ...baseParams }).canFinalize).toBe(false);
-    expect(
-      deriveConsensusResolution({
-        ...baseParams,
-        isComplete: false,
-        consensusDecisions: [dec('i1::f9', '2026-01-01T00:00:00Z')],
-        decisionCountByCoord: new Map([['i1::f9', 2]]),
-      }).canFinalize,
-    ).toBe(false);
+  });
+
+  it('canFinalize uses run-level completeness: a required coord satisfied only by a published value (no caller decision) still finalizes', () => {
+    // The bug: an arbitrator resolves a required field by adopting a peer's
+    // value — a PublishedState exists but nothing in the caller's own stream.
+    // requiredGaps must credit the published coord, so the run finalizes.
+    const v = deriveConsensusResolution({
+      ...baseParams,
+      requiredCoords: ['i1::f2'],
+      publishedCoords: new Set(['i1::f2']),
+      consensusDecisions: [dec('i1::f2', '2026-01-01T00:00:00Z', 'select_existing')],
+    });
+    expect(v.statusByCoord.get('i1::f2')).toBe('resolved');
+    expect(v.canFinalize).toBe(true);
   });
 
   it('a required gap blocks finalize even with a consensus decision elsewhere', () => {

--- a/frontend/lib/runs/reconciliation.ts
+++ b/frontend/lib/runs/reconciliation.ts
@@ -74,7 +74,6 @@ export function deriveConsensusResolution<C extends ResolvedConsensusLike>(p: {
   decisionCountByCoord: ReadonlyMap<string, number>;
   participantCount: number;
   requiredCoords: readonly string[];
-  isComplete: boolean;
 }): ConsensusResolutionView<C> {
   // Newest consensus decision wins per coord (the aggregate can carry more than
   // one if an arbitrator re-resolved a field).
@@ -109,11 +108,18 @@ export function deriveConsensusResolution<C extends ResolvedConsensusLike>(p: {
     }
   }
 
+  // Completeness is measured at the RUN level: `requiredGaps` already flags any
+  // required coord with no reviewer decision and no published value (a published
+  // state is written for every consensus decision, so adopted-peer resolutions
+  // count as filled). This deliberately does NOT consult a caller-scoped
+  // "isComplete" — an arbitrator who resolves a required field by adopting a
+  // peer's value has nothing in their own decision stream, yet the run is
+  // complete. Mirrors the backend gate (`_filled_coords`: published ∪ every
+  // reviewer's decision), so the button state matches what finalize will accept.
   const conflictsResolved = buckets.conflicts.every((c) => resolvedByCoord.has(c));
   const canFinalize =
     conflictsResolved &&
     buckets.requiredGaps.length === 0 &&
-    p.isComplete &&
     p.consensusDecisions.length > 0;
 
   return {

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -259,6 +259,7 @@ export default function ExtractionFullScreen() {
   // expected reviewer count, and pre-built finalize-warning message.
   const {
     requiredCoords,
+    requiredFieldsResolved,
     expectedReviewerCount,
     finalizeWarning,
   } = useConsensusReconciliation({
@@ -1056,10 +1057,10 @@ export default function ExtractionFullScreen() {
 
   // P0 guide handler: scroll the form container to top and show a toast.
   // Jump-to-first-empty-field is a documented P1 refinement — not wired here.
-  const onGuide = () => {
+  const onGuide = (message?: string) => {
     const el = document.querySelector('[data-scroll-container="extraction-form"] [data-radix-scroll-area-viewport]');
     if (el) el.scrollTop = 0;
-    toast.info(t('extraction', 'runHeaderGateBlocked'));
+    toast.info(message ?? t('extraction', 'runHeaderGateBlocked'));
   };
 
   // Stage-driven transition for the RunHeader PrimaryAction slot.
@@ -1084,6 +1085,7 @@ export default function ExtractionFullScreen() {
     isComplete,
     completed: completedFields,
     total: totalFields,
+    consensusComplete: requiredFieldsResolved,
     divergencesResolved,
     isReady,
     onMarkReady,
@@ -1143,7 +1145,6 @@ export default function ExtractionFullScreen() {
           onSelectExisting={handleSelectExisting}
           onManualOverride={handleManualOverride}
           onFinalize={handleApproveFinalize}
-          isComplete={isComplete}
           isResolving={consensusMutation.isPending}
           isFinalizing={advanceMutation.isPending || approveFinalize.isPending}
           showFinalize={false}

--- a/frontend/pages/ExtractionFullScreen.tsx
+++ b/frontend/pages/ExtractionFullScreen.tsx
@@ -255,8 +255,7 @@ export default function ExtractionFullScreen() {
 
   const inConsensusStage = runDetail?.run.stage === 'consensus';
 
-  // Consensus-page derived values: coord→label map, required coords,
-  // expected reviewer count, and pre-built finalize-warning message.
+  // Consensus-page derived values: required coords, run-level completeness, expected reviewer count, finalize warning.
   const {
     requiredCoords,
     requiredFieldsResolved,

--- a/frontend/pages/QualityAssessmentFullScreen.tsx
+++ b/frontend/pages/QualityAssessmentFullScreen.tsx
@@ -689,16 +689,6 @@ export default function QualityAssessmentFullScreen() {
   const showConsensusPanel = ready && inConsensusStage && !!runDetail;
   const showFormStage = ready && !inConsensusStage;
 
-  // Completeness signal for ConsensusPanel's no-divergence finalize fast-path.
-  // QA has no required-field gate (its publish preflight only requires at
-  // least one filled value — see handlePublish), so mirror that here: without
-  // this the panel never receives isComplete, canFinalize stays false, and a
-  // no-divergence QA run shows a wrong "incomplete" message with finalize
-  // disabled.
-  const qaIsComplete = Object.values(values).some(
-    (v) => v !== undefined && v !== null && v !== "",
-  );
-
   const formPanel = (
     <RunEditabilityProvider stage={runDetail?.run.stage ?? null}>
     <div className="space-y-3 p-4" data-testid="qa-form-panel">
@@ -735,7 +725,6 @@ export default function QualityAssessmentFullScreen() {
           onFinalize={handleFinalizeFromConsensus}
           isResolving={consensusMutation.isPending}
           isFinalizing={advanceMutation.isPending}
-          isComplete={qaIsComplete}
           requiredCoords={[]}
           peersRevealed={!!runDetail.peers_revealed}
           showFinalize

--- a/frontend/test/ConsensusResolutionPanel.test.tsx
+++ b/frontend/test/ConsensusResolutionPanel.test.tsx
@@ -86,7 +86,6 @@ const baseProps = {
   reviewerLabelById: { 'user-a': 'Alice', 'user-b': 'Bob' },
   reviewerAvatarById: { 'user-a': null, 'user-b': null },
   requiredCoords: [] as string[],
-  isComplete: true,
   isResolving: false,
   isFinalizing: false,
   peersRevealed: true,

--- a/frontend/test/RunReviewerComparison.resolve.test.tsx
+++ b/frontend/test/RunReviewerComparison.resolve.test.tsx
@@ -61,7 +61,6 @@ function buildResolution(
     decisionCountByCoord: new Map([['inst-1::field-1', 2]]),
     participantCount: 2,
     requiredCoords: [],
-    isComplete: true,
   });
   return {
     statusByCoord: view.statusByCoord,

--- a/frontend/test/stageTransition.test.ts
+++ b/frontend/test/stageTransition.test.ts
@@ -12,6 +12,7 @@ function makeArgs(overrides: Partial<Parameters<typeof buildExtractionTransition
     isComplete: false,
     completed: 0,
     total: 30,
+    consensusComplete: false,
     divergencesResolved: true,
     isReady: false,
     onMarkReady: noop,
@@ -68,7 +69,7 @@ describe('buildExtractionTransition', () => {
   it('Consensus + manager + complete + resolved → Approve & finalize, onAdvance===onApproveFinalize', () => {
     const onApproveFinalize = vi.fn();
     const r = buildExtractionTransition(
-      makeArgs({ stage: 'consensus', canResolveConflicts: true, isComplete: true, divergencesResolved: true, onApproveFinalize }),
+      makeArgs({ stage: 'consensus', canResolveConflicts: true, consensusComplete: true, divergencesResolved: true, onApproveFinalize }),
     );
     expect(r!.to).toBe('finalized');
     expect(r!.label).toBe('runHeaderApproveFinalize');
@@ -77,24 +78,47 @@ describe('buildExtractionTransition', () => {
     expect(r!.onAdvance).toBe(onApproveFinalize);
   });
 
-  it('Consensus + manager + unresolved divergence → gated, onAdvance===onGuide', () => {
+  it('Consensus finalize uses run-level completeness, not the caller-scoped form (bug: arbitrator adopted peers)', () => {
+    // The reported dead end: the run is reconciled (consensusComplete) but the
+    // arbitrator's own form is empty (isComplete=false). The gate must open.
+    const onApproveFinalize = vi.fn();
+    const r = buildExtractionTransition(
+      makeArgs({
+        stage: 'consensus',
+        canResolveConflicts: true,
+        consensusComplete: true,
+        isComplete: false,
+        divergencesResolved: true,
+        onApproveFinalize,
+      }),
+    );
+    expect(r!.gate.ok).toBe(true);
+    expect(r!.onAdvance).toBe(onApproveFinalize);
+  });
+
+  it('Consensus + manager + unresolved divergence → gated, onAdvance toasts the gate reason', () => {
     const onGuide = vi.fn();
     const onApproveFinalize = vi.fn();
     const r = buildExtractionTransition(
-      makeArgs({ stage: 'consensus', canResolveConflicts: true, isComplete: true, divergencesResolved: false, onGuide, onApproveFinalize }),
+      makeArgs({ stage: 'consensus', canResolveConflicts: true, consensusComplete: true, divergencesResolved: false, onGuide, onApproveFinalize }),
     );
     expect(r!.gate.ok).toBe(false);
-    expect(r!.onAdvance).toBe(onGuide);
+    expect((r!.gate as { ok: false; reason: string }).reason).toBe('runHeaderApproveBlocked');
+    // Blocked click toasts the SAME copy as the tooltip, not the extract-stage default.
+    void r!.onAdvance();
+    expect(onGuide).toHaveBeenCalledWith('runHeaderApproveBlocked');
+    expect(onApproveFinalize).not.toHaveBeenCalled();
   });
 
-  it('Consensus + manager + incomplete → gated, onAdvance===onGuide', () => {
+  it('Consensus + manager + incomplete → gated, onAdvance toasts the gate reason', () => {
     const onGuide = vi.fn();
     const r = buildExtractionTransition(
-      makeArgs({ stage: 'consensus', canResolveConflicts: true, isComplete: false, divergencesResolved: true, completed: 5, total: 20, onGuide }),
+      makeArgs({ stage: 'consensus', canResolveConflicts: true, consensusComplete: false, divergencesResolved: true, completed: 5, total: 20, onGuide }),
     );
     expect(r!.gate.ok).toBe(false);
     expect((r!.gate as { ok: false; remaining: number }).remaining).toBe(15);
-    expect(r!.onAdvance).toBe(onGuide);
+    void r!.onAdvance();
+    expect(onGuide).toHaveBeenCalledWith('runHeaderApproveBlocked');
   });
 
   it('Consensus without canResolveConflicts → null (reviewer cannot finalize)', () => {


### PR DESCRIPTION
## Problem

On the Consensus screen the panel reported **"Needs attention · 0 / Resolved · 33"** and **"Nothing to reconcile. Use 'Approve & finalize' in the header"**, yet clicking **Approve & finalize** showed a blocked toast and never finalized — a dead-end.

## Root cause

Two different definitions of "complete". The panel measured completeness at the **run** level (published states ∪ every reviewer's decision ∪ consensus decisions); the header gate measured `isComplete` from the **caller's own form** (`current_values`, scoped to the reviewer). When an arbitrator resolves required fields by adopting a peer's value, that writes a `ConsensusDecision` + `PublishedState` but nothing to their own decision stream — so the run is complete while the caller-scoped gate blocked the click before it reached the backend. The backend (`run_lifecycle_service._filled_coords`) was already correct.

## Fix (frontend only)

- `lib/runs/reconciliation.ts` — drop `isComplete` from `canFinalize`.
- `hooks/extraction/useConsensusReconciliation.ts` — expose `requiredFieldsResolved` (run-level: `requiredGaps === 0`).
- `lib/extraction/stageTransition.ts` — the consensus finalize gate keys off `consensusComplete` (run-level) instead of `isComplete`; blocked-click toast aligned to the gate's own reason.
- `pages/ExtractionFullScreen.tsx` / `QualityAssessmentFullScreen.tsx` — wiring + removal of the `qaIsComplete` workaround.
- `components/runs/ConsensusResolutionPanel.tsx` — drop the unused `isComplete` prop.
- Tests: `stageTransition`, `reconciliation`, `ConsensusResolutionPanel`, `RunReviewerComparison.resolve`.

Mirrors the backend gate (`_filled_coords`: published ∪ every reviewer's decision), so the button state matches what finalize will accept.

## Verification (local, end-to-end)

Reproduced the exact state by driving the real API as 3 users (2 reviewers diverge on all 33 required fields, arbitrator adopts the peer value on each; arbitrator's own form `0/33`), then drove the real UI as the arbitrator:

- **Red** (gate temporarily reverted to `isComplete`): click → *"Resolve every diverging field and fill all required fields first"*, run stays `consensus`.
- **Green** (fix): same data → click → *"Extraction completed successfully!"*, `stage=finalized, status=completed, 33 published_states` (DB-confirmed).
- **QA (PROBAST)**, same arbitrator-adopts-peers scenario: in-panel **Finalize** enabled → finalizes (`quality_assessment finalized/completed`). No regression from dropping `qaIsComplete`.
- Gate: `typecheck` ✅, `lint` ✅, `test:run` ✅ **1162/1162**, architectural fitness ✅ (a 1-line comment shrink keeps `ExtractionFullScreen.tsx` at its file-size cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
