### PR TITLE
test(integration): pin row-discovery pickers to conftest SEED ids

### DIFF
--- a/backend/tests/integration/test_absent_reason_gate.py
+++ b/backend/tests/integration/test_absent_reason_gate.py
@@ -39,6 +39,7 @@ from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.extraction_review_service import ExtractionReviewService
 from app.services.hitl_session_service import HITLSessionService
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 _MARKER = {"value": None, "absent_reason": "no_information"}
 
@@ -52,13 +53,8 @@ async def _coords(
     dev DB is not seeded."""
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM "
-                "public.project_extraction_templates t JOIN public.extraction_entity_types et "
-                "ON et.project_template_id = t.id JOIN public.extraction_fields f "
-                "ON f.entity_type_id = et.id JOIN public.extraction_instances i "
-                "ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (

--- a/backend/tests/integration/test_article_files_endpoints.py
+++ b/backend/tests/integration/test_article_files_endpoints.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
 from app.models.article import Article, ArticleFile
+from tests.integration.conftest import SEED
 
 
 @pytest_asyncio.fixture
@@ -22,7 +23,11 @@ async def member_article(
     """Yield (project_id, member_user_id, article_id); JWT override = member."""
     row = (
         await db_session.execute(
-            text("SELECT pm.project_id, pm.user_id FROM public.project_members pm LIMIT 1")
+            text(
+                "SELECT project_id, user_id FROM public.project_members "
+                "WHERE project_id = :pid AND user_id = :uid"
+            ),
+            {"pid": str(SEED.primary_project), "uid": str(SEED.primary_profile)},
         )
     ).first()
     if row is None:

--- a/backend/tests/integration/test_blind_review_isolation.py
+++ b/backend/tests/integration/test_blind_review_isolation.py
@@ -36,6 +36,7 @@ from app.models.extraction_workflow import (
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.extraction_review_service import ExtractionReviewService
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 # Sentinel id for an in-test second reviewer (rolled back with the SAVEPOINT).
 SECOND_REVIEWER_ID = UUID("ffffffff-9999-0000-0000-0000000000aa")
@@ -52,7 +53,11 @@ async def _build_two_reviewer_review_run(
     """
     project_id = (
         await db.execute(
-            text("SELECT project_id FROM public.project_members WHERE role = 'reviewer' LIMIT 1")
+            text(
+                "SELECT project_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'reviewer' LIMIT 1"
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     if project_id is None:

--- a/backend/tests/integration/test_coordinate_coherence.py
+++ b/backend/tests/integration/test_coordinate_coherence.py
@@ -17,9 +17,8 @@ from tests.integration.conftest import SEED
 async def _coherent_triplet(db: AsyncSession):
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -39,8 +38,10 @@ async def _coherent_triplet(db: AsyncSession):
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):

--- a/backend/tests/integration/test_evidence_evolution.py
+++ b/backend/tests/integration/test_evidence_evolution.py
@@ -5,6 +5,8 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.integration.conftest import SEED
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -66,9 +68,8 @@ async def test_evidence_check_constraint_present(db_session: AsyncSession) -> No
 async def test_evidence_check_blocks_empty_insert(db_session: AsyncSession) -> None:
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -80,8 +81,10 @@ async def test_evidence_check_blocks_empty_insert(db_session: AsyncSession) -> N
     profile_id = (
         await db_session.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, profile_id)):

--- a/backend/tests/integration/test_extraction_consensus_service.py
+++ b/backend/tests/integration/test_extraction_consensus_service.py
@@ -20,6 +20,7 @@ from app.services.extraction_consensus_service import (
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.extraction_review_service import ExtractionReviewService
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _setup_consensus_run(
@@ -28,9 +29,8 @@ async def _setup_consensus_run(
     """Build run, advance to consensus stage, return (run_id, instance_id, field_id, profile_id, decision_id)."""
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -50,8 +50,10 @@ async def _setup_consensus_run(
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):
@@ -298,9 +300,8 @@ async def test_select_existing_rejects_reject_decision(
     # Build a run where the existing decision is a REJECT (not accept_proposal).
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -320,8 +321,10 @@ async def test_select_existing_rejects_reject_decision(
     profile_id = (
         await db_session.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):
@@ -445,9 +448,8 @@ async def test_publish_requires_consensus_stage(
     """Issue #43: publish() must reject runs that are not in CONSENSUS stage."""
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -467,8 +469,10 @@ async def test_publish_requires_consensus_stage(
     profile_id = (
         await db_session.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):
@@ -518,8 +522,10 @@ async def test_publish_unknown_run_raises(db_session: AsyncSession) -> None:
     profile_id = (
         await db_session.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     if profile_id is None:

--- a/backend/tests/integration/test_extraction_export_ai_outcome.py
+++ b/backend/tests/integration/test_extraction_export_ai_outcome.py
@@ -60,6 +60,7 @@ from app.services.extraction_export_service import (
     SectionDescriptor,
 )
 from app.services.hitl_session_service import HITLSessionService
+from tests.integration.conftest import SEED
 
 pytestmark = pytest.mark.asyncio
 
@@ -85,8 +86,10 @@ async def _coord(
     profile = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     row = (
@@ -98,10 +101,11 @@ async def _coord(
                 JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
                 JOIN public.extraction_fields f ON f.entity_type_id = et.id
                 JOIN public.project_extraction_templates t ON t.id = i.template_id
-                WHERE t.kind = 'extraction'
+                WHERE t.kind = 'extraction' AND t.project_id = :pid
                 LIMIT 1
                 """
-            )
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).first()
     if profile is None or row is None:
@@ -303,13 +307,8 @@ async def test_ai_outcome_accept_not_masked_by_other_reviewer_reject(
 
     # Two distinct reviewers on the same coord: target accepts, other rejects.
     reviewer_accept = profile_id
-    reviewer_reject = (
-        await db_session.execute(
-            text("SELECT id FROM public.profiles WHERE id <> :pid LIMIT 1"),
-            {"pid": str(profile_id)},
-        )
-    ).scalar()
-    assert reviewer_reject is not None, "need a second profile for the multi-reviewer case"
+    # Seeded reviewer of the same project — distinct from the manager.
+    reviewer_reject = SEED.reviewer_profile
     await _record_decision(
         db_session,
         run_id=run.id,
@@ -385,13 +384,8 @@ async def test_ai_outcome_single_user_scoped_to_target(
     await db_session.flush()
 
     target_reviewer = profile_id
-    other_reviewer = (
-        await db_session.execute(
-            text("SELECT id FROM public.profiles WHERE id <> :pid LIMIT 1"),
-            {"pid": str(profile_id)},
-        )
-    ).scalar()
-    assert other_reviewer is not None
+    # Seeded reviewer of the same project — distinct from the manager.
+    other_reviewer = SEED.reviewer_profile
     await _record_decision(
         db_session,
         run_id=run.id,

--- a/backend/tests/integration/test_extraction_export_ai_outcome_ordering.py
+++ b/backend/tests/integration/test_extraction_export_ai_outcome_ordering.py
@@ -44,6 +44,7 @@ from app.services.extraction_export_service import (
     SectionDescriptor,
 )
 from app.services.hitl_session_service import HITLSessionService
+from tests.integration.conftest import SEED
 
 # Same created_at on both proposals → forces the equal-timestamp tie the
 # ``id`` ordering must break. Distinct, hand-picked ids make "latest"
@@ -64,8 +65,10 @@ async def _coord(
     profile = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     row = (
@@ -77,10 +80,11 @@ async def _coord(
                 JOIN public.extraction_entity_types et ON et.id = i.entity_type_id
                 JOIN public.extraction_fields f ON f.entity_type_id = et.id
                 JOIN public.project_extraction_templates t ON t.id = i.template_id
-                WHERE t.kind = 'extraction'
+                WHERE t.kind = 'extraction' AND t.project_id = :pid
                 LIMIT 1
                 """
-            )
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).first()
     if profile is None or row is None:

--- a/backend/tests/integration/test_extraction_export_snapshot_diff.py
+++ b/backend/tests/integration/test_extraction_export_snapshot_diff.py
@@ -13,14 +13,14 @@ from app.repositories.extraction_template_version_repository import (
     ExtractionTemplateVersionRepository,
 )
 from app.services.exports.extraction_snapshot_reader import load_export_sections
+from tests.integration.conftest import SEED
 
 
 async def _seeded_template_id(db: AsyncSession) -> UUID:
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     template_id = (
@@ -93,8 +93,10 @@ async def test_obsolete_field_reported_when_run_pinned_to_older_version(
     published_by = (
         await db_session.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     assert published_by is not None, "seed graph must carry at least one profile"

--- a/backend/tests/integration/test_extraction_manual_only_flow.py
+++ b/backend/tests/integration/test_extraction_manual_only_flow.py
@@ -51,6 +51,7 @@ from app.services.extraction_review_service import ExtractionReviewService
 from app.services.hitl_session_service import HITLSessionService
 from app.services.run_lifecycle_service import RunLifecycleService
 from app.services.section_extraction_service import SectionExtractionService
+from tests.integration.conftest import SEED
 
 
 async def _coords(
@@ -62,9 +63,8 @@ async def _coords(
     not seeded."""
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -85,8 +85,10 @@ async def _coords(
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):

--- a/backend/tests/integration/test_extraction_proposal_service.py
+++ b/backend/tests/integration/test_extraction_proposal_service.py
@@ -14,6 +14,7 @@ from app.services.extraction_proposal_service import (
 )
 from app.services.run_lifecycle_service import RunLifecycleService
 from tests.factories.template_factory import TemplateFactory
+from tests.integration.conftest import SEED
 
 
 async def _setup_qa_run_with_instance_field(
@@ -33,9 +34,8 @@ async def _setup_qa_run_with_instance_field(
     """
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -47,8 +47,10 @@ async def _setup_qa_run_with_instance_field(
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, profile_id)):
@@ -126,9 +128,8 @@ async def _setup_run_with_instance_field(
     """
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -167,8 +168,10 @@ async def _setup_run_with_instance_field(
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):

--- a/backend/tests/integration/test_extraction_review_service.py
+++ b/backend/tests/integration/test_extraction_review_service.py
@@ -17,6 +17,7 @@ from app.services.extraction_review_service import (
     InvalidDecisionError,
 )
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _setup_review_run(
@@ -25,9 +26,8 @@ async def _setup_review_run(
     """Build run, advance to extract, return (run_id, instance_id, field_id, profile_id, proposal_id, alt_profile_id)."""
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -47,8 +47,10 @@ async def _setup_review_run(
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):

--- a/backend/tests/integration/test_extraction_run_lock.py
+++ b/backend/tests/integration/test_extraction_run_lock.py
@@ -49,6 +49,7 @@ from app.models.extraction import ExtractionRunStage
 from app.models.extraction_workflow import ExtractionProposalSource
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _setup_proposal_run(
@@ -57,9 +58,8 @@ async def _setup_proposal_run(
     """Build a run + advance to EXTRACT; return (run_id, instance_id, field_id, profile_id)."""
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -79,8 +79,10 @@ async def _setup_proposal_run(
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):

--- a/backend/tests/integration/test_hitl_config_service.py
+++ b/backend/tests/integration/test_hitl_config_service.py
@@ -15,6 +15,7 @@ from app.services.hitl_config_service import (
     SYSTEM_DEFAULT_HITL_CONFIG,
     HitlConfigService,
 )
+from tests.integration.conftest import SEED
 
 
 @pytest.mark.asyncio
@@ -34,9 +35,8 @@ async def test_resolve_returns_project_config_when_template_has_none(
 ) -> None:
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     template_id = (
@@ -85,9 +85,8 @@ async def test_resolve_template_overrides_project(
 ) -> None:
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     template_id = (
@@ -101,8 +100,10 @@ async def test_resolve_template_overrides_project(
     profile_id = (
         await db_session.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not (project_id and template_id and profile_id):

--- a/backend/tests/integration/test_hitl_configs_endpoints.py
+++ b/backend/tests/integration/test_hitl_configs_endpoints.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import TokenPayload, get_current_user
 from app.main import app
+from tests.integration.conftest import SEED
 
 
 async def _delete_existing_configs(
@@ -51,10 +52,11 @@ async def manager_project(
                 FROM public.project_members pm
                 JOIN public.project_extraction_templates pet
                   ON pet.project_id = pm.project_id
-                WHERE pm.role = 'manager'
+                WHERE pm.project_id = :pid AND pm.role = 'manager'
                 LIMIT 1
                 """
-            )
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).first()
     if row is None:

--- a/backend/tests/integration/test_hitl_configs_lifecycle.py
+++ b/backend/tests/integration/test_hitl_configs_lifecycle.py
@@ -10,6 +10,7 @@ from app.models.extraction_versioning import (
     ExtractionHitlConfig,
     HitlConfigScopeKind,
 )
+from tests.integration.conftest import SEED
 
 
 @pytest.mark.asyncio
@@ -25,9 +26,8 @@ async def test_hitl_config_insert_project_scope_and_unique_per_scope(
     db_session: AsyncSession,
 ) -> None:
     project_row = await db_session.execute(
-        text(
-            "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-        ),
+        text("SELECT id FROM public.projects WHERE id = :pid"),
+        {"pid": str(SEED.primary_project)},
     )
     project_id = project_row.scalar()
     if project_id is None:
@@ -59,9 +59,8 @@ async def test_hitl_config_arbitrator_required_when_rule_is_arbitrator(
     db_session: AsyncSession,
 ) -> None:
     project_row = await db_session.execute(
-        text(
-            "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-        ),
+        text("SELECT id FROM public.projects WHERE id = :pid"),
+        {"pid": str(SEED.primary_project)},
     )
     project_id = project_row.scalar()
     if project_id is None:

--- a/backend/tests/integration/test_hitl_session.py
+++ b/backend/tests/integration/test_hitl_session.py
@@ -96,8 +96,10 @@ async def home_project_fixture(
     raw = (
         await db_session.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     if raw is not None:
@@ -281,15 +283,21 @@ async def _pick_extraction_project_template(db: AsyncSession) -> UUID | None:
         await db.execute(
             text(
                 "SELECT id FROM public.project_extraction_templates "
-                "WHERE kind = 'extraction' LIMIT 1"
-            )
+                "WHERE project_id = :pid AND kind = 'extraction' LIMIT 1"
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     return UUID(str(raw)) if raw is not None else None
 
 
 async def _pick_article(db: AsyncSession) -> tuple[UUID, UUID] | None:
-    raw = (await db.execute(text("SELECT id, project_id FROM public.articles LIMIT 1"))).first()
+    raw = (
+        await db.execute(
+            text("SELECT id, project_id FROM public.articles WHERE id = :aid"),
+            {"aid": str(SEED.primary_article)},
+        )
+    ).first()
     if raw is None:
         return None
     return UUID(str(raw[0])), UUID(str(raw[1]))
@@ -1154,7 +1162,7 @@ async def test_session_backfills_singleton_children_added_after_model_creation(
                     (project_id, article_id, template_id, entity_type_id,
                      parent_instance_id, label, sort_order, created_by)
                 VALUES (:pid, :aid, :tid, :etid, NULL, 'XGBoost', 0,
-                        (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1))
+                        (SELECT user_id FROM public.project_members WHERE project_id = :pid AND role = 'manager' LIMIT 1))
                 RETURNING id
                 """
             ),
@@ -1278,7 +1286,7 @@ async def test_session_backfill_is_idempotent(
                     (project_id, article_id, template_id, entity_type_id,
                      parent_instance_id, label, sort_order, created_by)
                 VALUES (:pid, :aid, :tid, :etid, NULL, 'XGBoost', 0,
-                        (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1))
+                        (SELECT user_id FROM public.project_members WHERE project_id = :pid AND role = 'manager' LIMIT 1))
                 RETURNING id
                 """
             ),

--- a/backend/tests/integration/test_hitl_session_concurrency.py
+++ b/backend/tests/integration/test_hitl_session_concurrency.py
@@ -45,9 +45,8 @@ async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], 
 async def _pick_basic_fixtures(db: AsyncSession) -> tuple[UUID, UUID, UUID] | None:
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -59,8 +58,10 @@ async def _pick_basic_fixtures(db: AsyncSession) -> tuple[UUID, UUID, UUID] | No
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, profile_id)):

--- a/backend/tests/integration/test_hitl_telemetry.py
+++ b/backend/tests/integration/test_hitl_telemetry.py
@@ -65,8 +65,13 @@ async def _pick_template(db: AsyncSession) -> tuple[UUID, UUID, UUID] | None:
                 "FROM public.projects p "
                 "JOIN public.articles a ON a.project_id = p.id "
                 "JOIN public.project_extraction_templates t ON t.project_id = p.id "
-                "LIMIT 1"
-            )
+                "WHERE p.id = :pid AND a.id = :aid AND t.id = :tid"
+            ),
+            {
+                "pid": str(SEED.primary_project),
+                "aid": str(SEED.primary_article),
+                "tid": str(SEED.primary_template),
+            },
         )
     ).first()
     if row is None:

--- a/backend/tests/integration/test_multi_run_scoping.py
+++ b/backend/tests/integration/test_multi_run_scoping.py
@@ -41,6 +41,7 @@ from app.services.extraction_review_service import (
     InvalidDecisionError,
 )
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _coords(
@@ -51,9 +52,8 @@ async def _coords(
     Returns None if the dev DB hasn't been seeded — caller should ``pytest.skip``."""
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (
@@ -74,8 +74,10 @@ async def _coords(
     profile_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((project_id, article_id, template_id, profile_id)):

--- a/backend/tests/integration/test_parsing_tasks_durable_failure.py
+++ b/backend/tests/integration/test_parsing_tasks_durable_failure.py
@@ -9,15 +9,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.article import Article, ArticleFile
 from app.worker._session import worker_session
 from app.worker.tasks.parsing_tasks import _mark_parse_failed
+from tests.integration.conftest import SEED
 
 
 async def _seed_pending_file(db: AsyncSession) -> UUID:
     """Insert an article + a pending PDF file under a seeded project."""
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar_one_or_none()
     if project_id is None:

--- a/backend/tests/integration/test_proposal_decision_idempotency.py
+++ b/backend/tests/integration/test_proposal_decision_idempotency.py
@@ -17,17 +17,24 @@ from app.models.extraction_workflow import ExtractionProposalSource
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.extraction_review_service import ExtractionReviewService
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _coord(db: AsyncSession):
-    user_id = (await db.execute(text("SELECT id FROM public.profiles LIMIT 1"))).scalar()
+    user_id = (
+        await db.execute(
+            text(
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(SEED.primary_project)},
+        )
+    ).scalar()
     if user_id is None:
         return None
     # Derive a coherent (project, article, template, instance, field) tuple
-    # from a real extraction instance with a field chain. Scoping off the
-    # instance (rather than picking projects LIMIT 1, which on the shared dev
-    # DB can land on a project that has no extraction template) keeps the
-    # graph coherent so create_run / record_proposal don't fail.
+    # from the seeded extraction instance's field chain, scoped to the seed
+    # project so E2E fixture rows on a shared dev DB can never be picked.
     row = (
         await db.execute(
             text(
@@ -36,8 +43,9 @@ async def _coord(db: AsyncSession):
                 "JOIN public.extraction_entity_types et ON et.id=i.entity_type_id "
                 "JOIN public.extraction_fields f ON f.entity_type_id=et.id "
                 "JOIN public.project_extraction_templates t ON t.id=i.template_id "
-                "WHERE t.kind='extraction' LIMIT 1"
-            )
+                "WHERE t.kind='extraction' AND t.project_id = :pid LIMIT 1"
+            ),
+            {"pid": str(SEED.primary_project)},
         )
     ).first()
     if row is None:

--- a/backend/tests/integration/test_qa_publish_flow.py
+++ b/backend/tests/integration/test_qa_publish_flow.py
@@ -72,7 +72,12 @@ def _auth_as(profile_id: UUID) -> None:
 
 
 async def _pick_article(db: AsyncSession) -> tuple[UUID, UUID] | None:
-    row = (await db.execute(text("SELECT id, project_id FROM public.articles LIMIT 1"))).first()
+    row = (
+        await db.execute(
+            text("SELECT id, project_id FROM public.articles WHERE id = :aid"),
+            {"aid": str(SEED.primary_article)},
+        )
+    ).first()
     if row is None:
         return None
     return UUID(str(row[0])), UUID(str(row[1]))

--- a/backend/tests/integration/test_reviewer_rls.py
+++ b/backend/tests/integration/test_reviewer_rls.py
@@ -4,6 +4,8 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.integration.conftest import SEED
+
 
 @pytest.mark.asyncio
 async def test_is_project_reviewer_function_exists(db_session: AsyncSession) -> None:
@@ -28,9 +30,8 @@ async def test_is_project_reviewer_admits_manager_reviewer_consensus(
     legitimately writes workflow rows: manager, reviewer, consensus."""
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     if project_id is None:
@@ -64,9 +65,8 @@ async def test_is_project_reviewer_admits_manager_reviewer_consensus(
 async def test_is_project_reviewer_rejects_outsider(db_session: AsyncSession) -> None:
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     if project_id is None:

--- a/backend/tests/integration/test_run_proposals_latest_wins.py
+++ b/backend/tests/integration/test_run_proposals_latest_wins.py
@@ -39,6 +39,7 @@ from app.models.extraction_workflow import ExtractionProposalSource
 from app.services.extraction_proposal_service import ExtractionProposalService
 from app.services.extraction_run_read_service import get_run_with_workflow_history
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _proposal_stage_coord(
@@ -47,9 +48,8 @@ async def _proposal_stage_coord(
     """Build an EXTRACT-stage run; return (run_id, instance_id, field_id, user_id)."""
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     if project_id is None:
@@ -72,8 +72,10 @@ async def _proposal_stage_coord(
     user_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((article_id, template_id, user_id)):

--- a/backend/tests/integration/test_run_reopen.py
+++ b/backend/tests/integration/test_run_reopen.py
@@ -49,9 +49,8 @@ async def auth_as_profile(
 async def _pick_fixtures(db: AsyncSession) -> tuple[str, str, str, str, str] | None:
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (

--- a/backend/tests/integration/test_run_reviewers_endpoint.py
+++ b/backend/tests/integration/test_run_reviewers_endpoint.py
@@ -46,9 +46,8 @@ async def auth_as_profile(
 async def _pick_fixtures(db: AsyncSession) -> tuple[str, str, str, str, str] | None:
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     article_id = (

--- a/backend/tests/integration/test_run_view_entity_types.py
+++ b/backend/tests/integration/test_run_view_entity_types.py
@@ -11,14 +11,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.schemas.extraction_run import RunSummaryResponse
 from app.services.extraction_run_read_service import _entity_types_for_run
 from app.services.run_lifecycle_service import RunLifecycleService
+from tests.integration.conftest import SEED
 
 
 async def _new_run(db: AsyncSession):
     project_id = (
         await db.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     if project_id is None:
@@ -41,8 +41,10 @@ async def _new_run(db: AsyncSession):
     user_id = (
         await db.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
     if not all((article_id, template_id, user_id)):

--- a/backend/tests/integration/test_session_backfill_extensive.py
+++ b/backend/tests/integration/test_session_backfill_extensive.py
@@ -49,7 +49,12 @@ async def auth_as_profile(db_session: AsyncSession) -> AsyncGenerator[UUID, None
 
 
 async def _pick_article(db: AsyncSession) -> tuple[UUID, UUID] | None:
-    row = (await db.execute(text("SELECT id, project_id FROM public.articles LIMIT 1"))).first()
+    row = (
+        await db.execute(
+            text("SELECT id, project_id FROM public.articles WHERE id = :aid"),
+            {"aid": str(SEED.primary_article)},
+        )
+    ).first()
     if row is None:
         return None
     return UUID(str(row[0])), UUID(str(row[1]))
@@ -125,7 +130,7 @@ async def _insert_model_instance(
                     (project_id, article_id, template_id, entity_type_id,
                      parent_instance_id, label, sort_order, created_by)
                 VALUES (:pid, :aid, :tid, :etid, NULL, :label, 0,
-                        (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1))
+                        (SELECT user_id FROM public.project_members WHERE project_id = :pid AND role = 'manager' LIMIT 1))
                 RETURNING id
                 """
             ),
@@ -735,7 +740,7 @@ async def test_backfill_preserves_user_created_label(
                     (project_id, article_id, template_id, entity_type_id,
                      parent_instance_id, label, sort_order, created_by)
                 VALUES (:pid, :aid, :tid, :etid, :parent, 'My custom label', 0,
-                        (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1))
+                        (SELECT user_id FROM public.project_members WHERE project_id = :pid AND role = 'manager' LIMIT 1))
                 RETURNING id
                 """
             ),

--- a/backend/tests/integration/test_single_active_extraction_invariant.py
+++ b/backend/tests/integration/test_single_active_extraction_invariant.py
@@ -22,6 +22,8 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.integration.conftest import SEED
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -29,7 +31,12 @@ pytestmark = pytest.mark.asyncio
 
 
 async def _pick_project_with_member(db: AsyncSession) -> tuple[UUID, UUID] | None:
-    """Return (project_id, profile_id) for any project with at least one member."""
+    """Return (project_id, profile_id) for the seeded sentinel project + manager.
+
+    Pinned to the seed (vs ``LIMIT 1`` over all projects) because the caller
+    wipes every extraction template in the picked project — an unscoped pick
+    on a shared dev DB would destroy the Playwright E2E fixture graph.
+    """
     row = (
         await db.execute(
             text(
@@ -37,9 +44,11 @@ async def _pick_project_with_member(db: AsyncSession) -> tuple[UUID, UUID] | Non
                 SELECT p.id, pm.user_id
                 FROM public.projects p
                 JOIN public.project_members pm ON pm.project_id = p.id
+                WHERE p.id = :pid AND pm.user_id = :uid
                 LIMIT 1
                 """
-            )
+            ),
+            {"pid": str(SEED.primary_project), "uid": str(SEED.primary_profile)},
         )
     ).first()
     if row is None:

--- a/backend/tests/integration/test_snapshot_disposition_flags.py
+++ b/backend/tests/integration/test_snapshot_disposition_flags.py
@@ -9,6 +9,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.extraction_snapshot import build_template_version_snapshot
+from tests.integration.conftest import SEED
 
 
 @pytest.mark.asyncio
@@ -18,8 +19,10 @@ async def test_snapshot_carries_disposition_flags(db_session: AsyncSession) -> N
             text(
                 "SELECT t.id FROM public.project_extraction_templates t "
                 "JOIN public.extraction_entity_types et ON et.project_template_id = t.id "
-                "JOIN public.extraction_fields f ON f.entity_type_id = et.id LIMIT 1"
-            )
+                "JOIN public.extraction_fields f ON f.entity_type_id = et.id "
+                "WHERE t.id = :tid LIMIT 1"
+            ),
+            {"tid": str(SEED.primary_template)},
         )
     ).scalar()
     if tid is None:

--- a/backend/tests/integration/test_template_clone_extraction.py
+++ b/backend/tests/integration/test_template_clone_extraction.py
@@ -41,7 +41,12 @@ async def auth_as_profile(
 
 
 async def _pick_article(db: AsyncSession) -> tuple[UUID, UUID] | None:
-    raw = (await db.execute(text("SELECT id, project_id FROM public.articles LIMIT 1"))).first()
+    raw = (
+        await db.execute(
+            text("SELECT id, project_id FROM public.articles WHERE id = :aid"),
+            {"aid": str(SEED.primary_article)},
+        )
+    ).first()
     if raw is None:
         return None
     return UUID(str(raw[0])), UUID(str(raw[1]))
@@ -262,7 +267,7 @@ async def test_clone_extraction_deactivates_sibling_extraction_templates(
                  is_active, created_by)
             VALUES (:id, :pid, 'Legacy E2E', 'legacy', 'CUSTOM', '1.0', 'extraction',
                     '{}'::jsonb, true,
-                    (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1))
+                    (SELECT user_id FROM public.project_members WHERE project_id = :pid AND role = 'manager' LIMIT 1))
             ON CONFLICT (id) DO UPDATE SET is_active = true
             """
         ),
@@ -276,11 +281,11 @@ async def test_clone_extraction_deactivates_sibling_extraction_templates(
                 (project_template_id, version, schema, published_at,
                  published_by, is_active)
             VALUES (:tid, 1, '{}'::jsonb, NOW(),
-                    (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1), true)
+                    (SELECT user_id FROM public.project_members WHERE project_id = :pid AND role = 'manager' LIMIT 1), true)
             ON CONFLICT DO NOTHING
             """
         ),
-        {"tid": str(legacy_id)},
+        {"tid": str(legacy_id), "pid": str(project_id)},
     )
     # Also create an active QA template — must stay active after clone.
     probast_clone_url = f"/api/v1/projects/{project_id}/templates/clone"
@@ -355,8 +360,10 @@ async def test_partial_unique_index_blocks_second_active_extraction_template(
     profile_id = (
         await db_session.execute(
             text(
-                "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
-            )
+                "SELECT user_id FROM public.project_members "
+                "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
+            ),
+            {"pid": str(project_id)},
         )
     ).scalar()
 
@@ -856,7 +863,7 @@ async def test_clone_heals_project_template_with_no_structure(
                  is_active, created_by, global_template_id)
             VALUES (:id, :pid, 'CHARMS (partial)', NULL, 'CHARMS', '1.0', 'extraction',
                     '{}'::jsonb, true,
-                    (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1),
+                    (SELECT user_id FROM public.project_members WHERE project_id = :pid AND role = 'manager' LIMIT 1),
                     :gid)
             ON CONFLICT (id) DO UPDATE SET is_active = true
             """
@@ -871,10 +878,10 @@ async def test_clone_heals_project_template_with_no_structure(
             INSERT INTO public.extraction_template_versions
                 (id, project_template_id, version, schema, published_at, published_by, is_active)
             VALUES (gen_random_uuid(), :tid, 1, '{}'::jsonb, NOW(),
-                    (SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1), true)
+                    (SELECT user_id FROM public.project_members WHERE project_id = :pid AND role = 'manager' LIMIT 1), true)
             """
         ),
-        {"tid": str(partial_id)},
+        {"tid": str(partial_id), "pid": str(project_id)},
     )
     await db_session.commit()
 

--- a/backend/tests/integration/test_template_version_snapshot_shape.py
+++ b/backend/tests/integration/test_template_version_snapshot_shape.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.extraction_snapshot import build_template_version_snapshot
+from tests.integration.conftest import SEED
 
 _ENTITY_KEYS = {
     "id",
@@ -51,8 +52,9 @@ async def test_snapshot_carries_role_and_all_field_columns(
         await db_session.execute(
             text(
                 "SELECT id FROM public.project_extraction_templates "
-                "WHERE kind = 'extraction' LIMIT 1"
-            )
+                "WHERE id = :tid AND kind = 'extraction' LIMIT 1"
+            ),
+            {"tid": str(SEED.primary_template)},
         )
     ).scalar()
     if template_id is None:

--- a/backend/tests/integration/test_template_versions_lifecycle.py
+++ b/backend/tests/integration/test_template_versions_lifecycle.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.extraction_versioning import ExtractionTemplateVersion
+from tests.integration.conftest import SEED
 
 
 @pytest.mark.asyncio
@@ -25,9 +26,8 @@ async def test_template_version_unique_template_version_constraint(
     # Pick a real existing project_template_id from backfill (v1 was seeded for each)
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     row = await db_session.execute(
@@ -42,8 +42,10 @@ async def test_template_version_unique_template_version_constraint(
 
     profile_row = await db_session.execute(
         text(
-            "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
+            "SELECT user_id FROM public.project_members "
+            "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
         ),
+        {"pid": str(SEED.primary_project)},
     )
     profile_id = profile_row.scalar()
     assert profile_id is not None
@@ -66,9 +68,8 @@ async def test_template_version_only_one_active_per_template(
 ) -> None:
     project_id = (
         await db_session.execute(
-            text(
-                "SELECT p.id FROM public.projects p WHERE EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = p.id) ORDER BY p.id LIMIT 1"
-            )
+            text("SELECT id FROM public.projects WHERE id = :pid"),
+            {"pid": str(SEED.primary_project)},
         )
     ).scalar()
     row = await db_session.execute(
@@ -83,8 +84,10 @@ async def test_template_version_only_one_active_per_template(
 
     profile_row = await db_session.execute(
         text(
-            "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
+            "SELECT user_id FROM public.project_members "
+            "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
         ),
+        {"pid": str(SEED.primary_project)},
     )
     profile_id = profile_row.scalar()
     assert profile_id is not None
@@ -130,8 +133,10 @@ async def test_run_lifecycle_lazy_creates_v1_for_template_without_version(
 
     profile_row = await db_session.execute(
         text(
-            "SELECT pm.user_id FROM public.project_members pm WHERE pm.role = 'manager' AND EXISTS (SELECT 1 FROM public.project_extraction_templates t JOIN public.extraction_entity_types et ON et.project_template_id = t.id JOIN public.extraction_fields f ON f.entity_type_id = et.id JOIN public.extraction_instances i ON i.template_id = t.id WHERE t.project_id = pm.project_id) ORDER BY pm.user_id LIMIT 1"
+            "SELECT user_id FROM public.project_members "
+            "WHERE project_id = :pid AND role = 'manager' LIMIT 1"
         ),
+        {"pid": str(SEED.primary_project)},
     )
     profile_id = profile_row.scalar()
     assert profile_id is not None


### PR DESCRIPTION
## Problem

Backend integration setup helpers discovered rows with unscoped `LIMIT 1` queries — the `SELECT p.id … WHERE EXISTS(instance chain) ORDER BY p.id LIMIT 1` project picker, `articles LIMIT 1`, `project_members … role='manager' LIMIT 1`, `profiles LIMIT 1`, `kind='extraction' LIMIT 1`, and `_pick_article`.

On a local dev DB that **also carries the Playwright E2E fixture graph**, those UUIDs (`5b9d8976-…` "E2E Test Project", `e2e00001-…`) sort **before** the integration SEED sentinels (`ffffffff-9999-…`), so the pickers land on E2E rows. When the pickers are *independent*, they resolve to a cross-project-incoherent `(project A / article A / template B / manager C)` tuple, and `create_run` / `record_*` raise coordinate-coherence errors — poisoning `make test-backend` until `make db-fresh`. Every local `npm run test:e2e:local` re-poisons it.

Two helpers were **destructive** on the mis-picked project — `test_single_active_extraction_invariant` wipes its extraction templates, and `test_template_clone_extraction._pick_article` commits clone churn — so an unscoped pick could destroy the E2E fixture graph outright, not just fail.

**CI is unaffected** (isolated empty DB); this is a local cross-suite poisoning only.

## Fix

Per the project rule *"integration setup helpers must scope article/template queries by `project_id`"*, pin every such picker to `tests.integration.conftest.SEED`:
- project → `SEED.primary_project`, article → `SEED.primary_article`, template → `SEED.primary_template`
- manager pickers → project-scoped `WHERE project_id = :pid AND role='manager' LIMIT 1` (`SEED.primary_profile` manages both seed projects)
- second-reviewer / peer pickers → `SEED.reviewer_profile`

**34 files, test-only — no app code touched.**

## Verification

Ran on a poisoned local DB (`test:e2e:local` first, **no `make db-fresh` in between**):

| Condition | Result |
|---|---|
| Pre-fix picker on the poisoned DB | returns E2E project `5b9d8976-…` (confirmed live) |
| Full suite, **fix reverted** | **19 failed** — all coordinate-coherence class, all in files touched here |
| Full suite, **fix applied** (rebased on current `dev`, incl. #491/#492) | **2477 passed, 3 skipped, 0 failed** |
| ruff + format on `tests/integration/` | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)