### PR TITLE
ci: drop permanently-skipped remote-smoke jobs and calm scheduled crons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,40 +554,6 @@ jobs:
           VITE_SUPABASE_ANON_KEY: placeholder_key
           VITE_API_URL: http://localhost:8000
 
-  # =================== E2E CONFIG GATE ===================
-  # Single setup job that probes which E2E secrets are configured and exposes
-  # the result as job outputs. Downstream e2e jobs gate on those outputs.
-  #
-  # Why: GitHub does not allow `secrets.*` in job-level `if:` expressions
-  # (the workflow YAML fails validation, producing a 0-job/0-second run).
-  # Job outputs derived from secrets ARE allowed in `if:`, so we route
-  # secret-presence detection through this setup job.
-  e2e-config:
-    name: E2E config gate
-    runs-on: ubuntu-latest
-    outputs:
-      has_local: ${{ steps.probe.outputs.has_local }}
-      has_remote: ${{ steps.probe.outputs.has_remote }}
-    steps:
-      - id: probe
-        env:
-          E2E_API_URL: ${{ secrets.E2E_API_URL }}
-          E2E_FRONTEND_URL: ${{ secrets.E2E_FRONTEND_URL }}
-          E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
-          E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
-        run: |
-          if [[ -n "${E2E_API_URL}" ]]; then
-            echo "has_local=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_local=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -n "${E2E_FRONTEND_URL}" && -n "${E2E_API_URL}" \
-             && -n "${E2E_USER_EMAIL}" && -n "${E2E_USER_PASSWORD}" ]]; then
-            echo "has_remote=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_remote=false" >> "$GITHUB_OUTPUT"
-          fi
-
   # =================== FRONTEND E2E (EPHEMERAL STACK) ===================
   # Boots the full stack inside the runner — Supabase (CLI/Docker) +
   # Alembic migrations + seed + FastAPI + built frontend — and runs the
@@ -709,49 +675,3 @@ jobs:
             test-results/
           retention-days: 7
           if-no-files-found: ignore
-
-  # =================== FRONTEND E2E REMOTE ===================
-  frontend-e2e-remote:
-    name: Frontend E2E Remote Smoke
-    runs-on: ubuntu-latest
-    needs: [frontend-e2e-ephemeral, e2e-config]
-    if: needs.e2e-config.outputs.has_remote == 'true'
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
-
-      - name: Run remote smoke project
-        run: npm run test:e2e:remote
-        env:
-          E2E_FRONTEND_URL: ${{ secrets.E2E_FRONTEND_URL }}
-          E2E_API_URL: ${{ secrets.E2E_API_URL }}
-          E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
-          E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
-          E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
-          E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
-          E2E_AUTH_TOKEN: ${{ secrets.E2E_AUTH_TOKEN }}
-          E2E_PROJECT_ID: ${{ secrets.E2E_PROJECT_ID }}
-          E2E_ARTICLE_ID: ${{ secrets.E2E_ARTICLE_ID }}
-          E2E_TEMPLATE_ID: ${{ secrets.E2E_TEMPLATE_ID }}
-          E2E_ENTITY_TYPE_ID: ${{ secrets.E2E_ENTITY_TYPE_ID }}
-
-      - name: Upload Playwright remote artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-remote-results
-          path: |
-            playwright-report
-            test-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,10 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, dev]
+    # main only: every dev commit lands via a PR that was already scanned
+    # by the pull_request trigger below — a second scan on push added
+    # nothing.
+    branches: [main]
   pull_request:
     branches: [dev]
   schedule:

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -6,14 +6,15 @@ name: Post-deploy Smoke
 # prod is stale, nobody notices.
 #
 # Runs after every push to main (deploy trigger) with a delay for
-# Railway's Wait-for-CI + build, plus hourly as a synthetic monitor.
-# A failure emails the repo owner via standard workflow notifications.
+# Railway's Wait-for-CI + build, plus every 6 hours as a synthetic
+# monitor. A failure emails the repo owner via standard workflow
+# notifications.
 
 on:
   push:
     branches: [main]
   schedule:
-    - cron: "7 * * * *"
+    - cron: "7 */6 * * *"
   workflow_dispatch:
 
 jobs:

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_reviewed: 2026-06-27
+last_reviewed: 2026-07-05
 owner: '@raphaelfh'
 ---
 
@@ -237,8 +237,8 @@ head commit. As of 2026-05-24 the relevant ones for backend code:
      corruption. Snapshot today is 89%.
 4. **`backend-e2e`** — `pytest -m e2e`.
 5. **`backend-build`** — Docker image build.
-6. **`frontend-lint`** + **`frontend-build`** + the E2E gates when the
-   corresponding secrets are configured.
+6. **`frontend-lint`** + **`frontend-build`** + the ephemeral-stack
+   frontend E2E (self-provisioned, no secrets needed).
 7. **`docs-ci`** — runs on the same push. Railway's "Wait for CI" waits
    for the **full** Actions suite (CI **and** `docs-ci`), so a `docs-ci`
    that reports SKIPPED (path-filtered) can wedge the deploy — recover
@@ -246,9 +246,9 @@ head commit. As of 2026-05-24 the relevant ones for backend code:
    from the repo root).
 
 After a deploy, the `post-deploy-smoke` workflow (push-triggered +
-hourly) re-checks `/health`, the frontend, and a CORS preflight from the
-prod origin; a failure emails the owner. It is the deploy safety net,
-not a gate.
+every 6 hours) re-checks `/health`, the frontend, and a CORS preflight
+from the prod origin; a failure emails the owner. It is the deploy
+safety net, not a gate.
 
 Override the env-driven thresholds via repo variables
 (`PRUMO_DIFF_COVERAGE_MIN`, `PRUMO_CRITICAL_COVERAGE_MIN`) when


### PR DESCRIPTION
## Why

The repo's scheduled CI routines accumulated dead weight: `frontend-e2e-remote` has been skipped on every single run (its gating `E2E_*` remote secrets were never configured — prod verification happens via local FE + prod VITE env instead), the `e2e-config` gate job existed only to feed that skip, `post-deploy-smoke` fired **hourly** (~15 runs/day of Actions-tab noise for a synthetic monitor), and CodeQL double-scanned every change (PR event + push-to-dev of the same diff).

## What changed

- **ci.yml**: deleted `frontend-e2e-remote` + `e2e-config` (−80 lines). Evidence: latest CI run shows `Frontend E2E Remote Smoke: skipped` with all else green; `has_local` output had zero consumers (grep); neither job is in the 9 required checks on `dev`/`main` (`gh api .../branches/*/protection`).
- **post-deploy-smoke.yml**: cron `7 * * * *` → `7 */6 * * *`. Push-to-main trigger (the real deploy safety net) unchanged.
- **codeql.yml**: `push: [main, dev]` → `push: [main]`; every dev commit already arrives via a scanned PR.
- **docs/reference/deployment.md**: updated to match (E2E gate wording, smoke cadence, `last_reviewed`).

## Risk

Low. No required branch check is touched (verified against branch protection on both branches). Remote-smoke coverage lost = zero (it never ran). Synthetic prod monitoring drops from hourly to 6-hourly — worst-case detection lag for silent prod breakage rises accordingly; push-triggered smoke still guards every deploy.

## Test plan

- [x] YAML parses (`yaml.safe_load` on all three workflows)
- [x] No dangling references to removed jobs (`grep e2e-config|has_remote|frontend-e2e-remote` → none)
- [x] Required checks on `dev` and `main` verified untouched
- [ ] CI green on this PR (the workflows themselves are exercised by this push)

## Out of scope

- The Playwright `remote` project + `test:e2e:remote` npm script remain (usable locally against prod if ever needed).
- CodeQL weekly cron and security-audit weekly cron kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
