### PR TITLE
refactor(extraction): remove client-suppliable source_user_id from proposal writes

### DIFF
--- a/backend/app/api/v1/endpoints/extraction_runs.py
+++ b/backend/app/api/v1/endpoints/extraction_runs.py
@@ -230,20 +230,12 @@ async def create_proposal(
         )
     service = ExtractionProposalService(db)
     trace_id = _trace(request)
-    # source='human' requires a user attribution. Default to the
-    # authenticated caller so clients don't have to thread it through — and
-    # REJECT any other value: D8-c materialization converts source_user_id
-    # into decision attribution at consensus entry, so a caller-supplied
-    # foreign id would forge another reviewer's audit rows. (source='ai'/
-    # 'system' never carry reviewer-attribution semantics — unaffected.)
-    source_user_id = body.source_user_id
-    if body.source == "human":
-        if source_user_id is not None and source_user_id != current_user_sub:
-            raise HTTPException(
-                status_code=400,
-                detail="source_user_id on a human proposal must be the authenticated caller",
-            )
-        source_user_id = current_user_sub
+    # source='human' is attributed server-side to the authenticated caller;
+    # the request schema carries no attribution field, so forged attribution
+    # is unrepresentable at the API boundary. (D8-c materialization reads this
+    # persisted source_user_id as decision attribution at consensus entry —
+    # now always the caller for human rows; ai/system carry no attribution.)
+    source_user_id = current_user_sub if body.source == "human" else None
     try:
         record = await service.record_proposal(
             run_id=run_id,

--- a/backend/app/schemas/extraction_run.py
+++ b/backend/app/schemas/extraction_run.py
@@ -17,11 +17,15 @@ class CreateRunRequest(BaseModel):
 
 
 class CreateProposalRequest(BaseModel):
+    # No attribution field: human proposals are attributed server-side to the
+    # authenticated caller. extra="forbid" makes a client-sent
+    # ``source_user_id`` a loud 422 instead of a silently-dropped forgery.
+    model_config = ConfigDict(extra="forbid")
+
     instance_id: UUID
     field_id: UUID
     source: str = Field(pattern="^(ai|human|system)$")
     proposed_value: dict[str, Any]
-    source_user_id: UUID | None = None
     confidence_score: float | None = None
     rationale: str | None = None
 

--- a/backend/tests/integration/test_decision_link_guard.py
+++ b/backend/tests/integration/test_decision_link_guard.py
@@ -286,6 +286,35 @@ async def test_link_guard_service_direct(
 
 
 @pytest.mark.asyncio
+async def test_human_proposal_forged_source_user_id_rejected(
+    db_client: AsyncClient,
+    db_session: AsyncSession,
+    auth_as_manager: UUID,  # noqa: ARG001
+) -> None:
+    """``CreateProposalRequest`` carries no attribution field (extra='forbid'):
+    a client-supplied ``source_user_id`` is an unknown field and dies at body
+    validation. Human proposals are attributed server-side to the
+    authenticated caller, so forged attribution is unrepresentable at the
+    API boundary — not merely guarded."""
+    if not await _seeded(db_session):
+        pytest.skip("Missing fixtures.")
+    run_id = await _create_run_in_extract(db_client)
+
+    res = await db_client.post(
+        f"{API_PREFIX}/{run_id}/proposals",
+        json={
+            "instance_id": str(SEED.primary_instance),
+            "field_id": str(SEED.primary_field),
+            "source": "human",
+            "proposed_value": {"value": "typed"},
+            "source_user_id": str(SEED.outsider_profile),
+        },
+    )
+    assert res.status_code == 422, res.text
+    assert "source_user_id" in res.text
+
+
+@pytest.mark.asyncio
 async def test_viewer_cannot_write_decisions_or_proposals(
     db_client: AsyncClient,
     db_session: AsyncSession,
@@ -329,69 +358,6 @@ async def test_viewer_cannot_write_decisions_or_proposals(
         },
     )
     assert prop.status_code == 403, prop.text
-
-
-@pytest.mark.asyncio
-async def test_human_proposal_forged_source_user_id_rejected(
-    db_client: AsyncClient,
-    db_session: AsyncSession,
-    auth_as_manager: UUID,  # noqa: ARG001
-) -> None:
-    """D8-c guard: materialization converts ``source_user_id`` into decision
-    attribution, so a caller-supplied value differing from the authenticated
-    caller is a forged-attribution attempt and must 400 before persisting."""
-    if not await _seeded(db_session):
-        pytest.skip("Missing fixtures.")
-    run_id = await _create_run_in_extract(db_client)
-
-    res = await db_client.post(
-        f"{API_PREFIX}/{run_id}/proposals",
-        json={
-            "instance_id": str(SEED.primary_instance),
-            "field_id": str(SEED.primary_field),
-            "source": "human",
-            "source_user_id": str(uuid4()),
-            "proposed_value": {"value": "forged attribution"},
-        },
-    )
-    assert res.status_code == 400, res.text
-    assert "authenticated caller" in res.json()["error"]["message"].lower()
-    count = (
-        await db_session.execute(
-            text(
-                "SELECT count(*) FROM public.extraction_proposal_records "
-                "WHERE run_id = :r AND source = 'human'"
-            ),
-            {"r": str(run_id)},
-        )
-    ).scalar()
-    assert count == 0, "nothing persisted on a forged attribution"
-
-
-@pytest.mark.asyncio
-async def test_ai_proposal_keeps_arbitrary_source_user_id(
-    db_client: AsyncClient,
-    db_session: AsyncSession,
-    auth_as_manager: UUID,  # noqa: ARG001
-) -> None:
-    """AI seeding is unchanged: source='ai' never carries reviewer attribution
-    semantics, so the forged-attribution guard must not fire. Uses a real
-    non-caller profile (the column carries a profiles FK)."""
-    if not await _seeded(db_session):
-        pytest.skip("Missing fixtures.")
-    run_id = await _create_run_in_extract(db_client)
-
-    res = await db_client.post(
-        f"{API_PREFIX}/{run_id}/proposals",
-        json={
-            "instance_id": str(SEED.primary_instance),
-            "field_id": str(SEED.primary_field),
-            "source": "ai",
-            "source_user_id": str(SEED.outsider_profile),
-            "proposed_value": {"value": "ai candidate"},
-        },
-    )
-    assert res.status_code == 201, res.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_extraction_run_schemas.py
+++ b/backend/tests/unit/test_extraction_run_schemas.py
@@ -92,18 +92,19 @@ class TestCreateProposalRequest:
 
     def test_optional_defaults(self) -> None:
         req = CreateProposalRequest(**self._kwargs())
-        assert req.source_user_id is None
         assert req.confidence_score is None
         assert req.rationale is None
 
     def test_all_optionals_populated(self) -> None:
-        uid = uuid4()
-        req = CreateProposalRequest(
-            **self._kwargs(source_user_id=uid, confidence_score=0.9, rationale="why")
-        )
-        assert req.source_user_id == uid
+        req = CreateProposalRequest(**self._kwargs(confidence_score=0.9, rationale="why"))
         assert req.confidence_score == 0.9
         assert req.rationale == "why"
+
+    def test_client_attribution_rejected(self) -> None:
+        """Attribution is server-side: a client-supplied ``source_user_id``
+        is an unknown field under ``extra='forbid'``, not silently dropped."""
+        with pytest.raises(ValidationError):
+            CreateProposalRequest(**self._kwargs(source_user_id=uuid4()))
 
     def test_missing_proposed_value_rejected(self) -> None:
         kwargs = self._kwargs()

--- a/backend/tests/unit/test_run_write_endpoints_unit.py
+++ b/backend/tests/unit/test_run_write_endpoints_unit.py
@@ -103,43 +103,6 @@ async def test_create_proposal_awaits_reviewer_role_gate() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_proposal_rejects_forged_human_source_user_id() -> None:
-    """D8-c guard: a human proposal whose body.source_user_id differs from the
-    authenticated caller 400s BEFORE the service runs (materialization turns
-    that column into decision attribution)."""
-    from fastapi import HTTPException
-
-    run_id, project_id, caller = uuid4(), uuid4(), uuid4()
-    body = CreateProposalRequest(
-        instance_id=uuid4(),
-        field_id=uuid4(),
-        source="human",
-        source_user_id=uuid4(),  # != caller
-        proposed_value={"value": "forged"},
-    )
-    service = MagicMock()
-    service.record_proposal = AsyncMock()
-
-    with (
-        patch(f"{_EP}._load_run_and_check_member", AsyncMock(return_value=_run(project_id))),
-        patch(f"{_EP}.ensure_project_reviewer", AsyncMock()),
-        patch(f"{_EP}.ExtractionProposalService", return_value=service),
-        patch(f"{_EP}._trace", return_value=None),
-        pytest.raises(HTTPException) as exc,
-    ):
-        await create_proposal(
-            run_id=run_id,
-            body=body,
-            request=MagicMock(),
-            db=AsyncMock(),
-            current_user_sub=caller,
-        )
-
-    assert exc.value.status_code == 400
-    service.record_proposal.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_advance_run_awaits_reviewer_role_gate() -> None:
     """/advance is reviewer-role-gated (viewers 403) — D8-c materialization
     writes decision rows on QA advances, so membership alone is not enough."""

--- a/frontend/types/api/openapi.json
+++ b/frontend/types/api/openapi.json
@@ -3047,6 +3047,7 @@
         "type": "object"
       },
       "CreateProposalRequest": {
+        "additionalProperties": false,
         "properties": {
           "confidence_score": {
             "anyOf": [
@@ -3089,18 +3090,6 @@
             "pattern": "^(ai|human|system)$",
             "title": "Source",
             "type": "string"
-          },
-          "source_user_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source User Id"
           }
         },
         "required": [

--- a/frontend/types/api/schema.d.ts
+++ b/frontend/types/api/schema.d.ts
@@ -2298,8 +2298,6 @@ export interface components {
             rationale?: string | null;
             /** Source */
             source: string;
-            /** Source User Id */
-            source_user_id?: string | null;
         };
         /** CreateRunRequest */
         CreateRunRequest: {


### PR DESCRIPTION
## Why

`CreateProposalRequest` accepted a client-suppliable `source_user_id`. Rather than *guard* forged attribution (the approach in #491, which 400s when the value differs from the caller), this **removes the field**, eliminating the forged-attribution class instead of policing it. The sibling `CreateDecisionRequest` already accepts no client attribution, and no consumer sends `source_user_id` (frontend, e2e, scripts — grep-verified).

## What changed

- `backend/app/schemas/extraction_run.py`: drop `source_user_id` from `CreateProposalRequest`; add `extra="forbid"` so a client-sent value is a loud **422** instead of a silently-dropped forgery. The `ProposalRecordResponse` read schema keeps the field.
- `backend/app/api/v1/endpoints/extraction_runs.py`: `create_proposal` attributes `source='human'` to the authenticated caller server-side; `ai`/`system` carry no attribution.
- Tests: `test_human_proposal_forged_source_user_id_rejected` becomes a 422-unknown-field pin; a schema unit pin (`test_client_attribution_rejected`) covers the `extra='forbid'` boundary.
- Regenerated `frontend/types/api/{openapi.json,schema.d.ts}`; dropped the field from the `frontend/hooks/runs/types.ts` hand-mirror.

## Stacked on #491 (merge order)

#491 (consensus PR2 / D8) **adds** the `source_user_id` mismatch guard and its two attribution tests; this PR **supersedes** that guard with field removal. It must land **after** #491, then be rebased so it: keeps #491's orthogonal protections (`source='system'` rejection, create_run/advance_run/reopen reviewer gates, ran-by scrub), and replaces #491's guard + `test_human_proposal_forged_source_user_id_rejected` (400) / `test_ai_proposal_keeps_arbitrary_source_user_id` / `test_create_proposal_rejects_forged_human_source_user_id` with the field-removal equivalents.

## Risk

Low. Backend contract narrows (a previously-accepted-but-unused field now 422s). D8-c materialization still reads the persisted `source_user_id`, which for human proposals is now always the authenticated caller — behavior preserved.

## Test plan

- [x] `make lint-backend` clean
- [x] touched backend tests pass (unit + integration guard tests)
- [x] `npm run generate:api-types` committed; tsc + vitest + eslint green
- [ ] full backend suite re-run after rebase onto post-#491 dev